### PR TITLE
1.x: safeguard against building with 2.* tags

### DIFF
--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -3,6 +3,13 @@
 
 git fsck --full
 
+buildTag="$TRAVIS_TAG"
+
+if [ "$buildTag" != "" ] && [ "${buildTag:0:3}" != "v1." ]; then
+   echo -e "Wrong tag on the 1.x brach: $buildTag : build stopped"
+   exit 1
+fi
+
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
   ./gradlew -Prelease.useLastTag=true build --stacktrace


### PR DESCRIPTION
This PR adds a safeguard so that when releasing, mis-tagging the 1.x branch won't build and release `io.reactivex:rxjava:2.*` (2.x goes into `io.reactivex.rxjava2:rxjava:2.*`).

Since I can't try this locally (or can't really try a real tag&release), the PR will get a few commits along the way.
