### PR TITLE
1.x: enhance generics doOnError doOnRequest

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -5879,7 +5879,7 @@ public class Observable<T> {
      * @return the source Observable with the side-effecting behavior applied
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      */
-    public final Observable<T> doOnError(final Action1<Throwable> onError) {
+    public final Observable<T> doOnError(final Action1<? super Throwable> onError) {
         Action1<T> onNext = Actions.empty();
         Action0 onCompleted = Actions.empty();
         Observer<T> observer = new ActionObserver<T>(onNext, onError, onCompleted);
@@ -5934,7 +5934,7 @@ public class Observable<T> {
      *      documentation: Do</a>
      * @since 1.2
      */
-    public final Observable<T> doOnRequest(final Action1<Long> onRequest) {
+    public final Observable<T> doOnRequest(final Action1<? super Long> onRequest) {
         return lift(new OperatorDoOnRequest<T>(onRequest));
     }
 

--- a/src/main/java/rx/internal/operators/OperatorDoOnRequest.java
+++ b/src/main/java/rx/internal/operators/OperatorDoOnRequest.java
@@ -28,9 +28,9 @@ import rx.functions.Action1;
  */
 public class OperatorDoOnRequest<T> implements Operator<T, T> {
 
-    final Action1<Long> request;
+    final Action1<? super Long> request;
 
-    public OperatorDoOnRequest(Action1<Long> request) {
+    public OperatorDoOnRequest(Action1<? super Long> request) {
         this.request = request;
     }
 

--- a/src/main/java/rx/internal/util/ActionObserver.java
+++ b/src/main/java/rx/internal/util/ActionObserver.java
@@ -25,10 +25,10 @@ import rx.functions.*;
 public final class ActionObserver<T> implements Observer<T> {
 
     final Action1<? super T> onNext;
-    final Action1<Throwable> onError;
+    final Action1<? super Throwable> onError;
     final Action0 onCompleted;
 
-    public ActionObserver(Action1<? super T> onNext, Action1<Throwable> onError, Action0 onCompleted) {
+    public ActionObserver(Action1<? super T> onNext, Action1<? super Throwable> onError, Action0 onCompleted) {
         this.onNext = onNext;
         this.onError = onError;
         this.onCompleted = onCompleted;

--- a/src/test/java/rx/ObservableDoOnTest.java
+++ b/src/test/java/rx/ObservableDoOnTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import rx.functions.Action0;
 import rx.functions.Action1;
+import rx.observers.TestSubscriber;
 
 public class ObservableDoOnTest {
 
@@ -64,6 +65,21 @@ public class ObservableDoOnTest {
 
         assertNotNull(t);
         assertEquals(t, r.get());
+    }
+    
+    @Test
+    public void testDoOnErrorWithActionOfTypeObject() {
+        final AtomicReference<Boolean> r = new AtomicReference<Boolean>();
+        TestSubscriber<String> ts = TestSubscriber.create();
+        Observable.<String> error(new RuntimeException("an error"))
+            .doOnError(new Action1<Object>() {
+
+                @Override
+                public void call(Object v) {
+                    r.set(true);
+                }
+            }).subscribe(ts);
+        assertTrue(r.get());
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/OperatorDoOnRequestTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDoOnRequestTest.java
@@ -27,6 +27,7 @@ import rx.*;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.functions.*;
+import rx.observers.TestSubscriber;
 
 public class OperatorDoOnRequestTest {
 
@@ -139,5 +140,20 @@ public class OperatorDoOnRequestTest {
         } else {
             Assert.assertEquals(Arrays.asList(0L, 1L), requested);
         }
+    }
+    
+    @Test
+    public void canCallDoOnRequestWithActionOfTypeObject() {
+        final AtomicReference<Boolean> r = new AtomicReference<Boolean>();
+        TestSubscriber<String> ts = TestSubscriber.create();
+        Observable.just("a").doOnRequest(
+            new Action1<Object>() {
+
+                @Override
+                public void call(Object v) {
+                    r.set(true);
+                }
+            }).subscribe(ts);
+        assertTrue(r.get());
     }
 }


### PR DESCRIPTION
want to able to call `doOnError(Action1<Object>)` and similarly enhanced `doOnRequest` while I was about it.
