### PR TITLE
Add switchIfEmpty(SingleSource) method.

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3482,6 +3482,25 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
+     * Returns a Single that emits the items emitted by the source Maybe or the items of an alternate
+     * SingleSource if the current Maybe is empty.
+     * <p/>
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code switchIfEmpty} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other
+     *              the alternate SingleSource to subscribe to if the main does not emit any items
+     * @return  a Single that emits the items emitted by the source Maybe or the items of an
+     *          alternate SingleSource if the source Maybe is empty.
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Single<T> switchIfEmpty(SingleSource<? extends T> other) {
+        return switchIfEmpty(Single.wrap(other).toMaybe()).toSingle();
+    }
+
+    /**
      * Returns a Maybe that emits the items emitted by the source Maybe until a second MaybeSource
      * emits an item.
      * <p>
@@ -3744,10 +3763,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * to those values and emits the BiFunction's resulting value to downstream.
      *
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
-     * 
+     *
      * <p>If either this or the other MaybeSource is empty or signals an error, the resulting Maybe will
      * terminate immediately and dispose the other source.
-     * 
+     *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zipWith} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -2997,4 +2997,15 @@ public class MaybeTest {
             }
         }).test().assertResult(1);
     }
+
+    @Test
+    public void switchIfEmptySingle() {
+        Maybe.empty().switchIfEmpty(Single.just(1)).test().assertResult(1);
+
+        Maybe.just(1).switchIfEmpty(Single.just(2)).test().assertResult(1);
+
+        Throwable throwable = new RuntimeException();
+
+        Maybe.empty().switchIfEmpty(Single.error(throwable)).test().assertError(throwable);
+    }
 }


### PR DESCRIPTION
If you have Maybe, and do a switchIfEmpty with a Single,
you are semantically guaranteed to never get an onComplete
event.  Thus the result of the operation should be a Single
rather than a Maybe.  Let's add a convenience method for
doing this for you.
