### PR TITLE
2.x: small cleanup and TCK fix

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -13017,7 +13017,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <V>
      *            the timeout value type (ignored)
-     * @param timeoutSelector
+     * @param itemTimeoutIndicator
      *            a function that returns a Publisher for each item emitted by the source
      *            Publisher and that determines the timeout window for the subsequent item
      * @return a Flowable that mirrors the source Publisher, but notifies Subscribers of a
@@ -13027,8 +13027,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <V> Flowable<T> timeout(Function<? super T, ? extends Publisher<V>> timeoutSelector) {
-        return timeout0(null, timeoutSelector, null);
+    public final <V> Flowable<T> timeout(Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator) {
+        return timeout0(null, itemTimeoutIndicator, null);
     }
 
     /**
@@ -13052,7 +13052,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <V>
      *            the timeout value type (ignored)
-     * @param timeoutSelector
+     * @param itemTimeoutIndicator
      *            a function that returns a Publisher, for each item emitted by the source Publisher, that
      *            determines the timeout window for the subsequent item
      * @param other
@@ -13064,9 +13064,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <V> Flowable<T> timeout(Function<? super T, ? extends Publisher<V>> timeoutSelector, Flowable<? extends T> other) {
+    public final <V> Flowable<T> timeout(Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator, Flowable<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return timeout0(null, timeoutSelector, other);
+        return timeout0(null, itemTimeoutIndicator, other);
     }
 
     /**
@@ -13149,17 +13149,17 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            maximum duration between items before a timeout occurs
      * @param timeUnit
      *            the unit of time that applies to the {@code timeout} argument
-     * @param other
-     *            the Publisher to use as the fallback in case of a timeout
      * @param scheduler
      *            the {@link Scheduler} to run the timeout timers on
+     * @param other
+     *            the Publisher to use as the fallback in case of a timeout
      * @return the source Publisher modified so that it will switch to the fallback Publisher in case of a
      *         timeout
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> timeout(long timeout, TimeUnit timeUnit, Flowable<? extends T> other, Scheduler scheduler) {
+    public final Flowable<T> timeout(long timeout, TimeUnit timeUnit, Scheduler scheduler, Flowable<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, scheduler);
     }
@@ -13214,10 +13214,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the first timeout value type (ignored)
      * @param <V>
      *            the subsequent timeout value type (ignored)
-     * @param firstTimeoutSelector
+     * @param firstTimeoutIndicator
      *            a function that returns a Publisher that determines the timeout window for the first source
      *            item
-     * @param timeoutSelector
+     * @param itemTimeoutIndicator
      *            a function that returns a Publisher for each item emitted by the source Publisher and that
      *            determines the timeout window in which the subsequent source item must arrive in order to
      *            continue the sequence
@@ -13228,10 +13228,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, V> Flowable<T> timeout(Callable<? extends Publisher<U>> firstTimeoutSelector,
-            Function<? super T, ? extends Publisher<V>> timeoutSelector) {
-        ObjectHelper.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
-        return timeout0(firstTimeoutSelector, timeoutSelector, null);
+    public final <U, V> Flowable<T> timeout(Publisher<U> firstTimeoutIndicator,
+            Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator) {
+        ObjectHelper.requireNonNull(firstTimeoutIndicator, "firstTimeoutIndicator is null");
+        return timeout0(firstTimeoutIndicator, itemTimeoutIndicator, null);
     }
 
     /**
@@ -13254,10 +13254,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the first timeout value type (ignored)
      * @param <V>
      *            the subsequent timeout value type (ignored)
-     * @param firstTimeoutSelector
+     * @param firstTimeoutIndicator
      *            a function that returns a Publisher which determines the timeout window for the first source
      *            item
-     * @param timeoutSelector
+     * @param itemTimeoutIndicator
      *            a function that returns a Publisher for each item emitted by the source Publisher and that
      *            determines the timeout window in which the subsequent source item must arrive in order to
      *            continue the sequence
@@ -13267,18 +13267,18 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         either the first item emitted by the source Publisher or any subsequent item doesn't arrive
      *         within time windows defined by the timeout selectors
      * @throws NullPointerException
-     *             if {@code timeoutSelector} is null
+     *             if {@code itemTimeoutIndicator} is null
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, V> Flowable<T> timeout(
-            Callable<? extends Publisher<U>> firstTimeoutSelector,
-            Function<? super T, ? extends Publisher<V>> timeoutSelector,
+            Publisher<U> firstTimeoutIndicator,
+            Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator,
                     Publisher<? extends T> other) {
-        ObjectHelper.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
+        ObjectHelper.requireNonNull(firstTimeoutIndicator, "firstTimeoutSelector is null");
         ObjectHelper.requireNonNull(other, "other is null");
-        return timeout0(firstTimeoutSelector, timeoutSelector, other);
+        return timeout0(firstTimeoutIndicator, itemTimeoutIndicator, other);
     }
 
     private Flowable<T> timeout0(long timeout, TimeUnit timeUnit, Flowable<? extends T> other,
@@ -13289,11 +13289,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     private <U, V> Flowable<T> timeout0(
-            Callable<? extends Publisher<U>> firstTimeoutSelector,
-            Function<? super T, ? extends Publisher<V>> timeoutSelector,
+            Publisher<U> firstTimeoutIndicator,
+            Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator,
                     Publisher<? extends T> other) {
-        ObjectHelper.requireNonNull(timeoutSelector, "timeoutSelector is null");
-        return RxJavaPlugins.onAssembly(new FlowableTimeout<T, U, V>(this, firstTimeoutSelector, timeoutSelector, other));
+        ObjectHelper.requireNonNull(itemTimeoutIndicator, "itemTimeoutIndicator is null");
+        return RxJavaPlugins.onAssembly(new FlowableTimeout<T, U, V>(this, firstTimeoutIndicator, itemTimeoutIndicator, other));
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -10903,7 +10903,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <V>
      *            the timeout value type (ignored)
-     * @param timeoutSelector
+     * @param itemTimeoutIndicator
      *            a function that returns an ObservableSource for each item emitted by the source
      *            ObservableSource and that determines the timeout window for the subsequent item
      * @return an Observable that mirrors the source ObservableSource, but notifies observers of a
@@ -10912,8 +10912,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <V> Observable<T> timeout(Function<? super T, ? extends ObservableSource<V>> timeoutSelector) {
-        return timeout0(null, timeoutSelector, null);
+    public final <V> Observable<T> timeout(Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator) {
+        return timeout0(null, itemTimeoutIndicator, null);
     }
 
     /**
@@ -10932,7 +10932,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <V>
      *            the timeout value type (ignored)
-     * @param timeoutSelector
+     * @param itemTimeoutIndicator
      *            a function that returns an ObservableSource, for each item emitted by the source ObservableSource, that
      *            determines the timeout window for the subsequent item
      * @param other
@@ -10943,10 +10943,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <V> Observable<T> timeout(Function<? super T, ? extends ObservableSource<V>> timeoutSelector,
+    public final <V> Observable<T> timeout(Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
             ObservableSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
-        return timeout0(null, timeoutSelector, other);
+        return timeout0(null, itemTimeoutIndicator, other);
     }
 
     /**
@@ -11014,16 +11014,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            maximum duration between items before a timeout occurs
      * @param timeUnit
      *            the unit of time that applies to the {@code timeout} argument
-     * @param other
-     *            the ObservableSource to use as the fallback in case of a timeout
      * @param scheduler
      *            the {@link Scheduler} to run the timeout timers on
+     * @param other
+     *            the ObservableSource to use as the fallback in case of a timeout
      * @return the source ObservableSource modified so that it will switch to the fallback ObservableSource in case of a
      *         timeout
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, ObservableSource<? extends T> other, Scheduler scheduler) {
+    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, Scheduler scheduler, ObservableSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, scheduler);
     }
@@ -11070,10 +11070,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the first timeout value type (ignored)
      * @param <V>
      *            the subsequent timeout value type (ignored)
-     * @param firstTimeoutSelector
+     * @param firstTimeoutIndicator
      *            a function that returns an ObservableSource that determines the timeout window for the first source
      *            item
-     * @param timeoutSelector
+     * @param itemTimeoutIndicator
      *            a function that returns an ObservableSource for each item emitted by the source ObservableSource and that
      *            determines the timeout window in which the subsequent source item must arrive in order to
      *            continue the sequence
@@ -11083,10 +11083,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, V> Observable<T> timeout(Callable<? extends ObservableSource<U>> firstTimeoutSelector,
-            Function<? super T, ? extends ObservableSource<V>> timeoutSelector) {
-        ObjectHelper.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
-        return timeout0(firstTimeoutSelector, timeoutSelector, null);
+    public final <U, V> Observable<T> timeout(ObservableSource<U> firstTimeoutIndicator,
+            Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator) {
+        ObjectHelper.requireNonNull(firstTimeoutIndicator, "firstTimeoutIndicator is null");
+        return timeout0(firstTimeoutIndicator, itemTimeoutIndicator, null);
     }
 
     /**
@@ -11104,10 +11104,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the first timeout value type (ignored)
      * @param <V>
      *            the subsequent timeout value type (ignored)
-     * @param firstTimeoutSelector
+     * @param firstTimeoutIndicator
      *            a function that returns an ObservableSource which determines the timeout window for the first source
      *            item
-     * @param timeoutSelector
+     * @param itemTimeoutIndicator
      *            a function that returns an ObservableSource for each item emitted by the source ObservableSource and that
      *            determines the timeout window in which the subsequent source item must arrive in order to
      *            continue the sequence
@@ -11117,17 +11117,17 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         either the first item emitted by the source ObservableSource or any subsequent item doesn't arrive
      *         within time windows defined by the timeout selectors
      * @throws NullPointerException
-     *             if {@code timeoutSelector} is null
+     *             if {@code itemTimeoutIndicator} is null
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, V> Observable<T> timeout(
-            Callable<? extends ObservableSource<U>> firstTimeoutSelector,
-            Function<? super T, ? extends ObservableSource<V>> timeoutSelector,
+            ObservableSource<U> firstTimeoutIndicator,
+            Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
                     ObservableSource<? extends T> other) {
-        ObjectHelper.requireNonNull(firstTimeoutSelector, "firstTimeoutSelector is null");
+        ObjectHelper.requireNonNull(firstTimeoutIndicator, "firstTimeoutIndicator is null");
         ObjectHelper.requireNonNull(other, "other is null");
-        return timeout0(firstTimeoutSelector, timeoutSelector, other);
+        return timeout0(firstTimeoutIndicator, itemTimeoutIndicator, other);
     }
 
     private Observable<T> timeout0(long timeout, TimeUnit timeUnit, ObservableSource<? extends T> other,
@@ -11138,11 +11138,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     private <U, V> Observable<T> timeout0(
-            Callable<? extends ObservableSource<U>> firstTimeoutSelector,
-            Function<? super T, ? extends ObservableSource<V>> timeoutSelector,
+            ObservableSource<U> firstTimeoutIndicator,
+            Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
                     ObservableSource<? extends T> other) {
-        ObjectHelper.requireNonNull(timeoutSelector, "timeoutSelector is null");
-        return RxJavaPlugins.onAssembly(new ObservableTimeout<T, U, V>(this, firstTimeoutSelector, timeoutSelector, other));
+        ObjectHelper.requireNonNull(itemTimeoutIndicator, "itemTimeoutIndicator is null");
+        return RxJavaPlugins.onAssembly(new ObservableTimeout<T, U, V>(this, firstTimeoutIndicator, itemTimeoutIndicator, other));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
@@ -26,18 +26,18 @@ import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpstream<T, T> {
-    final Callable<? extends ObservableSource<U>> firstTimeoutSelector;
-    final Function<? super T, ? extends ObservableSource<V>> timeoutSelector;
+    final ObservableSource<U> firstTimeoutIndicator;
+    final Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator;
     final ObservableSource<? extends T> other;
 
     public ObservableTimeout(
             ObservableSource<T> source,
-            Callable<? extends ObservableSource<U>> firstTimeoutSelector,
-            Function<? super T, ? extends ObservableSource<V>> timeoutSelector,
+            ObservableSource<U> firstTimeoutIndicator,
+            Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
                     ObservableSource<? extends T> other) {
         super(source);
-        this.firstTimeoutSelector = firstTimeoutSelector;
-        this.timeoutSelector = timeoutSelector;
+        this.firstTimeoutIndicator = firstTimeoutIndicator;
+        this.itemTimeoutIndicator = itemTimeoutIndicator;
         this.other = other;
     }
 
@@ -46,10 +46,10 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
         if (other == null) {
             source.subscribe(new TimeoutSubscriber<T, U, V>(
                     new SerializedObserver<T>(t),
-                    firstTimeoutSelector, timeoutSelector));
+                    firstTimeoutIndicator, itemTimeoutIndicator));
         } else {
             source.subscribe(new TimeoutOtherSubscriber<T, U, V>(
-                    t, firstTimeoutSelector, timeoutSelector, other));
+                    t, firstTimeoutIndicator, itemTimeoutIndicator, other));
         }
     }
 
@@ -59,19 +59,19 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
         /** */
         private static final long serialVersionUID = 2672739326310051084L;
         final Observer<? super T> actual;
-        final Callable<? extends ObservableSource<U>> firstTimeoutSelector;
-        final Function<? super T, ? extends ObservableSource<V>> timeoutSelector;
+        final ObservableSource<U> firstTimeoutIndicator;
+        final Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator;
 
         Disposable s;
 
         volatile long index;
 
         public TimeoutSubscriber(Observer<? super T> actual,
-                Callable<? extends ObservableSource<U>> firstTimeoutSelector,
-                Function<? super T, ? extends ObservableSource<V>> timeoutSelector) {
+                ObservableSource<U> firstTimeoutIndicator,
+                Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator) {
             this.actual = actual;
-            this.firstTimeoutSelector = firstTimeoutSelector;
-            this.timeoutSelector = timeoutSelector;
+            this.firstTimeoutIndicator = firstTimeoutIndicator;
+            this.itemTimeoutIndicator = itemTimeoutIndicator;
         }
 
         @Override
@@ -81,24 +81,9 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
 
                 Observer<? super T> a = actual;
 
-                ObservableSource<U> p;
+                ObservableSource<U> p = firstTimeoutIndicator;
 
-                if (firstTimeoutSelector != null) {
-                    try {
-                        p = firstTimeoutSelector.call();
-                    } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        dispose();
-                        EmptyDisposable.error(ex, a);
-                        return;
-                    }
-
-                    if (p == null) {
-                        dispose();
-                        EmptyDisposable.error(new NullPointerException("The first timeout Observable is null"), a);
-                        return;
-                    }
-
+                if (p != null) {
                     TimeoutInnerSubscriber<T, U, V> tis = new TimeoutInnerSubscriber<T, U, V>(this, 0);
 
                     if (compareAndSet(null, tis)) {
@@ -126,7 +111,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
             ObservableSource<V> p;
 
             try {
-                p = timeoutSelector.apply(t);
+                p = itemTimeoutIndicator.apply(t);
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 dispose();
@@ -228,8 +213,8 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
         /** */
         private static final long serialVersionUID = -1957813281749686898L;
         final Observer<? super T> actual;
-        final Callable<? extends ObservableSource<U>> firstTimeoutSelector;
-        final Function<? super T, ? extends ObservableSource<V>> timeoutSelector;
+        final ObservableSource<U> firstTimeoutIndicator;
+        final Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator;
         final ObservableSource<? extends T> other;
         final ObserverFullArbiter<T> arbiter;
 
@@ -240,11 +225,11 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
         volatile long index;
 
         public TimeoutOtherSubscriber(Observer<? super T> actual,
-                                      Callable<? extends ObservableSource<U>> firstTimeoutSelector,
-                                      Function<? super T, ? extends ObservableSource<V>> timeoutSelector, ObservableSource<? extends T> other) {
+                                      ObservableSource<U> firstTimeoutIndicator,
+                                      Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator, ObservableSource<? extends T> other) {
             this.actual = actual;
-            this.firstTimeoutSelector = firstTimeoutSelector;
-            this.timeoutSelector = timeoutSelector;
+            this.firstTimeoutIndicator = firstTimeoutIndicator;
+            this.itemTimeoutIndicator = itemTimeoutIndicator;
             this.other = other;
             this.arbiter = new ObserverFullArbiter<T>(actual, this, 8);
         }
@@ -259,24 +244,9 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
                 }
                 Observer<? super T> a = actual;
 
-                if (firstTimeoutSelector != null) {
-                    ObservableSource<U> p;
+                ObservableSource<U> p = firstTimeoutIndicator;
 
-                    try {
-                        p = firstTimeoutSelector.call();
-                    } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        dispose();
-                        EmptyDisposable.error(ex, a);
-                        return;
-                    }
-
-                    if (p == null) {
-                        dispose();
-                        EmptyDisposable.error(new NullPointerException("The first timeout Observable is null"), a);
-                        return;
-                    }
-
+                if (p != null) {
                     TimeoutInnerSubscriber<T, U, V> tis = new TimeoutInnerSubscriber<T, U, V>(this, 0);
 
                     if (compareAndSet(null, tis)) {
@@ -309,7 +279,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
             ObservableSource<V> p;
 
             try {
-                p = timeoutSelector.apply(t);
+                p = itemTimeoutIndicator.apply(t);
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 actual.onError(e);

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -2286,22 +2286,22 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void timeoutUnitNull() {
-        just1.timeout(1, null, just1, Schedulers.single());
+        just1.timeout(1, null, Schedulers.single(), just1);
     }
 
     @Test(expected = NullPointerException.class)
     public void timeouOtherNull() {
-        just1.timeout(1, TimeUnit.SECONDS, null, Schedulers.single());
+        just1.timeout(1, TimeUnit.SECONDS, Schedulers.single(), null);
     }
 
     @Test(expected = NullPointerException.class)
     public void timeouSchedulerNull() {
-        just1.timeout(1, TimeUnit.SECONDS, just1, null);
+        just1.timeout(1, TimeUnit.SECONDS, null, just1);
     }
 
     @Test(expected = NullPointerException.class)
     public void timeoutFirstNull() {
-        just1.timeout((Callable<Publisher<Integer>>)null, new Function<Integer, Publisher<Integer>>() {
+        just1.timeout((Publisher<Integer>)null, new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer v) {
                 return just1;
@@ -2310,38 +2310,13 @@ public class FlowableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void timeoutFirstReturnsNull() {
-        just1.timeout(new Callable<Publisher<Object>>() {
-            @Override
-            public Publisher<Object> call() {
-                return null;
-            }
-        }, new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return just1;
-            }
-        }).blockingSubscribe();
-    }
-
-    @Test(expected = NullPointerException.class)
     public void timeoutFirstItemNull() {
-        just1.timeout(new Callable<Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> call() {
-                return just1;
-            }
-        }, null);
+        just1.timeout(just1, null);
     }
 
     @Test(expected = NullPointerException.class)
     public void timeoutFirstItemReturnsNull() {
-        just1.timeout(new Callable<Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> call() {
-                return just1;
-            }
-        }, new Function<Integer, Publisher<Object>>() {
+        just1.timeout(just1, new Function<Integer, Publisher<Object>>() {
             @Override
             public Publisher<Object> apply(Integer v) {
                 return null;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -131,7 +131,7 @@ public class FlowableTimeoutTests {
     @Test
     public void shouldSwitchToOtherIfOnNextNotWithinTimeout() {
         Flowable<String> other = Flowable.just("a", "b", "c");
-        Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, other, testScheduler);
+        Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Subscriber<String> observer = TestHelper.mockSubscriber();
         TestSubscriber<String> ts = new TestSubscriber<String>(observer);
@@ -154,7 +154,7 @@ public class FlowableTimeoutTests {
     @Test
     public void shouldSwitchToOtherIfOnErrorNotWithinTimeout() {
         Flowable<String> other = Flowable.just("a", "b", "c");
-        Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, other, testScheduler);
+        Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Subscriber<String> observer = TestHelper.mockSubscriber();
         TestSubscriber<String> ts = new TestSubscriber<String>(observer);
@@ -177,7 +177,7 @@ public class FlowableTimeoutTests {
     @Test
     public void shouldSwitchToOtherIfOnCompletedNotWithinTimeout() {
         Flowable<String> other = Flowable.just("a", "b", "c");
-        Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, other, testScheduler);
+        Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Subscriber<String> observer = TestHelper.mockSubscriber();
         TestSubscriber<String> ts = new TestSubscriber<String>(observer);
@@ -200,7 +200,7 @@ public class FlowableTimeoutTests {
     @Test
     public void shouldSwitchToOtherAndCanBeUnsubscribedIfOnNextNotWithinTimeout() {
         PublishProcessor<String> other = PublishProcessor.create();
-        Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, other, testScheduler);
+        Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Subscriber<String> observer = TestHelper.mockSubscriber();
         TestSubscriber<String> ts = new TestSubscriber<String>(observer);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -48,19 +48,12 @@ public class FlowableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Flowable<Integer>> firstTimeoutFunc = new Callable<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> call() {
-                return timeout;
-            }
-        };
-
         Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
 
         Subscriber<Object> o = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(o);
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(o);
 
         source.onNext(1);
         source.onNext(2);
@@ -88,19 +81,12 @@ public class FlowableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Flowable<Integer>> firstTimeoutFunc = new Callable<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> call() {
-                return timeout;
-            }
-        };
-
         Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
 
         Subscriber<Object> o = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(o);
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(o);
 
         timeout.onNext(1);
 
@@ -133,7 +119,7 @@ public class FlowableTimeoutWithSelectorTest {
 
         Subscriber<Object> o = TestHelper.mockSubscriber();
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(Flowable.defer(firstTimeoutFunc), timeoutFunc, other).subscribe(o);
 
         verify(o).onError(any(TestException.class));
         verify(o, never()).onNext(any());
@@ -153,19 +139,12 @@ public class FlowableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Flowable<Integer>> firstTimeoutFunc = new Callable<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> call() {
-                return timeout;
-            }
-        };
-
         Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
 
         Subscriber<Object> o = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(o);
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(o);
 
         source.onNext(1);
 
@@ -187,18 +166,11 @@ public class FlowableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Flowable<Integer>> firstTimeoutFunc = new Callable<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> call() {
-                return Flowable.<Integer> error(new TestException());
-            }
-        };
-
         Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
 
         Subscriber<Object> o = TestHelper.mockSubscriber();
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(Flowable.<Integer> error(new TestException()), timeoutFunc, other).subscribe(o);
 
         verify(o).onError(any(TestException.class));
         verify(o, never()).onNext(any());
@@ -218,19 +190,12 @@ public class FlowableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Flowable<Integer>> firstTimeoutFunc = new Callable<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> call() {
-                return timeout;
-            }
-        };
-
         Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
 
         Subscriber<Object> o = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(o);
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(o);
 
         source.onNext(1);
 
@@ -245,13 +210,6 @@ public class FlowableTimeoutWithSelectorTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> timeout = PublishProcessor.create();
 
-        Callable<Flowable<Integer>> firstTimeoutFunc = new Callable<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> call() {
-                return timeout;
-            }
-        };
-
         Function<Integer, Flowable<Integer>> timeoutFunc = new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer t1) {
@@ -260,7 +218,7 @@ public class FlowableTimeoutWithSelectorTest {
         };
 
         Subscriber<Object> o = TestHelper.mockSubscriber();
-        source.timeout(firstTimeoutFunc, timeoutFunc).subscribe(o);
+        source.timeout(timeout, timeoutFunc).subscribe(o);
 
         timeout.onNext(1);
 
@@ -274,13 +232,6 @@ public class FlowableTimeoutWithSelectorTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> timeout = PublishProcessor.create();
 
-        Callable<Flowable<Integer>> firstTimeoutFunc = new Callable<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> call() {
-                return PublishProcessor.create();
-            }
-        };
-
         Function<Integer, Flowable<Integer>> timeoutFunc = new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer t1) {
@@ -289,7 +240,7 @@ public class FlowableTimeoutWithSelectorTest {
         };
 
         Subscriber<Object> o = TestHelper.mockSubscriber();
-        source.timeout(firstTimeoutFunc, timeoutFunc).subscribe(o);
+        source.timeout(PublishProcessor.create(), timeoutFunc).subscribe(o);
         source.onNext(1);
 
         timeout.onNext(1);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
@@ -130,7 +130,7 @@ public class ObservableTimeoutTests {
     @Test
     public void shouldSwitchToOtherIfOnNextNotWithinTimeout() {
         Observable<String> other = Observable.just("a", "b", "c");
-        Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, other, testScheduler);
+        Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
         TestObserver<String> ts = new TestObserver<String>(NbpObserver);
@@ -153,7 +153,7 @@ public class ObservableTimeoutTests {
     @Test
     public void shouldSwitchToOtherIfOnErrorNotWithinTimeout() {
         Observable<String> other = Observable.just("a", "b", "c");
-        Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, other, testScheduler);
+        Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
         TestObserver<String> ts = new TestObserver<String>(NbpObserver);
@@ -176,7 +176,7 @@ public class ObservableTimeoutTests {
     @Test
     public void shouldSwitchToOtherIfOnCompletedNotWithinTimeout() {
         Observable<String> other = Observable.just("a", "b", "c");
-        Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, other, testScheduler);
+        Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
         TestObserver<String> ts = new TestObserver<String>(NbpObserver);
@@ -199,7 +199,7 @@ public class ObservableTimeoutTests {
     @Test
     public void shouldSwitchToOtherAndCanBeUnsubscribedIfOnNextNotWithinTimeout() {
         PublishSubject<String> other = PublishSubject.create();
-        Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, other, testScheduler);
+        Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> NbpObserver = TestHelper.mockObserver();
         TestObserver<String> ts = new TestObserver<String>(NbpObserver);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -47,19 +47,12 @@ public class ObservableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Observable<Integer>> firstTimeoutFunc = new Callable<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> call() {
-                return timeout;
-            }
-        };
-
         Observable<Integer> other = Observable.fromIterable(Arrays.asList(100));
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(o);
 
         source.onNext(1);
         source.onNext(2);
@@ -87,19 +80,12 @@ public class ObservableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Observable<Integer>> firstTimeoutFunc = new Callable<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> call() {
-                return timeout;
-            }
-        };
-
         Observable<Integer> other = Observable.fromIterable(Arrays.asList(100));
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(o);
 
         timeout.onNext(1);
 
@@ -132,7 +118,7 @@ public class ObservableTimeoutWithSelectorTest {
 
         Observer<Object> o = TestHelper.mockObserver();
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(Observable.defer(firstTimeoutFunc), timeoutFunc, other).subscribe(o);
 
         verify(o).onError(any(TestException.class));
         verify(o, never()).onNext(any());
@@ -152,19 +138,12 @@ public class ObservableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Observable<Integer>> firstTimeoutFunc = new Callable<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> call() {
-                return timeout;
-            }
-        };
-
         Observable<Integer> other = Observable.fromIterable(Arrays.asList(100));
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(o);
 
         source.onNext(1);
 
@@ -186,18 +165,11 @@ public class ObservableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Observable<Integer>> firstTimeoutFunc = new Callable<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> call() {
-                return Observable.<Integer> error(new TestException());
-            }
-        };
-
         Observable<Integer> other = Observable.fromIterable(Arrays.asList(100));
 
         Observer<Object> o = TestHelper.mockObserver();
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(Observable.<Integer> error(new TestException()), timeoutFunc, other).subscribe(o);
 
         verify(o).onError(any(TestException.class));
         verify(o, never()).onNext(any());
@@ -217,19 +189,12 @@ public class ObservableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Observable<Integer>> firstTimeoutFunc = new Callable<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> call() {
-                return timeout;
-            }
-        };
-
         Observable<Integer> other = Observable.fromIterable(Arrays.asList(100));
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
-        source.timeout(firstTimeoutFunc, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(o);
 
         source.onNext(1);
 
@@ -244,13 +209,6 @@ public class ObservableTimeoutWithSelectorTest {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> timeout = PublishSubject.create();
 
-        Callable<Observable<Integer>> firstTimeoutFunc = new Callable<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> call() {
-                return timeout;
-            }
-        };
-
         Function<Integer, Observable<Integer>> timeoutFunc = new Function<Integer, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Integer t1) {
@@ -259,7 +217,7 @@ public class ObservableTimeoutWithSelectorTest {
         };
 
         Observer<Object> o = TestHelper.mockObserver();
-        source.timeout(firstTimeoutFunc, timeoutFunc).subscribe(o);
+        source.timeout(timeout, timeoutFunc).subscribe(o);
 
         timeout.onNext(1);
 
@@ -273,13 +231,6 @@ public class ObservableTimeoutWithSelectorTest {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> timeout = PublishSubject.create();
 
-        Callable<Observable<Integer>> firstTimeoutFunc = new Callable<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> call() {
-                return PublishSubject.create();
-            }
-        };
-
         Function<Integer, Observable<Integer>> timeoutFunc = new Function<Integer, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Integer t1) {
@@ -288,7 +239,7 @@ public class ObservableTimeoutWithSelectorTest {
         };
 
         Observer<Object> o = TestHelper.mockObserver();
-        source.timeout(firstTimeoutFunc, timeoutFunc).subscribe(o);
+        source.timeout(PublishSubject.create(), timeoutFunc).subscribe(o);
         source.onNext(1);
 
         timeout.onNext(1);

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -2357,22 +2357,22 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void timeoutUnitNull() {
-        just1.timeout(1, null, just1, Schedulers.single());
+        just1.timeout(1, null, Schedulers.single(), just1);
     }
 
     @Test(expected = NullPointerException.class)
     public void timeouOtherNull() {
-        just1.timeout(1, TimeUnit.SECONDS, null, Schedulers.single());
+        just1.timeout(1, TimeUnit.SECONDS, Schedulers.single(), null);
     }
 
     @Test(expected = NullPointerException.class)
     public void timeouSchedulerNull() {
-        just1.timeout(1, TimeUnit.SECONDS, just1, null);
+        just1.timeout(1, TimeUnit.SECONDS, null, just1);
     }
 
     @Test(expected = NullPointerException.class)
     public void timeoutFirstNull() {
-        just1.timeout((Callable<Observable<Integer>>)null, new Function<Integer, Observable<Integer>>() {
+        just1.timeout((Observable<Integer>)null, new Function<Integer, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Integer v) {
                 return just1;
@@ -2381,38 +2381,13 @@ public class ObservableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void timeoutFirstReturnsNull() {
-        just1.timeout(new Callable<Observable<Object>>() {
-            @Override
-            public Observable<Object> call() {
-                return null;
-            }
-        }, new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return just1;
-            }
-        }).blockingSubscribe();
-    }
-
-    @Test(expected = NullPointerException.class)
     public void timeoutFirstItemNull() {
-        just1.timeout(new Callable<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> call() {
-                return just1;
-            }
-        }, null);
+        just1.timeout(just1, null);
     }
 
     @Test(expected = NullPointerException.class)
     public void timeoutFirstItemReturnsNull() {
-        Observable.just(1, 1).timeout(new Callable<Observable<Object>>() {
-            @Override
-            public Observable<Object> call() {
-                return Observable.never();
-            }
-        }, new Function<Integer, Observable<Object>>() {
+        Observable.just(1, 1).timeout(Observable.never(), new Function<Integer, Observable<Object>>() {
             @Override
             public Observable<Object> apply(Integer v) {
                 return null;

--- a/src/test/java/io/reactivex/tck/DelayTckTest.java
+++ b/src/test/java/io/reactivex/tck/DelayTckTest.java
@@ -26,7 +26,9 @@ public class DelayTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
+            FlowableAwaitOnSubscribeTck.wrap(
                 Flowable.range(0, (int)elements).delay(1, TimeUnit.MILLISECONDS)
+            )
         );
     }
 }

--- a/src/test/java/io/reactivex/tck/FlowableAwaitOnSubscribeTck.java
+++ b/src/test/java/io/reactivex/tck/FlowableAwaitOnSubscribeTck.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.BackpressureHelper;
+
+/**
+ * Intercepts the onSubscribe call and makes sure calls to Subscription methods
+ * only happen after the child Subscriber has returned from its onSubscribe method.
+ * 
+ * <p>This helps with child Subscribers that don't expect a recursive call from
+ * onSubscribe into their onNext because, for example, they request immediately from
+ * their onSubscribe but don't finish their preparation before that and onNext
+ * runs into a half-prepared state. This can happen with non Rx mentality based Subscribers.
+ *
+ * @param <T> the value type
+ */
+public final class FlowableAwaitOnSubscribeTck<T> extends Flowable<T> {
+
+    final Publisher<T> source;
+
+    FlowableAwaitOnSubscribeTck(Publisher<T> source) {
+        this.source = source;
+    }
+
+    public static <T> Flowable<T> wrap(Publisher<T> source) {
+        return new FlowableAwaitOnSubscribeTck<T>(ObjectHelper.requireNonNull(source, "source is null"));
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        source.subscribe(new PublisherPostOnSubscribeSubscriber<T>(s));
+    }
+
+    static final class PublisherPostOnSubscribeSubscriber<T>
+    extends AtomicReference<Subscription>
+    implements Subscriber<T>, Subscription {
+
+        /** */
+        private static final long serialVersionUID = -4850665729904103852L;
+
+        final Subscriber<? super T> actual;
+
+        final AtomicLong requested;
+
+        public PublisherPostOnSubscribeSubscriber(Subscriber<? super T> actual) {
+            this.actual = actual;
+            this.requested = new AtomicLong();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.get(), s)) {
+
+                actual.onSubscribe(this);
+
+                if (SubscriptionHelper.setOnce(this, s)) {
+                    long r = requested.getAndSet(0L);
+                    if (r != 0L) {
+                        s.request(r);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+
+        @Override
+        public void request(long n) {
+            Subscription a = get();
+            if (a != null) {
+                a.request(n);
+            } else {
+                if (SubscriptionHelper.validate(n)) {
+                    BackpressureHelper.add(requested, n);
+                    a = get();
+                    if (a != null) {
+                        long r = requested.getAndSet(0L);
+                        if (r != 0L) {
+                            a.request(n);
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            SubscriptionHelper.cancel(this);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/tck/ObserveOnTckTest.java
+++ b/src/test/java/io/reactivex/tck/ObserveOnTckTest.java
@@ -25,7 +25,9 @@ public class ObserveOnTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(
+            FlowableAwaitOnSubscribeTck.wrap(
                 Flowable.range(0, (int)elements).observeOn(Schedulers.single())
+            )
         );
     }
 }


### PR DESCRIPTION
- Change the `Callable<Publisher<T>>` parameter of `timeout` to plain `Publisher<T>` to simplify the API surface; use `defer(Callable<Publisher<T>>)` as input instead
- change the parameter order of `timeout` from `(long, TimeUnit, Publisher, Scheduler)` to `(long, Timeunit, Scheduler, Publisher)` to better match the general pattern of time-unit-scheduler.
- `Observable.timeout` has been updated similarly
- Add `FlowableAwaitOnSubscribeTck` to workaround the case when calling `onNext` (indirectly) from `onSubscribe` may be unexpected (plus randomly fails the observeOn TCK test).
