### PR TITLE
2.x: cleanup of some javadoc errors and mentions of 'Nbp'

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -647,7 +647,7 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable instance which manages a resource along
      * with a custom Completable instance while the subscription is active.
      * <p>
-     * This overload performs an eager unsubscription before the terminal event is emitted.
+     * This overload disposes eagerly before the terminal event is emitted.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -670,7 +670,7 @@ public abstract class Completable implements CompletableSource {
      * with a custom Completable instance while the subscription is active and performs eager or lazy
      * resource disposition.
      * <p>
-     * If this overload performs a lazy unsubscription after the terminal event is emitted.
+     * If this overload performs a lazy cancellation after the terminal event is emitted.
      * Exceptions thrown at this time will be delivered to RxJavaPlugins only.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1797,7 +1797,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Completable unsubscribeOn(final Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new CompletableUnsubscribeOn(this, scheduler));
+        return RxJavaPlugins.onAssembly(new CompletableDisposeOn(this, scheduler));
     }
     // -------------------------------------------------------------------------
     // Fluent test support, super handy and reduces test preparation boilerplate

--- a/src/main/java/io/reactivex/CompletableEmitter.java
+++ b/src/main/java/io/reactivex/CompletableEmitter.java
@@ -39,14 +39,14 @@ public interface CompletableEmitter {
 
     /**
      * Sets a Disposable on this emitter; any previous Disposable
-     * or Cancellation will be unsubscribed/cancelled.
+     * or Cancellation will be disposed/cancelled.
      * @param d the disposable, null is allowed
      */
     void setDisposable(Disposable d);
 
     /**
      * Sets a Cancellable on this emitter; any previous Disposable
-     * or Cancellation will be unsubscribed/cancelled.
+     * or Cancellation will be disposed/cancelled.
      * @param c the cancellable resource, null is allowed
      */
     void setCancellable(Cancellable c);

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -3828,7 +3828,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Constructs a Publisher that creates a dependent resource object which is disposed of on unsubscription.
+     * Constructs a Publisher that creates a dependent resource object which is disposed of on cancellation.
      * <p>
      * <img width="640" height="400" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/using.png" alt="">
      * <dl>
@@ -3859,8 +3859,8 @@ public abstract class Flowable<T> implements Publisher<T> {
 
     /**
      * Constructs a Publisher that creates a dependent resource object which is disposed of just before
-     * termination if you have set {@code disposeEagerly} to {@code true} and unsubscription does not occur
-     * before termination. Otherwise resource disposal will occur on unsubscription.  Eager disposal is
+     * termination if you have set {@code disposeEagerly} to {@code true} and cancellation does not occur
+     * before termination. Otherwise resource disposal will occur on cancellation.  Eager disposal is
      * particularly appropriate for a synchronous Publisher that reuses resources. {@code disposeAction} will
      * only be called once per subscription.
      * <p>
@@ -3882,7 +3882,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param resourceDisposer
      *            the function that will dispose of the resource
      * @param eager
-     *            if {@code true} then disposal will happen either on unsubscription or just before emission of
+     *            if {@code true} then disposal will happen either on cancellation or just before emission of
      *            a terminal event ({@code onComplete} or {@code onError}).
      * @return the Publisher whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
@@ -3920,8 +3920,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <dl>
@@ -3972,8 +3972,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(just(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <p>
      * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.o.png" alt="">
      * <dl>
@@ -4027,8 +4027,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator expects backpressure from the sources and honors backpressure from the downstream.
@@ -4086,8 +4086,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator expects backpressure from the sources and honors backpressure from the downstream.
@@ -4147,8 +4147,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator expects backpressure from the sources and honors backpressure from the downstream.
@@ -4209,8 +4209,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator expects backpressure from the sources and honors backpressure from the downstream.
@@ -4273,8 +4273,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator expects backpressure from the sources and honors backpressure from the downstream.
@@ -4342,8 +4342,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator expects backpressure from the sources and honors backpressure from the downstream.
@@ -4414,8 +4414,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator expects backpressure from the sources and honors backpressure from the downstream.
@@ -4490,8 +4490,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator expects backpressure from the sources and honors backpressure from the downstream.
@@ -4571,8 +4571,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator expects backpressure from the sources and honors backpressure from the downstream.
@@ -4656,8 +4656,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h, i) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator expects backpressure from the sources and honors backpressure from the downstream.
@@ -4744,8 +4744,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <dl>
@@ -4804,8 +4804,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <dl>
@@ -5366,7 +5366,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * The unsubscription and backpressure is composed through.
+     * The cancellation and backpressure is composed through.
      * @param subscriber the subscriber to forward events and calls to in the current thread
      * @since 2.0
      */
@@ -7311,7 +7311,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Calls the unsubscribe {@code Action} if the downstream unsubscribes the sequence.
+     * Calls the unsubscribe {@code Action} if the downstream cancels the sequence.
      * <p>
      * The action is shared between subscriptions and thus may be called concurrently from multiple
      * threads; the action must be thread safe.
@@ -8482,7 +8482,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Groups the items emitted by a {@code Publisher} according to a specified criterion, and emits these
      * grouped items as {@link GroupedFlowable}s. The emitted {@code GroupedPublisher} allows only a single
-     * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
+     * {@link Subscriber} during its lifetime and if this {@code Subscriber} cancels before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedPublisher} emission.
      * <p>
@@ -8521,7 +8521,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Groups the items emitted by a {@code Publisher} according to a specified criterion, and emits these
      * grouped items as {@link GroupedFlowable}s. The emitted {@code GroupedPublisher} allows only a single
-     * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
+     * {@link Subscriber} during its lifetime and if this {@code Subscriber} cancels before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedPublisher} emission.
      * <p>
@@ -8563,7 +8563,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Groups the items emitted by a {@code Publisher} according to a specified criterion, and emits these
      * grouped items as {@link GroupedFlowable}s. The emitted {@code GroupedPublisher} allows only a single
-     * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
+     * {@link Subscriber} during its lifetime and if this {@code Subscriber} cancels before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedPublisher} emission.
      * <p>
@@ -8607,7 +8607,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Groups the items emitted by a {@code Publisher} according to a specified criterion, and emits these
      * grouped items as {@link GroupedFlowable}s. The emitted {@code GroupedPublisher} allows only a single
-     * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
+     * {@link Subscriber} during its lifetime and if this {@code Subscriber} cancels before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedPublisher} emission.
      * <p>
@@ -8654,7 +8654,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Groups the items emitted by a {@code Publisher} according to a specified criterion, and emits these
      * grouped items as {@link GroupedFlowable}s. The emitted {@code GroupedPublisher} allows only a single
-     * {@link Subscriber} during its lifetime and if this {@code Subscriber} unsubscribes before the
+     * {@link Subscriber} during its lifetime and if this {@code Subscriber} cancels before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedPublisher} emission.
      * <p>
@@ -9692,7 +9692,7 @@ public abstract class Flowable<T> implements Publisher<T> {
 
     /**
      * Nulls out references to the upstream producer and downstream Subscriber if
-     * the sequence is terminated or downstream unsubscribes.
+     * the sequence is terminated or downstream cancels.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s backpressure
@@ -9701,7 +9701,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return a Flowable which out references to the upstream producer and downstream Subscriber if
-     * the sequence is terminated or downstream unsubscribes
+     * the sequence is terminated or downstream cancels
      * @since 2.0
      */
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
@@ -13674,7 +13674,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Flowable<Map<K, Collection<T>>> toMultimap(Function<? super T, ? extends K> keySelector) {
-        Function<? super T, ? extends T> valueSelector = Functions.identity();
+        Function<T, T> valueSelector = Functions.identity();
         Callable<Map<K, Collection<T>>> mapSupplier = HashMapSupplier.asCallable();
         Function<K, List<T>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
@@ -13981,8 +13981,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      *
      * @param scheduler
-     *            the {@link Scheduler} to perform unsubscription actions on
-     * @return the source Publisher modified so that its unsubscriptions happen on the specified
+     *            the {@link Scheduler} to perform cancellation actions on
+     * @return the source Publisher modified so that its cancellations happen on the specified
      *         {@link Scheduler}
      * @see <a href="http://reactivex.io/documentation/operators/subscribeon.html">ReactiveX operators documentation: SubscribeOn</a>
      */
@@ -14941,8 +14941,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      *
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <dl>
@@ -14988,8 +14988,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      *
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <dl>
@@ -15038,8 +15038,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or cancellation.
      *
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <dl>

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -204,7 +204,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer and
      *  expects the {@code Publisher} to honor backpressure as well. If the sources {@code Publisher}
-     *  violates this, a {@code MissingBackpressurException} is signalled.</dd>
+     *  violates this, a {@link io.reactivex.exceptions.MissingBackpressureException} is signalled.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -225,7 +225,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer and
      *  expects the {@code Publisher} to honor backpressure as well. If the sources {@code Publisher}
-     *  violates this, a {@code MissingBackpressurException} is signalled.</dd>
+     *  violates this, a {@link io.reactivex.exceptions.MissingBackpressureException} is signalled.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -399,7 +399,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>Backpressure is honored towards the downstream and the outer Publisher is
      *  expected to support backpressure. Violating this assumption, the operator will
-     *  signal {@code MissingBackpressureException}.</dd>
+     *  signal {@link io.reactivex.exceptions.MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -1293,7 +1293,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Constructs a Maybe that creates a dependent resource object which is disposed of on unsubscription.
+     * Constructs a Maybe that creates a dependent resource object which is disposed of when the
+     * upstream terminates or the downstream calls dispose().
      * <p>
      * <img width="640" height="400" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/using.png" alt="">
      * <dl>
@@ -1321,8 +1322,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * Constructs a Maybe that creates a dependent resource object which is disposed of just before
-     * termination if you have set {@code disposeEagerly} to {@code true} and unsubscription does not occur
-     * before termination. Otherwise resource disposal will occur on unsubscription.  Eager disposal is
+     * termination if you have set {@code disposeEagerly} to {@code true} and a downstream dispose() does not occur
+     * before termination. Otherwise resource disposal will occur on call to dispose().  Eager disposal is
      * particularly appropriate for a synchronous Maybe that reuses resources. {@code disposeAction} will
      * only be called once per subscription.
      * <p>
@@ -1341,7 +1342,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param resourceDisposer
      *            the function that will dispose of the resource
      * @param eager
-     *            if {@code true} then disposal will happen either on unsubscription or just before emission of
+     *            if {@code true} then disposal will happen either on a dispose() call or just before emission of
      *            a terminal event ({@code onComplete} or {@code onError}).
      * @return the Maybe whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
@@ -3003,13 +3004,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
     /**
      * Nulls out references to the upstream producer and downstream MaybeObserver if
-     * the sequence is terminated or downstream unsubscribes.
+     * the sequence is terminated or downstream calls dispose().
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return a Maybe which out references to the upstream producer and downstream MaybeObserver if
-     * the sequence is terminated or downstream unsubscribes
+     * the sequence is terminated or downstream calls dispose()
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> onTerminateDetach() {
@@ -3649,7 +3650,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Maybe<T> timeout(MaybeSource<U> timeoutIndicator) {
-        ObjectHelper.requireNonNull(timeoutIndicator, "timoutIndicator is null");
+        ObjectHelper.requireNonNull(timeoutIndicator, "timeoutIndicator is null");
         return RxJavaPlugins.onAssembly(new MaybeTimeoutMaybe<T, U>(this, timeoutIndicator, null));
     }
 
@@ -3669,7 +3670,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Maybe<T> timeout(MaybeSource<U> timeoutIndicator, MaybeSource<? extends T> fallback) {
-        ObjectHelper.requireNonNull(timeoutIndicator, "timoutIndicator is null");
+        ObjectHelper.requireNonNull(timeoutIndicator, "timeoutIndicator is null");
         ObjectHelper.requireNonNull(fallback, "fallback is null");
         return RxJavaPlugins.onAssembly(new MaybeTimeoutMaybe<T, U>(this, timeoutIndicator, fallback));
     }
@@ -3692,7 +3693,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Maybe<T> timeout(Publisher<U> timeoutIndicator) {
-        ObjectHelper.requireNonNull(timeoutIndicator, "timoutIndicator is null");
+        ObjectHelper.requireNonNull(timeoutIndicator, "timeoutIndicator is null");
         return RxJavaPlugins.onAssembly(new MaybeTimeoutPublisher<T, U>(this, timeoutIndicator, null));
     }
 
@@ -3716,7 +3717,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Maybe<T> timeout(Publisher<U> timeoutIndicator, MaybeSource<? extends T> fallback) {
-        ObjectHelper.requireNonNull(timeoutIndicator, "timoutIndicator is null");
+        ObjectHelper.requireNonNull(timeoutIndicator, "timeoutIndicator is null");
         ObjectHelper.requireNonNull(fallback, "fallback is null");
         return RxJavaPlugins.onAssembly(new MaybeTimeoutPublisher<T, U>(this, timeoutIndicator, fallback));
     }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -3315,7 +3315,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Constructs an ObservableSource that creates a dependent resource object which is disposed of on unsubscription.
+     * Constructs an ObservableSource that creates a dependent resource object which is disposed of when the downstream
+     * calls dispose().
      * <p>
      * <img width="640" height="400" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/using.png" alt="">
      * <dl>
@@ -3341,8 +3342,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Constructs an ObservableSource that creates a dependent resource object which is disposed of just before
-     * termination if you have set {@code disposeEagerly} to {@code true} and unsubscription does not occur
-     * before termination. Otherwise resource disposal will occur on unsubscription.  Eager disposal is
+     * termination if you have set {@code disposeEagerly} to {@code true} and a dispose() call does not occur
+     * before termination. Otherwise resource disposal will occur on a dispose() call.  Eager disposal is
      * particularly appropriate for a synchronous ObservableSource that reuses resources. {@code disposeAction} will
      * only be called once per subscription.
      * <p>
@@ -3361,7 +3362,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param disposer
      *            the function that will dispose of the resource
      * @param eager
-     *            if {@code true} then disposal will happen either on unsubscription or just before emission of
+     *            if {@code true} then disposal will happen either on a dispose() call or just before emission of
      *            a terminal event ({@code onComplete} or {@code onError}).
      * @return the ObservableSource whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
@@ -3418,8 +3419,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <p>
      * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
      * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
@@ -3470,8 +3471,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(just(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <p>
      * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
      * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
@@ -3527,8 +3528,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3579,8 +3580,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3632,8 +3633,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3687,8 +3688,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3743,8 +3744,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3803,8 +3804,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3865,8 +3866,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3930,8 +3931,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3999,8 +4000,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -4071,8 +4072,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h, i) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -4144,8 +4145,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <p>
      * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
      * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
@@ -4204,8 +4205,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      * <p>
      * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
      * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
@@ -4683,7 +4684,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * The unsubscription is composed through.
+     * The a dispose() call is composed through.
      * @param subscriber the subscriber to forward events and calls to in the current thread
      * @since 2.0
      */
@@ -4805,7 +4806,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Returns an Observable that emits buffers of items it collects from the source ObservableSource. The resulting
-     * ObservableSource starts a new buffer periodically, as determined by the {@code timeshift} argument. It emits
+     * ObservableSource starts a new buffer periodically, as determined by the {@code timeskip} argument. It emits
      * each buffer after a fixed timespan, specified by the {@code timespan} argument. When the source
      * ObservableSource completes or encounters an error, the resulting ObservableSource emits the current buffer and
      * propagates the notification from the source ObservableSource.
@@ -4821,7 +4822,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param timeskip
      *            the period of time after which a new buffer will be created
      * @param unit
-     *            the unit of time that applies to the {@code timespan} and {@code timeshift} arguments
+     *            the unit of time that applies to the {@code timespan} and {@code timeskip} arguments
      * @return an Observable that emits new buffers of items emitted by the source ObservableSource periodically after
      *         a fixed timespan has elapsed
      * @see <a href="http://reactivex.io/documentation/operators/buffer.html">ReactiveX operators documentation: Buffer</a>
@@ -4833,7 +4834,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Returns an Observable that emits buffers of items it collects from the source ObservableSource. The resulting
-     * ObservableSource starts a new buffer periodically, as determined by the {@code timeshift} argument, and on the
+     * ObservableSource starts a new buffer periodically, as determined by the {@code timeskip} argument, and on the
      * specified {@code scheduler}. It emits each buffer after a fixed timespan, specified by the
      * {@code timespan} argument. When the source ObservableSource completes or encounters an error, the resulting
      * ObservableSource emits the current buffer and propagates the notification from the source ObservableSource.
@@ -4849,7 +4850,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param timeskip
      *            the period of time after which a new buffer will be created
      * @param unit
-     *            the unit of time that applies to the {@code timespan} and {@code timeshift} arguments
+     *            the unit of time that applies to the {@code timespan} and {@code timeskip} arguments
      * @param scheduler
      *            the {@link Scheduler} to use when determining the end and start of a buffer
      * @return an Observable that emits new buffers of items emitted by the source ObservableSource periodically after
@@ -4863,7 +4864,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Returns an Observable that emits buffers of items it collects from the source ObservableSource. The resulting
-     * ObservableSource starts a new buffer periodically, as determined by the {@code timeshift} argument, and on the
+     * ObservableSource starts a new buffer periodically, as determined by the {@code timeskip} argument, and on the
      * specified {@code scheduler}. It emits each buffer after a fixed timespan, specified by the
      * {@code timespan} argument. When the source ObservableSource completes or encounters an error, the resulting
      * ObservableSource emits the current buffer and propagates the notification from the source ObservableSource.
@@ -4880,7 +4881,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param timeskip
      *            the period of time after which a new buffer will be created
      * @param unit
-     *            the unit of time that applies to the {@code timespan} and {@code timeshift} arguments
+     *            the unit of time that applies to the {@code timespan} and {@code timeskip} arguments
      * @param scheduler
      *            the {@link Scheduler} to use when determining the end and start of a buffer
      * @param bufferSupplier
@@ -6364,7 +6365,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Calls the unsubscribe {@code Action} if the downstream unsubscribes the sequence.
+     * Calls the unsubscribe {@code Action} if the downstream disposes the sequence.
      * <p>
      * The action is shared between subscriptions and thus may be called concurrently from multiple
      * threads; the action must be thread safe.
@@ -7313,7 +7314,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Groups the items emitted by an {@code ObservableSource} according to a specified criterion, and emits these
      * grouped items as {@link GroupedObservable}s. The emitted {@code GroupedObservableSource} allows only a single
-     * {@link Observer} during its lifetime and if this {@code Observer} unsubscribes before the
+     * {@link Observer} during its lifetime and if this {@code Observer} calls dispose() before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedObservableSource} emission.
      * <p>
@@ -7346,7 +7347,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Groups the items emitted by an {@code ObservableSource} according to a specified criterion, and emits these
      * grouped items as {@link GroupedObservable}s. The emitted {@code GroupedObservableSource} allows only a single
-     * {@link Observer} during its lifetime and if this {@code Observer} unsubscribes before the
+     * {@link Observer} during its lifetime and if this {@code Observer} calls dispose() before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedObservableSource} emission.
      * <p>
@@ -7382,7 +7383,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Groups the items emitted by an {@code ObservableSource} according to a specified criterion, and emits these
      * grouped items as {@link GroupedObservable}s. The emitted {@code GroupedObservableSource} allows only a single
-     * {@link Observer} during its lifetime and if this {@code Observer} unsubscribes before the
+     * {@link Observer} during its lifetime and if this {@code Observer} calls dispose() before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedObservableSource} emission.
      * <p>
@@ -7419,7 +7420,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Groups the items emitted by an {@code ObservableSource} according to a specified criterion, and emits these
      * grouped items as {@link GroupedObservable}s. The emitted {@code GroupedObservableSource} allows only a single
-     * {@link Observer} during its lifetime and if this {@code Observer} unsubscribes before the
+     * {@link Observer} during its lifetime and if this {@code Observer} calls dispose() before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedObservableSource} emission.
      * <p>
@@ -7459,7 +7460,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Groups the items emitted by an {@code ObservableSource} according to a specified criterion, and emits these
      * grouped items as {@link GroupedObservable}s. The emitted {@code GroupedObservableSource} allows only a single
-     * {@link Observer} during its lifetime and if this {@code Observer} unsubscribes before the
+     * {@link Observer} during its lifetime and if this {@code Observer} calls dispose() before the
      * source terminates, the next emission by the source having the same key will trigger a new
      * {@code GroupedObservableSource} emission.
      * <p>
@@ -8064,13 +8065,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Nulls out references to the upstream producer and downstream Observer if
-     * the sequence is terminated or downstream unsubscribes.
+     * the sequence is terminated or downstream calls dispose().
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return an Observable which out references to the upstream producer and downstream Observer if
-     * the sequence is terminated or downstream unsubscribes
+     * the sequence is terminated or downstream calls dispose()
      * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -11768,8 +11769,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @param scheduler
-     *            the {@link Scheduler} to perform unsubscription actions on
-     * @return the source ObservableSource modified so that its unsubscriptions happen on the specified
+     *            the {@link Scheduler} to perform the call to dispose() of the upstream Disposable
+     * @return the source ObservableSource modified so that its dispose() calls happen on the specified
      *         {@link Scheduler}
      * @see <a href="http://reactivex.io/documentation/operators/subscribeon.html">ReactiveX operators documentation: SubscribeOn</a>
      */
@@ -11864,7 +11865,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Returns an Observable that emits windows of items it collects from the source ObservableSource. The resulting
-     * ObservableSource starts a new window periodically, as determined by the {@code timeshift} argument. It emits
+     * ObservableSource starts a new window periodically, as determined by the {@code timeskip} argument. It emits
      * each window after a fixed timespan, specified by the {@code timespan} argument. When the source
      * ObservableSource completes or ObservableSource completes or encounters an error, the resulting ObservableSource emits the
      * current window and propagates the notification from the source ObservableSource.
@@ -11880,7 +11881,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param timeskip
      *            the period of time after which a new window will be created
      * @param unit
-     *            the unit of time that applies to the {@code timespan} and {@code timeshift} arguments
+     *            the unit of time that applies to the {@code timespan} and {@code timeskip} arguments
      * @return an Observable that emits new windows periodically as a fixed timespan elapses
      * @see <a href="http://reactivex.io/documentation/operators/window.html">ReactiveX operators documentation: Window</a>
      */
@@ -11891,7 +11892,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Returns an Observable that emits windows of items it collects from the source ObservableSource. The resulting
-     * ObservableSource starts a new window periodically, as determined by the {@code timeshift} argument. It emits
+     * ObservableSource starts a new window periodically, as determined by the {@code timeskip} argument. It emits
      * each window after a fixed timespan, specified by the {@code timespan} argument. When the source
      * ObservableSource completes or ObservableSource completes or encounters an error, the resulting ObservableSource emits the
      * current window and propagates the notification from the source ObservableSource.
@@ -11907,7 +11908,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param timeskip
      *            the period of time after which a new window will be created
      * @param unit
-     *            the unit of time that applies to the {@code timespan} and {@code timeshift} arguments
+     *            the unit of time that applies to the {@code timespan} and {@code timeskip} arguments
      * @param scheduler
      *            the {@link Scheduler} to use when determining the end and start of a window
      * @return an Observable that emits new windows periodically as a fixed timespan elapses
@@ -11920,7 +11921,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Returns an Observable that emits windows of items it collects from the source ObservableSource. The resulting
-     * ObservableSource starts a new window periodically, as determined by the {@code timeshift} argument. It emits
+     * ObservableSource starts a new window periodically, as determined by the {@code timeskip} argument. It emits
      * each window after a fixed timespan, specified by the {@code timespan} argument. When the source
      * ObservableSource completes or ObservableSource completes or encounters an error, the resulting ObservableSource emits the
      * current window and propagates the notification from the source ObservableSource.
@@ -11936,7 +11937,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param timeskip
      *            the period of time after which a new window will be created
      * @param unit
-     *            the unit of time that applies to the {@code timespan} and {@code timeshift} arguments
+     *            the unit of time that applies to the {@code timespan} and {@code timeskip} arguments
      * @param scheduler
      *            the {@link Scheduler} to use when determining the end and start of a window
      * @param bufferSize
@@ -12599,8 +12600,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      *
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <dl>
@@ -12642,8 +12643,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      *
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <dl>
@@ -12687,8 +12688,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
-     * use {@code doOnUnsubscribed()} as well or use {@code using()} to do cleanup in case of completion
-     * or unsubscription.
+     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
+     * or a dispose() call.
      *
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <dl>

--- a/src/main/java/io/reactivex/internal/disposables/ObserverFullArbiter.java
+++ b/src/main/java/io/reactivex/internal/disposables/ObserverFullArbiter.java
@@ -119,40 +119,37 @@ public final class ObserverFullArbiter<T> extends FullArbiterPad1 implements Dis
 
                 Object v = q.poll();
 
-                if (o != s) {
-                    continue;
-                } else
-                if (NotificationLite.isDisposable(v)) {
-                    Disposable next = NotificationLite.getDisposable(v);
-                    s.dispose();
-                    if (!cancelled) {
-                        s = next;
-                    } else {
-                        next.dispose();
-                    }
-                } else
-                if (NotificationLite.isError(v)) {
-                    q.clear();
-                    disposeResource();
+                if (o == s) {
+                    if (NotificationLite.isDisposable(v)) {
+                        Disposable next = NotificationLite.getDisposable(v);
+                        s.dispose();
+                        if (!cancelled) {
+                            s = next;
+                        } else {
+                            next.dispose();
+                        }
+                    } else if (NotificationLite.isError(v)) {
+                        q.clear();
+                        disposeResource();
 
-                    Throwable ex = NotificationLite.getError(v);
-                    if (!cancelled) {
-                        cancelled = true;
-                        a.onError(ex);
-                    } else {
-                        RxJavaPlugins.onError(ex);
-                    }
-                } else
-                if (NotificationLite.isComplete(v)) {
-                    q.clear();
-                    disposeResource();
+                        Throwable ex = NotificationLite.getError(v);
+                        if (!cancelled) {
+                            cancelled = true;
+                            a.onError(ex);
+                        } else {
+                            RxJavaPlugins.onError(ex);
+                        }
+                    } else if (NotificationLite.isComplete(v)) {
+                        q.clear();
+                        disposeResource();
 
-                    if (!cancelled) {
-                        cancelled = true;
-                        a.onComplete();
+                        if (!cancelled) {
+                            cancelled = true;
+                            a.onComplete();
+                        }
+                    } else {
+                        a.onNext(NotificationLite.<T>getValue(v));
                     }
-                } else {
-                    a.onNext(NotificationLite.<T>getValue(v));
                 }
             }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDisposeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDisposeOn.java
@@ -16,13 +16,13 @@ package io.reactivex.internal.operators.completable;
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 
-public final class CompletableUnsubscribeOn extends Completable {
+public final class CompletableDisposeOn extends Completable {
 
     final CompletableSource source;
 
     final Scheduler scheduler;
 
-    public CompletableUnsubscribeOn(CompletableSource source, Scheduler scheduler) {
+    public CompletableDisposeOn(CompletableSource source, Scheduler scheduler) {
         this.source = source;
         this.scheduler = scheduler;
     }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMerge.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMerge.java
@@ -128,11 +128,11 @@ public final class CompletableMerge extends Completable {
 
         void terminate() {
             if (decrementAndGet() == 0) {
-                Throwable ex = error.terminate();
-                if (ex == null && ex != ExceptionHelper.TERMINATED) {
+                Throwable ex = error.get();
+                if (ex == null) {
                     actual.onComplete();
                 } else {
-                    actual.onError(ex);
+                    actual.onError(error.terminate());
                 }
             }
             else if (!delayErrors) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBlockingSubscribe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBlockingSubscribe.java
@@ -35,7 +35,7 @@ public enum FlowableBlockingSubscribe {
      * Subscribes to the source and calls the Subscriber methods on the current thread.
      * <p>
      * @param o the source publisher
-     * The unsubscription and backpressure is composed through.
+     * The cancellation and backpressure is composed through.
      * @param subscriber the subscriber to forward events and calls to in the current thread
      * @param <T> the value type
      */

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -195,7 +195,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
         public void run() {
             /*
              * If running on a synchronous scheduler, the timer might never
-             * be set so the periodic timer can't be stopped this loopback way.
+             * be set so the periodic timer can't be stopped this loop-back way.
              * The last resort is to crash the task so it hopefully won't
              * be rescheduled.
              */

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeCount.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeCount.java
@@ -19,7 +19,7 @@ import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
 
 /**
- * Singals 1L if the source signalled an item or 0L if the source is empty.
+ * Signals 1L if the source signalled an item or 0L if the source is empty.
  *
  * @param <T> the source value type
  */

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherPublisher.java
@@ -47,7 +47,7 @@ public final class MaybeDelayOtherPublisher<T, U> extends AbstractMaybeWithUpstr
     implements MaybeObserver<T>, Disposable {
         final OtherSubscriber<T> other;
 
-        Publisher<U> otherSource;
+        final Publisher<U> otherSource;
 
         Disposable d;
 

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromFuture.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromFuture.java
@@ -19,8 +19,8 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 
 /**
- * Waits until the source Future completes or the wait times out; treates null
- * result as indication for empty.
+ * Waits until the source Future completes or the wait times out; treats a {@code null}
+ * result as indication to signal {@code onComplete} instead of {@code onSuccess}.
  *
  * @param <T> the value type
  */

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBlockingSubscribe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBlockingSubscribe.java
@@ -36,7 +36,7 @@ public enum ObservableBlockingSubscribe {
      * Subscribes to the source and calls the Subscriber methods on the current thread.
      * <p>
      * @param o the source publisher
-     * The unsubscription and backpressure is composed through.
+     * The call to dispose() is composed through.
      * @param subscriber the subscriber to forward events and calls to in the current thread
      * @param <T> the value type
      */

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -190,7 +190,7 @@ extends AbstractObservableWithUpstream<T, U> {
         public void run() {
             /*
              * If running on a synchronous scheduler, the timer might never
-             * be set so the periodic timer can't be stopped this loopback way.
+             * be set so the periodic timer can't be stopped this loop-back way.
              * The last resort is to crash the task so it hopefully won't
              * be rescheduled.
              */

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
@@ -212,7 +212,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
                         ObservableSource<? extends U> o;
 
                         try {
-                            o = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null ObservableConsumable");
+                            o = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null ObservableSource");
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
                             dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -329,7 +329,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
 
                 if (svq != null) {
                     for (;;) {
-                        U o = null;
+                        U o;
                         for (;;) {
                             if (checkTerminate()) {
                                 return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -260,13 +260,13 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
 
     @Override
     public void connect(Consumer<? super Disposable> connection) {
-        boolean doConnect = false;
+        boolean doConnect;
         ReplaySubscriber<T> ps;
         // we loop because concurrent connect/disconnect and termination may change the state
         for (;;) {
             // retrieve the current subscriber-to-source instance
             ps = current.get();
-            // if there is none yet or the current has unsubscribed
+            // if there is none yet or the current has been disposed
             if (ps == null || ps.isDisposed()) {
                 // create a new subscriber-to-source
                 ReplayBuffer<T> buf;
@@ -302,7 +302,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
          *
          * Note however, that asynchronously disconnecting a running source might leave
          * child-subscribers without any terminal event; ReplaySubject does not have this
-         * issue because the unsubscription was always triggered by the child-subscribers
+         * issue because the dispose() call was always triggered by the child-subscribers
          * themselves.
          */
 
@@ -503,14 +503,14 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
         }
     }
     /**
-     * A Producer and Subscription that manages the request and unsubscription state of a
+     * A Producer and Subscription that manages the request and disposed state of a
      * child subscriber in thread-safe manner.
      * @param <T> the value type
      */
     static final class InnerSubscription<T> implements Disposable {
         /**
          * The parent subscriber-to-source used to allow removing the child in case of
-         * child unsubscription.
+         * child dispose() call.
          */
         final ReplaySubscriber<T> parent;
         /** The actual child subscriber. */

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFromObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFromObservable.java
@@ -21,8 +21,9 @@ import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 
 public final class SingleFromObservable<T> extends Single<T> {
-    private final Observable<T> upstream;
-    private final T defaultValue;
+    final Observable<T> upstream;
+
+    final T defaultValue;
 
     public SingleFromObservable(Observable<T> upstream, T defaultValue) {
         this.upstream = upstream;

--- a/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
@@ -21,7 +21,7 @@ import org.reactivestreams.Subscriber;
  * Note that the class leaks all methods of {@link java.util.concurrent.atomic.AtomicLong}.
  * Use {@link #complete(Object)} to signal the single value.
  * <p>
- * The this atomic integer stores a bitfield:<br>
+ * The this atomic integer stores a bit field:<br>
  * bit 0: indicates that there is a value available<br>
  * bit 1: indicates that there was a request made<br>
  * bit 2: indicates there was a cancellation, exclusively set<br>

--- a/src/main/java/io/reactivex/internal/subscriptions/FullArbiter.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/FullArbiter.java
@@ -151,46 +151,43 @@ public final class FullArbiter<T> extends FullArbiterPad2 implements Subscriptio
                         s.request(mr);
                     }
                 } else
-                if (o != s) {
-                    continue;
-                } else
-                if (NotificationLite.isSubscription(v)) {
-                    Subscription next = NotificationLite.getSubscription(v);
-                    if (!cancelled) {
-                        s = next;
-                        long r = requested;
-                        if (r != 0L) {
-                            next.request(r);
+                if (o == s) {
+                    if (NotificationLite.isSubscription(v)) {
+                        Subscription next = NotificationLite.getSubscription(v);
+                        if (!cancelled) {
+                            s = next;
+                            long r = requested;
+                            if (r != 0L) {
+                                next.request(r);
+                            }
+                        } else {
+                            next.cancel();
+                        }
+                    } else if (NotificationLite.isError(v)) {
+                        q.clear();
+                        dispose();
+
+                        Throwable ex = NotificationLite.getError(v);
+                        if (!cancelled) {
+                            cancelled = true;
+                            a.onError(ex);
+                        } else {
+                            RxJavaPlugins.onError(ex);
+                        }
+                    } else if (NotificationLite.isComplete(v)) {
+                        q.clear();
+                        dispose();
+
+                        if (!cancelled) {
+                            cancelled = true;
+                            a.onComplete();
                         }
                     } else {
-                        next.cancel();
-                    }
-                } else
-                if (NotificationLite.isError(v)) {
-                    q.clear();
-                    dispose();
-
-                    Throwable ex = NotificationLite.getError(v);
-                    if (!cancelled) {
-                        cancelled = true;
-                        a.onError(ex);
-                    } else {
-                        RxJavaPlugins.onError(ex);
-                    }
-                } else
-                if (NotificationLite.isComplete(v)) {
-                    q.clear();
-                    dispose();
-
-                    if (!cancelled) {
-                        cancelled = true;
-                        a.onComplete();
-                    }
-                } else {
-                    long r = requested;
-                    if (r != 0) {
-                        a.onNext(NotificationLite.<T>getValue(v));
-                        requested = r - 1;
+                        long r = requested;
+                        if (r != 0) {
+                            a.onNext(NotificationLite.<T>getValue(v));
+                            requested = r - 1;
+                        }
                     }
                 }
             }

--- a/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
@@ -49,7 +49,15 @@ public final class ExceptionHelper {
      * A singleton instance of a Throwable indicating a terminal state for exceptions,
      * don't leak this!
      */
-    public static final Throwable TERMINATED = new Throwable("No further exceptions");
+    public static final Throwable TERMINATED = new Throwable("No further exceptions") {
+        /** */
+        private static final long serialVersionUID = -4649703670690200604L;
+
+        @Override
+        public Throwable fillInStackTrace() {
+            return this;
+        }
+    };
 
     public static <T> boolean addThrowable(AtomicReference<Throwable> field, Throwable exception) {
         for (;;) {

--- a/src/main/java/io/reactivex/observers/DefaultObserver.java
+++ b/src/main/java/io/reactivex/observers/DefaultObserver.java
@@ -39,7 +39,7 @@ public abstract class DefaultObserver<T> implements Observer<T> {
      */
     protected final void cancel() {
         Disposable s = this.s;
-        this.s = DisposableHelper.DISPOSED;;
+        this.s = DisposableHelper.DISPOSED;
         s.dispose();
     }
     /**

--- a/src/main/java/io/reactivex/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/observers/TestObserver.java
@@ -574,8 +574,8 @@ public class TestObserver<T> implements Observer<T>, Disposable {
         int i = 0;
         Iterator<T> vit = values.iterator();
         Iterator<? extends T> it = sequence.iterator();
-        boolean actualNext = false;
-        boolean expectedNext = false;
+        boolean actualNext;
+        boolean expectedNext;
         for (;;) {
             actualNext = it.hasNext();
             expectedNext = vit.hasNext();
@@ -591,8 +591,6 @@ public class TestObserver<T> implements Observer<T>, Disposable {
                 throw fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
             }
             i++;
-            actualNext = false;
-            expectedNext = false;
         }
 
         if (actualNext) {

--- a/src/main/java/io/reactivex/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/processors/PublishProcessor.java
@@ -99,7 +99,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
                 remove(ps);
             }
         } else {
-            Throwable ex = error;;
+            Throwable ex = error;
             if (ex != null) {
                 t.onError(ex);
             } else {

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -235,9 +235,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
             if (missed == 0) {
                 break;
             }
-            if (a == null) {
-                a = actual.get();
-            }
+            a = actual.get();
         }
     }
 

--- a/src/main/java/io/reactivex/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/subjects/PublishSubject.java
@@ -88,7 +88,7 @@ public final class PublishSubject<T> extends Subject<T> {
                 remove(ps);
             }
         } else {
-            Throwable ex = error;;
+            Throwable ex = error;
             if (ex != null) {
                 t.onError(ex);
             } else {
@@ -166,7 +166,6 @@ public final class PublishSubject<T> extends Subject<T> {
     public void onSubscribe(Disposable s) {
         if (subscribers.get() == TERMINATED) {
             s.dispose();
-            return;
         }
     }
 

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -312,9 +312,7 @@ public final class UnicastSubject<T> extends Subject<T> {
                 break;
             }
 
-            if (a == null) {
-                a = actual.get();
-            }
+            a = actual.get();
         }
     }
 

--- a/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
@@ -222,7 +222,6 @@ public final class SafeSubscriber<T> implements Subscriber<T>, Subscription {
                 return;
             }
             RxJavaPlugins.onError(e);
-            return;
         }
     }
 
@@ -233,7 +232,6 @@ public final class SafeSubscriber<T> implements Subscriber<T>, Subscription {
         } catch (Throwable e1) {
             Exceptions.throwIfFatal(e1);
             RxJavaPlugins.onError(e1);
-            return;
         }
     }
 }

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -618,8 +618,8 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
         int i = 0;
         Iterator<T> vit = values.iterator();
         Iterator<? extends T> it = sequence.iterator();
-        boolean actualNext = false;
-        boolean expectedNext = false;
+        boolean actualNext;
+        boolean expectedNext;
         for (;;) {
             actualNext = it.hasNext();
             expectedNext = vit.hasNext();
@@ -635,8 +635,6 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
                 throw fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
             }
             i++;
-            actualNext = false;
-            expectedNext = false;
         }
 
         if (actualNext) {

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -77,6 +77,26 @@ public enum TestHelper {
     }
 
     /**
+     * Mocks an MaybeObserver with the proper receiver type.
+     * @param <T> the value type
+     * @return the mocked observer
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> MaybeObserver<T> mockMaybeObserver() {
+        return mock(MaybeObserver.class);
+    }
+
+    /**
+     * Mocks an SingleObserver with the proper receiver type.
+     * @param <T> the value type
+     * @return the mocked observer
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> SingleObserver<T> mockSingleObserver() {
+        return mock(SingleObserver.class);
+    }
+
+    /**
      * Validates that the given class, when forcefully instantiated throws
      * an IllegalArgumentException("No instances!") exception.
      * @param clazz the class to test, not null

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableNextTest.java
@@ -88,7 +88,7 @@ public class BlockingObservableNextTest {
         } catch (NoSuchElementException e) {
         }
 
-        // If the NbpObservable is completed, hasNext always returns false and next always throw a NoSuchElementException.
+        // If the Observable is completed, hasNext always returns false and next always throw a NoSuchElementException.
         assertFalse(it.hasNext());
         try {
             it.next();
@@ -127,7 +127,7 @@ public class BlockingObservableNextTest {
         } catch (NoSuchElementException e) {
         }
 
-        // If the NbpObservable is completed, hasNext always returns false and next always throw a NoSuchElementException.
+        // If the Observable is completed, hasNext always returns false and next always throw a NoSuchElementException.
         assertFalse(it.hasNext());
         try {
             it.next();
@@ -170,7 +170,7 @@ public class BlockingObservableNextTest {
     }
 
     private void assertErrorAfterObservableFail(Iterator<String> it) {
-        // After the NbpObservable fails, hasNext and next always throw the exception.
+        // After the Observable fails, hasNext and next always throw the exception.
         try {
             it.hasNext();
             fail("hasNext should throw a TestException");
@@ -221,7 +221,7 @@ public class BlockingObservableNextTest {
     }
 
     /**
-     * Confirm that no buffering or blocking of the NbpObservable onNext calls occurs and it just grabs the next emitted value.
+     * Confirm that no buffering or blocking of the Observable onNext calls occurs and it just grabs the next emitted value.
      * <p/>
      * This results in output such as => a: 1 b: 2 c: 89
      *

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToIteratorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToIteratorTest.java
@@ -49,10 +49,10 @@ public class BlockingObservableToIteratorTest {
         Observable<String> obs = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                NbpObserver.onNext("one");
-                NbpObserver.onError(new TestException());
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onNext("one");
+                observer.onError(new TestException());
             }
         });
 
@@ -70,7 +70,7 @@ public class BlockingObservableToIteratorTest {
     public void testExceptionThrownFromOnSubscribe() {
         Iterable<String> strings = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpSubscriber) {
+            public void subscribe(Observer<? super String> observer) {
                 throw new TestException("intentional");
             }
         }).blockingIterable();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAllTest.java
@@ -32,7 +32,7 @@ public class ObservableAllTest {
     public void testAll() {
         Observable<String> obs = Observable.just("one", "two", "six");
 
-        Observer <Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer <Boolean> observer = TestHelper.mockObserver();
 
         obs.all(new Predicate<String>() {
             @Override
@@ -40,19 +40,19 @@ public class ObservableAllTest {
                 return s.length() == 3;
             }
         })
-        .subscribe(NbpObserver);
+        .subscribe(observer);
 
-        verify(NbpObserver).onSubscribe((Disposable)any());
-        verify(NbpObserver).onNext(true);
-        verify(NbpObserver).onComplete();
-        verifyNoMoreInteractions(NbpObserver);
+        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onNext(true);
+        verify(observer).onComplete();
+        verifyNoMoreInteractions(observer);
     }
 
     @Test
     public void testNotAll() {
         Observable<String> obs = Observable.just("one", "two", "three", "six");
 
-        Observer <Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer <Boolean> observer = TestHelper.mockObserver();
 
         obs.all(new Predicate<String>() {
             @Override
@@ -60,19 +60,19 @@ public class ObservableAllTest {
                 return s.length() == 3;
             }
         })
-        .subscribe(NbpObserver);
+        .subscribe(observer);
 
-        verify(NbpObserver).onSubscribe((Disposable)any());
-        verify(NbpObserver).onNext(false);
-        verify(NbpObserver).onComplete();
-        verifyNoMoreInteractions(NbpObserver);
+        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onNext(false);
+        verify(observer).onComplete();
+        verifyNoMoreInteractions(observer);
     }
 
     @Test
     public void testEmpty() {
         Observable<String> obs = Observable.empty();
 
-        Observer <Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer <Boolean> observer = TestHelper.mockObserver();
 
         obs.all(new Predicate<String>() {
             @Override
@@ -80,12 +80,12 @@ public class ObservableAllTest {
                 return s.length() == 3;
             }
         })
-        .subscribe(NbpObserver);
+        .subscribe(observer);
 
-        verify(NbpObserver).onSubscribe((Disposable)any());
-        verify(NbpObserver).onNext(true);
-        verify(NbpObserver).onComplete();
-        verifyNoMoreInteractions(NbpObserver);
+        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onNext(true);
+        verify(observer).onComplete();
+        verifyNoMoreInteractions(observer);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class ObservableAllTest {
         Throwable error = new Throwable();
         Observable<String> obs = Observable.error(error);
 
-        Observer <Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer <Boolean> observer = TestHelper.mockObserver();
 
         obs.all(new Predicate<String>() {
             @Override
@@ -101,11 +101,11 @@ public class ObservableAllTest {
                 return s.length() == 3;
             }
         })
-        .subscribe(NbpObserver);
+        .subscribe(observer);
 
-        verify(NbpObserver).onSubscribe((Disposable)any());
-        verify(NbpObserver).onError(error);
-        verifyNoMoreInteractions(NbpObserver);
+        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onError(error);
+        verifyNoMoreInteractions(observer);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
@@ -46,17 +46,17 @@ public class ObservableAmbTest {
         return Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(final Observer<? super String> NbpSubscriber) {
+            public void subscribe(final Observer<? super String> observer) {
                 CompositeDisposable parentSubscription = new CompositeDisposable();
 
-                NbpSubscriber.onSubscribe(parentSubscription);
+                observer.onSubscribe(parentSubscription);
 
                 long delay = interval;
                 for (final String value : values) {
                     parentSubscription.add(innerScheduler.schedule(new Runnable() {
                         @Override
                         public void run() {
-                            NbpSubscriber.onNext(value);
+                            observer.onNext(value);
                         }
                     }
                     , delay, TimeUnit.MILLISECONDS));
@@ -66,9 +66,9 @@ public class ObservableAmbTest {
                     @Override
                     public void run() {
                             if (e == null) {
-                                NbpSubscriber.onComplete();
+                                observer.onComplete();
                             } else {
-                                NbpSubscriber.onError(e);
+                                observer.onError(e);
                             }
                     }
                 }, delay, TimeUnit.MILLISECONDS));
@@ -89,17 +89,17 @@ public class ObservableAmbTest {
         Observable<String> o = Observable.ambArray(observable1,
                 observable2, observable3);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext("2");
-        inOrder.verify(NbpObserver, times(1)).onNext("22");
-        inOrder.verify(NbpObserver, times(1)).onNext("222");
-        inOrder.verify(NbpObserver, times(1)).onNext("2222");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext("2");
+        inOrder.verify(observer, times(1)).onNext("22");
+        inOrder.verify(observer, times(1)).onNext("222");
+        inOrder.verify(observer, times(1)).onNext("2222");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -118,17 +118,17 @@ public class ObservableAmbTest {
         Observable<String> o = Observable.ambArray(observable1,
                 observable2, observable3);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext("2");
-        inOrder.verify(NbpObserver, times(1)).onNext("22");
-        inOrder.verify(NbpObserver, times(1)).onNext("222");
-        inOrder.verify(NbpObserver, times(1)).onNext("2222");
-        inOrder.verify(NbpObserver, times(1)).onError(expectedException);
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext("2");
+        inOrder.verify(observer, times(1)).onNext("22");
+        inOrder.verify(observer, times(1)).onNext("222");
+        inOrder.verify(observer, times(1)).onNext("2222");
+        inOrder.verify(observer, times(1)).onError(expectedException);
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -145,12 +145,12 @@ public class ObservableAmbTest {
         Observable<String> o = Observable.ambArray(observable1,
                 observable2, observable3);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -180,10 +180,10 @@ public class ObservableAmbTest {
 
     @Test
     public void testSynchronousSources() {
-        // under async subscription the second NbpObservable would complete before
+        // under async subscription the second Observable would complete before
         // the first but because this is a synchronous subscription to sources
-        // then second NbpObservable does not get subscribed to before first
-        // subscription completes hence first NbpObservable emits result through
+        // then second Observable does not get subscribed to before first
+        // subscription completes hence first Observable emits result through
         // amb
         int result = Observable.just(1).doOnNext(new Consumer<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAnyTest.java
@@ -29,187 +29,187 @@ public class ObservableAnyTest {
     @Test
     public void testAnyWithTwoItems() {
         Observable<Integer> w = Observable.just(1, 2);
-        Observable<Boolean> NbpObservable = w.any(new Predicate<Integer>() {
+        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
             }
         });
 
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, never()).onNext(false);
-        verify(NbpObserver, times(1)).onNext(true);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testIsEmptyWithTwoItems() {
         Observable<Integer> w = Observable.just(1, 2);
-        Observable<Boolean> NbpObservable = w.isEmpty();
+        Observable<Boolean> observable = w.isEmpty();
 
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, never()).onNext(true);
-        verify(NbpObserver, times(1)).onNext(false);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, never()).onNext(true);
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAnyWithOneItem() {
         Observable<Integer> w = Observable.just(1);
-        Observable<Boolean> NbpObservable = w.any(new Predicate<Integer>() {
+        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
             }
         });
 
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, never()).onNext(false);
-        verify(NbpObserver, times(1)).onNext(true);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testIsEmptyWithOneItem() {
         Observable<Integer> w = Observable.just(1);
-        Observable<Boolean> NbpObservable = w.isEmpty();
+        Observable<Boolean> observable = w.isEmpty();
 
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, never()).onNext(true);
-        verify(NbpObserver, times(1)).onNext(false);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, never()).onNext(true);
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAnyWithEmpty() {
         Observable<Integer> w = Observable.empty();
-        Observable<Boolean> NbpObservable = w.any(new Predicate<Integer>() {
+        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
             }
         });
 
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onNext(false);
-        verify(NbpObserver, never()).onNext(true);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testIsEmptyWithEmpty() {
         Observable<Integer> w = Observable.empty();
-        Observable<Boolean> NbpObservable = w.isEmpty();
+        Observable<Boolean> observable = w.isEmpty();
 
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onNext(true);
-        verify(NbpObserver, never()).onNext(false);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onNext(false);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAnyWithPredicate1() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Observable<Boolean> NbpObservable = w.any(new Predicate<Integer>() {
+        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 2;
             }
         });
 
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, never()).onNext(false);
-        verify(NbpObserver, times(1)).onNext(true);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testExists1() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Observable<Boolean> NbpObservable = w.any(new Predicate<Integer>() {
+        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 2;
             }
         });
 
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, never()).onNext(false);
-        verify(NbpObserver, times(1)).onNext(true);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAnyWithPredicate2() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Observable<Boolean> NbpObservable = w.any(new Predicate<Integer>() {
+        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 1;
             }
         });
 
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onNext(false);
-        verify(NbpObserver, never()).onNext(true);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAnyWithEmptyAndPredicate() {
         // If the source is empty, always output false.
         Observable<Integer> w = Observable.empty();
-        Observable<Boolean> NbpObservable = w.any(new Predicate<Integer>() {
+        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t) {
                 return true;
             }
         });
 
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onNext(false);
-        verify(NbpObserver, never()).onNext(true);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -35,13 +35,13 @@ import io.reactivex.subjects.PublishSubject;
 
 public class ObservableBufferTest {
 
-    private Observer<List<String>> NbpObserver;
+    private Observer<List<String>> observer;
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
 
     @Before
     public void before() {
-        NbpObserver = TestHelper.mockObserver();
+        observer = TestHelper.mockObserver();
         scheduler = new TestScheduler();
         innerScheduler = scheduler.createWorker();
     }
@@ -51,37 +51,37 @@ public class ObservableBufferTest {
         Observable<String> source = Observable.empty();
 
         Observable<List<String>> buffered = source.buffer(3, 3);
-        buffered.subscribe(NbpObserver);
+        buffered.subscribe(observer);
 
-        Mockito.verify(NbpObserver, Mockito.never()).onNext(Mockito.anyListOf(String.class));
-        Mockito.verify(NbpObserver, Mockito.never()).onError(Mockito.any(Throwable.class));
-        Mockito.verify(NbpObserver, Mockito.times(1)).onComplete();
+        Mockito.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        Mockito.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
+        Mockito.verify(observer, Mockito.times(1)).onComplete();
     }
 
     @Test
     public void testSkipAndCountOverlappingBuffers() {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                NbpObserver.onNext("one");
-                NbpObserver.onNext("two");
-                NbpObserver.onNext("three");
-                NbpObserver.onNext("four");
-                NbpObserver.onNext("five");
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onNext("one");
+                observer.onNext("two");
+                observer.onNext("three");
+                observer.onNext("four");
+                observer.onNext("five");
             }
         });
 
         Observable<List<String>> buffered = source.buffer(3, 1);
-        buffered.subscribe(NbpObserver);
+        buffered.subscribe(observer);
 
-        InOrder inOrder = Mockito.inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("one", "two", "three"));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("two", "three", "four"));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("three", "four", "five"));
-        inOrder.verify(NbpObserver, Mockito.never()).onNext(Mockito.anyListOf(String.class));
-        inOrder.verify(NbpObserver, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(NbpObserver, Mockito.never()).onComplete();
+        InOrder inOrder = Mockito.inOrder(observer);
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two", "three"));
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("two", "three", "four"));
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("three", "four", "five"));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(observer, Mockito.never()).onComplete();
     }
 
     @Test
@@ -89,14 +89,14 @@ public class ObservableBufferTest {
         Observable<String> source = Observable.just("one", "two", "three", "four", "five");
 
         Observable<List<String>> buffered = source.buffer(3, 3);
-        buffered.subscribe(NbpObserver);
+        buffered.subscribe(observer);
 
-        InOrder inOrder = Mockito.inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("one", "two", "three"));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(NbpObserver, Mockito.never()).onNext(Mockito.anyListOf(String.class));
-        inOrder.verify(NbpObserver, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onComplete();
+        InOrder inOrder = Mockito.inOrder(observer);
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two", "three"));
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
 
     @Test
@@ -104,104 +104,104 @@ public class ObservableBufferTest {
         Observable<String> source = Observable.just("one", "two", "three", "four", "five");
 
         Observable<List<String>> buffered = source.buffer(2, 3);
-        buffered.subscribe(NbpObserver);
+        buffered.subscribe(observer);
 
-        InOrder inOrder = Mockito.inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("one", "two"));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(NbpObserver, Mockito.never()).onNext(Mockito.anyListOf(String.class));
-        inOrder.verify(NbpObserver, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onComplete();
+        InOrder inOrder = Mockito.inOrder(observer);
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two"));
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
 
     @Test
     public void testTimedAndCount() {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                push(NbpObserver, "one", 10);
-                push(NbpObserver, "two", 90);
-                push(NbpObserver, "three", 110);
-                push(NbpObserver, "four", 190);
-                push(NbpObserver, "five", 210);
-                complete(NbpObserver, 250);
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                push(observer, "one", 10);
+                push(observer, "two", 90);
+                push(observer, "three", 110);
+                push(observer, "four", 190);
+                push(observer, "five", 210);
+                complete(observer, 250);
             }
         });
 
         Observable<List<String>> buffered = source.buffer(100, TimeUnit.MILLISECONDS, 2, scheduler);
-        buffered.subscribe(NbpObserver);
+        buffered.subscribe(observer);
 
-        InOrder inOrder = Mockito.inOrder(NbpObserver);
+        InOrder inOrder = Mockito.inOrder(observer);
         scheduler.advanceTimeTo(100, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("one", "two"));
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two"));
 
         scheduler.advanceTimeTo(200, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("three", "four"));
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("three", "four"));
 
         scheduler.advanceTimeTo(300, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(NbpObserver, Mockito.never()).onNext(Mockito.anyListOf(String.class));
-        inOrder.verify(NbpObserver, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onComplete();
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
 
     @Test
     public void testTimed() {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                push(NbpObserver, "one", 97);
-                push(NbpObserver, "two", 98);
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                push(observer, "one", 97);
+                push(observer, "two", 98);
                 /**
                  * Changed from 100. Because scheduling the cut to 100ms happens before this
-                 * NbpObservable even runs due how lift works, pushing at 100ms would execute after the
+                 * Observable even runs due how lift works, pushing at 100ms would execute after the
                  * buffer cut.
                  */
-                push(NbpObserver, "three", 99);
-                push(NbpObserver, "four", 101);
-                push(NbpObserver, "five", 102);
-                complete(NbpObserver, 150);
+                push(observer, "three", 99);
+                push(observer, "four", 101);
+                push(observer, "five", 102);
+                complete(observer, 150);
             }
         });
 
         Observable<List<String>> buffered = source.buffer(100, TimeUnit.MILLISECONDS, scheduler);
-        buffered.subscribe(NbpObserver);
+        buffered.subscribe(observer);
 
-        InOrder inOrder = Mockito.inOrder(NbpObserver);
+        InOrder inOrder = Mockito.inOrder(observer);
         scheduler.advanceTimeTo(101, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("one", "two", "three"));
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two", "three"));
 
         scheduler.advanceTimeTo(201, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(NbpObserver, Mockito.never()).onNext(Mockito.anyListOf(String.class));
-        inOrder.verify(NbpObserver, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onComplete();
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
 
     @Test
     public void testObservableBasedOpenerAndCloser() {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                push(NbpObserver, "one", 10);
-                push(NbpObserver, "two", 60);
-                push(NbpObserver, "three", 110);
-                push(NbpObserver, "four", 160);
-                push(NbpObserver, "five", 210);
-                complete(NbpObserver, 500);
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                push(observer, "one", 10);
+                push(observer, "two", 60);
+                push(observer, "three", 110);
+                push(observer, "four", 160);
+                push(observer, "five", 210);
+                complete(observer, 500);
             }
         });
 
         Observable<Object> openings = Observable.unsafeCreate(new ObservableSource<Object>() {
             @Override
-            public void subscribe(Observer<Object> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                push(NbpObserver, new Object(), 50);
-                push(NbpObserver, new Object(), 200);
-                complete(NbpObserver, 250);
+            public void subscribe(Observer<Object> observer) {
+                observer.onSubscribe(Disposables.empty());
+                push(observer, new Object(), 50);
+                push(observer, new Object(), 200);
+                complete(observer, 250);
             }
         });
 
@@ -210,39 +210,39 @@ public class ObservableBufferTest {
             public Observable<Object> apply(Object opening) {
                 return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
-                    public void subscribe(Observer<? super Object> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        push(NbpObserver, new Object(), 100);
-                        complete(NbpObserver, 101);
+                    public void subscribe(Observer<? super Object> observer) {
+                        observer.onSubscribe(Disposables.empty());
+                        push(observer, new Object(), 100);
+                        complete(observer, 101);
                     }
                 });
             }
         };
 
         Observable<List<String>> buffered = source.buffer(openings, closer);
-        buffered.subscribe(NbpObserver);
+        buffered.subscribe(observer);
 
-        InOrder inOrder = Mockito.inOrder(NbpObserver);
+        InOrder inOrder = Mockito.inOrder(observer);
         scheduler.advanceTimeTo(500, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("two", "three"));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(NbpObserver, Mockito.never()).onNext(Mockito.anyListOf(String.class));
-        inOrder.verify(NbpObserver, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onComplete();
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("two", "three"));
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
 
     @Test
     public void testObservableBasedCloser() {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                push(NbpObserver, "one", 10);
-                push(NbpObserver, "two", 60);
-                push(NbpObserver, "three", 110);
-                push(NbpObserver, "four", 160);
-                push(NbpObserver, "five", 210);
-                complete(NbpObserver, 250);
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                push(observer, "one", 10);
+                push(observer, "two", 60);
+                push(observer, "three", 110);
+                push(observer, "four", 160);
+                push(observer, "five", 210);
+                complete(observer, 250);
             }
         });
 
@@ -251,28 +251,28 @@ public class ObservableBufferTest {
             public Observable<Object> call() {
                 return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
-                    public void subscribe(Observer<? super Object> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        push(NbpObserver, new Object(), 100);
-                        push(NbpObserver, new Object(), 200);
-                        push(NbpObserver, new Object(), 300);
-                        complete(NbpObserver, 301);
+                    public void subscribe(Observer<? super Object> observer) {
+                        observer.onSubscribe(Disposables.empty());
+                        push(observer, new Object(), 100);
+                        push(observer, new Object(), 200);
+                        push(observer, new Object(), 300);
+                        complete(observer, 301);
                     }
                 });
             }
         };
 
         Observable<List<String>> buffered = source.buffer(closer);
-        buffered.subscribe(NbpObserver);
+        buffered.subscribe(observer);
 
-        InOrder inOrder = Mockito.inOrder(NbpObserver);
+        InOrder inOrder = Mockito.inOrder(observer);
         scheduler.advanceTimeTo(500, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("one", "two"));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("three", "four"));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(NbpObserver, Mockito.never()).onNext(Mockito.anyListOf(String.class));
-        inOrder.verify(NbpObserver, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(NbpObserver, Mockito.times(1)).onComplete();
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two"));
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("three", "four"));
+        inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
 
     @Test
@@ -317,20 +317,20 @@ public class ObservableBufferTest {
         return list;
     }
 
-    private <T> void push(final Observer<T> NbpObserver, final T value, int delay) {
+    private <T> void push(final Observer<T> observer, final T value, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                NbpObserver.onNext(value);
+                observer.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private void complete(final Observer<?> NbpObserver, int delay) {
+    private void complete(final Observer<?> observer, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                NbpObserver.onComplete();
+                observer.onComplete();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
@@ -68,7 +68,7 @@ public class ObservableCacheTest {
                     @Override
                     public void run() {
                         counter.incrementAndGet();
-                        System.out.println("published NbpObservable being executed");
+                        System.out.println("published Observable being executed");
                         observer.onNext("one");
                         observer.onComplete();
                     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCastTest.java
@@ -24,29 +24,29 @@ public class ObservableCastTest {
     @Test
     public void testCast() {
         Observable<?> source = Observable.just(1, 2);
-        Observable<Integer> NbpObservable = source.cast(Integer.class);
+        Observable<Integer> observable = source.cast(Integer.class);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onNext(1);
-        verify(NbpObserver, times(1)).onNext(1);
-        verify(NbpObserver, never()).onError(
+        verify(observer, times(1)).onNext(1);
+        verify(observer, times(1)).onNext(1);
+        verify(observer, never()).onError(
                 org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testCastWithWrongType() {
         Observable<?> source = Observable.just(1, 2);
-        Observable<Boolean> NbpObservable = source.cast(Boolean.class);
+        Observable<Boolean> observable = source.cast(Boolean.class);
 
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onError(
+        verify(observer, times(1)).onError(
                 org.mockito.Matchers.any(ClassCastException.class));
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
@@ -86,7 +86,7 @@ public class ObservableCombineLatestTest {
         w3.onNext("3d");
         w3.onComplete();
 
-        /* we should have been called 4 times on the NbpObserver */
+        /* we should have been called 4 times on the Observer */
         InOrder inOrder = inOrder(w);
         inOrder.verify(w).onNext("1a2a3a");
         inOrder.verify(w).onNext("1a2b3a");
@@ -123,7 +123,7 @@ public class ObservableCombineLatestTest {
         w3.onNext("3a");
         w3.onComplete();
 
-        /* we should have been called 1 time only on the NbpObserver since we only combine the "latest" we don't go back and loop through others once completed */
+        /* we should have been called 1 time only on the Observer since we only combine the "latest" we don't go back and loop through others once completed */
         InOrder inOrder = inOrder(w);
         inOrder.verify(w, times(1)).onNext("1d2b3a");
         inOrder.verify(w, never()).onNext(anyString());
@@ -158,7 +158,7 @@ public class ObservableCombineLatestTest {
         w2.onComplete();
         w3.onComplete();
 
-        /* we should have been called 5 times on the NbpObserver */
+        /* we should have been called 5 times on the Observer */
         InOrder inOrder = inOrder(w);
         inOrder.verify(w).onNext("1a2b3a");
         inOrder.verify(w).onNext("1b2b3a");
@@ -174,48 +174,48 @@ public class ObservableCombineLatestTest {
     public void testCombineLatest2Types() {
         BiFunction<String, Integer, String> combineLatestFunction = getConcatStringIntegerCombineLatestFunction();
 
-        /* define a NbpObserver to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> w = Observable.combineLatest(Observable.just("one", "two"), Observable.just(2, 3, 4), combineLatestFunction);
-        w.subscribe(NbpObserver);
+        w.subscribe(observer);
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("two2");
-        verify(NbpObserver, times(1)).onNext("two3");
-        verify(NbpObserver, times(1)).onNext("two4");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("two2");
+        verify(observer, times(1)).onNext("two3");
+        verify(observer, times(1)).onNext("two4");
     }
 
     @Test
     public void testCombineLatest3TypesA() {
         Function3<String, Integer, int[], String> combineLatestFunction = getConcatStringIntegerIntArrayCombineLatestFunction();
 
-        /* define a NbpObserver to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> w = Observable.combineLatest(Observable.just("one", "two"), Observable.just(2), Observable.just(new int[] { 4, 5, 6 }), combineLatestFunction);
-        w.subscribe(NbpObserver);
+        w.subscribe(observer);
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("two2[4, 5, 6]");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("two2[4, 5, 6]");
     }
 
     @Test
     public void testCombineLatest3TypesB() {
         Function3<String, Integer, int[], String> combineLatestFunction = getConcatStringIntegerIntArrayCombineLatestFunction();
 
-        /* define a NbpObserver to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> w = Observable.combineLatest(Observable.just("one"), Observable.just(2), Observable.just(new int[] { 4, 5, 6 }, new int[] { 7, 8 }), combineLatestFunction);
-        w.subscribe(NbpObserver);
+        w.subscribe(observer);
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("one2[4, 5, 6]");
-        verify(NbpObserver, times(1)).onNext("one2[7, 8]");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one2[4, 5, 6]");
+        verify(observer, times(1)).onNext("one2[7, 8]");
     }
 
     private Function3<String, String, String, String> getConcat3StringsCombineLatestFunction() {
@@ -282,33 +282,33 @@ public class ObservableCombineLatestTest {
 
         Observable<Integer> source = Observable.combineLatest(a, b, or);
 
-        Observer<Object> NbpObserver = TestHelper.mockObserver();
-        InOrder inOrder = inOrder(NbpObserver);
+        Observer<Object> observer = TestHelper.mockObserver();
+        InOrder inOrder = inOrder(observer);
 
-        source.subscribe(NbpObserver);
+        source.subscribe(observer);
 
         a.onNext(1);
 
-        inOrder.verify(NbpObserver, never()).onNext(any());
+        inOrder.verify(observer, never()).onNext(any());
 
         a.onNext(2);
 
-        inOrder.verify(NbpObserver, never()).onNext(any());
+        inOrder.verify(observer, never()).onNext(any());
 
         b.onNext(0x10);
 
-        inOrder.verify(NbpObserver, times(1)).onNext(0x12);
+        inOrder.verify(observer, times(1)).onNext(0x12);
 
         b.onNext(0x20);
-        inOrder.verify(NbpObserver, times(1)).onNext(0x22);
+        inOrder.verify(observer, times(1)).onNext(0x22);
 
         b.onComplete();
 
-        inOrder.verify(NbpObserver, never()).onComplete();
+        inOrder.verify(observer, never()).onComplete();
 
         a.onComplete();
 
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
 
         a.onNext(3);
         b.onNext(0x30);
@@ -316,7 +316,7 @@ public class ObservableCombineLatestTest {
         b.onComplete();
 
         inOrder.verifyNoMoreInteractions();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -383,19 +383,19 @@ public class ObservableCombineLatestTest {
 
         Observable<Integer> source = Observable.combineLatest(a, b, or);
 
-        Observer<Object> NbpObserver = TestHelper.mockObserver();
-        InOrder inOrder = inOrder(NbpObserver);
+        Observer<Object> observer = TestHelper.mockObserver();
+        InOrder inOrder = inOrder(observer);
 
-        source.subscribe(NbpObserver);
+        source.subscribe(observer);
 
         b.onNext(0x10);
         b.onNext(0x20);
 
         a.onComplete();
 
-        inOrder.verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, never()).onNext(any());
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onComplete();
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -405,10 +405,10 @@ public class ObservableCombineLatestTest {
 
         Observable<Integer> source = Observable.combineLatest(a, b, or);
 
-        Observer<Object> NbpObserver = TestHelper.mockObserver();
-        InOrder inOrder = inOrder(NbpObserver);
+        Observer<Object> observer = TestHelper.mockObserver();
+        InOrder inOrder = inOrder(observer);
 
-        source.subscribe(NbpObserver);
+        source.subscribe(observer);
 
         a.onNext(0x1);
         a.onNext(0x2);
@@ -416,9 +416,9 @@ public class ObservableCombineLatestTest {
         b.onComplete();
         a.onComplete();
 
-        inOrder.verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, never()).onNext(any());
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onComplete();
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     public void test0Sources() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDefaultIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDefaultIfEmptyTest.java
@@ -27,32 +27,32 @@ public class ObservableDefaultIfEmptyTest {
     @Test
     public void testDefaultIfEmpty() {
         Observable<Integer> source = Observable.just(1, 2, 3);
-        Observable<Integer> NbpObservable = source.defaultIfEmpty(10);
+        Observable<Integer> observable = source.defaultIfEmpty(10);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, never()).onNext(10);
-        verify(NbpObserver).onNext(1);
-        verify(NbpObserver).onNext(2);
-        verify(NbpObserver).onNext(3);
-        verify(NbpObserver).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(10);
+        verify(observer).onNext(1);
+        verify(observer).onNext(2);
+        verify(observer).onNext(3);
+        verify(observer).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testDefaultIfEmptyWithEmpty() {
         Observable<Integer> source = Observable.empty();
-        Observable<Integer> NbpObservable = source.defaultIfEmpty(10);
+        Observable<Integer> observable = source.defaultIfEmpty(10);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver).onNext(10);
-        verify(NbpObserver).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer).onNext(10);
+        verify(observer).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
@@ -35,14 +35,14 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
 
 public class ObservableDelayTest {
-    private Observer<Long> NbpObserver;
+    private Observer<Long> observer;
     private Observer<Long> observer2;
 
     private TestScheduler scheduler;
 
     @Before
     public void before() {
-        NbpObserver = TestHelper.mockObserver();
+        observer = TestHelper.mockObserver();
         observer2 = TestHelper.mockObserver();
 
         scheduler = new TestScheduler();
@@ -52,69 +52,69 @@ public class ObservableDelayTest {
     public void testDelay() {
         Observable<Long> source = Observable.interval(1L, TimeUnit.SECONDS, scheduler).take(3);
         Observable<Long> delayed = source.delay(500L, TimeUnit.MILLISECONDS, scheduler);
-        delayed.subscribe(NbpObserver);
+        delayed.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         scheduler.advanceTimeTo(1499L, TimeUnit.MILLISECONDS);
-        verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(1500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(0L);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext(0L);
+        inOrder.verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2400L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(1L);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext(1L);
+        inOrder.verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(3400L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(3500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(2L);
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext(2L);
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testLongDelay() {
         Observable<Long> source = Observable.interval(1L, TimeUnit.SECONDS, scheduler).take(3);
         Observable<Long> delayed = source.delay(5L, TimeUnit.SECONDS, scheduler);
-        delayed.subscribe(NbpObserver);
+        delayed.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
         scheduler.advanceTimeTo(5999L, TimeUnit.MILLISECONDS);
-        verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(6000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(0L);
+        inOrder.verify(observer, times(1)).onNext(0L);
         scheduler.advanceTimeTo(6999L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
+        inOrder.verify(observer, never()).onNext(anyLong());
         scheduler.advanceTimeTo(7000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(1L);
+        inOrder.verify(observer, times(1)).onNext(1L);
         scheduler.advanceTimeTo(7999L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
+        inOrder.verify(observer, never()).onNext(anyLong());
         scheduler.advanceTimeTo(8000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(2L);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
-        inOrder.verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext(2L);
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, never()).onNext(anyLong());
+        inOrder.verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -130,64 +130,64 @@ public class ObservableDelayTest {
             }
         });
         Observable<Long> delayed = source.delay(1L, TimeUnit.SECONDS, scheduler);
-        delayed.subscribe(NbpObserver);
+        delayed.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
         scheduler.advanceTimeTo(1999L, TimeUnit.MILLISECONDS);
-        verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
+        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
 
         scheduler.advanceTimeTo(5000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
+        inOrder.verify(observer, never()).onNext(anyLong());
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
     }
 
     @Test
     public void testDelayWithMultipleSubscriptions() {
         Observable<Long> source = Observable.interval(1L, TimeUnit.SECONDS, scheduler).take(3);
         Observable<Long> delayed = source.delay(500L, TimeUnit.MILLISECONDS, scheduler);
-        delayed.subscribe(NbpObserver);
+        delayed.subscribe(observer);
         delayed.subscribe(observer2);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         InOrder inOrder2 = inOrder(observer2);
 
         scheduler.advanceTimeTo(1499L, TimeUnit.MILLISECONDS);
-        verify(NbpObserver, never()).onNext(anyLong());
+        verify(observer, never()).onNext(anyLong());
         verify(observer2, never()).onNext(anyLong());
 
         scheduler.advanceTimeTo(1500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(0L);
+        inOrder.verify(observer, times(1)).onNext(0L);
         inOrder2.verify(observer2, times(1)).onNext(0L);
 
         scheduler.advanceTimeTo(2499L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
+        inOrder.verify(observer, never()).onNext(anyLong());
         inOrder2.verify(observer2, never()).onNext(anyLong());
 
         scheduler.advanceTimeTo(2500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(1L);
+        inOrder.verify(observer, times(1)).onNext(1L);
         inOrder2.verify(observer2, times(1)).onNext(1L);
 
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, never()).onComplete();
         verify(observer2, never()).onComplete();
 
         scheduler.advanceTimeTo(3500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(2L);
+        inOrder.verify(observer, times(1)).onNext(2L);
         inOrder2.verify(observer2, times(1)).onNext(2L);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
+        inOrder.verify(observer, never()).onNext(anyLong());
         inOrder2.verify(observer2, never()).onNext(anyLong());
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder2.verify(observer2, times(1)).onComplete();
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer2, never()).onError(any(Throwable.class));
     }
 
@@ -542,40 +542,40 @@ public class ObservableDelayTest {
         };
 
         Observable<Long> delayed = source.delay(delayFunc);
-        delayed.subscribe(NbpObserver);
+        delayed.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         scheduler.advanceTimeTo(1499L, TimeUnit.MILLISECONDS);
-        verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(1500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(0L);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext(0L);
+        inOrder.verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2400L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(1L);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext(1L);
+        inOrder.verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(3400L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(3500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(2L);
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext(2L);
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -631,11 +631,11 @@ public class ObservableDelayTest {
             }
 
         });
-        TestObserver<Integer> NbpObserver = new TestObserver<Integer>();
-        delayed.subscribe(NbpObserver);
+        TestObserver<Integer> observer = new TestObserver<Integer>();
+        delayed.subscribe(observer);
         // all will be delivered after 500ms since range does not delay between them
         scheduler.advanceTimeBy(500L, TimeUnit.MILLISECONDS);
-        NbpObserver.assertValues(1, 2, 3, 4, 5);
+        observer.assertValues(1, 2, 3, 4, 5);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDematerializeTest.java
@@ -45,13 +45,13 @@ public class ObservableDematerializeTest {
         Observable<Integer> o = Observable.error(exception);
         Observable<Integer> dematerialize = o.materialize().dematerialize();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
-        dematerialize.subscribe(NbpObserver);
+        dematerialize.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onError(exception);
-        verify(NbpObserver, times(0)).onComplete();
-        verify(NbpObserver, times(0)).onNext(any(Integer.class));
+        verify(observer, times(1)).onError(exception);
+        verify(observer, times(0)).onComplete();
+        verify(observer, times(0)).onNext(any(Integer.class));
     }
 
     @Test
@@ -60,13 +60,13 @@ public class ObservableDematerializeTest {
         Observable<Integer> o = Observable.error(exception);
         Observable<Integer> dematerialize = o.materialize().dematerialize();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
-        dematerialize.subscribe(NbpObserver);
+        dematerialize.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onError(exception);
-        verify(NbpObserver, times(0)).onComplete();
-        verify(NbpObserver, times(0)).onNext(any(Integer.class));
+        verify(observer, times(1)).onError(exception);
+        verify(observer, times(0)).onComplete();
+        verify(observer, times(0)).onNext(any(Integer.class));
     }
 
     @Test
@@ -75,13 +75,13 @@ public class ObservableDematerializeTest {
         Observable<Integer> o = Observable.error(exception);
         Observable<Integer> dematerialize = o.dematerialize();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
-        dematerialize.subscribe(NbpObserver);
+        dematerialize.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onError(exception);
-        verify(NbpObserver, times(0)).onComplete();
-        verify(NbpObserver, times(0)).onNext(any(Integer.class));
+        verify(observer, times(1)).onError(exception);
+        verify(observer, times(0)).onComplete();
+        verify(observer, times(0)).onNext(any(Integer.class));
     }
 
     @Test
@@ -89,16 +89,16 @@ public class ObservableDematerializeTest {
         Observable<Integer> o = Observable.empty();
         Observable<Integer> dematerialize = o.dematerialize();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>(NbpObserver);
+        TestObserver<Integer> ts = new TestObserver<Integer>(observer);
         dematerialize.subscribe(ts);
 
         System.out.println(ts.errors());
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(0)).onNext(any(Integer.class));
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(0)).onNext(any(Integer.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
@@ -43,14 +43,14 @@ public class ObservableDoOnEachTest {
 
         doOnEach.subscribe(subscribedObserver);
 
-        // ensure the leaf NbpObserver is still getting called
+        // ensure the leaf Observer is still getting called
         verify(subscribedObserver, never()).onError(any(Throwable.class));
         verify(subscribedObserver, times(1)).onNext("a");
         verify(subscribedObserver, times(1)).onNext("b");
         verify(subscribedObserver, times(1)).onNext("c");
         verify(subscribedObserver, times(1)).onComplete();
 
-        // ensure our injected NbpObserver is getting called
+        // ensure our injected Observer is getting called
         verify(sideEffectObserver, never()).onError(any(Throwable.class));
         verify(sideEffectObserver, times(1)).onNext("a");
         verify(sideEffectObserver, times(1)).onNext("b");
@@ -160,17 +160,17 @@ public class ObservableDoOnEachTest {
         assertEquals(expectedCount, count.get());
     }
 
-    // FIXME crashing ObservableConsumable can't propagate to a NbpSubscriber
+    // FIXME crashing ObservableSource can't propagate to a Observer
 //    @Test
 //    public void testFatalError() {
 //        try {
-//            NbpObservable.just(1, 2, 3)
-//                    .flatMap(new Function<Integer, NbpObservable<?>>() {
+//            Observable.just(1, 2, 3)
+//                    .flatMap(new Function<Integer, Observable<?>>() {
 //                        @Override
-//                        public NbpObservable<?> apply(Integer integer) {
-//                            return NbpObservable.create(new ObservableConsumable<Object>() {
+//                        public Observable<?> apply(Integer integer) {
+//                            return Observable.create(new ObservableSource<Object>() {
 //                                @Override
-//                                public void accept(NbpSubscriber<Object> o) {
+//                                public void accept(Observer<Object> o) {
 //                                    throw new NullPointerException("Test NPE");
 //                                }
 //                            });

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
@@ -45,7 +45,7 @@ public class ObservableDoOnUnsubscribeTest {
                     @Override
                     public void run() {
                         // Test that upper stream will be notified for un-subscription
-                        // from a child NbpSubscriber
+                        // from a child Observer
                             upperLatch.countDown();
                             upperCount.incrementAndGet();
                     }
@@ -70,10 +70,10 @@ public class ObservableDoOnUnsubscribeTest {
         List<TestObserver<Long>> subscribers = new ArrayList<TestObserver<Long>>();
 
         for (int i = 0; i < subCount; ++i) {
-            TestObserver<Long> NbpSubscriber = new TestObserver<Long>();
-            subscriptions.add(NbpSubscriber);
-            longs.subscribe(NbpSubscriber);
-            subscribers.add(NbpSubscriber);
+            TestObserver<Long> observer = new TestObserver<Long>();
+            subscriptions.add(observer);
+            longs.subscribe(observer);
+            subscribers.add(observer);
         }
 
         onNextLatch.await();
@@ -133,10 +133,10 @@ public class ObservableDoOnUnsubscribeTest {
         List<TestObserver<Long>> subscribers = new ArrayList<TestObserver<Long>>();
 
         for (int i = 0; i < subCount; ++i) {
-            TestObserver<Long> NbpSubscriber = new TestObserver<Long>();
-            longs.subscribe(NbpSubscriber);
-            subscriptions.add(NbpSubscriber);
-            subscribers.add(NbpSubscriber);
+            TestObserver<Long> observer = new TestObserver<Long>();
+            longs.subscribe(observer);
+            subscriptions.add(observer);
+            subscribers.add(observer);
         }
 
         onNextLatch.await();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFilterTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFilterTest.java
@@ -27,7 +27,7 @@ public class ObservableFilterTest {
     @Test
     public void testFilter() {
         Observable<String> w = Observable.just("one", "two", "three");
-        Observable<String> NbpObservable = w.filter(new Predicate<String>() {
+        Observable<String> observable = w.filter(new Predicate<String>() {
 
             @Override
             public boolean test(String t1) {
@@ -35,22 +35,22 @@ public class ObservableFilterTest {
             }
         });
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, Mockito.never()).onNext("one");
-        verify(NbpObserver, times(1)).onNext("two");
-        verify(NbpObserver, Mockito.never()).onNext("three");
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     // FIXME subscribers are not allowed to throw
 //    @Test
 //    public void testFatalError() {
 //        try {
-//            NbpObservable.just(1)
+//            Observable.just(1)
 //            .filter(new Predicate<Integer>() {
 //                @Override
 //                public boolean test(Integer t) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFirstTest.java
@@ -88,12 +88,12 @@ public class ObservableFirstTest {
     public void testFirst() {
         Observable<Integer> o = Observable.just(1, 2, 3).first();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(1);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -101,12 +101,12 @@ public class ObservableFirstTest {
     public void testFirstWithOneElement() {
         Observable<Integer> o = Observable.just(1).first();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(1);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -114,11 +114,11 @@ public class ObservableFirstTest {
     public void testFirstWithEmpty() {
         Observable<Integer> o = Observable.<Integer> empty().first();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
                 isA(NoSuchElementException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -134,12 +134,12 @@ public class ObservableFirstTest {
                 })
                 .first();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -154,12 +154,12 @@ public class ObservableFirstTest {
                 })
                 .first();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -174,11 +174,11 @@ public class ObservableFirstTest {
                 })
                 .first();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
                 isA(NoSuchElementException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -188,12 +188,12 @@ public class ObservableFirstTest {
         Observable<Integer> o = Observable.just(1, 2, 3)
                 .first(4);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(1);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -201,12 +201,12 @@ public class ObservableFirstTest {
     public void testFirstOrDefaultWithOneElement() {
         Observable<Integer> o = Observable.just(1).first(2);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(1);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -215,12 +215,12 @@ public class ObservableFirstTest {
         Observable<Integer> o = Observable.<Integer> empty()
                 .first(1);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(1);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -235,12 +235,12 @@ public class ObservableFirstTest {
                 })
                 .first(8);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -255,12 +255,12 @@ public class ObservableFirstTest {
                 })
                 .first(4);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -275,12 +275,12 @@ public class ObservableFirstTest {
                 })
                 .first(2);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromIterableTest.java
@@ -40,15 +40,15 @@ public class ObservableFromIterableTest {
     public void testListIterable() {
         Observable<String> o = Observable.fromIterable(Arrays.<String> asList("one", "two", "three"));
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
-        o.subscribe(NbpObserver);
+        o.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, times(1)).onNext("two");
-        verify(NbpObserver, times(1)).onNext("three");
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     /**
@@ -84,30 +84,30 @@ public class ObservableFromIterableTest {
         };
         Observable<String> o = Observable.fromIterable(it);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
-        o.subscribe(NbpObserver);
+        o.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onNext("1");
-        verify(NbpObserver, times(1)).onNext("2");
-        verify(NbpObserver, times(1)).onNext("3");
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext("1");
+        verify(observer, times(1)).onNext("2");
+        verify(observer, times(1)).onNext("3");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testObservableFromIterable() {
         Observable<String> o = Observable.fromIterable(Arrays.<String> asList("one", "two", "three"));
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
-        o.subscribe(NbpObserver);
+        o.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, times(1)).onNext("two");
-        verify(NbpObserver, times(1)).onNext("three");
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
@@ -144,11 +144,11 @@ public class ObservableGroupByTest {
         assertNotNull(error.get());
     }
 
-    private static <K, V> Map<K, Collection<V>> toMap(Observable<GroupedObservable<K, V>> NbpObservable) {
+    private static <K, V> Map<K, Collection<V>> toMap(Observable<GroupedObservable<K, V>> observable) {
 
         final ConcurrentHashMap<K, Collection<V>> result = new ConcurrentHashMap<K, Collection<V>>();
 
-        NbpObservable.blockingForEach(new Consumer<GroupedObservable<K, V>>() {
+        observable.blockingForEach(new Consumer<GroupedObservable<K, V>>() {
 
             @Override
             public void accept(final GroupedObservable<K, V> o) {
@@ -185,8 +185,8 @@ public class ObservableGroupByTest {
         Observable<Event> es = Observable.unsafeCreate(new ObservableSource<Event>() {
 
             @Override
-            public void subscribe(final Observer<? super Event> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
+            public void subscribe(final Observer<? super Event> observer) {
+                observer.onSubscribe(Disposables.empty());
                 System.out.println("*** Subscribing to EventStream ***");
                 subscribeCounter.incrementAndGet();
                 new Thread(new Runnable() {
@@ -197,9 +197,9 @@ public class ObservableGroupByTest {
                             Event e = new Event();
                             e.source = i % groupCount;
                             e.message = "Event-" + i;
-                            NbpObserver.onNext(e);
+                            observer.onNext(e);
                         }
-                        NbpObserver.onComplete();
+                        observer.onComplete();
                     }
 
                 }).start();
@@ -217,7 +217,7 @@ public class ObservableGroupByTest {
 
             @Override
             public Observable<String> apply(GroupedObservable<Integer, Event> eventGroupedObservable) {
-                System.out.println("NbpGroupedObservable Key: " + eventGroupedObservable.getKey());
+                System.out.println("GroupedObservable Key: " + eventGroupedObservable.getKey());
                 groupCounter.incrementAndGet();
 
                 return eventGroupedObservable.map(new Function<Event, String>() {
@@ -297,7 +297,7 @@ public class ObservableGroupByTest {
 
                     @Override
                     public Observable<String> apply(GroupedObservable<Integer, Event> eventGroupedObservable) {
-                        System.out.println("testUnsubscribe => NbpGroupedObservable Key: " + eventGroupedObservable.getKey());
+                        System.out.println("testUnsubscribe => GroupedObservable Key: " + eventGroupedObservable.getKey());
                         groupCounter.incrementAndGet();
 
                         return eventGroupedObservable
@@ -1202,7 +1202,7 @@ public class ObservableGroupByTest {
     }
 
     /**
-     * Assert we get an IllegalStateException if trying to subscribe to an inner NbpGroupedObservable more than once
+     * Assert we get an IllegalStateException if trying to subscribe to an inner GroupedObservable more than once
      */
     @Test
     public void testExceptionIfSubscribeToChildMoreThanOnce() {
@@ -1355,9 +1355,9 @@ public class ObservableGroupByTest {
         }).subscribe(new Consumer<GroupedObservable<String, String>>() {
 
             @Override
-            public void accept(GroupedObservable<String, String> NbpGroupedObservable) {
-                key[0] = NbpGroupedObservable.getKey();
-                NbpGroupedObservable.subscribe(new Consumer<String>() {
+            public void accept(GroupedObservable<String, String> groupedObservable) {
+                key[0] = groupedObservable.getKey();
+                groupedObservable.subscribe(new Consumer<String>() {
 
                     @Override
                     public void accept(String s) {
@@ -1376,8 +1376,8 @@ public class ObservableGroupByTest {
         Observable<Integer> o = Observable.unsafeCreate(
                 new ObservableSource<Integer>() {
                     @Override
-                    public void subscribe(Observer<? super Integer> NbpSubscriber) {
-                        NbpSubscriber.onSubscribe(s);
+                    public void subscribe(Observer<? super Integer> observer) {
+                        observer.onSubscribe(s);
                     }
                 }
         );
@@ -1425,11 +1425,11 @@ public class ObservableGroupByTest {
         Observable.unsafeCreate(
                 new ObservableSource<Integer>() {
                     @Override
-                    public void subscribe(Observer<? super Integer> NbpSubscriber) {
-                        NbpSubscriber.onSubscribe(Disposables.empty());
-                        NbpSubscriber.onNext(0);
-                        NbpSubscriber.onNext(1);
-                        NbpSubscriber.onError(e);
+                    public void subscribe(Observer<? super Integer> observer) {
+                        observer.onSubscribe(Disposables.empty());
+                        observer.onNext(0);
+                        observer.onNext(1);
+                        observer.onError(e);
                     }
                 }
         ).groupBy(new Function<Integer, Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableLastTest.java
@@ -55,12 +55,12 @@ public class ObservableLastTest {
     public void testLast() {
         Observable<Integer> o = Observable.just(1, 2, 3).last();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(3);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(3);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -68,12 +68,12 @@ public class ObservableLastTest {
     public void testLastWithOneElement() {
         Observable<Integer> o = Observable.just(1).last();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(1);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -81,11 +81,11 @@ public class ObservableLastTest {
     public void testLastWithEmpty() {
         Observable<Integer> o = Observable.<Integer> empty().last();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
                 isA(NoSuchElementException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -102,12 +102,12 @@ public class ObservableLastTest {
                 })
                 .last();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(6);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(6);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -124,12 +124,12 @@ public class ObservableLastTest {
                 })
             .last();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -145,11 +145,11 @@ public class ObservableLastTest {
                     }
                 }).last();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
                 isA(NoSuchElementException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -159,12 +159,12 @@ public class ObservableLastTest {
         Observable<Integer> o = Observable.just(1, 2, 3)
                 .last(4);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(3);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(3);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -172,12 +172,12 @@ public class ObservableLastTest {
     public void testLastOrDefaultWithOneElement() {
         Observable<Integer> o = Observable.just(1).last(2);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(1);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -186,12 +186,12 @@ public class ObservableLastTest {
         Observable<Integer> o = Observable.<Integer> empty()
                 .last(1);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(1);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -207,12 +207,12 @@ public class ObservableLastTest {
                 })
                 .last(8);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(6);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(6);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -228,12 +228,12 @@ public class ObservableLastTest {
                 })
                 .last(4);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -250,12 +250,12 @@ public class ObservableLastTest {
                 })
                 .last(2);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMapTest.java
@@ -75,7 +75,7 @@ public class ObservableMapTest {
 
             @Override
             public Observable<String> apply(Integer id) {
-                /* simulate making a nested async call which creates another NbpObservable */
+                /* simulate making a nested async call which creates another Observable */
                 Observable<Map<String, String>> subObservable = null;
                 if (id == 1) {
                     Map<String, String> m1 = getMap("One");
@@ -251,23 +251,23 @@ public class ObservableMapTest {
 //    @Test(expected = OnErrorNotImplementedException.class)
 //    public void verifyExceptionIsThrownIfThereIsNoExceptionHandler() {
 //
-//        ObservableConsumable<Object> creator = new ObservableConsumable<Object>() {
+//        ObservableSource<Object> creator = new ObservableSource<Object>() {
 //
 //            @Override
-//            public void accept(NbpSubscriber<? super Object> NbpObserver) {
-//                NbpObserver.onSubscribe(EmptyDisposable.INSTANCE);
-//                NbpObserver.onNext("a");
-//                NbpObserver.onNext("b");
-//                NbpObserver.onNext("c");
-//                NbpObserver.onComplete();
+//            public void subscribeActual(Observer<? super Object> observer) {
+//                observer.onSubscribe(EmptyDisposable.INSTANCE);
+//                observer.onNext("a");
+//                observer.onNext("b");
+//                observer.onNext("c");
+//                observer.onComplete();
 //            }
 //        };
 //
-//        Function<Object, NbpObservable<Object>> manyMapper = new Function<Object, NbpObservable<Object>>() {
+//        Function<Object, Observable<Object>> manyMapper = new Function<Object, Observable<Object>>() {
 //
 //            @Override
-//            public NbpObservable<Object> apply(Object object) {
-//                return NbpObservable.just(object);
+//            public Observable<Object> apply(Object object) {
+//                return Observable.just(object);
 //            }
 //        };
 //
@@ -293,7 +293,7 @@ public class ObservableMapTest {
 //        };
 //
 //        try {
-//            NbpObservable.create(creator).flatMap(manyMapper).map(mapper).subscribe(onNext);
+//            Observable.unsafeCreate(creator).flatMap(manyMapper).map(mapper).subscribe(onNext);
 //        } catch (RuntimeException e) {
 //            e.printStackTrace();
 //            throw e;
@@ -310,15 +310,15 @@ public class ObservableMapTest {
     // FIXME RS subscribers can't throw
 //    @Test(expected = OnErrorNotImplementedException.class)
 //    public void testShouldNotSwallowOnErrorNotImplementedException() {
-//        NbpObservable.just("a", "b").flatMap(new Function<String, NbpObservable<String>>() {
+//        Observable.just("a", "b").flatMap(new Function<String, Observable<String>>() {
 //            @Override
-//            public NbpObservable<String> apply(String s) {
-//                return NbpObservable.just(s + "1", s + "2");
+//            public Observable<String> apply(String s) {
+//                return Observable.just(s + "1", s + "2");
 //            }
-//        }).flatMap(new Function<String, NbpObservable<String>>() {
+//        }).flatMap(new Function<String, Observable<String>>() {
 //            @Override
-//            public NbpObservable<String> apply(String s) {
-//                return NbpObservable.error(new Exception("test"));
+//            public Observable<String> apply(String s) {
+//                return Observable.error(new Exception("test"));
 //            }
 //        }).forEach(new Consumer<String>() {
 //            @Override

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMaterializeTest.java
@@ -148,8 +148,8 @@ public class ObservableMaterializeTest {
         volatile Thread t;
 
         @Override
-        public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(Disposables.empty());
+        public void subscribe(final Observer<? super String> observer) {
+            observer.onSubscribe(Disposables.empty());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -162,14 +162,14 @@ public class ObservableMaterializeTest {
                             } catch (Throwable e) {
 
                             }
-                            NbpObserver.onError(new NullPointerException());
+                            observer.onError(new NullPointerException());
                             return;
                         } else {
-                            NbpObserver.onNext(s);
+                            observer.onNext(s);
                         }
                     }
                     System.out.println("subscription complete");
-                    NbpObserver.onComplete();
+                    observer.onComplete();
                 }
 
             });

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -54,10 +54,10 @@ public class ObservableMergeDelayErrorTest {
         verify(stringObserver, times(1)).onNext("three");
         verify(stringObserver, times(1)).onNext("four");
         verify(stringObserver, times(0)).onNext("five");
-        // despite not expecting it ... we don't do anything to prevent it if the source NbpObservable keeps sending after onError
-        // inner NbpObservable errors are considered terminal for that source
+        // despite not expecting it ... we don't do anything to prevent it if the source Observable keeps sending after onError
+        // inner Observable errors are considered terminal for that source
 //        verify(stringObserver, times(1)).onNext("six");
-        // inner NbpObservable errors are considered terminal for that source
+        // inner Observable errors are considered terminal for that source
     }
 
     @Test
@@ -77,8 +77,8 @@ public class ObservableMergeDelayErrorTest {
         verify(stringObserver, times(1)).onNext("three");
         verify(stringObserver, times(1)).onNext("four");
         verify(stringObserver, times(0)).onNext("five");
-        // despite not expecting it ... we don't do anything to prevent it if the source NbpObservable keeps sending after onError
-        // inner NbpObservable errors are considered terminal for that source
+        // despite not expecting it ... we don't do anything to prevent it if the source Observable keeps sending after onError
+        // inner Observable errors are considered terminal for that source
 //        verify(stringObserver, times(1)).onNext("six");
         verify(stringObserver, times(1)).onNext("seven");
         verify(stringObserver, times(1)).onNext("eight");
@@ -179,8 +179,8 @@ public class ObservableMergeDelayErrorTest {
         verify(stringObserver, times(0)).onNext("three");
         verify(stringObserver, times(1)).onNext("four");
         verify(stringObserver, times(0)).onNext("five");
-        // despite not expecting it ... we don't do anything to prevent it if the source NbpObservable keeps sending after onError
-        // inner NbpObservable errors are considered terminal for that source
+        // despite not expecting it ... we don't do anything to prevent it if the source Observable keeps sending after onError
+        // inner Observable errors are considered terminal for that source
 //        verify(stringObserver, times(1)).onNext("six");
     }
 
@@ -218,12 +218,12 @@ public class ObservableMergeDelayErrorTest {
         Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
 
             @Override
-            public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                // simulate what would happen in an NbpObservable
-                NbpObserver.onNext(o1);
-                NbpObserver.onNext(o2);
-                NbpObserver.onComplete();
+            public void subscribe(Observer<? super Observable<String>> observer) {
+                observer.onSubscribe(Disposables.empty());
+                // simulate what would happen in an Observable
+                observer.onNext(o1);
+                observer.onNext(o2);
+                observer.onComplete();
             }
 
         });
@@ -316,10 +316,10 @@ public class ObservableMergeDelayErrorTest {
     private static class TestSynchronousObservable implements ObservableSource<String> {
 
         @Override
-        public void subscribe(Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(Disposables.empty());
-            NbpObserver.onNext("hello");
-            NbpObserver.onComplete();
+        public void subscribe(Observer<? super String> observer) {
+            observer.onSubscribe(Disposables.empty());
+            observer.onNext("hello");
+            observer.onComplete();
         }
     }
 
@@ -327,14 +327,14 @@ public class ObservableMergeDelayErrorTest {
         Thread t;
 
         @Override
-        public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(Disposables.empty());
+        public void subscribe(final Observer<? super String> observer) {
+            observer.onSubscribe(Disposables.empty());
             t = new Thread(new Runnable() {
 
                 @Override
                 public void run() {
-                    NbpObserver.onNext("hello");
-                    NbpObserver.onComplete();
+                    observer.onNext("hello");
+                    observer.onComplete();
                 }
 
             });
@@ -351,22 +351,22 @@ public class ObservableMergeDelayErrorTest {
         }
 
         @Override
-        public void subscribe(Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(Disposables.empty());
+        public void subscribe(Observer<? super String> observer) {
+            observer.onSubscribe(Disposables.empty());
             boolean errorThrown = false;
             for (String s : valuesToReturn) {
                 if (s == null) {
                     System.out.println("throwing exception");
-                    NbpObserver.onError(new NullPointerException());
+                    observer.onError(new NullPointerException());
                     errorThrown = true;
                     // purposefully not returning here so it will continue calling onNext
                     // so that we also test that we handle bad sequences like this
                 } else {
-                    NbpObserver.onNext(s);
+                    observer.onNext(s);
                 }
             }
             if (!errorThrown) {
-                NbpObserver.onComplete();
+                observer.onComplete();
             }
         }
     }
@@ -382,8 +382,8 @@ public class ObservableMergeDelayErrorTest {
         Thread t;
 
         @Override
-        public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(Disposables.empty());
+        public void subscribe(final Observer<? super String> observer) {
+            observer.onSubscribe(Disposables.empty());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -396,14 +396,14 @@ public class ObservableMergeDelayErrorTest {
                             } catch (Throwable e) {
 
                             }
-                            NbpObserver.onError(new NullPointerException());
+                            observer.onError(new NullPointerException());
                             return;
                         } else {
-                            NbpObserver.onNext(s);
+                            observer.onNext(s);
                         }
                     }
                     System.out.println("subscription complete");
-                    NbpObserver.onComplete();
+                    observer.onComplete();
                 }
 
             });
@@ -534,8 +534,8 @@ public class ObservableMergeDelayErrorTest {
         Thread t;
 
         @Override
-        public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(Disposables.empty());
+        public void subscribe(final Observer<? super String> observer) {
+            observer.onSubscribe(Disposables.empty());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -543,10 +543,10 @@ public class ObservableMergeDelayErrorTest {
                     try {
                         Thread.sleep(100);
                     } catch (InterruptedException e) {
-                        NbpObserver.onError(e);
+                        observer.onError(e);
                     }
-                    NbpObserver.onNext("hello");
-                    NbpObserver.onComplete();
+                    observer.onNext("hello");
+                    observer.onComplete();
                 }
 
             });

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMulticastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMulticastTest.java
@@ -18,13 +18,12 @@ public class ObservableMulticastTest {
 //
 //    @Test
 //    public void testMulticast() {
-//        Subject<String, String> source = NbpPublishSubject.create();
+//        Subject<String, String> source = PublishSubject.create();
 //
 //        ConnectableObservable<String> multicasted = new OperatorMulticast<String, String>(source, new PublishSubjectFactory());
 //
-//        @SuppressWarnings("unchecked")
-//        NbpObserver<String> NbpObserver = mock(NbpObserver.class);
-//        multicasted.subscribe(NbpObserver);
+//        Observer<String> observer = TestHelper.mockObserver(Observer.class);
+//        multicasted.subscribe(observer);
 //
 //        source.onNext("one");
 //        source.onNext("two");
@@ -35,23 +34,23 @@ public class ObservableMulticastTest {
 //        source.onNext("four");
 //        source.onCompleted();
 //
-//        verify(NbpObserver, never()).onNext("one");
-//        verify(NbpObserver, never()).onNext("two");
-//        verify(NbpObserver, times(1)).onNext("three");
-//        verify(NbpObserver, times(1)).onNext("four");
-//        verify(NbpObserver, times(1)).onCompleted();
+//        verify(observer, never()).onNext("one");
+//        verify(observer, never()).onNext("two");
+//        verify(observer, times(1)).onNext("three");
+//        verify(observer, times(1)).onNext("four");
+//        verify(observer, times(1)).onCompleted();
 //
 //    }
 //
 //    @Test
 //    public void testMulticastConnectTwice() {
-//        Subject<String, String> source = NbpPublishSubject.create();
+//        Subject<String, String> source = PublishSubject.create();
 //
 //        ConnectableObservable<String> multicasted = new OperatorMulticast<String, String>(source, new PublishSubjectFactory());
 //
 //        @SuppressWarnings("unchecked")
-//        NbpObserver<String> NbpObserver = mock(NbpObserver.class);
-//        multicasted.subscribe(NbpObserver);
+//        Observer<String> observer = TestHelper.mockObserver(Observer.class);
+//        multicasted.subscribe(observer);
 //
 //        source.onNext("one");
 //
@@ -61,9 +60,9 @@ public class ObservableMulticastTest {
 //        source.onNext("two");
 //        source.onCompleted();
 //
-//        verify(NbpObserver, never()).onNext("one");
-//        verify(NbpObserver, times(1)).onNext("two");
-//        verify(NbpObserver, times(1)).onCompleted();
+//        verify(observer, never()).onNext("one");
+//        verify(observer, times(1)).onNext("two");
+//        verify(observer, times(1)).onCompleted();
 //
 //        assertEquals(sub, sub2);
 //
@@ -71,13 +70,13 @@ public class ObservableMulticastTest {
 //
 //    @Test
 //    public void testMulticastDisconnect() {
-//        Subject<String, String> source = NbpPublishSubject.create();
+//        Subject<String, String> source = PublisherSubject.create();
 //
 //        ConnectableObservable<String> multicasted = new OperatorMulticast<String, String>(source, new PublishSubjectFactory());
 //
 //        @SuppressWarnings("unchecked")
-//        NbpObserver<String> NbpObserver = mock(NbpObserver.class);
-//        multicasted.subscribe(NbpObserver);
+//        Observer<String> observer = mock(Observer.class);
+//        multicasted.subscribe(observer);
 //
 //        source.onNext("one");
 //
@@ -88,17 +87,17 @@ public class ObservableMulticastTest {
 //        source.onNext("three");
 //
 //        // subscribe again
-//        multicasted.subscribe(NbpObserver);
+//        multicasted.subscribe(observer);
 //        // reconnect
 //        multicasted.connect();
 //        source.onNext("four");
 //        source.onCompleted();
 //
-//        verify(NbpObserver, never()).onNext("one");
-//        verify(NbpObserver, times(1)).onNext("two");
-//        verify(NbpObserver, never()).onNext("three");
-//        verify(NbpObserver, times(1)).onNext("four");
-//        verify(NbpObserver, times(1)).onCompleted();
+//        verify(observer, never()).onNext("one");
+//        verify(observer, times(1)).onNext("two");
+//        verify(observer, never()).onNext("three");
+//        verify(observer, times(1)).onNext("four");
+//        verify(observer, times(1)).onCompleted();
 //
 //    }
 //
@@ -106,7 +105,7 @@ public class ObservableMulticastTest {
 //
 //        @Override
 //        public Subject<String, String> call() {
-//            return NbpPublishSubject.<String> create();
+//            return PublisherSubject.<String> create();
 //        }
 //
 //    }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
@@ -38,25 +38,25 @@ public class ObservableObserveOnTest {
      */
     @Test
     public void testObserveOn() {
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        Observable.just(1, 2, 3).observeOn(ImmediateThinScheduler.INSTANCE).subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        Observable.just(1, 2, 3).observeOn(ImmediateThinScheduler.INSTANCE).subscribe(observer);
 
-        verify(NbpObserver, times(1)).onNext(1);
-        verify(NbpObserver, times(1)).onNext(2);
-        verify(NbpObserver, times(1)).onNext(3);
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext(1);
+        verify(observer, times(1)).onNext(2);
+        verify(observer, times(1)).onNext(3);
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testOrdering() throws InterruptedException {
-//        NbpObservable<String> obs = NbpObservable.just("one", null, "two", "three", "four");
+//        Observable<String> obs = Observable.just("one", null, "two", "three", "four");
         // FIXME null values not allowed
         Observable<String> obs = Observable.just("one", "null", "two", "three", "four");
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
-        InOrder inOrder = inOrder(NbpObserver);
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        InOrder inOrder = inOrder(observer);
+        TestObserver<String> ts = new TestObserver<String>(observer);
 
         obs.observeOn(Schedulers.computation()).subscribe(ts);
 
@@ -68,12 +68,12 @@ public class ObservableObserveOnTest {
             fail("failed with exception");
         }
 
-        inOrder.verify(NbpObserver, times(1)).onNext("one");
-        inOrder.verify(NbpObserver, times(1)).onNext("null");
-        inOrder.verify(NbpObserver, times(1)).onNext("two");
-        inOrder.verify(NbpObserver, times(1)).onNext("three");
-        inOrder.verify(NbpObserver, times(1)).onNext("four");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onNext("one");
+        inOrder.verify(observer, times(1)).onNext("null");
+        inOrder.verify(observer, times(1)).onNext("two");
+        inOrder.verify(observer, times(1)).onNext("three");
+        inOrder.verify(observer, times(1)).onNext("four");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -81,10 +81,10 @@ public class ObservableObserveOnTest {
     public void testThreadName() throws InterruptedException {
         System.out.println("Main Thread: " + Thread.currentThread().getName());
         // FIXME null values not allowed
-//        NbpObservable<String> obs = NbpObservable.just("one", null, "two", "three", "four");
+//        Observable<String> obs = Observable.just("one", null, "two", "three", "four");
         Observable<String> obs = Observable.just("one", "null", "two", "three", "four");
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         final String parentThreadName = Thread.currentThread().getName();
 
         final CountDownLatch completedLatch = new CountDownLatch(1);
@@ -119,15 +119,15 @@ public class ObservableObserveOnTest {
                 completedLatch.countDown();
 
             }
-        }).subscribe(NbpObserver);
+        }).subscribe(observer);
 
         if (!completedLatch.await(1000, TimeUnit.MILLISECONDS)) {
             fail("timed out waiting");
         }
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(5)).onNext(any(String.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(5)).onNext(any(String.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -379,8 +379,8 @@ public class ObservableObserveOnTest {
     public void testAfterUnsubscribeCalledThenObserverOnNextNeverCalled() {
         final TestScheduler testScheduler = new TestScheduler();
 
-        final Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        TestObserver<Integer> ts = new TestObserver<Integer>(NbpObserver);
+        final Observer<Integer> observer = TestHelper.mockObserver();
+        TestObserver<Integer> ts = new TestObserver<Integer>(observer);
 
         Observable.just(1, 2, 3)
                 .observeOn(testScheduler)
@@ -389,11 +389,11 @@ public class ObservableObserveOnTest {
         ts.dispose();
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        final InOrder inOrder = inOrder(NbpObserver);
+        final InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(NbpObserver, never()).onNext(anyInt());
-        inOrder.verify(NbpObserver, never()).onError(any(Exception.class));
-        inOrder.verify(NbpObserver, never()).onComplete();
+        inOrder.verify(observer, never()).onNext(anyInt());
+        inOrder.verify(observer, never()).onError(any(Exception.class));
+        inOrder.verify(observer, never()).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaFunctionTest.java
@@ -37,12 +37,12 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
         Observable<String> w = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                NbpObserver.onNext("one");
-                NbpObserver.onError(new Throwable("injected failure"));
-                NbpObserver.onNext("two");
-                NbpObserver.onNext("three");
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onNext("one");
+                observer.onError(new Throwable("injected failure"));
+                observer.onNext("two");
+                observer.onNext("three");
             }
         });
 
@@ -55,19 +55,19 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
             }
 
         };
-        Observable<String> NbpObservable = w.onErrorResumeNext(resume);
+        Observable<String> observable = w.onErrorResumeNext(resume);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, Mockito.never()).onNext("two");
-        verify(NbpObserver, Mockito.never()).onNext("three");
-        verify(NbpObserver, times(1)).onNext("twoResume");
-        verify(NbpObserver, times(1)).onNext("threeResume");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, times(1)).onNext("twoResume");
+        verify(observer, times(1)).onNext("threeResume");
         assertNotNull(receivedException.get());
     }
 
@@ -87,9 +87,9 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
         };
         Observable<String> o = Observable.unsafeCreate(w).onErrorResumeNext(resume);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
-        o.subscribe(NbpObserver);
+        o.subscribe(observer);
 
         try {
             w.t.join();
@@ -97,13 +97,13 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
             fail(e.getMessage());
         }
 
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, Mockito.never()).onNext("two");
-        verify(NbpObserver, Mockito.never()).onNext("three");
-        verify(NbpObserver, times(1)).onNext("twoResume");
-        verify(NbpObserver, times(1)).onNext("threeResume");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, times(1)).onNext("twoResume");
+        verify(observer, times(1)).onNext("threeResume");
         assertNotNull(receivedException.get());
     }
 
@@ -125,8 +125,8 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
         Observable<String> o = Observable.unsafeCreate(w).onErrorResumeNext(resume);
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> NbpObserver = mock(DefaultObserver.class);
-        o.subscribe(NbpObserver);
+        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        o.subscribe(observer);
 
         try {
             w.t.join();
@@ -135,11 +135,11 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
         }
 
         // we should get the "one" value before the error
-        verify(NbpObserver, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("one");
 
-        // we should have received an onError call on the NbpObserver since the resume function threw an exception
-        verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        verify(NbpObserver, times(0)).onComplete();
+        // we should have received an onError call on the Observer since the resume function threw an exception
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, times(0)).onComplete();
     }
 
     /**
@@ -147,7 +147,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
      * does not have manual try/catch handling like map does.
      */
     @Test
-    @Ignore("Failed operator may leave the child NbpSubscriber in an inconsistent state which prevents further error delivery.")
+    @Ignore("Failed operator may leave the child Observer in an inconsistent state which prevents further error delivery.")
     public void testOnErrorResumeReceivesErrorFromPreviousNonProtectedOperator() {
         TestObserver<String> ts = new TestObserver<String>();
         Observable.just(1).lift(new ObservableOperator<String, Integer>() {
@@ -235,7 +235,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
         // Trigger multiple failures
         Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
 
-        // Introduce map function that fails intermittently (Map does not prevent this when the NbpObserver is a
+        // Introduce map function that fails intermittently (Map does not prevent this when the Observer is a
         //  rx.operator incl onErrorResumeNextViaObservable)
         w = w.map(new Function<String, String>() {
             @Override
@@ -257,19 +257,19 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
         });
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> NbpObserver = mock(DefaultObserver.class);
+        DefaultObserver<String> observer = mock(DefaultObserver.class);
 
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        TestObserver<String> ts = new TestObserver<String>(observer);
         o.subscribe(ts);
         ts.awaitTerminalEvent();
 
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, Mockito.never()).onNext("two");
-        verify(NbpObserver, Mockito.never()).onNext("three");
-        verify(NbpObserver, times(1)).onNext("twoResume");
-        verify(NbpObserver, times(1)).onNext("threeResume");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, times(1)).onNext("twoResume");
+        verify(observer, times(1)).onNext("threeResume");
     }
 
     private static class TestObservable implements ObservableSource<String> {
@@ -282,9 +282,9 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
         }
 
         @Override
-        public void subscribe(final Observer<? super String> NbpObserver) {
+        public void subscribe(final Observer<? super String> observer) {
             System.out.println("TestObservable subscribed to ...");
-            NbpObserver.onSubscribe(Disposables.empty());
+            observer.onSubscribe(Disposables.empty());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -293,11 +293,11 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
                         System.out.println("running TestObservable thread");
                         for (String s : values) {
                             System.out.println("TestObservable onNext: " + s);
-                            NbpObserver.onNext(s);
+                            observer.onNext(s);
                         }
                         throw new RuntimeException("Forced Failure");
                     } catch (Throwable e) {
-                        NbpObserver.onError(e);
+                        observer.onError(e);
                     }
                 }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaObservableTest.java
@@ -35,10 +35,10 @@ public class ObservableOnErrorResumeNextViaObservableTest {
         TestObservable f = new TestObservable(s, "one", "fail", "two", "three");
         Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
-        Observable<String> NbpObservable = w.onErrorResumeNext(resume);
+        Observable<String> observable = w.onErrorResumeNext(resume);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
 
         try {
             f.t.join();
@@ -46,13 +46,13 @@ public class ObservableOnErrorResumeNextViaObservableTest {
             fail(e.getMessage());
         }
 
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, Mockito.never()).onNext("two");
-        verify(NbpObserver, Mockito.never()).onNext("three");
-        verify(NbpObserver, times(1)).onNext("twoResume");
-        verify(NbpObserver, times(1)).onNext("threeResume");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, times(1)).onNext("twoResume");
+        verify(observer, times(1)).onNext("threeResume");
     }
 
     @Test
@@ -60,11 +60,11 @@ public class ObservableOnErrorResumeNextViaObservableTest {
         Disposable sr = mock(Disposable.class);
         // Trigger multiple failures
         Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
-        // Resume NbpObservable is async
+        // Resume Observable is async
         TestObservable f = new TestObservable(sr, "twoResume", "threeResume");
         Observable<String> resume = Observable.unsafeCreate(f);
 
-        // Introduce map function that fails intermittently (Map does not prevent this when the NbpObserver is a
+        // Introduce map function that fails intermittently (Map does not prevent this when the Observer is a
         //  rx.operator incl onErrorResumeNextViaObservable)
         w = w.map(new Function<String, String>() {
             @Override
@@ -76,11 +76,11 @@ public class ObservableOnErrorResumeNextViaObservableTest {
             }
         });
 
-        Observable<String> NbpObservable = w.onErrorResumeNext(resume);
+        Observable<String> observable = w.onErrorResumeNext(resume);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
-        NbpObservable.subscribe(NbpObserver);
+        observable.subscribe(observer);
 
         try {
             f.t.join();
@@ -88,13 +88,13 @@ public class ObservableOnErrorResumeNextViaObservableTest {
             fail(e.getMessage());
         }
 
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, Mockito.never()).onNext("two");
-        verify(NbpObserver, Mockito.never()).onNext("three");
-        verify(NbpObserver, times(1)).onNext("twoResume");
-        verify(NbpObserver, times(1)).onNext("threeResume");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, times(1)).onNext("twoResume");
+        verify(observer, times(1)).onNext("threeResume");
     }
 
     @Test
@@ -109,14 +109,14 @@ public class ObservableOnErrorResumeNextViaObservableTest {
 
         });
         Observable<String> resume = Observable.just("resume");
-        Observable<String> NbpObservable = testObservable.onErrorResumeNext(resume);
+        Observable<String> observable = testObservable.onErrorResumeNext(resume);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
 
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("resume");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("resume");
     }
 
     @Test
@@ -131,18 +131,18 @@ public class ObservableOnErrorResumeNextViaObservableTest {
 
         });
         Observable<String> resume = Observable.just("resume");
-        Observable<String> NbpObservable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeNext(resume);
+        Observable<String> observable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeNext(resume);
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> NbpObserver = mock(DefaultObserver.class);
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
-        NbpObservable.subscribe(ts);
+        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        TestObserver<String> ts = new TestObserver<String>(observer);
+        observable.subscribe(ts);
 
         ts.awaitTerminalEvent();
 
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("resume");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("resume");
     }
 
     private static class TestObservable implements ObservableSource<String> {
@@ -157,9 +157,9 @@ public class ObservableOnErrorResumeNextViaObservableTest {
         }
 
         @Override
-        public void subscribe(final Observer<? super String> NbpObserver) {
+        public void subscribe(final Observer<? super String> observer) {
             System.out.println("TestObservable subscribed to ...");
-            NbpObserver.onSubscribe(s);
+            observer.onSubscribe(s);
             t = new Thread(new Runnable() {
 
                 @Override
@@ -170,13 +170,13 @@ public class ObservableOnErrorResumeNextViaObservableTest {
                             if ("fail".equals(s))
                                 throw new RuntimeException("Forced Failure");
                             System.out.println("TestObservable onNext: " + s);
-                            NbpObserver.onNext(s);
+                            observer.onNext(s);
                         }
                         System.out.println("TestObservable onCompleted");
-                        NbpObserver.onComplete();
+                        observer.onComplete();
                     } catch (Throwable e) {
                         System.out.println("TestObservable onError: " + e);
-                        NbpObserver.onError(e);
+                        observer.onError(e);
                     }
                 }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
@@ -37,7 +37,7 @@ public class ObservableOnErrorReturnTest {
         Observable<String> w = Observable.unsafeCreate(f);
         final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
 
-        Observable<String> NbpObservable = w.onErrorReturn(new Function<Throwable, String>() {
+        Observable<String> observable = w.onErrorReturn(new Function<Throwable, String>() {
 
             @Override
             public String apply(Throwable e) {
@@ -48,8 +48,8 @@ public class ObservableOnErrorReturnTest {
         });
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> NbpObserver = mock(DefaultObserver.class);
-        NbpObservable.subscribe(NbpObserver);
+        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        observable.subscribe(observer);
 
         try {
             f.t.join();
@@ -57,10 +57,10 @@ public class ObservableOnErrorReturnTest {
             fail(e.getMessage());
         }
 
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, times(1)).onNext("failure");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("failure");
         assertNotNull(capturedException.get());
     }
 
@@ -73,7 +73,7 @@ public class ObservableOnErrorReturnTest {
         Observable<String> w = Observable.unsafeCreate(f);
         final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
 
-        Observable<String> NbpObservable = w.onErrorReturn(new Function<Throwable, String>() {
+        Observable<String> observable = w.onErrorReturn(new Function<Throwable, String>() {
 
             @Override
             public String apply(Throwable e) {
@@ -84,8 +84,8 @@ public class ObservableOnErrorReturnTest {
         });
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> NbpObserver = mock(DefaultObserver.class);
-        NbpObservable.subscribe(NbpObserver);
+        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        observable.subscribe(observer);
 
         try {
             f.t.join();
@@ -94,11 +94,11 @@ public class ObservableOnErrorReturnTest {
         }
 
         // we should get the "one" value before the error
-        verify(NbpObserver, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("one");
 
-        // we should have received an onError call on the NbpObserver since the resume function threw an exception
-        verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        verify(NbpObserver, times(0)).onComplete();
+        // we should have received an onError call on the Observer since the resume function threw an exception
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, times(0)).onComplete();
         assertNotNull(capturedException.get());
     }
 
@@ -107,7 +107,7 @@ public class ObservableOnErrorReturnTest {
         // Trigger multiple failures
         Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
 
-        // Introduce map function that fails intermittently (Map does not prevent this when the NbpObserver is a
+        // Introduce map function that fails intermittently (Map does not prevent this when the Observer is a
         //  rx.operator incl onErrorResumeNextViaObservable)
         w = w.map(new Function<String, String>() {
             @Override
@@ -119,7 +119,7 @@ public class ObservableOnErrorReturnTest {
             }
         });
 
-        Observable<String> NbpObservable = w.onErrorReturn(new Function<Throwable, String>() {
+        Observable<String> observable = w.onErrorReturn(new Function<Throwable, String>() {
 
             @Override
             public String apply(Throwable t1) {
@@ -129,17 +129,17 @@ public class ObservableOnErrorReturnTest {
         });
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<String> NbpObserver = mock(DefaultObserver.class);
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
-        NbpObservable.subscribe(ts);
+        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        TestObserver<String> ts = new TestObserver<String>(observer);
+        observable.subscribe(ts);
         ts.awaitTerminalEvent();
 
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, Mockito.never()).onNext("two");
-        verify(NbpObserver, Mockito.never()).onNext("three");
-        verify(NbpObserver, times(1)).onNext("resume");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, times(1)).onNext("resume");
     }
 
     @Test
@@ -187,8 +187,8 @@ public class ObservableOnErrorReturnTest {
         }
 
         @Override
-        public void subscribe(final Observer<? super String> NbpSubscriber) {
-            NbpSubscriber.onSubscribe(Disposables.empty());
+        public void subscribe(final Observer<? super String> observer) {
+            observer.onSubscribe(Disposables.empty());
             System.out.println("TestObservable subscribed to ...");
             t = new Thread(new Runnable() {
 
@@ -198,11 +198,11 @@ public class ObservableOnErrorReturnTest {
                         System.out.println("running TestObservable thread");
                         for (String s : values) {
                             System.out.println("TestObservable onNext: " + s);
-                            NbpSubscriber.onNext(s);
+                            observer.onNext(s);
                         }
                         throw new RuntimeException("Forced Failure");
                     } catch (Throwable e) {
-                        NbpSubscriber.onError(e);
+                        observer.onError(e);
                     }
                 }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnExceptionResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnExceptionResumeNextViaObservableTest.java
@@ -34,10 +34,10 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
         TestObservable f = new TestObservable("one", "EXCEPTION", "two", "three");
         Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
-        Observable<String> NbpObservable = w.onExceptionResumeNext(resume);
+        Observable<String> observable = w.onExceptionResumeNext(resume);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
 
         try {
             f.t.join();
@@ -45,15 +45,15 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
             fail(e.getMessage());
         }
 
-        verify(NbpObserver).onSubscribe((Disposable)any());
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, Mockito.never()).onNext("two");
-        verify(NbpObserver, Mockito.never()).onNext("three");
-        verify(NbpObserver, times(1)).onNext("twoResume");
-        verify(NbpObserver, times(1)).onNext("threeResume");
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verifyNoMoreInteractions(NbpObserver);
+        verify(observer).onSubscribe((Disposable)any());
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, times(1)).onNext("twoResume");
+        verify(observer, times(1)).onNext("threeResume");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verifyNoMoreInteractions(observer);
     }
 
     @Test
@@ -62,10 +62,10 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
         TestObservable f = new TestObservable("one", "RUNTIMEEXCEPTION", "two", "three");
         Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
-        Observable<String> NbpObservable = w.onExceptionResumeNext(resume);
+        Observable<String> observable = w.onExceptionResumeNext(resume);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
 
         try {
             f.t.join();
@@ -73,15 +73,15 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
             fail(e.getMessage());
         }
 
-        verify(NbpObserver).onSubscribe((Disposable)any());
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, Mockito.never()).onNext("two");
-        verify(NbpObserver, Mockito.never()).onNext("three");
-        verify(NbpObserver, times(1)).onNext("twoResume");
-        verify(NbpObserver, times(1)).onNext("threeResume");
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verifyNoMoreInteractions(NbpObserver);
+        verify(observer).onSubscribe((Disposable)any());
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, times(1)).onNext("twoResume");
+        verify(observer, times(1)).onNext("threeResume");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verifyNoMoreInteractions(observer);
     }
 
     @Test
@@ -90,10 +90,10 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
         TestObservable f = new TestObservable("one", "THROWABLE", "two", "three");
         Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
-        Observable<String> NbpObservable = w.onExceptionResumeNext(resume);
+        Observable<String> observable = w.onExceptionResumeNext(resume);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
 
         try {
             f.t.join();
@@ -101,15 +101,15 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
             fail(e.getMessage());
         }
 
-        verify(NbpObserver).onSubscribe((Disposable)any());
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onNext("two");
-        verify(NbpObserver, never()).onNext("three");
-        verify(NbpObserver, never()).onNext("twoResume");
-        verify(NbpObserver, never()).onNext("threeResume");
-        verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
-        verifyNoMoreInteractions(NbpObserver);
+        verify(observer).onSubscribe((Disposable)any());
+        verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onNext("two");
+        verify(observer, never()).onNext("three");
+        verify(observer, never()).onNext("twoResume");
+        verify(observer, never()).onNext("threeResume");
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verifyNoMoreInteractions(observer);
     }
 
     @Test
@@ -118,10 +118,10 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
         TestObservable f = new TestObservable("one", "ERROR", "two", "three");
         Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
-        Observable<String> NbpObservable = w.onExceptionResumeNext(resume);
+        Observable<String> observable = w.onExceptionResumeNext(resume);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
 
         try {
             f.t.join();
@@ -129,26 +129,26 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
             fail(e.getMessage());
         }
 
-        verify(NbpObserver).onSubscribe((Disposable)any());
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onNext("two");
-        verify(NbpObserver, never()).onNext("three");
-        verify(NbpObserver, never()).onNext("twoResume");
-        verify(NbpObserver, never()).onNext("threeResume");
-        verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
-        verifyNoMoreInteractions(NbpObserver);
+        verify(observer).onSubscribe((Disposable)any());
+        verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onNext("two");
+        verify(observer, never()).onNext("three");
+        verify(observer, never()).onNext("twoResume");
+        verify(observer, never()).onNext("threeResume");
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verifyNoMoreInteractions(observer);
     }
 
     @Test
     public void testMapResumeAsyncNext() {
         // Trigger multiple failures
         Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
-        // Resume NbpObservable is async
+        // Resume Observable is async
         TestObservable f = new TestObservable("twoResume", "threeResume");
         Observable<String> resume = Observable.unsafeCreate(f);
 
-        // Introduce map function that fails intermittently (Map does not prevent this when the NbpObserver is a
+        // Introduce map function that fails intermittently (Map does not prevent this when the Observer is a
         //  rx.operator incl onErrorResumeNextViaObservable)
         w = w.map(new Function<String, String>() {
             @Override
@@ -160,10 +160,10 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
             }
         });
 
-        Observable<String> NbpObservable = w.onExceptionResumeNext(resume);
+        Observable<String> observable = w.onExceptionResumeNext(resume);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
 
         try {
             // if the thread gets started (which it shouldn't if it's working correctly)
@@ -174,13 +174,13 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
             fail(e.getMessage());
         }
 
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onNext("two");
-        verify(NbpObserver, never()).onNext("three");
-        verify(NbpObserver, times(1)).onNext("twoResume");
-        verify(NbpObserver, times(1)).onNext("threeResume");
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onNext("two");
+        verify(observer, never()).onNext("three");
+        verify(observer, times(1)).onNext("twoResume");
+        verify(observer, times(1)).onNext("threeResume");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
 
@@ -223,8 +223,8 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
         }
 
         @Override
-        public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(Disposables.empty());
+        public void subscribe(final Observer<? super String> observer) {
+            observer.onSubscribe(Disposables.empty());
             System.out.println("TestObservable subscribed to ...");
             t = new Thread(new Runnable() {
 
@@ -242,13 +242,13 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
                             else if ("THROWABLE".equals(s))
                                 throw new Throwable("Forced Throwable");
                             System.out.println("TestObservable onNext: " + s);
-                            NbpObserver.onNext(s);
+                            observer.onNext(s);
                         }
                         System.out.println("TestObservable onCompleted");
-                        NbpObserver.onComplete();
+                        observer.onComplete();
                     } catch (Throwable e) {
                         System.out.println("TestObservable onError: " + e);
-                        NbpObserver.onError(e);
+                        observer.onError(e);
                     }
                 }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -38,15 +38,15 @@ public class ObservablePublishTest {
         ConnectableObservable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(final Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
+            public void subscribe(final Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
                 new Thread(new Runnable() {
 
                     @Override
                     public void run() {
                         counter.incrementAndGet();
-                        NbpObserver.onNext("one");
-                        NbpObserver.onComplete();
+                        observer.onNext("one");
+                        observer.onComplete();
                     }
                 }).start();
             }
@@ -251,13 +251,13 @@ public class ObservablePublishTest {
         co.connect();
         // Emit 0
         scheduler.advanceTimeBy(15, TimeUnit.MILLISECONDS);
-        TestObserver<Long> NbpSubscriber = new TestObserver<Long>();
-        co.subscribe(NbpSubscriber);
+        TestObserver<Long> to = new TestObserver<Long>();
+        co.subscribe(to);
         // Emit 1 and 2
         scheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS);
-        NbpSubscriber.assertValues(1L, 2L);
-        NbpSubscriber.assertNoErrors();
-        NbpSubscriber.assertTerminated();
+        to.assertValues(1L, 2L);
+        to.assertNoErrors();
+        to.assertTerminated();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRangeTest.java
@@ -29,21 +29,21 @@ public class ObservableRangeTest {
 
     @Test
     public void testRangeStartAt2Count3() {
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
-        Observable.range(2, 3).subscribe(NbpObserver);
+        Observable.range(2, 3).subscribe(observer);
 
-        verify(NbpObserver, times(1)).onNext(2);
-        verify(NbpObserver, times(1)).onNext(3);
-        verify(NbpObserver, times(1)).onNext(4);
-        verify(NbpObserver, never()).onNext(5);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext(2);
+        verify(observer, times(1)).onNext(3);
+        verify(observer, times(1)).onNext(4);
+        verify(observer, never()).onNext(5);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testRangeUnsubscribe() {
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
         final AtomicInteger count = new AtomicInteger();
 
@@ -53,14 +53,14 @@ public class ObservableRangeTest {
                 count.incrementAndGet();
             }
         })
-        .take(3).subscribe(NbpObserver);
+        .take(3).subscribe(observer);
 
-        verify(NbpObserver, times(1)).onNext(1);
-        verify(NbpObserver, times(1)).onNext(2);
-        verify(NbpObserver, times(1)).onNext(3);
-        verify(NbpObserver, never()).onNext(4);
-        verify(NbpObserver, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext(1);
+        verify(observer, times(1)).onNext(2);
+        verify(observer, times(1)).onNext(3);
+        verify(observer, never()).onNext(4);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
         assertEquals(3, count.get());
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReduceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReduceTest.java
@@ -24,11 +24,11 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 
 public class ObservableReduceTest {
-    Observer<Object> NbpObserver;
+    Observer<Object> observer;
 
     @Before
     public void before() {
-        NbpObserver = TestHelper.mockObserver();
+        observer = TestHelper.mockObserver();
     }
 
     BiFunction<Integer, Integer, Integer> sum = new BiFunction<Integer, Integer, Integer>() {
@@ -49,11 +49,11 @@ public class ObservableReduceTest {
                     }
                 });
 
-        result.subscribe(NbpObserver);
+        result.subscribe(observer);
 
-        verify(NbpObserver).onNext(1 + 2 + 3 + 4 + 5);
-        verify(NbpObserver).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer).onNext(1 + 2 + 3 + 4 + 5);
+        verify(observer).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -67,11 +67,11 @@ public class ObservableReduceTest {
                     }
                 });
 
-        result.subscribe(NbpObserver);
+        result.subscribe(observer);
 
-        verify(NbpObserver, never()).onNext(any());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, times(1)).onError(any(TestException.class));
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onError(any(TestException.class));
     }
 
     @Test
@@ -91,11 +91,11 @@ public class ObservableReduceTest {
                     }
                 });
 
-        result.subscribe(NbpObserver);
+        result.subscribe(observer);
 
-        verify(NbpObserver, never()).onNext(any());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, times(1)).onError(any(TestException.class));
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onError(any(TestException.class));
     }
 
     @Test
@@ -112,11 +112,11 @@ public class ObservableReduceTest {
         Observable<Integer> result = Observable.just(1, 2, 3, 4, 5)
                 .reduce(0, sum).map(error);
 
-        result.subscribe(NbpObserver);
+        result.subscribe(observer);
 
-        verify(NbpObserver, never()).onNext(any());
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, times(1)).onError(any(TestException.class));
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onError(any(TestException.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -71,7 +71,7 @@ public class ObservableRefCountTest {
         }
 
         // now unsubscribe
-        s2.dispose(); // unsubscribe s2 first as we're counting in 1 and there can be a race between unsubscribe and one NbpSubscriber getting a value but not the other
+        s2.dispose(); // unsubscribe s2 first as we're counting in 1 and there can be a race between unsubscribe and one Observer getting a value but not the other
         s1.dispose();
 
         System.out.println("onNext: " + nextCount.get());
@@ -118,7 +118,7 @@ public class ObservableRefCountTest {
         }
 
         // now unsubscribe
-        s2.dispose(); // unsubscribe s2 first as we're counting in 1 and there can be a race between unsubscribe and one NbpSubscriber getting a value but not the other
+        s2.dispose(); // unsubscribe s2 first as we're counting in 1 and there can be a race between unsubscribe and one Observer getting a value but not the other
         s1.dispose();
 
         System.out.println("onNext Count: " + nextCount.get());
@@ -299,9 +299,9 @@ public class ObservableRefCountTest {
     private Observable<Long> synchronousInterval() {
         return Observable.unsafeCreate(new ObservableSource<Long>() {
             @Override
-            public void subscribe(Observer<? super Long> NbpSubscriber) {
+            public void subscribe(Observer<? super Long> observer) {
                 final AtomicBoolean cancel = new AtomicBoolean();
-                NbpSubscriber.onSubscribe(Disposables.fromRunnable(new Runnable() {
+                observer.onSubscribe(Disposables.fromRunnable(new Runnable() {
                     @Override
                     public void run() {
                         cancel.set(true);
@@ -315,7 +315,7 @@ public class ObservableRefCountTest {
                         Thread.sleep(100);
                     } catch (InterruptedException e) {
                     }
-                    NbpSubscriber.onNext(1L);
+                    observer.onNext(1L);
                 }
             }
         });
@@ -327,9 +327,9 @@ public class ObservableRefCountTest {
         final AtomicInteger unsubscriptionCount = new AtomicInteger();
         Observable<Integer> o = Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
-            public void subscribe(Observer<? super Integer> NbpObserver) {
+            public void subscribe(Observer<? super Integer> observer) {
                 subscriptionCount.incrementAndGet();
-                NbpObserver.onSubscribe(Disposables.fromRunnable(new Runnable() {
+                observer.onSubscribe(Disposables.fromRunnable(new Runnable() {
                     @Override
                     public void run() {
                             unsubscriptionCount.incrementAndGet();
@@ -540,14 +540,14 @@ public class ObservableRefCountTest {
                 .doOnError(new Consumer<Throwable>() {
                     @Override
                     public void accept(Throwable t1) {
-                            System.out.println("NbpSubscriber 1 onError: " + t1);
+                            System.out.println("Observer 1 onError: " + t1);
                     }
                 })
                 .retry(5)
                 .subscribe(new Consumer<String>() {
                     @Override
                     public void accept(String t1) {
-                            System.out.println("NbpSubscriber 1: " + t1);
+                            System.out.println("Observer 1: " + t1);
                     }
                 });
         Thread.sleep(100);
@@ -555,14 +555,14 @@ public class ObservableRefCountTest {
         .doOnError(new Consumer<Throwable>() {
             @Override
             public void accept(Throwable t1) {
-                    System.out.println("NbpSubscriber 2 onError: " + t1);
+                    System.out.println("Observer 2 onError: " + t1);
             }
         })
         .retry(5)
                 .subscribe(new Consumer<String>() {
                     @Override
                     public void accept(String t1) {
-                            System.out.println("NbpSubscriber 2: " + t1);
+                            System.out.println("Observer 2: " + t1);
                     }
                 });
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -517,7 +517,7 @@ public class ObservableReplayTest {
         Observer<Integer> spiedSubscriberBeforeConnect = TestHelper.mockObserver();
         Observer<Integer> spiedSubscriberAfterConnect = TestHelper.mockObserver();
 
-        // NbpObservable under test
+        // Observable under test
         Observable<Integer> source = Observable.just(1,2);
 
         ConnectableObservable<Integer> replay = source
@@ -569,7 +569,7 @@ public class ObservableReplayTest {
         Observer<Integer> mockObserverBeforeConnect = TestHelper.mockObserver();
         Observer<Integer> mockObserverAfterConnect = TestHelper.mockObserver();
 
-        // NbpObservable under test
+        // Observable under test
         ConnectableObservable<Integer> replay = Observable.just(1, 2, 3)
                 .doOnNext(sourceNext)
                 .doOnDispose(sourceUnsubscribed)
@@ -622,7 +622,7 @@ public class ObservableReplayTest {
         Observer<Integer> mockObserverBeforeConnect = TestHelper.mockObserver();
         Observer<Integer> mockObserverAfterConnect = TestHelper.mockObserver();
 
-        // NbpObservable under test
+        // Observable under test
         Function<Integer, Integer> mockFunc = mock(Function.class);
         IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
         when(mockFunc.apply(1)).thenReturn(1);
@@ -801,16 +801,16 @@ public class ObservableReplayTest {
         Observable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(final Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
+            public void subscribe(final Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
                 new Thread(new Runnable() {
 
                     @Override
                     public void run() {
                         counter.incrementAndGet();
-                        System.out.println("published NbpObservable being executed");
-                        NbpObserver.onNext("one");
-                        NbpObserver.onComplete();
+                        System.out.println("published Observable being executed");
+                        observer.onNext("one");
+                        observer.onComplete();
                     }
                 }).start();
             }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
@@ -111,29 +111,29 @@ public class ObservableRetryTest {
 
     @Test
     public void testRetryIndefinitely() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         int NUM_RETRIES = 20;
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
-        origin.retry().subscribe(new TestObserver<String>(NbpObserver));
+        origin.retry().subscribe(new TestObserver<String>(observer));
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         // should show 3 attempts
-        inOrder.verify(NbpObserver, times(NUM_RETRIES + 1)).onNext("beginningEveryTime");
+        inOrder.verify(observer, times(NUM_RETRIES + 1)).onNext("beginningEveryTime");
         // should have no errors
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         // should have a single success
-        inOrder.verify(NbpObserver, times(1)).onNext("onSuccessOnly");
+        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
         // should have a single successful onCompleted
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testSchedulingNotificationHandler() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         int NUM_RETRIES = 2;
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
-        TestObserver<String> NbpSubscriber = new TestObserver<String>(NbpObserver);
+        TestObserver<String> to = new TestObserver<String>(observer);
         origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<Object>>() {
             @Override
             public Observable<Object> apply(Observable<? extends Throwable> t1) {
@@ -153,24 +153,24 @@ public class ObservableRetryTest {
                 e.printStackTrace();
             }
         })
-        .subscribe(NbpSubscriber);
+        .subscribe(to);
 
-        NbpSubscriber.awaitTerminalEvent();
-        InOrder inOrder = inOrder(NbpObserver);
+        to.awaitTerminalEvent();
+        InOrder inOrder = inOrder(observer);
         // should show 3 attempts
-        inOrder.verify(NbpObserver, times(1 + NUM_RETRIES)).onNext("beginningEveryTime");
+        inOrder.verify(observer, times(1 + NUM_RETRIES)).onNext("beginningEveryTime");
         // should have no errors
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         // should have a single success
-        inOrder.verify(NbpObserver, times(1)).onNext("onSuccessOnly");
+        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
         // should have a single successful onCompleted
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testOnNextFromNotificationHandler() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         int NUM_RETRIES = 2;
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
         origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<Object>>() {
@@ -184,58 +184,58 @@ public class ObservableRetryTest {
                     }
                 }).startWith(0).cast(Object.class);
             }
-        }).subscribe(NbpObserver);
+        }).subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         // should show 3 attempts
-        inOrder.verify(NbpObserver, times(NUM_RETRIES + 1)).onNext("beginningEveryTime");
+        inOrder.verify(observer, times(NUM_RETRIES + 1)).onNext("beginningEveryTime");
         // should have no errors
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         // should have a single success
-        inOrder.verify(NbpObserver, times(1)).onNext("onSuccessOnly");
+        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
         // should have a single successful onCompleted
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testOnCompletedFromNotificationHandler() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(1));
-        TestObserver<String> NbpSubscriber = new TestObserver<String>(NbpObserver);
+        TestObserver<String> to = new TestObserver<String>(observer);
         origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<?>>() {
             @Override
             public Observable<?> apply(Observable<? extends Throwable> t1) {
                 return Observable.empty();
             }
-        }).subscribe(NbpSubscriber);
+        }).subscribe(to);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver).onSubscribe((Disposable)notNull());
-        inOrder.verify(NbpObserver, never()).onNext("beginningEveryTime");
-        inOrder.verify(NbpObserver, never()).onNext("onSuccessOnly");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
-        inOrder.verify(NbpObserver, never()).onError(any(Exception.class));
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer).onSubscribe((Disposable)notNull());
+        inOrder.verify(observer, never()).onNext("beginningEveryTime");
+        inOrder.verify(observer, never()).onNext("onSuccessOnly");
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, never()).onError(any(Exception.class));
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testOnErrorFromNotificationHandler() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(2));
         origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<?>>() {
             @Override
             public Observable<?> apply(Observable<? extends Throwable> t1) {
                 return Observable.error(new RuntimeException());
             }
-        }).subscribe(NbpObserver);
+        }).subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver).onSubscribe((Disposable)notNull());
-        inOrder.verify(NbpObserver, never()).onNext("beginningEveryTime");
-        inOrder.verify(NbpObserver, never()).onNext("onSuccessOnly");
-        inOrder.verify(NbpObserver, never()).onComplete();
-        inOrder.verify(NbpObserver, times(1)).onError(any(IllegalStateException.class));
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer).onSubscribe((Disposable)notNull());
+        inOrder.verify(observer, never()).onNext("beginningEveryTime");
+        inOrder.verify(observer, never()).onNext("onSuccessOnly");
+        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(observer, times(1)).onError(any(IllegalStateException.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -244,11 +244,11 @@ public class ObservableRetryTest {
         final AtomicInteger inc = new AtomicInteger(0);
         ObservableSource<Integer> onSubscribe = new ObservableSource<Integer>() {
             @Override
-            public void subscribe(Observer<? super Integer> NbpSubscriber) {
-                NbpSubscriber.onSubscribe(Disposables.empty());
+            public void subscribe(Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposables.empty());
                 final int emit = inc.incrementAndGet();
-                NbpSubscriber.onNext(emit);
-                NbpSubscriber.onComplete();
+                observer.onNext(emit);
+                observer.onComplete();
             }
         };
 
@@ -266,77 +266,77 @@ public class ObservableRetryTest {
                 })
                 .blockingFirst();
 
-        assertEquals("NbpObserver did not receive the expected output", 1, first);
+        assertEquals("Observer did not receive the expected output", 1, first);
         assertEquals("Subscribe was not called once", 1, inc.get());
     }
 
     @Test
     public void testOriginFails() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(1));
-        origin.subscribe(NbpObserver);
+        origin.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext("beginningEveryTime");
-        inOrder.verify(NbpObserver, times(1)).onError(any(RuntimeException.class));
-        inOrder.verify(NbpObserver, never()).onNext("onSuccessOnly");
-        inOrder.verify(NbpObserver, never()).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext("beginningEveryTime");
+        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
+        inOrder.verify(observer, never()).onNext("onSuccessOnly");
+        inOrder.verify(observer, never()).onComplete();
     }
 
     @Test
     public void testRetryFail() {
         int NUM_RETRIES = 1;
         int NUM_FAILURES = 2;
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
-        origin.retry(NUM_RETRIES).subscribe(NbpObserver);
+        origin.retry(NUM_RETRIES).subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         // should show 2 attempts (first time fail, second time (1st retry) fail)
-        inOrder.verify(NbpObserver, times(1 + NUM_RETRIES)).onNext("beginningEveryTime");
+        inOrder.verify(observer, times(1 + NUM_RETRIES)).onNext("beginningEveryTime");
         // should only retry once, fail again and emit onError
-        inOrder.verify(NbpObserver, times(1)).onError(any(RuntimeException.class));
+        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
         // no success
-        inOrder.verify(NbpObserver, never()).onNext("onSuccessOnly");
-        inOrder.verify(NbpObserver, never()).onComplete();
+        inOrder.verify(observer, never()).onNext("onSuccessOnly");
+        inOrder.verify(observer, never()).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testRetrySuccess() {
         int NUM_FAILURES = 1;
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
-        origin.retry(3).subscribe(NbpObserver);
+        origin.retry(3).subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         // should show 3 attempts
-        inOrder.verify(NbpObserver, times(1 + NUM_FAILURES)).onNext("beginningEveryTime");
+        inOrder.verify(observer, times(1 + NUM_FAILURES)).onNext("beginningEveryTime");
         // should have no errors
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         // should have a single success
-        inOrder.verify(NbpObserver, times(1)).onNext("onSuccessOnly");
+        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
         // should have a single successful onCompleted
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testInfiniteRetry() {
         int NUM_FAILURES = 20;
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
-        origin.retry().subscribe(NbpObserver);
+        origin.retry().subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         // should show 3 attempts
-        inOrder.verify(NbpObserver, times(1 + NUM_FAILURES)).onNext("beginningEveryTime");
+        inOrder.verify(observer, times(1 + NUM_FAILURES)).onNext("beginningEveryTime");
         // should have no errors
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         // should have a single success
-        inOrder.verify(NbpObserver, times(1)).onNext("onSuccessOnly");
+        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
         // should have a single successful onCompleted
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -357,7 +357,7 @@ public class ObservableRetryTest {
         Consumer<Integer> throwException = mock(Consumer.class);
         doThrow(new RuntimeException()).when(throwException).accept(Mockito.anyInt());
 
-        // create a retrying NbpObservable based on a NbpPublishSubject
+        // create a retrying Observable based on a PublishSubject
         PublishSubject<Integer> subject = PublishSubject.create();
         subject
         // record item
@@ -531,9 +531,9 @@ public class ObservableRetryTest {
         }
 
         @Override
-        public void subscribe(final Observer<? super Long> NbpSubscriber) {
+        public void subscribe(final Observer<? super Long> observer) {
             final AtomicBoolean terminate = new AtomicBoolean(false);
-            NbpSubscriber.onSubscribe(Disposables.fromRunnable(new Runnable() {
+            observer.onSubscribe(Disposables.fromRunnable(new Runnable() {
                 @Override
                 public void run() {
                         terminate.set(true);
@@ -551,9 +551,9 @@ public class ObservableRetryTest {
                         while (!terminate.get()) {
                             Thread.sleep(emitDelay);
                             if (nextBeforeFailure.getAndDecrement() > 0) {
-                                NbpSubscriber.onNext(nr++);
+                                observer.onNext(nr++);
                             } else {
-                                NbpSubscriber.onError(new RuntimeException("expected-failed"));
+                                observer.onError(new RuntimeException("expected-failed"));
                             }
                         }
                     } catch (InterruptedException t) {
@@ -564,7 +564,7 @@ public class ObservableRetryTest {
         }
     }
 
-    /** NbpObserver for listener on seperate thread */
+    /** Observer for listener on seperate thread */
     static final class AsyncObserver<T> extends DefaultObserver<T> {
 
         protected CountDownLatch latch = new CountDownLatch(1);
@@ -572,7 +572,7 @@ public class ObservableRetryTest {
         protected Observer<T> target;
 
         /**
-         * Wrap existing NbpObserver
+         * Wrap existing Observer
          * @param target the target nbp subscriber
          */
         public AsyncObserver(Observer<T> target) {
@@ -588,7 +588,7 @@ public class ObservableRetryTest {
             }
         }
 
-        // NbpObserver implementation
+        // Observer implementation
 
         @Override
         public void onComplete() {
@@ -611,22 +611,22 @@ public class ObservableRetryTest {
     @Test(timeout = 10000)
     public void testUnsubscribeAfterError() {
 
-        Observer<Long> NbpObserver = TestHelper.mockObserver();
+        Observer<Long> observer = TestHelper.mockObserver();
 
-        // NbpObservable that always fails after 100ms
+        // Observable that always fails after 100ms
         SlowObservable so = new SlowObservable(100, 0);
         Observable<Long> o = Observable.unsafeCreate(so).retry(5);
 
-        AsyncObserver<Long> async = new AsyncObserver<Long>(NbpObserver);
+        AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
 
         o.subscribe(async);
 
         async.await();
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         // Should fail once
-        inOrder.verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        inOrder.verify(NbpObserver, never()).onComplete();
+        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onComplete();
 
         assertEquals("Start 6 threads, retry 5 then fail on 6", 6, so.efforts.get());
         assertEquals("Only 1 active subscription", 1, so.maxActive.get());
@@ -636,22 +636,22 @@ public class ObservableRetryTest {
     public void testTimeoutWithRetry() {
 
         @SuppressWarnings("unchecked")
-        DefaultObserver<Long> NbpObserver = mock(DefaultObserver.class);
+        DefaultObserver<Long> observer = mock(DefaultObserver.class);
 
-        // NbpObservable that sends every 100ms (timeout fails instead)
+        // Observable that sends every 100ms (timeout fails instead)
         SlowObservable so = new SlowObservable(100, 10);
         Observable<Long> o = Observable.unsafeCreate(so).timeout(80, TimeUnit.MILLISECONDS).retry(5);
 
-        AsyncObserver<Long> async = new AsyncObserver<Long>(NbpObserver);
+        AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
 
         o.subscribe(async);
 
         async.await();
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         // Should fail once
-        inOrder.verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        inOrder.verify(NbpObserver, never()).onComplete();
+        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onComplete();
 
         assertEquals("Start 6 threads, retry 5 then fail on 6", 6, so.efforts.get());
     }
@@ -662,21 +662,21 @@ public class ObservableRetryTest {
         for (int j=0;j<NUM_LOOPS;j++) {
             final int NUM_RETRIES = Flowable.bufferSize() * 2;
             for (int i = 0; i < 400; i++) {
-                Observer<String> NbpObserver = TestHelper.mockObserver();
+                Observer<String> observer = TestHelper.mockObserver();
                 Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
-                TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+                TestObserver<String> ts = new TestObserver<String>(observer);
                 origin.retry().observeOn(Schedulers.computation()).subscribe(ts);
                 ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
 
-                InOrder inOrder = inOrder(NbpObserver);
+                InOrder inOrder = inOrder(observer);
                 // should have no errors
-                verify(NbpObserver, never()).onError(any(Throwable.class));
+                verify(observer, never()).onError(any(Throwable.class));
                 // should show NUM_RETRIES attempts
-                inOrder.verify(NbpObserver, times(NUM_RETRIES + 1)).onNext("beginningEveryTime");
+                inOrder.verify(observer, times(NUM_RETRIES + 1)).onNext("beginningEveryTime");
                 // should have a single success
-                inOrder.verify(NbpObserver, times(1)).onNext("onSuccessOnly");
+                inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
                 // should have a single successful onCompleted
-                inOrder.verify(NbpObserver, times(1)).onComplete();
+                inOrder.verify(observer, times(1)).onComplete();
                 inOrder.verifyNoMoreInteractions();
             }
         }
@@ -783,7 +783,7 @@ public class ObservableRetryTest {
     }
     @Test//(timeout = 3000)
     public void testIssue1900() throws InterruptedException {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         final int NUM_MSG = 1034;
         final AtomicInteger count = new AtomicInteger();
 
@@ -808,22 +808,22 @@ public class ObservableRetryTest {
                 return t1.take(1);
             }
         })
-        .subscribe(new TestObserver<String>(NbpObserver));
+        .subscribe(new TestObserver<String>(observer));
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         // should show 3 attempts
-        inOrder.verify(NbpObserver, times(NUM_MSG)).onNext(any(java.lang.String.class));
+        inOrder.verify(observer, times(NUM_MSG)).onNext(any(java.lang.String.class));
         //        // should have no errors
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         // should have a single success
-        //inOrder.verify(NbpObserver, times(1)).onNext("onSuccessOnly");
+        //inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
         // should have a single successful onCompleted
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
     @Test//(timeout = 3000)
     public void testIssue1900SourceNotSupportingBackpressure() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         final int NUM_MSG = 1034;
         final AtomicInteger count = new AtomicInteger();
 
@@ -852,17 +852,17 @@ public class ObservableRetryTest {
                 return t1.take(1);
             }
         })
-        .subscribe(new TestObserver<String>(NbpObserver));
+        .subscribe(new TestObserver<String>(observer));
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         // should show 3 attempts
-        inOrder.verify(NbpObserver, times(NUM_MSG)).onNext(any(java.lang.String.class));
+        inOrder.verify(observer, times(NUM_MSG)).onNext(any(java.lang.String.class));
         //        // should have no errors
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         // should have a single success
-        //inOrder.verify(NbpObserver, times(1)).onNext("onSuccessOnly");
+        //inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
         // should have a single successful onCompleted
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -225,24 +225,24 @@ public class ObservableRetryWithPredicateTest {
     @Test(timeout = 10000)
     public void testUnsubscribeAfterError() {
 
-        Observer<Long> NbpObserver = TestHelper.mockObserver();
+        Observer<Long> observer = TestHelper.mockObserver();
 
-        // NbpObservable that always fails after 100ms
+        // Observable that always fails after 100ms
         ObservableRetryTest.SlowObservable so = new ObservableRetryTest.SlowObservable(100, 0);
         Observable<Long> o = Observable
                 .unsafeCreate(so)
                 .retry(retry5);
 
-        ObservableRetryTest.AsyncObserver<Long> async = new ObservableRetryTest.AsyncObserver<Long>(NbpObserver);
+        ObservableRetryTest.AsyncObserver<Long> async = new ObservableRetryTest.AsyncObserver<Long>(observer);
 
         o.subscribe(async);
 
         async.await();
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         // Should fail once
-        inOrder.verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        inOrder.verify(NbpObserver, never()).onComplete();
+        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onComplete();
 
         assertEquals("Start 6 threads, retry 5 then fail on 6", 6, so.efforts.get());
         assertEquals("Only 1 active subscription", 1, so.maxActive.get());
@@ -251,25 +251,25 @@ public class ObservableRetryWithPredicateTest {
     @Test(timeout = 10000)
     public void testTimeoutWithRetry() {
 
-        Observer<Long> NbpObserver = TestHelper.mockObserver();
+        Observer<Long> observer = TestHelper.mockObserver();
 
-        // NbpObservable that sends every 100ms (timeout fails instead)
+        // Observable that sends every 100ms (timeout fails instead)
         ObservableRetryTest.SlowObservable so = new ObservableRetryTest.SlowObservable(100, 10);
         Observable<Long> o = Observable
                 .unsafeCreate(so)
                 .timeout(80, TimeUnit.MILLISECONDS)
                 .retry(retry5);
 
-        ObservableRetryTest.AsyncObserver<Long> async = new ObservableRetryTest.AsyncObserver<Long>(NbpObserver);
+        ObservableRetryTest.AsyncObserver<Long> async = new ObservableRetryTest.AsyncObserver<Long>(observer);
 
         o.subscribe(async);
 
         async.await();
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
         // Should fail once
-        inOrder.verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        inOrder.verify(NbpObserver, never()).onComplete();
+        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onComplete();
 
         assertEquals("Start 6 threads, retry 5 then fail on 6", 6, so.efforts.get());
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSampleTest.java
@@ -29,7 +29,7 @@ import io.reactivex.subjects.PublishSubject;
 public class ObservableSampleTest {
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
-    private Observer<Long> NbpObserver;
+    private Observer<Long> observer;
     private Observer<Object> observer2;
 
     @Before
@@ -37,7 +37,7 @@ public class ObservableSampleTest {
     public void before() {
         scheduler = new TestScheduler();
         innerScheduler = scheduler.createWorker();
-        NbpObserver = TestHelper.mockObserver();
+        observer = TestHelper.mockObserver();
         observer2 = TestHelper.mockObserver();
     }
 
@@ -69,38 +69,38 @@ public class ObservableSampleTest {
         });
 
         Observable<Long> sampled = source.sample(400L, TimeUnit.MILLISECONDS, scheduler);
-        sampled.subscribe(NbpObserver);
+        sampled.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
         scheduler.advanceTimeTo(800L, TimeUnit.MILLISECONDS);
-        verify(NbpObserver, never()).onNext(any(Long.class));
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(any(Long.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(1200L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, times(1)).onNext(1L);
-        verify(NbpObserver, never()).onNext(2L);
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext(1L);
+        verify(observer, never()).onNext(2L);
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(1600L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(1L);
-        verify(NbpObserver, never()).onNext(2L);
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(1L);
+        verify(observer, never()).onNext(2L);
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(1L);
-        inOrder.verify(NbpObserver, times(1)).onNext(2L);
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(1L);
+        inOrder.verify(observer, times(1)).onNext(2L);
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(3000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(NbpObserver, never()).onNext(1L);
-        inOrder.verify(NbpObserver, never()).onNext(2L);
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onNext(1L);
+        inOrder.verify(observer, never()).onNext(2L);
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -126,7 +126,7 @@ public class ObservableSampleTest {
         inOrder.verify(observer2, never()).onNext(3);
         inOrder.verify(observer2, times(1)).onNext(4);
         inOrder.verify(observer2, times(1)).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -156,7 +156,7 @@ public class ObservableSampleTest {
         inOrder.verify(observer2, never()).onNext(3);
         inOrder.verify(observer2, times(1)).onNext(4);
         inOrder.verify(observer2, times(1)).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -180,7 +180,7 @@ public class ObservableSampleTest {
         inOrder.verify(observer2, times(1)).onNext(2);
         inOrder.verify(observer2, times(1)).onComplete();
         inOrder.verify(observer2, never()).onNext(any());
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -205,7 +205,7 @@ public class ObservableSampleTest {
         inOrder.verify(observer2, never()).onNext(3);
         inOrder.verify(observer2, times(1)).onComplete();
         inOrder.verify(observer2, never()).onNext(any());
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -222,7 +222,7 @@ public class ObservableSampleTest {
         InOrder inOrder = inOrder(observer2);
         inOrder.verify(observer2, times(1)).onComplete();
         verify(observer2, never()).onNext(any());
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -240,7 +240,7 @@ public class ObservableSampleTest {
         InOrder inOrder = inOrder(observer2);
         inOrder.verify(observer2, times(1)).onError(any(Throwable.class));
         verify(observer2, never()).onNext(any());
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, never()).onComplete();
     }
 
     @Test
@@ -258,7 +258,7 @@ public class ObservableSampleTest {
         InOrder inOrder = inOrder(observer2);
         inOrder.verify(observer2, times(1)).onNext(1);
         inOrder.verify(observer2, times(1)).onError(any(RuntimeException.class));
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, never()).onComplete();
     }
 
     @Test
@@ -267,8 +267,8 @@ public class ObservableSampleTest {
         Observable<Integer> o = Observable.unsafeCreate(
                 new ObservableSource<Integer>() {
                     @Override
-                    public void subscribe(Observer<? super Integer> NbpSubscriber) {
-                        NbpSubscriber.onSubscribe(s);
+                    public void subscribe(Observer<? super Integer> observer) {
+                        observer.onSubscribe(s);
                     }
                 }
         );

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableScanTest.java
@@ -34,7 +34,7 @@ public class ObservableScanTest {
 
     @Test
     public void testScanIntegersWithInitialValue() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<Integer> o = Observable.just(1, 2, 3);
 
@@ -46,21 +46,21 @@ public class ObservableScanTest {
             }
 
         });
-        m.subscribe(NbpObserver);
+        m.subscribe(observer);
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onNext("");
-        verify(NbpObserver, times(1)).onNext("1");
-        verify(NbpObserver, times(1)).onNext("12");
-        verify(NbpObserver, times(1)).onNext("123");
-        verify(NbpObserver, times(4)).onNext(anyString());
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onNext("");
+        verify(observer, times(1)).onNext("1");
+        verify(observer, times(1)).onNext("12");
+        verify(observer, times(1)).onNext("123");
+        verify(observer, times(4)).onNext(anyString());
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testScanIntegersWithoutInitialValue() {
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
         Observable<Integer> o = Observable.just(1, 2, 3);
 
@@ -72,21 +72,21 @@ public class ObservableScanTest {
             }
 
         });
-        m.subscribe(NbpObserver);
+        m.subscribe(observer);
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onNext(0);
-        verify(NbpObserver, times(1)).onNext(1);
-        verify(NbpObserver, times(1)).onNext(3);
-        verify(NbpObserver, times(1)).onNext(6);
-        verify(NbpObserver, times(3)).onNext(anyInt());
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(0);
+        verify(observer, times(1)).onNext(1);
+        verify(observer, times(1)).onNext(3);
+        verify(observer, times(1)).onNext(6);
+        verify(observer, times(3)).onNext(anyInt());
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testScanIntegersWithoutInitialValueAndOnlyOneValue() {
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
         Observable<Integer> o = Observable.just(1);
 
@@ -98,14 +98,14 @@ public class ObservableScanTest {
             }
 
         });
-        m.subscribe(NbpObserver);
+        m.subscribe(observer);
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onNext(0);
-        verify(NbpObserver, times(1)).onNext(1);
-        verify(NbpObserver, times(1)).onNext(anyInt());
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(0);
+        verify(observer, times(1)).onNext(1);
+        verify(observer, times(1)).onNext(anyInt());
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -203,11 +203,11 @@ public class ObservableScanTest {
             }
 
         }).take(1);
-        TestObserver<Integer> NbpSubscriber = new TestObserver<Integer>();
-        o.subscribe(NbpSubscriber);
-        NbpSubscriber.assertValue(0);
-        NbpSubscriber.assertTerminated();
-        NbpSubscriber.assertNoErrors();
+        TestObserver<Integer> observer = new TestObserver<Integer>();
+        o.subscribe(observer);
+        observer.assertValue(0);
+        observer.assertTerminated();
+        observer.assertNoErrors();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
@@ -130,22 +130,22 @@ public class ObservableSequenceEqualTest {
     }
 
     private void verifyResult(Observable<Boolean> o, boolean result) {
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
+        Observer<Boolean> observer = TestHelper.mockObserver();
 
-        o.subscribe(NbpObserver);
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(result);
-        inOrder.verify(NbpObserver).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(result);
+        inOrder.verify(observer).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
-    private void verifyError(Observable<Boolean> NbpObservable) {
-        Observer<Boolean> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
+    private void verifyError(Observable<Boolean> observable) {
+        Observer<Boolean> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(isA(TestException.class));
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(isA(TestException.class));
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
@@ -31,12 +31,12 @@ public class ObservableSingleTest {
     public void testSingle() {
         Observable<Integer> o = Observable.just(1).single();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(1);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -44,11 +44,11 @@ public class ObservableSingleTest {
     public void testSingleWithTooManyElements() {
         Observable<Integer> o = Observable.just(1, 2).single();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
                 isA(IllegalArgumentException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -57,11 +57,11 @@ public class ObservableSingleTest {
     public void testSingleWithEmpty() {
         Observable<Integer> o = Observable.<Integer> empty().single();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
                 isA(NoSuchElementException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -79,12 +79,12 @@ public class ObservableSingleTest {
                 })
                 .single();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -101,11 +101,11 @@ public class ObservableSingleTest {
                 })
                 .single();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
                 isA(IllegalArgumentException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -122,11 +122,11 @@ public class ObservableSingleTest {
                     }
                 })
                 .single();
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
                 isA(NoSuchElementException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -135,12 +135,12 @@ public class ObservableSingleTest {
     public void testSingleOrDefault() {
         Observable<Integer> o = Observable.just(1).single(2);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(1);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -148,11 +148,11 @@ public class ObservableSingleTest {
     public void testSingleOrDefaultWithTooManyElements() {
         Observable<Integer> o = Observable.just(1, 2).single(3);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
                 isA(IllegalArgumentException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -162,12 +162,12 @@ public class ObservableSingleTest {
         Observable<Integer> o = Observable.<Integer> empty()
                 .single(1);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(1);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(1);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -182,12 +182,12 @@ public class ObservableSingleTest {
                 })
                 .single(4);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -202,11 +202,11 @@ public class ObservableSingleTest {
                 })
                 .single(6);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
                 isA(IllegalArgumentException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -222,12 +222,12 @@ public class ObservableSingleTest {
                 })
                 .single(2);
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTest.java
@@ -32,49 +32,49 @@ public class ObservableSkipLastTest {
     public void testSkipLastEmpty() {
         Observable<String> o = Observable.<String> empty().skipLast(2);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
-        verify(NbpObserver, never()).onNext(any(String.class));
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
+        verify(observer, never()).onNext(any(String.class));
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testSkipLast1() {
         Observable<String> o = Observable.fromIterable(Arrays.asList("one", "two", "three")).skipLast(2);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        InOrder inOrder = inOrder(NbpObserver);
-        o.subscribe(NbpObserver);
-        inOrder.verify(NbpObserver, never()).onNext("two");
-        inOrder.verify(NbpObserver, never()).onNext("three");
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        InOrder inOrder = inOrder(observer);
+        o.subscribe(observer);
+        inOrder.verify(observer, never()).onNext("two");
+        inOrder.verify(observer, never()).onNext("three");
+        verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testSkipLast2() {
         Observable<String> o = Observable.fromIterable(Arrays.asList("one", "two")).skipLast(2);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
-        verify(NbpObserver, never()).onNext(any(String.class));
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
+        verify(observer, never()).onNext(any(String.class));
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testSkipLastWithZeroCount() {
         Observable<String> w = Observable.just("one", "two");
-        Observable<String> NbpObservable = w.skipLast(0);
+        Observable<String> observable = w.skipLast(0);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, times(1)).onNext("two");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -82,13 +82,13 @@ public class ObservableSkipLastTest {
     public void testSkipLastWithNull() {
         Observable<String> o = Observable.fromIterable(Arrays.asList("one", null, "two")).skipLast(1);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        o.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, times(1)).onNext(null);
-        verify(NbpObserver, never()).onNext("two");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        o.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext(null);
+        verify(observer, never()).onNext("two");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipTest.java
@@ -31,13 +31,13 @@ public class ObservableSkipTest {
 
         Observable<String> skip = Observable.just("one", "two", "three").skip(-99);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        skip.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, times(1)).onNext("two");
-        verify(NbpObserver, times(1)).onNext("three");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        skip.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -45,13 +45,13 @@ public class ObservableSkipTest {
 
         Observable<String> skip = Observable.just("one", "two", "three").skip(0);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        skip.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, times(1)).onNext("two");
-        verify(NbpObserver, times(1)).onNext("three");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        skip.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -59,13 +59,13 @@ public class ObservableSkipTest {
 
         Observable<String> skip = Observable.just("one", "two", "three").skip(1);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        skip.subscribe(NbpObserver);
-        verify(NbpObserver, never()).onNext("one");
-        verify(NbpObserver, times(1)).onNext("two");
-        verify(NbpObserver, times(1)).onNext("three");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        skip.subscribe(observer);
+        verify(observer, never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -73,13 +73,13 @@ public class ObservableSkipTest {
 
         Observable<String> skip = Observable.just("one", "two", "three").skip(2);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        skip.subscribe(NbpObserver);
-        verify(NbpObserver, never()).onNext("one");
-        verify(NbpObserver, never()).onNext("two");
-        verify(NbpObserver, times(1)).onNext("three");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        skip.subscribe(observer);
+        verify(observer, never()).onNext("one");
+        verify(observer, never()).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -88,11 +88,11 @@ public class ObservableSkipTest {
         Observable<String> w = Observable.empty();
         Observable<String> skip = w.skip(1);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        skip.subscribe(NbpObserver);
-        verify(NbpObserver, never()).onNext(any(String.class));
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        skip.subscribe(observer);
+        verify(observer, never()).onNext(any(String.class));
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -126,12 +126,12 @@ public class ObservableSkipTest {
 
         Observable<String> skip = Observable.concat(ok, error).skip(100);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        skip.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        skip.subscribe(observer);
 
-        verify(NbpObserver, never()).onNext(any(String.class));
-        verify(NbpObserver, times(1)).onError(e);
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, never()).onNext(any(String.class));
+        verify(observer, times(1)).onError(e);
+        verify(observer, never()).onComplete();
 
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipUntilTest.java
@@ -22,11 +22,11 @@ import io.reactivex.*;
 import io.reactivex.subjects.PublishSubject;
 
 public class ObservableSkipUntilTest {
-    Observer<Object> NbpObserver;
+    Observer<Object> observer;
 
     @Before
     public void before() {
-        NbpObserver = TestHelper.mockObserver();
+        observer = TestHelper.mockObserver();
     }
 
     @Test
@@ -35,7 +35,7 @@ public class ObservableSkipUntilTest {
         PublishSubject<Integer> other = PublishSubject.create();
 
         Observable<Integer> m = source.skipUntil(other);
-        m.subscribe(NbpObserver);
+        m.subscribe(observer);
 
         source.onNext(0);
         source.onNext(1);
@@ -47,11 +47,11 @@ public class ObservableSkipUntilTest {
         source.onNext(4);
         source.onComplete();
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onNext(2);
-        verify(NbpObserver, times(1)).onNext(3);
-        verify(NbpObserver, times(1)).onNext(4);
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onNext(2);
+        verify(observer, times(1)).onNext(3);
+        verify(observer, times(1)).onNext(4);
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -60,7 +60,7 @@ public class ObservableSkipUntilTest {
 
         Observable<Integer> m = source.skipUntil(Observable.never());
 
-        m.subscribe(NbpObserver);
+        m.subscribe(observer);
 
         source.onNext(0);
         source.onNext(1);
@@ -69,9 +69,9 @@ public class ObservableSkipUntilTest {
         source.onNext(4);
         source.onComplete();
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onNext(any());
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(any());
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -80,11 +80,11 @@ public class ObservableSkipUntilTest {
 
         Observable<Integer> m = source.skipUntil(Observable.empty());
 
-        m.subscribe(NbpObserver);
+        m.subscribe(observer);
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onNext(any());
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onNext(any());
+        verify(observer, never()).onComplete();
     }
 
     @Test
@@ -93,7 +93,7 @@ public class ObservableSkipUntilTest {
         PublishSubject<Integer> other = PublishSubject.create();
 
         Observable<Integer> m = source.skipUntil(other);
-        m.subscribe(NbpObserver);
+        m.subscribe(observer);
 
         source.onNext(0);
         source.onNext(1);
@@ -106,11 +106,11 @@ public class ObservableSkipUntilTest {
         source.onNext(4);
         source.onComplete();
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onNext(2);
-        verify(NbpObserver, times(1)).onNext(3);
-        verify(NbpObserver, times(1)).onNext(4);
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onNext(2);
+        verify(observer, times(1)).onNext(3);
+        verify(observer, times(1)).onNext(4);
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -119,7 +119,7 @@ public class ObservableSkipUntilTest {
         PublishSubject<Integer> other = PublishSubject.create();
 
         Observable<Integer> m = source.skipUntil(other);
-        m.subscribe(NbpObserver);
+        m.subscribe(observer);
 
         source.onNext(0);
         source.onNext(1);
@@ -130,9 +130,9 @@ public class ObservableSkipUntilTest {
         source.onNext(2);
         source.onError(new RuntimeException("Forced failure"));
 
-        verify(NbpObserver, times(1)).onNext(2);
-        verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, times(1)).onNext(2);
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
     }
 
     @Test
@@ -141,15 +141,15 @@ public class ObservableSkipUntilTest {
         PublishSubject<Integer> other = PublishSubject.create();
 
         Observable<Integer> m = source.skipUntil(other);
-        m.subscribe(NbpObserver);
+        m.subscribe(observer);
 
         source.onNext(0);
         source.onNext(1);
 
         other.onError(new RuntimeException("Forced failure"));
 
-        verify(NbpObserver, never()).onNext(any());
-        verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, never()).onNext(any());
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
@@ -34,14 +34,14 @@ public class ObservableSubscribeOnTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(1);
 
-        TestObserver<Integer> NbpObserver = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable
         .unsafeCreate(new ObservableSource<Integer>() {
             @Override
             public void subscribe(
-                    final Observer<? super Integer> NbpSubscriber) {
-                NbpSubscriber.onSubscribe(Disposables.empty());
+                    final Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposables.empty());
                 scheduled.countDown();
                 try {
                     try {
@@ -51,27 +51,27 @@ public class ObservableSubscribeOnTest {
                         // ... but we'll pretend we are like many Observables that ignore interrupts
                     }
 
-                    NbpSubscriber.onComplete();
+                    observer.onComplete();
                 } catch (Throwable e) {
-                    NbpSubscriber.onError(e);
+                    observer.onError(e);
                 } finally {
                     doneLatch.countDown();
                 }
             }
-        }).subscribeOn(Schedulers.computation()).subscribe(NbpObserver);
+        }).subscribeOn(Schedulers.computation()).subscribe(to);
 
         // wait for scheduling
         scheduled.await();
         // trigger unsubscribe
-        NbpObserver.dispose();
+        to.dispose();
         latch.countDown();
         doneLatch.await();
-        NbpObserver.assertNoErrors();
-        NbpObserver.assertComplete();
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
-    @Ignore("ObservableConsumable.subscribe can't throw")
+    @Ignore("ObservableSource.subscribe can't throw")
     public void testThrownErrorHandling() {
         TestObserver<String> ts = new TestObserver<String>();
         Observable.unsafeCreate(new ObservableSource<String>() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchIfEmptyTest.java
@@ -59,9 +59,9 @@ public class ObservableSwitchIfEmptyTest {
 
         Observable<Long> withProducer = Observable.unsafeCreate(new ObservableSource<Long>() {
             @Override
-            public void subscribe(final Observer<? super Long> NbpSubscriber) {
-                NbpSubscriber.onSubscribe(d);
-                NbpSubscriber.onNext(42L);
+            public void subscribe(final Observer<? super Long> observer) {
+                observer.onSubscribe(d);
+                observer.onNext(42L);
             }
         });
 
@@ -102,9 +102,9 @@ public class ObservableSwitchIfEmptyTest {
 
         Observable.unsafeCreate(new ObservableSource<Long>() {
             @Override
-            public void subscribe(final Observer<? super Long> NbpSubscriber) {
-                NbpSubscriber.onSubscribe(d);
-                NbpSubscriber.onComplete();
+            public void subscribe(final Observer<? super Long> observer) {
+                observer.onSubscribe(d);
+                observer.onComplete();
             }
         }).switchIfEmpty(Observable.<Long>never()).subscribe();
         assertTrue(d.isDisposed());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
@@ -51,18 +51,18 @@ public class ObservableSwitchTest {
     public void testSwitchWhenOuterCompleteBeforeInner() {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
-            public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
+            public void subscribe(Observer<? super Observable<String>> outerObserver) {
+                outerObserver.onSubscribe(Disposables.empty());
+                publishNext(outerObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishNext(NbpObserver, 70, "one");
-                        publishNext(NbpObserver, 100, "two");
-                        publishCompleted(NbpObserver, 200);
+                    public void subscribe(Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishNext(innerObserver, 70, "one");
+                        publishNext(innerObserver, 100, "two");
+                        publishCompleted(innerObserver, 200);
                     }
                 }));
-                publishCompleted(NbpObserver, 60);
+                publishCompleted(outerObserver, 60);
             }
         });
 
@@ -80,28 +80,28 @@ public class ObservableSwitchTest {
     public void testSwitchWhenInnerCompleteBeforeOuter() {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
-            public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                publishNext(NbpObserver, 10, Observable.unsafeCreate(new ObservableSource<String>() {
+            public void subscribe(Observer<? super Observable<String>> outerObserver) {
+                outerObserver.onSubscribe(Disposables.empty());
+                publishNext(outerObserver, 10, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishNext(NbpObserver, 0, "one");
-                        publishNext(NbpObserver, 10, "two");
-                        publishCompleted(NbpObserver, 20);
+                    public void subscribe(Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishNext(innerObserver, 0, "one");
+                        publishNext(innerObserver, 10, "two");
+                        publishCompleted(innerObserver, 20);
                     }
                 }));
 
-                publishNext(NbpObserver, 100, Observable.unsafeCreate(new ObservableSource<String>() {
+                publishNext(outerObserver, 100, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishNext(NbpObserver, 0, "three");
-                        publishNext(NbpObserver, 10, "four");
-                        publishCompleted(NbpObserver, 20);
+                    public void subscribe(Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishNext(innerObserver, 0, "three");
+                        publishNext(innerObserver, 10, "four");
+                        publishCompleted(innerObserver, 20);
                     }
                 }));
-                publishCompleted(NbpObserver, 200);
+                publishCompleted(outerObserver, 200);
             }
         });
 
@@ -126,27 +126,27 @@ public class ObservableSwitchTest {
     public void testSwitchWithComplete() {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
-            public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
+            public void subscribe(Observer<? super Observable<String>> outerObserver) {
+                outerObserver.onSubscribe(Disposables.empty());
+                publishNext(outerObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(final Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishNext(NbpObserver, 60, "one");
-                        publishNext(NbpObserver, 100, "two");
+                    public void subscribe(final Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishNext(innerObserver, 60, "one");
+                        publishNext(innerObserver, 100, "two");
                     }
                 }));
 
-                publishNext(NbpObserver, 200, Observable.unsafeCreate(new ObservableSource<String>() {
+                publishNext(outerObserver, 200, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(final Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishNext(NbpObserver, 0, "three");
-                        publishNext(NbpObserver, 100, "four");
+                    public void subscribe(final Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishNext(innerObserver, 0, "three");
+                        publishNext(innerObserver, 100, "four");
                     }
                 }));
 
-                publishCompleted(NbpObserver, 250);
+                publishCompleted(outerObserver, 250);
             }
         });
 
@@ -185,27 +185,27 @@ public class ObservableSwitchTest {
     public void testSwitchWithError() {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
-            public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
+            public void subscribe(Observer<? super Observable<String>> outerObserver) {
+                outerObserver.onSubscribe(Disposables.empty());
+                publishNext(outerObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(final Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishNext(NbpObserver, 50, "one");
-                        publishNext(NbpObserver, 100, "two");
+                    public void subscribe(final Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishNext(innerObserver, 50, "one");
+                        publishNext(innerObserver, 100, "two");
                     }
                 }));
 
-                publishNext(NbpObserver, 200, Observable.unsafeCreate(new ObservableSource<String>() {
+                publishNext(outerObserver, 200, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishNext(NbpObserver, 0, "three");
-                        publishNext(NbpObserver, 100, "four");
+                    public void subscribe(Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishNext(innerObserver, 0, "three");
+                        publishNext(innerObserver, 100, "four");
                     }
                 }));
 
-                publishError(NbpObserver, 250, new TestException());
+                publishError(outerObserver, 250, new TestException());
             }
         });
 
@@ -244,30 +244,30 @@ public class ObservableSwitchTest {
     public void testSwitchWithSubsequenceComplete() {
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
-            public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                publishNext(NbpObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
+            public void subscribe(Observer<? super Observable<String>> outerObserver) {
+                outerObserver.onSubscribe(Disposables.empty());
+                publishNext(outerObserver, 50, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishNext(NbpObserver, 50, "one");
-                        publishNext(NbpObserver, 100, "two");
+                    public void subscribe(Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishNext(innerObserver, 50, "one");
+                        publishNext(innerObserver, 100, "two");
                     }
                 }));
 
-                publishNext(NbpObserver, 130, Observable.unsafeCreate(new ObservableSource<String>() {
+                publishNext(outerObserver, 130, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishCompleted(NbpObserver, 0);
+                    public void subscribe(Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishCompleted(innerObserver, 0);
                     }
                 }));
 
-                publishNext(NbpObserver, 150, Observable.unsafeCreate(new ObservableSource<String>() {
+                publishNext(outerObserver, 150, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishNext(NbpObserver, 50, "three");
+                    public void subscribe(Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishNext(innerObserver, 50, "three");
                     }
                 }));
             }
@@ -349,20 +349,20 @@ public class ObservableSwitchTest {
         verify(observer, times(1)).onError(any(TestException.class));
     }
 
-    private <T> void publishCompleted(final Observer<T> NbpObserver, long delay) {
+    private <T> void publishCompleted(final Observer<T> observer, long delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                NbpObserver.onComplete();
+                observer.onComplete();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private <T> void publishError(final Observer<T> NbpObserver, long delay, final Throwable error) {
+    private <T> void publishError(final Observer<T> observer, long delay, final Throwable error) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                NbpObserver.onError(error);
+                observer.onError(error);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
@@ -381,30 +381,30 @@ public class ObservableSwitchTest {
         // https://github.com/ReactiveX/RxJava/issues/737
         Observable<Observable<String>> source = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
             @Override
-            public void subscribe(Observer<? super Observable<String>> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                publishNext(NbpObserver, 0, Observable.unsafeCreate(new ObservableSource<String>() {
+            public void subscribe(Observer<? super Observable<String>> outerObserver) {
+                outerObserver.onSubscribe(Disposables.empty());
+                publishNext(outerObserver, 0, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishNext(NbpObserver, 10, "1-one");
-                        publishNext(NbpObserver, 20, "1-two");
+                    public void subscribe(Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishNext(innerObserver, 10, "1-one");
+                        publishNext(innerObserver, 20, "1-two");
                         // The following events will be ignored
-                        publishNext(NbpObserver, 30, "1-three");
-                        publishCompleted(NbpObserver, 40);
+                        publishNext(innerObserver, 30, "1-three");
+                        publishCompleted(innerObserver, 40);
                     }
                 }));
-                publishNext(NbpObserver, 25, Observable.unsafeCreate(new ObservableSource<String>() {
+                publishNext(outerObserver, 25, Observable.unsafeCreate(new ObservableSource<String>() {
                     @Override
-                    public void subscribe(Observer<? super String> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        publishNext(NbpObserver, 10, "2-one");
-                        publishNext(NbpObserver, 20, "2-two");
-                        publishNext(NbpObserver, 30, "2-three");
-                        publishCompleted(NbpObserver, 40);
+                    public void subscribe(Observer<? super String> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        publishNext(innerObserver, 10, "2-one");
+                        publishNext(innerObserver, 20, "2-two");
+                        publishNext(innerObserver, 30, "2-three");
+                        publishCompleted(innerObserver, 40);
                     }
                 }));
-                publishCompleted(NbpObserver, 30);
+                publishCompleted(outerObserver, 30);
             }
         });
 
@@ -429,10 +429,10 @@ public class ObservableSwitchTest {
         Observable.switchOnNext(
                 Observable.unsafeCreate(new ObservableSource<Observable<Integer>>() {
                     @Override
-                    public void subscribe(final Observer<? super Observable<Integer>> NbpSubscriber) {
+                    public void subscribe(final Observer<? super Observable<Integer>> observer) {
                         Disposable bs = Disposables.empty();
-                        NbpSubscriber.onSubscribe(bs);
-                        NbpSubscriber.onNext(Observable.just(1));
+                        observer.onSubscribe(bs);
+                        observer.onNext(Observable.just(1));
                         isUnsubscribed.set(bs.isDisposed());
                     }
                 })

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTest.java
@@ -34,11 +34,11 @@ public class ObservableTakeLastTest {
         Observable<String> w = Observable.empty();
         Observable<String> take = w.takeLast(2);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        take.subscribe(NbpObserver);
-        verify(NbpObserver, never()).onNext(any(String.class));
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        take.subscribe(observer);
+        verify(observer, never()).onNext(any(String.class));
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -46,14 +46,14 @@ public class ObservableTakeLastTest {
         Observable<String> w = Observable.just("one", "two", "three");
         Observable<String> take = w.takeLast(2);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        InOrder inOrder = inOrder(NbpObserver);
-        take.subscribe(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext("two");
-        inOrder.verify(NbpObserver, times(1)).onNext("three");
-        verify(NbpObserver, never()).onNext("one");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        InOrder inOrder = inOrder(observer);
+        take.subscribe(observer);
+        inOrder.verify(observer, times(1)).onNext("two");
+        inOrder.verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onNext("one");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -61,11 +61,11 @@ public class ObservableTakeLastTest {
         Observable<String> w = Observable.just("one");
         Observable<String> take = w.takeLast(10);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        take.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        take.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -73,11 +73,11 @@ public class ObservableTakeLastTest {
         Observable<String> w = Observable.just("one");
         Observable<String> take = w.takeLast(0);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        take.subscribe(NbpObserver);
-        verify(NbpObserver, never()).onNext("one");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        take.subscribe(observer);
+        verify(observer, never()).onNext("one");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -86,13 +86,13 @@ public class ObservableTakeLastTest {
         Observable<String> w = Observable.just("one", null, "three");
         Observable<String> take = w.takeLast(2);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        take.subscribe(NbpObserver);
-        verify(NbpObserver, never()).onNext("one");
-        verify(NbpObserver, times(1)).onNext(null);
-        verify(NbpObserver, times(1)).onNext("three");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        take.subscribe(observer);
+        verify(observer, never()).onNext("one");
+        verify(observer, times(1)).onNext(null);
+        verify(observer, times(1)).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test(expected = IndexOutOfBoundsException.class)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
@@ -39,13 +39,13 @@ public class ObservableTakeTest {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
         Observable<String> take = w.take(2);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        take.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, times(1)).onNext("two");
-        verify(NbpObserver, never()).onNext("three");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        take.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, never()).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -53,13 +53,13 @@ public class ObservableTakeTest {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
         Observable<String> take = w.take(1);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        take.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onNext("two");
-        verify(NbpObserver, never()).onNext("three");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        take.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onNext("two");
+        verify(observer, never()).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -83,10 +83,10 @@ public class ObservableTakeTest {
             }
         });
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        w.subscribe(NbpObserver);
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(any(IllegalArgumentException.class));
+        Observer<Integer> observer = TestHelper.mockObserver();
+        w.subscribe(observer);
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(any(IllegalArgumentException.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -99,10 +99,10 @@ public class ObservableTakeTest {
             }
         });
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        w.subscribe(NbpObserver);
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(any(IllegalArgumentException.class));
+        Observer<Integer> observer = TestHelper.mockObserver();
+        w.subscribe(observer);
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(any(IllegalArgumentException.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -110,23 +110,23 @@ public class ObservableTakeTest {
     public void testTakeDoesntLeakErrors() {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                NbpObserver.onNext("one");
-                NbpObserver.onError(new Throwable("test failed"));
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onNext("one");
+                observer.onError(new Throwable("test failed"));
             }
         });
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
-        source.take(1).subscribe(NbpObserver);
+        source.take(1).subscribe(observer);
 
-        verify(NbpObserver).onSubscribe((Disposable)notNull());
-        verify(NbpObserver, times(1)).onNext("one");
+        verify(observer).onSubscribe((Disposable)notNull());
+        verify(observer, times(1)).onNext("one");
         // even though onError is called we take(1) so shouldn't see it
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verifyNoMoreInteractions(NbpObserver);
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verifyNoMoreInteractions(observer);
     }
 
     @Test
@@ -136,24 +136,24 @@ public class ObservableTakeTest {
         final Disposable bs = Disposables.empty();
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
+            public void subscribe(Observer<? super String> observer) {
                 subscribed.set(true);
-                NbpObserver.onSubscribe(bs);
-                NbpObserver.onError(new Throwable("test failed"));
+                observer.onSubscribe(bs);
+                observer.onError(new Throwable("test failed"));
             }
         });
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
-        source.take(0).subscribe(NbpObserver);
+        source.take(0).subscribe(observer);
         assertTrue("source subscribed", subscribed.get());
         assertTrue("source unsubscribed", bs.isDisposed());
 
-        verify(NbpObserver, never()).onNext(anyString());
+        verify(observer, never()).onNext(anyString());
         // even though onError is called we take(0) so shouldn't see it
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verifyNoMoreInteractions(NbpObserver);
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verifyNoMoreInteractions(observer);
     }
 
     @Test
@@ -161,12 +161,12 @@ public class ObservableTakeTest {
         TestObservableFunc f = new TestObservableFunc("one", "two", "three");
         Observable<String> w = Observable.unsafeCreate(f);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> take = w.take(1);
-        take.subscribe(NbpObserver);
+        take.subscribe(observer);
 
-        // wait for the NbpObservable to complete
+        // wait for the Observable to complete
         try {
             f.t.join();
         } catch (Throwable e) {
@@ -175,14 +175,14 @@ public class ObservableTakeTest {
         }
 
         System.out.println("TestObservable thread finished");
-        verify(NbpObserver).onSubscribe((Disposable)notNull());
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onNext("two");
-        verify(NbpObserver, never()).onNext("three");
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer).onSubscribe((Disposable)notNull());
+        verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onNext("two");
+        verify(observer, never()).onNext("three");
+        verify(observer, times(1)).onComplete();
         // FIXME no longer assertable
 //        verify(s, times(1)).unsubscribe();
-        verifyNoMoreInteractions(NbpObserver);
+        verifyNoMoreInteractions(observer);
     }
 
     @Test(timeout = 2000)
@@ -238,8 +238,8 @@ public class ObservableTakeTest {
         }
 
         @Override
-        public void subscribe(final Observer<? super String> NbpObserver) {
-            NbpObserver.onSubscribe(Disposables.empty());
+        public void subscribe(final Observer<? super String> observer) {
+            observer.onSubscribe(Disposables.empty());
             System.out.println("TestObservable subscribed to ...");
             t = new Thread(new Runnable() {
 
@@ -249,9 +249,9 @@ public class ObservableTakeTest {
                         System.out.println("running TestObservable thread");
                         for (String s : values) {
                             System.out.println("TestObservable onNext: " + s);
-                            NbpObserver.onNext(s);
+                            observer.onNext(s);
                         }
-                        NbpObserver.onComplete();
+                        observer.onComplete();
                     } catch (Throwable e) {
                         throw new RuntimeException(e);
                     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
@@ -153,7 +153,7 @@ public class ObservableTakeUntilTest {
 
     private static class TestObservable implements ObservableSource<String> {
 
-        Observer<? super String> NbpObserver;
+        Observer<? super String> observer;
         Disposable s;
 
         public TestObservable(Disposable s) {
@@ -162,23 +162,23 @@ public class ObservableTakeUntilTest {
 
         /* used to simulate subscription */
         public void sendOnCompleted() {
-            NbpObserver.onComplete();
+            observer.onComplete();
         }
 
         /* used to simulate subscription */
         public void sendOnNext(String value) {
-            NbpObserver.onNext(value);
+            observer.onNext(value);
         }
 
         /* used to simulate subscription */
         public void sendOnError(Throwable e) {
-            NbpObserver.onError(e);
+            observer.onError(e);
         }
 
         @Override
-        public void subscribe(Observer<? super String> NbpObserver) {
-            this.NbpObserver = NbpObserver;
-            NbpObserver.onSubscribe(s);
+        public void subscribe(Observer<? super String> observer) {
+            this.observer = observer;
+            observer.onSubscribe(s);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeWhileTest.java
@@ -38,13 +38,13 @@ public class ObservableTakeWhileTest {
             }
         });
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        take.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext(1);
-        verify(NbpObserver, times(1)).onNext(2);
-        verify(NbpObserver, never()).onNext(3);
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<Integer> observer = TestHelper.mockObserver();
+        take.subscribe(observer);
+        verify(observer, times(1)).onNext(1);
+        verify(observer, times(1)).onNext(2);
+        verify(observer, never()).onNext(3);
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -57,8 +57,8 @@ public class ObservableTakeWhileTest {
             }
         });
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
-        take.subscribe(NbpObserver);
+        Observer<Integer> observer = TestHelper.mockObserver();
+        take.subscribe(observer);
 
         s.onNext(1);
         s.onNext(2);
@@ -67,13 +67,13 @@ public class ObservableTakeWhileTest {
         s.onNext(5);
         s.onComplete();
 
-        verify(NbpObserver, times(1)).onNext(1);
-        verify(NbpObserver, times(1)).onNext(2);
-        verify(NbpObserver, never()).onNext(3);
-        verify(NbpObserver, never()).onNext(4);
-        verify(NbpObserver, never()).onNext(5);
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, times(1)).onNext(1);
+        verify(observer, times(1)).onNext(2);
+        verify(observer, never()).onNext(3);
+        verify(observer, never()).onNext(4);
+        verify(observer, never()).onNext(5);
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
@@ -88,23 +88,23 @@ public class ObservableTakeWhileTest {
             }
         });
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        take.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, times(1)).onNext("two");
-        verify(NbpObserver, never()).onNext("three");
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<String> observer = TestHelper.mockObserver();
+        take.subscribe(observer);
+        verify(observer, times(1)).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, never()).onNext("three");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testTakeWhileDoesntLeakErrors() {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                NbpObserver.onNext("one");
-                NbpObserver.onError(new Throwable("test failed"));
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onNext("one");
+                observer.onError(new Throwable("test failed"));
             }
         });
 
@@ -121,7 +121,7 @@ public class ObservableTakeWhileTest {
         TestObservable source = new TestObservable(mock(Disposable.class), "one");
         final RuntimeException testException = new RuntimeException("test exception");
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         Observable<String> take = Observable.unsafeCreate(source)
                 .takeWhile(new Predicate<String>() {
             @Override
@@ -129,9 +129,9 @@ public class ObservableTakeWhileTest {
                 throw testException;
             }
         });
-        take.subscribe(NbpObserver);
+        take.subscribe(observer);
 
-        // wait for the NbpObservable to complete
+        // wait for the Observable to complete
         try {
             source.t.join();
         } catch (Throwable e) {
@@ -139,8 +139,8 @@ public class ObservableTakeWhileTest {
             fail(e.getMessage());
         }
 
-        verify(NbpObserver, never()).onNext(any(String.class));
-        verify(NbpObserver, times(1)).onError(testException);
+        verify(observer, never()).onNext(any(String.class));
+        verify(observer, times(1)).onError(testException);
     }
 
     @Test
@@ -148,7 +148,7 @@ public class ObservableTakeWhileTest {
         Disposable s = mock(Disposable.class);
         TestObservable w = new TestObservable(s, "one", "two", "three");
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
         Observable<String> take = Observable.unsafeCreate(w)
                 .takeWhile(new Predicate<String>() {
             int index = 0;
@@ -158,9 +158,9 @@ public class ObservableTakeWhileTest {
                 return index++ < 1;
             }
         });
-        take.subscribe(NbpObserver);
+        take.subscribe(observer);
 
-        // wait for the NbpObservable to complete
+        // wait for the Observable to complete
         try {
             w.t.join();
         } catch (Throwable e) {
@@ -169,9 +169,9 @@ public class ObservableTakeWhileTest {
         }
 
         System.out.println("TestObservable thread finished");
-        verify(NbpObserver, times(1)).onNext("one");
-        verify(NbpObserver, never()).onNext("two");
-        verify(NbpObserver, never()).onNext("three");
+        verify(observer, times(1)).onNext("one");
+        verify(observer, never()).onNext("two");
+        verify(observer, never()).onNext("three");
         verify(s, times(1)).dispose();
     }
 
@@ -187,9 +187,9 @@ public class ObservableTakeWhileTest {
         }
 
         @Override
-        public void subscribe(final Observer<? super String> NbpObserver) {
+        public void subscribe(final Observer<? super String> observer) {
             System.out.println("TestObservable subscribed to ...");
-            NbpObserver.onSubscribe(s);
+            observer.onSubscribe(s);
             t = new Thread(new Runnable() {
 
                 @Override
@@ -198,9 +198,9 @@ public class ObservableTakeWhileTest {
                         System.out.println("running TestObservable thread");
                         for (String s : values) {
                             System.out.println("TestObservable onNext: " + s);
-                            NbpObserver.onNext(s);
+                            observer.onNext(s);
                         }
-                        NbpObserver.onComplete();
+                        observer.onComplete();
                     } catch (Throwable e) {
                         throw new RuntimeException(e);
                     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeIntervalTest.java
@@ -30,24 +30,24 @@ public class ObservableTimeIntervalTest {
 
     private static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
 
-    private Observer<Timed<Integer>> NbpObserver;
+    private Observer<Timed<Integer>> observer;
 
     private TestScheduler testScheduler;
     private PublishSubject<Integer> subject;
-    private Observable<Timed<Integer>> NbpObservable;
+    private Observable<Timed<Integer>> observable;
 
     @Before
     public void setUp() {
-        NbpObserver = TestHelper.mockObserver();
+        observer = TestHelper.mockObserver();
         testScheduler = new TestScheduler();
         subject = PublishSubject.create();
-        NbpObservable = subject.timeInterval(testScheduler);
+        observable = subject.timeInterval(testScheduler);
     }
 
     @Test
     public void testTimeInterval() {
-        InOrder inOrder = inOrder(NbpObserver);
-        NbpObservable.subscribe(NbpObserver);
+        InOrder inOrder = inOrder(observer);
+        observable.subscribe(observer);
 
         testScheduler.advanceTimeBy(1000, TIME_UNIT);
         subject.onNext(1);
@@ -57,13 +57,13 @@ public class ObservableTimeIntervalTest {
         subject.onNext(3);
         subject.onComplete();
 
-        inOrder.verify(NbpObserver, times(1)).onNext(
+        inOrder.verify(observer, times(1)).onNext(
                 new Timed<Integer>(1, 1000, TIME_UNIT));
-        inOrder.verify(NbpObserver, times(1)).onNext(
+        inOrder.verify(observer, times(1)).onNext(
                 new Timed<Integer>(2, 2000, TIME_UNIT));
-        inOrder.verify(NbpObserver, times(1)).onNext(
+        inOrder.verify(observer, times(1)).onNext(
                 new Timed<Integer>(3, 3000, TIME_UNIT));
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
@@ -47,23 +47,23 @@ public class ObservableTimeoutTests {
 
     @Test
     public void shouldNotTimeoutIfOnNextWithinTimeout() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
 
         withTimeout.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
-        verify(NbpObserver).onNext("One");
+        verify(observer).onNext("One");
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         ts.dispose();
     }
 
     @Test
     public void shouldNotTimeoutIfSecondOnNextWithinTimeout() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
 
         withTimeout.subscribe(ts);
 
@@ -71,59 +71,59 @@ public class ObservableTimeoutTests {
         underlyingSubject.onNext("One");
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("Two");
-        verify(NbpObserver).onNext("Two");
+        verify(observer).onNext("Two");
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         ts.dispose();
     }
 
     @Test
     public void shouldTimeoutIfOnNextNotWithinTimeout() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
 
         withTimeout.subscribe(ts);
 
         testScheduler.advanceTimeBy(TIMEOUT + 1, TimeUnit.SECONDS);
-        verify(NbpObserver).onError(any(TimeoutException.class));
+        verify(observer).onError(any(TimeoutException.class));
         ts.dispose();
     }
 
     @Test
     public void shouldTimeoutIfSecondOnNextNotWithinTimeout() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
-        withTimeout.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
+        withTimeout.subscribe(observer);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
-        verify(NbpObserver).onNext("One");
+        verify(observer).onNext("One");
         testScheduler.advanceTimeBy(TIMEOUT + 1, TimeUnit.SECONDS);
-        verify(NbpObserver).onError(any(TimeoutException.class));
+        verify(observer).onError(any(TimeoutException.class));
         ts.dispose();
     }
 
     @Test
     public void shouldCompleteIfUnderlyingComletes() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
-        withTimeout.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
+        withTimeout.subscribe(observer);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onComplete();
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
-        verify(NbpObserver).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
         ts.dispose();
     }
 
     @Test
     public void shouldErrorIfUnderlyingErrors() {
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
-        withTimeout.subscribe(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
+        withTimeout.subscribe(observer);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onError(new UnsupportedOperationException());
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
-        verify(NbpObserver).onError(any(UnsupportedOperationException.class));
+        verify(observer).onError(any(UnsupportedOperationException.class));
         ts.dispose();
     }
 
@@ -132,20 +132,20 @@ public class ObservableTimeoutTests {
         Observable<String> other = Observable.just("a", "b", "c");
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS);
         underlyingSubject.onNext("Two");
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext("One");
-        inOrder.verify(NbpObserver, times(1)).onNext("a");
-        inOrder.verify(NbpObserver, times(1)).onNext("b");
-        inOrder.verify(NbpObserver, times(1)).onNext("c");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext("One");
+        inOrder.verify(observer, times(1)).onNext("a");
+        inOrder.verify(observer, times(1)).onNext("b");
+        inOrder.verify(observer, times(1)).onNext("c");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
         ts.dispose();
     }
@@ -155,20 +155,20 @@ public class ObservableTimeoutTests {
         Observable<String> other = Observable.just("a", "b", "c");
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS);
         underlyingSubject.onError(new UnsupportedOperationException());
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext("One");
-        inOrder.verify(NbpObserver, times(1)).onNext("a");
-        inOrder.verify(NbpObserver, times(1)).onNext("b");
-        inOrder.verify(NbpObserver, times(1)).onNext("c");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext("One");
+        inOrder.verify(observer, times(1)).onNext("a");
+        inOrder.verify(observer, times(1)).onNext("b");
+        inOrder.verify(observer, times(1)).onNext("c");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
         ts.dispose();
     }
@@ -178,20 +178,20 @@ public class ObservableTimeoutTests {
         Observable<String> other = Observable.just("a", "b", "c");
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS);
         underlyingSubject.onComplete();
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext("One");
-        inOrder.verify(NbpObserver, times(1)).onNext("a");
-        inOrder.verify(NbpObserver, times(1)).onNext("b");
-        inOrder.verify(NbpObserver, times(1)).onNext("c");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext("One");
+        inOrder.verify(observer, times(1)).onNext("a");
+        inOrder.verify(observer, times(1)).onNext("b");
+        inOrder.verify(observer, times(1)).onNext("c");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
         ts.dispose();
     }
@@ -201,8 +201,8 @@ public class ObservableTimeoutTests {
         PublishSubject<String> other = PublishSubject.create();
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -219,10 +219,10 @@ public class ObservableTimeoutTests {
         other.onNext("d");
         other.onComplete();
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext("One");
-        inOrder.verify(NbpObserver, times(1)).onNext("a");
-        inOrder.verify(NbpObserver, times(1)).onNext("b");
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext("One");
+        inOrder.verify(observer, times(1)).onNext("a");
+        inOrder.verify(observer, times(1)).onNext("b");
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -232,8 +232,8 @@ public class ObservableTimeoutTests {
         final CountDownLatch exit = new CountDownLatch(1);
         final CountDownLatch timeoutSetuped = new CountDownLatch(1);
 
-        final Observer<String> NbpObserver = TestHelper.mockObserver();
-        final TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        final Observer<String> observer = TestHelper.mockObserver();
+        final TestObserver<String> ts = new TestObserver<String>(observer);
 
         new Thread(new Runnable() {
 
@@ -262,8 +262,8 @@ public class ObservableTimeoutTests {
         timeoutSetuped.await();
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onError(isA(TimeoutException.class));
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(isA(TimeoutException.class));
         inOrder.verifyNoMoreInteractions();
 
         exit.countDown(); // exit the thread
@@ -276,22 +276,22 @@ public class ObservableTimeoutTests {
 
         Observable<String> never = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpSubscriber) {
-                NbpSubscriber.onSubscribe(s);
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(s);
             }
         });
 
         TestScheduler testScheduler = new TestScheduler();
         Observable<String> observableWithTimeout = never.timeout(1000, TimeUnit.MILLISECONDS, testScheduler);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
         observableWithTimeout.subscribe(ts);
 
         testScheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver).onError(isA(TimeoutException.class));
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer).onError(isA(TimeoutException.class));
         inOrder.verifyNoMoreInteractions();
 
         verify(s, times(1)).dispose();
@@ -305,9 +305,9 @@ public class ObservableTimeoutTests {
 
         Observable<String> immediatelyComplete = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpSubscriber) {
-                NbpSubscriber.onSubscribe(s);
-                NbpSubscriber.onComplete();
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(s);
+                observer.onComplete();
             }
         });
 
@@ -315,14 +315,14 @@ public class ObservableTimeoutTests {
         Observable<String> observableWithTimeout = immediatelyComplete.timeout(1000, TimeUnit.MILLISECONDS,
                 testScheduler);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
         observableWithTimeout.subscribe(ts);
 
         testScheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer).onComplete();
         inOrder.verifyNoMoreInteractions();
 
         verify(s, times(1)).dispose();
@@ -336,9 +336,9 @@ public class ObservableTimeoutTests {
 
         Observable<String> immediatelyError = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpSubscriber) {
-                NbpSubscriber.onSubscribe(s);
-                NbpSubscriber.onError(new IOException("Error"));
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(s);
+                observer.onError(new IOException("Error"));
             }
         });
 
@@ -346,14 +346,14 @@ public class ObservableTimeoutTests {
         Observable<String> observableWithTimeout = immediatelyError.timeout(1000, TimeUnit.MILLISECONDS,
                 testScheduler);
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
         observableWithTimeout.subscribe(ts);
 
         testScheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver).onError(isA(IOException.class));
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer).onError(isA(IOException.class));
         inOrder.verifyNoMoreInteractions();
 
         verify(s, times(1)).dispose();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -254,16 +254,16 @@ public class ObservableTimeoutWithSelectorTest {
     public void testTimeoutSelectorWithTimeoutAndOnNextRaceCondition() throws InterruptedException {
         // Thread 1                                    Thread 2
         //
-        // NbpObserver.onNext(1)
+        // observer.onNext(1)
         // start timeout
         // unsubscribe timeout in thread 2          start to do some long-time work in "unsubscribe"
-        // NbpObserver.onNext(2)
+        // observer.onNext(2)
         // timeout.onNext(1)
         //                                          "unsubscribe" done
         //
         //
         // In the above case, the timeout operator should ignore "timeout.onNext(1)"
-        // since "NbpObserver" has already seen 2.
+        // since "observer" has already seen 2.
         final CountDownLatch observerReceivedTwo = new CountDownLatch(1);
         final CountDownLatch timeoutEmittedOne = new CountDownLatch(1);
         final CountDownLatch observerCompleted = new CountDownLatch(1);
@@ -277,10 +277,10 @@ public class ObservableTimeoutWithSelectorTest {
                     // Force "unsubscribe" run on another thread
                     return Observable.unsafeCreate(new ObservableSource<Integer>() {
                         @Override
-                        public void subscribe(Observer<? super Integer> NbpSubscriber) {
-                            NbpSubscriber.onSubscribe(Disposables.empty());
+                        public void subscribe(Observer<? super Integer> observer) {
+                            observer.onSubscribe(Disposables.empty());
                             enteredTimeoutOne.countDown();
-                            // force the timeout message be sent after NbpObserver.onNext(2)
+                            // force the timeout message be sent after observer.onNext(2)
                             while (true) {
                                 try {
                                     if (!observerReceivedTwo.await(30, TimeUnit.SECONDS)) {
@@ -294,7 +294,7 @@ public class ObservableTimeoutWithSelectorTest {
                                     // we ignore the interrupt signal from Scheduler.
                                 }
                             }
-                            NbpSubscriber.onNext(1);
+                            observer.onNext(1);
                             timeoutEmittedOne.countDown();
                         }
                     }).subscribeOn(Schedulers.newThread());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimerTest.java
@@ -29,7 +29,7 @@ import io.reactivex.schedulers.TestScheduler;
 
 public class ObservableTimerTest {
     @Mock
-    Observer<Object> NbpObserver;
+    Observer<Object> observer;
     @Mock
     Observer<Long> observer2;
 
@@ -37,7 +37,7 @@ public class ObservableTimerTest {
 
     @Before
     public void before() {
-        NbpObserver = TestHelper.mockObserver();
+        observer = TestHelper.mockObserver();
 
         observer2 = TestHelper.mockObserver();
 
@@ -46,12 +46,12 @@ public class ObservableTimerTest {
 
     @Test
     public void testTimerOnce() {
-        Observable.timer(100, TimeUnit.MILLISECONDS, scheduler).subscribe(NbpObserver);
+        Observable.timer(100, TimeUnit.MILLISECONDS, scheduler).subscribe(observer);
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
-        verify(NbpObserver, times(1)).onNext(0L);
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onNext(0L);
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -233,26 +233,26 @@ public class ObservableTimerTest {
 
             @Override
             public void onError(Throwable e) {
-                NbpObserver.onError(e);
+                observer.onError(e);
             }
 
             @Override
             public void onComplete() {
-                NbpObserver.onComplete();
+                observer.onComplete();
             }
         });
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        verify(NbpObserver).onError(any(TestException.class));
-        verify(NbpObserver, never()).onNext(anyLong());
-        verify(NbpObserver, never()).onComplete();
+        verify(observer).onError(any(TestException.class));
+        verify(observer, never()).onNext(anyLong());
+        verify(observer, never()).onComplete();
     }
     @Test
     public void testPeriodicObserverThrows() {
         Observable<Long> source = Observable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
         source.safeSubscribe(new DefaultObserver<Long>() {
 
@@ -261,25 +261,25 @@ public class ObservableTimerTest {
                 if (t > 0) {
                     throw new TestException();
                 }
-                NbpObserver.onNext(t);
+                observer.onNext(t);
             }
 
             @Override
             public void onError(Throwable e) {
-                NbpObserver.onError(e);
+                observer.onError(e);
             }
 
             @Override
             public void onComplete() {
-                NbpObserver.onComplete();
+                observer.onComplete();
             }
         });
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        inOrder.verify(NbpObserver).onNext(0L);
-        inOrder.verify(NbpObserver).onError(any(TestException.class));
+        inOrder.verify(observer).onNext(0L);
+        inOrder.verify(observer).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, never()).onComplete();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimestampTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimestampTest.java
@@ -28,11 +28,11 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
 
 public class ObservableTimestampTest {
-    Observer<Object> NbpObserver;
+    Observer<Object> observer;
 
     @Before
     public void before() {
-        NbpObserver = TestHelper.mockObserver();
+        observer = TestHelper.mockObserver();
     }
 
     @Test
@@ -41,7 +41,7 @@ public class ObservableTimestampTest {
 
         PublishSubject<Integer> source = PublishSubject.create();
         Observable<Timed<Integer>> m = source.timestamp(scheduler);
-        m.subscribe(NbpObserver);
+        m.subscribe(observer);
 
         source.onNext(1);
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
@@ -49,14 +49,14 @@ public class ObservableTimestampTest {
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
         source.onNext(3);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(NbpObserver, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(NbpObserver, times(1)).onNext(new Timed<Integer>(2, 100, TimeUnit.MILLISECONDS));
-        inOrder.verify(NbpObserver, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(2, 100, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
     }
 
     @Test
@@ -65,7 +65,7 @@ public class ObservableTimestampTest {
 
         PublishSubject<Integer> source = PublishSubject.create();
         Observable<Timed<Integer>> m = source.timestamp(scheduler);
-        m.subscribe(NbpObserver);
+        m.subscribe(observer);
 
         source.onNext(1);
         source.onNext(2);
@@ -73,14 +73,14 @@ public class ObservableTimestampTest {
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
         source.onNext(3);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(NbpObserver, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(NbpObserver, times(1)).onNext(new Timed<Integer>(2, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(NbpObserver, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(2, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
@@ -31,37 +31,37 @@ public class ObservableToListTest {
     @Test
     public void testList() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
-        Observable<List<String>> NbpObservable = w.toList();
+        Observable<List<String>> observable = w.toList();
 
-        Observer<List<String>> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext(Arrays.asList("one", "two", "three"));
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<List<String>> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList("one", "two", "three"));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testListViaObservable() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
-        Observable<List<String>> NbpObservable = w.toList();
+        Observable<List<String>> observable = w.toList();
 
-        Observer<List<String>> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext(Arrays.asList("one", "two", "three"));
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<List<String>> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList("one", "two", "three"));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testListMultipleSubscribers() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
-        Observable<List<String>> NbpObservable = w.toList();
+        Observable<List<String>> observable = w.toList();
 
         Observer<List<String>> o1 = TestHelper.mockObserver();
-        NbpObservable.subscribe(o1);
+        observable.subscribe(o1);
 
         Observer<List<String>> o2 = TestHelper.mockObserver();
-        NbpObservable.subscribe(o2);
+        observable.subscribe(o2);
 
         List<String> expected = Arrays.asList("one", "two", "three");
 
@@ -78,13 +78,13 @@ public class ObservableToListTest {
     @Ignore("Null values are not allowed")
     public void testListWithNullValue() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", null, "three"));
-        Observable<List<String>> NbpObservable = w.toList();
+        Observable<List<String>> observable = w.toList();
 
-        Observer<List<String>> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext(Arrays.asList("one", null, "three"));
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<List<String>> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList("one", null, "three"));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToSortedListTest.java
@@ -32,19 +32,19 @@ public class ObservableToSortedListTest {
     @Test
     public void testSortedList() {
         Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);
-        Observable<List<Integer>> NbpObservable = w.toSortedList();
+        Observable<List<Integer>> observable = w.toSortedList();
 
-        Observer<List<Integer>> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext(Arrays.asList(1, 2, 3, 4, 5));
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<List<Integer>> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList(1, 2, 3, 4, 5));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testSortedListWithCustomFunction() {
         Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);
-        Observable<List<Integer>> NbpObservable = w.toSortedList(new Comparator<Integer>() {
+        Observable<List<Integer>> observable = w.toSortedList(new Comparator<Integer>() {
 
             @Override
             public int compare(Integer t1, Integer t2) {
@@ -53,11 +53,11 @@ public class ObservableToSortedListTest {
 
         });
 
-        Observer<List<Integer>> NbpObserver = TestHelper.mockObserver();
-        NbpObservable.subscribe(NbpObserver);
-        verify(NbpObserver, times(1)).onNext(Arrays.asList(5, 4, 3, 2, 1));
-        verify(NbpObserver, Mockito.never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        Observer<List<Integer>> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onNext(Arrays.asList(5, 4, 3, 2, 1));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
@@ -83,16 +83,16 @@ public class ObservableUsingTest {
             }
         };
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> o = Observable.using(resourceFactory, observableFactory,
                 new DisposeAction(), disposeEagerly);
-        o.subscribe(NbpObserver);
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext("Hello");
-        inOrder.verify(NbpObserver, times(1)).onNext("world!");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext("Hello");
+        inOrder.verify(observer, times(1)).onNext("world!");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
 
         // The resouce should be closed
@@ -143,22 +143,22 @@ public class ObservableUsingTest {
             }
         };
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> o = Observable.using(resourceFactory, observableFactory,
                 new DisposeAction(), disposeEagerly);
-        o.subscribe(NbpObserver);
-        o.subscribe(NbpObserver);
+        o.subscribe(observer);
+        o.subscribe(observer);
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(NbpObserver, times(1)).onNext("Hello");
-        inOrder.verify(NbpObserver, times(1)).onNext("world!");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onNext("Hello");
+        inOrder.verify(observer, times(1)).onNext("world!");
+        inOrder.verify(observer, times(1)).onComplete();
 
-        inOrder.verify(NbpObserver, times(1)).onNext("Hello");
-        inOrder.verify(NbpObserver, times(1)).onNext("world!");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onNext("Hello");
+        inOrder.verify(observer, times(1)).onNext("world!");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -287,14 +287,14 @@ public class ObservableUsingTest {
             }
         };
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> o = Observable.using(resourceFactory, observableFactory,
                 new DisposeAction(), true)
         .doOnDispose(unsub)
         .doOnComplete(completion);
 
-        o.safeSubscribe(NbpObserver);
+        o.safeSubscribe(observer);
 
         assertEquals(Arrays.asList("disposed", "completed" /* , "unsub" */), events);
 
@@ -314,14 +314,14 @@ public class ObservableUsingTest {
             }
         };
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> o = Observable.using(resourceFactory, observableFactory,
                 new DisposeAction(), false)
         .doOnDispose(unsub)
         .doOnComplete(completion);
 
-        o.safeSubscribe(NbpObserver);
+        o.safeSubscribe(observer);
 
         assertEquals(Arrays.asList("completed", /*"unsub",*/ "disposed"), events);
 
@@ -344,14 +344,14 @@ public class ObservableUsingTest {
             }
         };
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> o = Observable.using(resourceFactory, observableFactory,
                 new DisposeAction(), true)
         .doOnDispose(unsub)
         .doOnError(onError);
 
-        o.safeSubscribe(NbpObserver);
+        o.safeSubscribe(observer);
 
         assertEquals(Arrays.asList("disposed", "error" /*, "unsub"*/), events);
 
@@ -372,14 +372,14 @@ public class ObservableUsingTest {
             }
         };
 
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> o = Observable.using(resourceFactory, observableFactory,
                 new DisposeAction(), false)
         .doOnDispose(unsub)
         .doOnError(onError);
 
-        o.safeSubscribe(NbpObserver);
+        o.safeSubscribe(observer);
 
         assertEquals(Arrays.asList("error", /* "unsub",*/ "disposed"), events);
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -47,24 +47,24 @@ public class ObservableWindowWithStartEndObservableTest {
 
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                push(NbpObserver, "one", 10);
-                push(NbpObserver, "two", 60);
-                push(NbpObserver, "three", 110);
-                push(NbpObserver, "four", 160);
-                push(NbpObserver, "five", 210);
-                complete(NbpObserver, 500);
+            public void subscribe(Observer<? super String> innerObserver) {
+                innerObserver.onSubscribe(Disposables.empty());
+                push(innerObserver, "one", 10);
+                push(innerObserver, "two", 60);
+                push(innerObserver, "three", 110);
+                push(innerObserver, "four", 160);
+                push(innerObserver, "five", 210);
+                complete(innerObserver, 500);
             }
         });
 
         Observable<Object> openings = Observable.unsafeCreate(new ObservableSource<Object>() {
             @Override
-            public void subscribe(Observer<? super Object> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                push(NbpObserver, new Object(), 50);
-                push(NbpObserver, new Object(), 200);
-                complete(NbpObserver, 250);
+            public void subscribe(Observer<? super Object> innerObserver) {
+                innerObserver.onSubscribe(Disposables.empty());
+                push(innerObserver, new Object(), 50);
+                push(innerObserver, new Object(), 200);
+                complete(innerObserver, 250);
             }
         });
 
@@ -73,10 +73,10 @@ public class ObservableWindowWithStartEndObservableTest {
             public Observable<Object> apply(Object opening) {
                 return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
-                    public void subscribe(Observer<? super Object> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
-                        push(NbpObserver, new Object(), 100);
-                        complete(NbpObserver, 101);
+                    public void subscribe(Observer<? super Object> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
+                        push(innerObserver, new Object(), 100);
+                        complete(innerObserver, 101);
                     }
                 });
             }
@@ -98,14 +98,14 @@ public class ObservableWindowWithStartEndObservableTest {
 
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                push(NbpObserver, "one", 10);
-                push(NbpObserver, "two", 60);
-                push(NbpObserver, "three", 110);
-                push(NbpObserver, "four", 160);
-                push(NbpObserver, "five", 210);
-                complete(NbpObserver, 250);
+            public void subscribe(Observer<? super String> innerObserver) {
+                innerObserver.onSubscribe(Disposables.empty());
+                push(innerObserver, "one", 10);
+                push(innerObserver, "two", 60);
+                push(innerObserver, "three", 110);
+                push(innerObserver, "four", 160);
+                push(innerObserver, "five", 210);
+                complete(innerObserver, 250);
             }
         });
 
@@ -115,16 +115,16 @@ public class ObservableWindowWithStartEndObservableTest {
             public Observable<Object> call() {
                 return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
-                    public void subscribe(Observer<? super Object> NbpObserver) {
-                        NbpObserver.onSubscribe(Disposables.empty());
+                    public void subscribe(Observer<? super Object> innerObserver) {
+                        innerObserver.onSubscribe(Disposables.empty());
                         int c = calls++;
                         if (c == 0) {
-                            push(NbpObserver, new Object(), 100);
+                            push(innerObserver, new Object(), 100);
                         } else
                         if (c == 1) {
-                            push(NbpObserver, new Object(), 100);
+                            push(innerObserver, new Object(), 100);
                         } else {
-                            complete(NbpObserver, 101);
+                            complete(innerObserver, 101);
                         }
                     }
                 });
@@ -149,20 +149,20 @@ public class ObservableWindowWithStartEndObservableTest {
         return list;
     }
 
-    private <T> void push(final Observer<T> NbpObserver, final T value, int delay) {
+    private <T> void push(final Observer<T> observer, final T value, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                NbpObserver.onNext(value);
+                observer.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private void complete(final Observer<?> NbpObserver, int delay) {
+    private void complete(final Observer<?> observer, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                NbpObserver.onComplete();
+                observer.onComplete();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -49,14 +49,14 @@ public class ObservableWindowWithTimeTest {
 
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                push(NbpObserver, "one", 10);
-                push(NbpObserver, "two", 90);
-                push(NbpObserver, "three", 110);
-                push(NbpObserver, "four", 190);
-                push(NbpObserver, "five", 210);
-                complete(NbpObserver, 250);
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                push(observer, "one", 10);
+                push(observer, "two", 90);
+                push(observer, "three", 110);
+                push(observer, "four", 190);
+                push(observer, "five", 210);
+                complete(observer, 250);
             }
         });
 
@@ -83,14 +83,14 @@ public class ObservableWindowWithTimeTest {
 
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> NbpObserver) {
-                NbpObserver.onSubscribe(Disposables.empty());
-                push(NbpObserver, "one", 98);
-                push(NbpObserver, "two", 99);
-                push(NbpObserver, "three", 99); // FIXME happens after the window is open
-                push(NbpObserver, "four", 101);
-                push(NbpObserver, "five", 102);
-                complete(NbpObserver, 150);
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                push(observer, "one", 98);
+                push(observer, "two", 99);
+                push(observer, "three", 99); // FIXME happens after the window is open
+                push(observer, "four", 101);
+                push(observer, "five", 102);
+                complete(observer, 150);
             }
         });
 
@@ -114,20 +114,20 @@ public class ObservableWindowWithTimeTest {
         return list;
     }
 
-    private <T> void push(final Observer<T> NbpObserver, final T value, int delay) {
+    private <T> void push(final Observer<T> observer, final T value, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                NbpObserver.onNext(value);
+                observer.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private void complete(final Observer<?> NbpObserver, int delay) {
+    private void complete(final Observer<?> observer, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                NbpObserver.onComplete();
+                observer.onComplete();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableZipCompletionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableZipCompletionTest.java
@@ -23,8 +23,8 @@ import io.reactivex.functions.BiFunction;
 import io.reactivex.subjects.PublishSubject;
 
 /**
- * Systematically tests that when zipping an infinite and a finite NbpObservable,
- * the resulting NbpObservable is finite.
+ * Systematically tests that when zipping an infinite and a finite Observable,
+ * the resulting Observable is finite.
  *
  */
 public class ObservableZipCompletionTest {
@@ -34,7 +34,7 @@ public class ObservableZipCompletionTest {
     PublishSubject<String> s2;
     Observable<String> zipped;
 
-    Observer<String> NbpObserver;
+    Observer<String> observer;
     InOrder inOrder;
 
     @Before
@@ -50,10 +50,10 @@ public class ObservableZipCompletionTest {
         s2 = PublishSubject.create();
         zipped = Observable.zip(s1, s2, concat2Strings);
 
-        NbpObserver = TestHelper.mockObserver();
-        inOrder = inOrder(NbpObserver);
+        observer = TestHelper.mockObserver();
+        inOrder = inOrder(observer);
 
-        zipped.subscribe(NbpObserver);
+        zipped.subscribe(observer);
     }
 
     @Test
@@ -62,10 +62,10 @@ public class ObservableZipCompletionTest {
         s1.onNext("b");
         s1.onComplete();
         s2.onNext("1");
-        inOrder.verify(NbpObserver, times(1)).onNext("a-1");
+        inOrder.verify(observer, times(1)).onNext("a-1");
         s2.onNext("2");
-        inOrder.verify(NbpObserver, times(1)).onNext("b-2");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onNext("b-2");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -74,11 +74,11 @@ public class ObservableZipCompletionTest {
         s2.onNext("1");
         s2.onNext("2");
         s1.onNext("a");
-        inOrder.verify(NbpObserver, times(1)).onNext("a-1");
+        inOrder.verify(observer, times(1)).onNext("a-1");
         s1.onNext("b");
-        inOrder.verify(NbpObserver, times(1)).onNext("b-2");
+        inOrder.verify(observer, times(1)).onNext("b-2");
         s1.onComplete();
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -88,10 +88,10 @@ public class ObservableZipCompletionTest {
         s2.onNext("2");
         s2.onComplete();
         s1.onNext("a");
-        inOrder.verify(NbpObserver, times(1)).onNext("a-1");
+        inOrder.verify(observer, times(1)).onNext("a-1");
         s1.onNext("b");
-        inOrder.verify(NbpObserver, times(1)).onNext("b-2");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onNext("b-2");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -100,11 +100,11 @@ public class ObservableZipCompletionTest {
         s1.onNext("a");
         s1.onNext("b");
         s2.onNext("1");
-        inOrder.verify(NbpObserver, times(1)).onNext("a-1");
+        inOrder.verify(observer, times(1)).onNext("a-1");
         s2.onNext("2");
-        inOrder.verify(NbpObserver, times(1)).onNext("b-2");
+        inOrder.verify(observer, times(1)).onNext("b-2");
         s2.onComplete();
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableZipIterableTest.java
@@ -36,7 +36,7 @@ public class ObservableZipIterableTest {
     PublishSubject<String> s2;
     Observable<String> zipped;
 
-    Observer<String> NbpObserver;
+    Observer<String> observer;
     InOrder inOrder;
 
     @Before
@@ -52,10 +52,10 @@ public class ObservableZipIterableTest {
         s2 = PublishSubject.create();
         zipped = Observable.zip(s1, s2, concat2Strings);
 
-        NbpObserver = TestHelper.mockObserver();
-        inOrder = inOrder(NbpObserver);
+        observer = TestHelper.mockObserver();
+        inOrder = inOrder(observer);
 
-        zipped.subscribe(NbpObserver);
+        zipped.subscribe(observer);
     }
 
     BiFunction<Object, Object, String> zipr2 = new BiFunction<Object, Object, String>() {
@@ -78,7 +78,7 @@ public class ObservableZipIterableTest {
     @Test
     public void testZipIterableSameSize() {
         PublishSubject<String> r1 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
+        /* define a Observer to receive aggregated events */
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
@@ -103,7 +103,7 @@ public class ObservableZipIterableTest {
     @Test
     public void testZipIterableEmptyFirstSize() {
         PublishSubject<String> r1 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
+        /* define a Observer to receive aggregated events */
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
@@ -123,7 +123,7 @@ public class ObservableZipIterableTest {
     @Test
     public void testZipIterableEmptySecond() {
         PublishSubject<String> r1 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
+        /* define a Observer to receive aggregated events */
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
@@ -145,7 +145,7 @@ public class ObservableZipIterableTest {
     @Test
     public void testZipIterableFirstShorter() {
         PublishSubject<String> r1 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
+        /* define a Observer to receive aggregated events */
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
@@ -168,7 +168,7 @@ public class ObservableZipIterableTest {
     @Test
     public void testZipIterableSecondShorter() {
         PublishSubject<String> r1 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
+        /* define a Observer to receive aggregated events */
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
@@ -192,7 +192,7 @@ public class ObservableZipIterableTest {
     @Test
     public void testZipIterableFirstThrows() {
         PublishSubject<String> r1 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
+        /* define a Observer to receive aggregated events */
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
@@ -215,7 +215,7 @@ public class ObservableZipIterableTest {
     @Test
     public void testZipIterableIteratorThrows() {
         PublishSubject<String> r1 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
+        /* define a Observer to receive aggregated events */
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
@@ -242,7 +242,7 @@ public class ObservableZipIterableTest {
     @Test
     public void testZipIterableHasNextThrows() {
         PublishSubject<String> r1 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
+        /* define a Observer to receive aggregated events */
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
@@ -292,7 +292,7 @@ public class ObservableZipIterableTest {
     @Test
     public void testZipIterableNextThrows() {
         PublishSubject<String> r1 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
+        /* define a Observer to receive aggregated events */
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
@@ -41,7 +41,7 @@ public class ObservableZipTest {
     PublishSubject<String> s2;
     Observable<String> zipped;
 
-    Observer<String> NbpObserver;
+    Observer<String> observer;
     InOrder inOrder;
 
     @Before
@@ -57,10 +57,10 @@ public class ObservableZipTest {
         s2 = PublishSubject.create();
         zipped = Observable.zip(s1, s2, concat2Strings);
 
-        NbpObserver = TestHelper.mockObserver();
-        inOrder = inOrder(NbpObserver);
+        observer = TestHelper.mockObserver();
+        inOrder = inOrder(observer);
 
-        zipped.subscribe(NbpObserver);
+        zipped.subscribe(observer);
     }
 
     @SuppressWarnings("unchecked")
@@ -69,17 +69,17 @@ public class ObservableZipTest {
         Function<Object[], String> zipr = Functions.toFunction(getConcatStringIntegerIntArrayZipr());
         //Function3<String, Integer, int[], String>
 
-        /* define a NbpSubscriber to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
         @SuppressWarnings("rawtypes")
         Collection ws = java.util.Collections.singleton(Observable.just("one", "two"));
         Observable<String> w = Observable.zip(ws, zipr);
-        w.subscribe(NbpObserver);
+        w.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, never()).onNext(any(String.class));
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, never()).onNext(any(String.class));
     }
 
     @Test
@@ -97,20 +97,20 @@ public class ObservableZipTest {
 
         /* simulate sending data */
         // once for w1
-        w1.NbpObserver.onNext("1a");
-        w1.NbpObserver.onComplete();
+        w1.observer.onNext("1a");
+        w1.observer.onComplete();
         // twice for w2
-        w2.NbpObserver.onNext("2a");
-        w2.NbpObserver.onNext("2b");
-        w2.NbpObserver.onComplete();
+        w2.observer.onNext("2a");
+        w2.observer.onNext("2b");
+        w2.observer.onComplete();
         // 4 times for w3
-        w3.NbpObserver.onNext("3a");
-        w3.NbpObserver.onNext("3b");
-        w3.NbpObserver.onNext("3c");
-        w3.NbpObserver.onNext("3d");
-        w3.NbpObserver.onComplete();
+        w3.observer.onNext("3a");
+        w3.observer.onNext("3b");
+        w3.observer.onNext("3c");
+        w3.observer.onNext("3d");
+        w3.observer.onComplete();
 
-        /* we should have been called 1 time on the NbpSubscriber */
+        /* we should have been called 1 time on the Observer */
         InOrder io = inOrder(w);
         io.verify(w).onNext("1a2a3a");
 
@@ -130,20 +130,20 @@ public class ObservableZipTest {
 
         /* simulate sending data */
         // 4 times for w1
-        w1.NbpObserver.onNext("1a");
-        w1.NbpObserver.onNext("1b");
-        w1.NbpObserver.onNext("1c");
-        w1.NbpObserver.onNext("1d");
-        w1.NbpObserver.onComplete();
+        w1.observer.onNext("1a");
+        w1.observer.onNext("1b");
+        w1.observer.onNext("1c");
+        w1.observer.onNext("1d");
+        w1.observer.onComplete();
         // twice for w2
-        w2.NbpObserver.onNext("2a");
-        w2.NbpObserver.onNext("2b");
-        w2.NbpObserver.onComplete();
+        w2.observer.onNext("2a");
+        w2.observer.onNext("2b");
+        w2.observer.onComplete();
         // 1 times for w3
-        w3.NbpObserver.onNext("3a");
-        w3.NbpObserver.onComplete();
+        w3.observer.onNext("3a");
+        w3.observer.onComplete();
 
-        /* we should have been called 1 time on the NbpSubscriber */
+        /* we should have been called 1 time on the Observer */
         InOrder io = inOrder(w);
         io.verify(w).onNext("1a2a3a");
 
@@ -175,90 +175,90 @@ public class ObservableZipTest {
     public void testAggregatorSimple() {
         PublishSubject<String> r1 = PublishSubject.create();
         PublishSubject<String> r2 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
-        Observable.zip(r1, r2, zipr2).subscribe(NbpObserver);
+        Observable.zip(r1, r2, zipr2).subscribe(observer);
 
         /* simulate the Observables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext("world");
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
-        inOrder.verify(NbpObserver, times(1)).onNext("helloworld");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        inOrder.verify(observer, times(1)).onNext("helloworld");
 
         r1.onNext("hello ");
         r2.onNext("again");
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
-        inOrder.verify(NbpObserver, times(1)).onNext("hello again");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        inOrder.verify(observer, times(1)).onNext("hello again");
 
         r1.onComplete();
         r2.onComplete();
 
-        inOrder.verify(NbpObserver, never()).onNext(anyString());
-        verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, never()).onNext(anyString());
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAggregatorDifferentSizedResultsWithOnComplete() {
         /* create the aggregator which will execute the zip function when all Observables provide values */
-        /* define a NbpSubscriber to receive aggregated events */
+        /* define a Observer to receive aggregated events */
         PublishSubject<String> r1 = PublishSubject.create();
         PublishSubject<String> r2 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        Observable.zip(r1, r2, zipr2).subscribe(NbpObserver);
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
+        Observable.zip(r1, r2, zipr2).subscribe(observer);
 
         /* simulate the Observables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext("world");
         r2.onComplete();
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
-        inOrder.verify(NbpObserver, times(1)).onNext("helloworld");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("helloworld");
+        inOrder.verify(observer, times(1)).onComplete();
 
         r1.onNext("hi");
         r1.onComplete();
 
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
-        inOrder.verify(NbpObserver, never()).onComplete();
-        inOrder.verify(NbpObserver, never()).onNext(anyString());
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(observer, never()).onNext(anyString());
     }
 
     @Test
     public void testAggregateMultipleTypes() {
         PublishSubject<String> r1 = PublishSubject.create();
         PublishSubject<Integer> r2 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
-        Observable.zip(r1, r2, zipr2).subscribe(NbpObserver);
+        Observable.zip(r1, r2, zipr2).subscribe(observer);
 
         /* simulate the Observables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext(1);
         r2.onComplete();
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
-        inOrder.verify(NbpObserver, times(1)).onNext("hello1");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onNext("hello1");
+        inOrder.verify(observer, times(1)).onComplete();
 
         r1.onNext("hi");
         r1.onComplete();
 
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
-        inOrder.verify(NbpObserver, never()).onComplete();
-        inOrder.verify(NbpObserver, never()).onNext(anyString());
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(observer, never()).onNext(anyString());
     }
 
     @Test
@@ -266,29 +266,29 @@ public class ObservableZipTest {
         PublishSubject<String> r1 = PublishSubject.create();
         PublishSubject<Integer> r2 = PublishSubject.create();
         PublishSubject<List<Integer>> r3 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
-        Observable.zip(r1, r2, r3, zipr3).subscribe(NbpObserver);
+        Observable.zip(r1, r2, r3, zipr3).subscribe(observer);
 
         /* simulate the Observables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext(2);
         r3.onNext(Arrays.asList(5, 6, 7));
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, times(1)).onNext("hello2[5, 6, 7]");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onNext("hello2[5, 6, 7]");
     }
 
     @Test
     public void testAggregatorsWithDifferentSizesAndTiming() {
         PublishSubject<String> r1 = PublishSubject.create();
         PublishSubject<String> r2 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
-        Observable.zip(r1, r2, zipr2).subscribe(NbpObserver);
+        Observable.zip(r1, r2, zipr2).subscribe(observer);
 
         /* simulate the Observables pushing data into the aggregator */
         r1.onNext("one");
@@ -296,60 +296,60 @@ public class ObservableZipTest {
         r1.onNext("three");
         r2.onNext("A");
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, times(1)).onNext("oneA");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onNext("oneA");
 
         r1.onNext("four");
         r1.onComplete();
         r2.onNext("B");
-        verify(NbpObserver, times(1)).onNext("twoB");
+        verify(observer, times(1)).onNext("twoB");
         r2.onNext("C");
-        verify(NbpObserver, times(1)).onNext("threeC");
+        verify(observer, times(1)).onNext("threeC");
         r2.onNext("D");
-        verify(NbpObserver, times(1)).onNext("fourD");
+        verify(observer, times(1)).onNext("fourD");
         r2.onNext("E");
-        verify(NbpObserver, never()).onNext("E");
+        verify(observer, never()).onNext("E");
         r2.onComplete();
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAggregatorError() {
         PublishSubject<String> r1 = PublishSubject.create();
         PublishSubject<String> r2 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
-        Observable.zip(r1, r2, zipr2).subscribe(NbpObserver);
+        Observable.zip(r1, r2, zipr2).subscribe(observer);
 
         /* simulate the Observables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext("world");
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, times(1)).onNext("helloworld");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onNext("helloworld");
 
         r1.onError(new RuntimeException(""));
         r1.onNext("hello");
         r2.onNext("again");
 
-        verify(NbpObserver, times(1)).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
         // we don't want to be called again after an error
-        verify(NbpObserver, times(0)).onNext("helloagain");
+        verify(observer, times(0)).onNext("helloagain");
     }
 
     @Test
     public void testAggregatorUnsubscribe() {
         PublishSubject<String> r1 = PublishSubject.create();
         PublishSubject<String> r2 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(NbpObserver);
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
+        TestObserver<String> ts = new TestObserver<String>(observer);
 
         Observable.zip(r1, r2, zipr2).subscribe(ts);
 
@@ -357,28 +357,28 @@ public class ObservableZipTest {
         r1.onNext("hello");
         r2.onNext("world");
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
-        verify(NbpObserver, times(1)).onNext("helloworld");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
+        verify(observer, times(1)).onNext("helloworld");
 
         ts.dispose();
         r1.onNext("hello");
         r2.onNext("again");
 
-        verify(NbpObserver, times(0)).onError(any(Throwable.class));
-        verify(NbpObserver, never()).onComplete();
+        verify(observer, times(0)).onError(any(Throwable.class));
+        verify(observer, never()).onComplete();
         // we don't want to be called again after an error
-        verify(NbpObserver, times(0)).onNext("helloagain");
+        verify(observer, times(0)).onNext("helloagain");
     }
 
     @Test
     public void testAggregatorEarlyCompletion() {
         PublishSubject<String> r1 = PublishSubject.create();
         PublishSubject<String> r2 = PublishSubject.create();
-        /* define a NbpSubscriber to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
-        Observable.zip(r1, r2, zipr2).subscribe(NbpObserver);
+        Observable.zip(r1, r2, zipr2).subscribe(observer);
 
         /* simulate the Observables pushing data into the aggregator */
         r1.onNext("one");
@@ -386,62 +386,62 @@ public class ObservableZipTest {
         r1.onComplete();
         r2.onNext("A");
 
-        InOrder inOrder = inOrder(NbpObserver);
+        InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
-        inOrder.verify(NbpObserver, never()).onComplete();
-        inOrder.verify(NbpObserver, times(1)).onNext("oneA");
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(observer, times(1)).onNext("oneA");
 
         r2.onComplete();
 
-        inOrder.verify(NbpObserver, never()).onError(any(Throwable.class));
-        inOrder.verify(NbpObserver, times(1)).onComplete();
-        inOrder.verify(NbpObserver, never()).onNext(anyString());
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, never()).onNext(anyString());
     }
 
     @Test
     public void testStart2Types() {
         BiFunction<String, Integer, String> zipr = getConcatStringIntegerZipr();
 
-        /* define a NbpSubscriber to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> w = Observable.zip(Observable.just("one", "two"), Observable.just(2, 3, 4), zipr);
-        w.subscribe(NbpObserver);
+        w.subscribe(observer);
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("one2");
-        verify(NbpObserver, times(1)).onNext("two3");
-        verify(NbpObserver, never()).onNext("4");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one2");
+        verify(observer, times(1)).onNext("two3");
+        verify(observer, never()).onNext("4");
     }
 
     @Test
     public void testStart3Types() {
         Function3<String, Integer, int[], String> zipr = getConcatStringIntegerIntArrayZipr();
 
-        /* define a NbpSubscriber to receive aggregated events */
-        Observer<String> NbpObserver = TestHelper.mockObserver();
+        /* define a Observer to receive aggregated events */
+        Observer<String> observer = TestHelper.mockObserver();
 
         Observable<String> w = Observable.zip(Observable.just("one", "two"), Observable.just(2), Observable.just(new int[] { 4, 5, 6 }), zipr);
-        w.subscribe(NbpObserver);
+        w.subscribe(observer);
 
-        verify(NbpObserver, never()).onError(any(Throwable.class));
-        verify(NbpObserver, times(1)).onComplete();
-        verify(NbpObserver, times(1)).onNext("one2[4, 5, 6]");
-        verify(NbpObserver, never()).onNext("two");
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext("one2[4, 5, 6]");
+        verify(observer, never()).onNext("two");
     }
 
     @Test
     public void testOnNextExceptionInvokesOnError() {
         BiFunction<Integer, Integer, Integer> zipr = getDivideZipr();
 
-        Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        Observer<Integer> observer = TestHelper.mockObserver();
 
         Observable<Integer> w = Observable.zip(Observable.just(10, 20, 30), Observable.just(0, 1, 2), zipr);
-        w.subscribe(NbpObserver);
+        w.subscribe(observer);
 
-        verify(NbpObserver, times(1)).onError(any(Throwable.class));
+        verify(observer, times(1)).onError(any(Throwable.class));
     }
 
     @Test
@@ -617,13 +617,13 @@ public class ObservableZipTest {
 
     private static class TestObservable implements ObservableSource<String> {
 
-        Observer<? super String> NbpObserver;
+        Observer<? super String> observer;
 
         @Override
-        public void subscribe(Observer<? super String> NbpObserver) {
+        public void subscribe(Observer<? super String> observer) {
             // just store the variable where it can be accessed so we can manually trigger it
-            this.NbpObserver = NbpObserver;
-            NbpObserver.onSubscribe(Disposables.empty());
+            this.observer = observer;
+            observer.onSubscribe(Disposables.empty());
         }
 
     }
@@ -634,10 +634,10 @@ public class ObservableZipTest {
         s1.onNext("b");
         s1.onComplete();
         s2.onNext("1");
-        inOrder.verify(NbpObserver, times(1)).onNext("a-1");
+        inOrder.verify(observer, times(1)).onNext("a-1");
         s2.onNext("2");
-        inOrder.verify(NbpObserver, times(1)).onNext("b-2");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onNext("b-2");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -646,11 +646,11 @@ public class ObservableZipTest {
         s2.onNext("1");
         s2.onNext("2");
         s1.onNext("a");
-        inOrder.verify(NbpObserver, times(1)).onNext("a-1");
+        inOrder.verify(observer, times(1)).onNext("a-1");
         s1.onNext("b");
-        inOrder.verify(NbpObserver, times(1)).onNext("b-2");
+        inOrder.verify(observer, times(1)).onNext("b-2");
         s1.onComplete();
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -660,10 +660,10 @@ public class ObservableZipTest {
         s2.onNext("2");
         s2.onComplete();
         s1.onNext("a");
-        inOrder.verify(NbpObserver, times(1)).onNext("a-1");
+        inOrder.verify(observer, times(1)).onNext("a-1");
         s1.onNext("b");
-        inOrder.verify(NbpObserver, times(1)).onNext("b-2");
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onNext("b-2");
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -672,11 +672,11 @@ public class ObservableZipTest {
         s1.onNext("a");
         s1.onNext("b");
         s2.onNext("1");
-        inOrder.verify(NbpObserver, times(1)).onNext("a-1");
+        inOrder.verify(observer, times(1)).onNext("a-1");
         s2.onNext("2");
-        inOrder.verify(NbpObserver, times(1)).onNext("b-2");
+        inOrder.verify(observer, times(1)).onNext("b-2");
         s2.onComplete();
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -685,14 +685,14 @@ public class ObservableZipTest {
         s2.onNext("a");
         s1.onError(new RuntimeException("Forced failure"));
 
-        inOrder.verify(NbpObserver, times(1)).onError(any(RuntimeException.class));
+        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
 
         s2.onNext("b");
         s1.onNext("1");
         s1.onNext("2");
 
-        inOrder.verify(NbpObserver, never()).onComplete();
-        inOrder.verify(NbpObserver, never()).onNext(any(String.class));
+        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(observer, never()).onNext(any(String.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -702,13 +702,13 @@ public class ObservableZipTest {
         s1.onNext("b");
         s2.onError(new RuntimeException("Forced failure"));
 
-        inOrder.verify(NbpObserver, times(1)).onError(any(RuntimeException.class));
+        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
 
         s2.onNext("1");
         s2.onNext("2");
 
-        inOrder.verify(NbpObserver, never()).onComplete();
-        inOrder.verify(NbpObserver, never()).onNext(any(String.class));
+        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(observer, never()).onNext(any(String.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -716,14 +716,14 @@ public class ObservableZipTest {
     public void testStartWithOnCompletedTwice() {
         // issue: https://groups.google.com/forum/#!topic/rxjava/79cWTv3TFp0
         // The problem is the original "zip" implementation does not wrap
-        // an internal NbpObserver with a SafeSubscriber. However, in the "zip",
+        // an internal observer with a SafeSubscriber. However, in the "zip",
         // it may calls "onCompleted" twice. That breaks the Rx contract.
 
         // This test tries to emulate this case.
-        // As "TestHelper.mockNbpSubscriber()" will create an instance in the package "rx",
-        // we need to wrap "TestHelper.mockNbpSubscriber()" with an NbpObserver instance
+        // As "TestHelper.mockObserver()" will create an instance in the package "rx",
+        // we need to wrap "TestHelper.mockObserver()" with an observer instance
         // which is in the package "rx.operators".
-        final Observer<Integer> NbpObserver = TestHelper.mockObserver();
+        final Observer<Integer> observer = TestHelper.mockObserver();
 
         Observable.zip(Observable.just(1),
                 Observable.just(1), new BiFunction<Integer, Integer, Integer>() {
@@ -735,24 +735,24 @@ public class ObservableZipTest {
 
             @Override
             public void onComplete() {
-                NbpObserver.onComplete();
+                observer.onComplete();
             }
 
             @Override
             public void onError(Throwable e) {
-                NbpObserver.onError(e);
+                observer.onError(e);
             }
 
             @Override
             public void onNext(Integer args) {
-                NbpObserver.onNext(args);
+                observer.onNext(args);
             }
 
         });
 
-        InOrder inOrder = inOrder(NbpObserver);
-        inOrder.verify(NbpObserver, times(1)).onNext(2);
-        inOrder.verify(NbpObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onNext(2);
+        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/observable/ObservableCombineLatestTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableCombineLatestTests.java
@@ -67,10 +67,10 @@ public class ObservableCombineLatestTests {
     @Test
     public void testNullEmitting() throws Exception {
         // FIXME this is no longer allowed
-        Observable<Boolean> nullNbpObservable = BehaviorSubject.createDefault((Boolean) null);
-        Observable<Boolean> nonNullNbpObservable = BehaviorSubject.createDefault(true);
+        Observable<Boolean> nullObservable = BehaviorSubject.createDefault((Boolean) null);
+        Observable<Boolean> nonNullObservable = BehaviorSubject.createDefault(true);
         Observable<Boolean> combined =
-                combineLatest(nullNbpObservable, nonNullNbpObservable, new BiFunction<Boolean, Boolean, Boolean>() {
+                combineLatest(nullObservable, nonNullObservable, new BiFunction<Boolean, Boolean, Boolean>() {
                     @Override
                     public Boolean apply(Boolean bool1, Boolean bool2) {
                         return bool1 == null ? null : bool2;

--- a/src/test/java/io/reactivex/observable/ObservableCovarianceTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableCovarianceTest.java
@@ -42,7 +42,7 @@ public class ObservableCovarianceTest {
     public void testCovarianceOfFrom() {
         Observable.<Movie> just(new HorrorMovie());
         Observable.<Movie> fromIterable(new ArrayList<HorrorMovie>());
-        // NbpObservable.<HorrorMovie>from(new Movie()); // may not compile
+        // Observable.<HorrorMovie>from(new Movie()); // may not compile
     }
 
     @Test

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -996,8 +996,8 @@ public class ObservableTest {
 // FIXME this test doesn't make sense
 //    @Test // cf. https://github.com/ReactiveX/RxJava/issues/2599
 //    public void testSubscribingSubscriberAsObserverMaintainsSubscriptionChain() {
-//        NbpTestSubscriber<Object> subscriber = new NbpTestSubscriber<T>();
-//        Subscription subscription = Observable.just("event").subscribe((Observer<Object>) subscriber);
+//        TestObserver<Object> observer = new TestObserver<T>();
+//        Subscription subscription = Observable.just("event").subscribe((Observer<Object>) observer);
 //        subscription.unsubscribe();
 //
 //        subscriber.assertUnsubscribed();

--- a/src/test/java/io/reactivex/subjects/AsyncSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/AsyncSubjectTest.java
@@ -273,7 +273,7 @@ public class AsyncSubjectTest {
     // FIXME subscriber methods are not allowed to throw
 //    @Test
 //    public void testOnErrorThrowsDoesntPreventDelivery() {
-//        NbpAsyncSubject<String> ps = NbpAsyncSubject.create();
+//        AsyncSubject<String> ps = AsyncSubject.create();
 //
 //        ps.subscribe();
 //        TestObserver<String> ts = new TestObserver<String>();
@@ -296,7 +296,7 @@ public class AsyncSubjectTest {
 //     */
 //    @Test
 //    public void testOnErrorThrowsDoesntPreventDelivery2() {
-//        NbpAsyncSubject<String> ps = NbpAsyncSubject.create();
+//        AsyncSubject<String> ps = AsyncSubject.create();
 //
 //        ps.subscribe();
 //        ps.subscribe();

--- a/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
@@ -354,10 +354,10 @@ public class BehaviorSubjectTest {
     // FIXME RS subscribers are not allowed to throw
 //    @Test
 //    public void testOnErrorThrowsDoesntPreventDelivery() {
-//        NbpBehaviorSubject<String> ps = NbpBehaviorSubject.create();
+//        BehaviorSubject<String> ps = BehaviorSubject.create();
 //
 //        ps.subscribe();
-//        TestNbpSubscriber<String> ts = new TestNbpSubscriber<T>();
+//        TestObserver<String> ts = new TestObserver<T>();
 //        ps.subscribe(ts);
 //
 //        try {
@@ -376,11 +376,11 @@ public class BehaviorSubjectTest {
 //     */
 //    @Test
 //    public void testOnErrorThrowsDoesntPreventDelivery2() {
-//        NbpBehaviorSubject<String> ps = NbpBehaviorSubject.create();
+//        BehaviorSubject<String> ps = BehaviorSubject.create();
 //
 //        ps.subscribe();
 //        ps.subscribe();
-//        TestNbpSubscriber<String> ts = new TestNbpSubscriber<String>();
+//        TestObserver<String> ts = new TestObserver<String>();
 //        ps.subscribe(ts);
 //        ps.subscribe();
 //        ps.subscribe();

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
@@ -32,7 +32,7 @@ import io.reactivex.schedulers.Schedulers;
 public class ReplaySubjectConcurrencyTest {
 
     @Test(timeout = 4000)
-    public void testNbpReplaySubjectConcurrentSubscribersDoingReplayDontBlockEachOther() throws InterruptedException {
+    public void testReplaySubjectConcurrentSubscribersDoingReplayDontBlockEachOther() throws InterruptedException {
         final ReplaySubject<Long> replay = ReplaySubject.create();
         Thread source = new Thread(new Runnable() {
 
@@ -142,7 +142,7 @@ public class ReplaySubjectConcurrencyTest {
     }
 
     @Test
-    public void testNbpReplaySubjectConcurrentSubscriptions() throws InterruptedException {
+    public void testReplaySubjectConcurrentSubscriptions() throws InterruptedException {
         final ReplaySubject<Long> replay = ReplaySubject.create();
         Thread source = new Thread(new Runnable() {
 
@@ -323,7 +323,7 @@ public class ReplaySubjectConcurrencyTest {
         }
     }
     @Test
-    public void testNbpReplaySubjectEmissionSubscriptionRace() throws Exception {
+    public void testReplaySubjectEmissionSubscriptionRace() throws Exception {
         Scheduler s = Schedulers.io();
         Scheduler.Worker worker = Schedulers.io().createWorker();
         try {

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
@@ -531,10 +531,10 @@ public class ReplaySubjectTest {
     // FIXME RS subscribers can't throw
 //    @Test
 //    public void testOnErrorThrowsDoesntPreventDelivery() {
-//        NbpReplaySubject<String> ps = NbpReplaySubject.create();
+//        ReplaySubject<String> ps = ReplaySubject.create();
 //
 //        ps.subscribe();
-//        NbpTestSubscriber<String> ts = new NbpTestSubscriber<String>();
+//        TestObserver<String> ts = new TestObserver<String>();
 //        ps.subscribe(ts);
 //
 //        try {
@@ -553,11 +553,11 @@ public class ReplaySubjectTest {
 //     */
 //    @Test
 //    public void testOnErrorThrowsDoesntPreventDelivery2() {
-//        NbpReplaySubject<String> ps = NbpReplaySubject.create();
+//        ReplaySubject<String> ps = ReplaySubject.create();
 //
 //        ps.subscribe();
 //        ps.subscribe();
-//        NbpTestSubscriber<String> ts = new NbpTestSubscriber<String>();
+//        TestObserver<String> ts = new TestObserver<String>();
 //        ps.subscribe(ts);
 //        ps.subscribe();
 //        ps.subscribe();

--- a/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
@@ -388,7 +388,7 @@ public class SerializedSubjectTest {
     }
 
     @Test
-    public void testDontWrapNbpSerializedSubjectAgain() {
+    public void testDontWrapSerializedSubjectAgain() {
         PublishSubject<Object> s = PublishSubject.create();
         Subject<Object> s1 = s.toSerialized();
         Subject<Object> s2 = s1.toSerialized();


### PR DESCRIPTION
- fix some javadoc typos
- replace javadoc mentioning of "unsubscribe" with either "cancel" or "dispose"
- some minor algorithm reorganizations based on IntelliJ analysis
- remove the mention of "Nbp" from the code and documentation (it refers to an earlier naming scheme for Observables and Observers)
