### PR TITLE
2.x: last() to return Single

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -8877,14 +8877,14 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code last} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a Flowable that emits the last item from the source Publisher or notifies Subscribers of an
+     * @return a Single that emits the last item from the source Publisher or notifies Subscribers of an
      *         error
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX operators documentation: Last</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> last() {
-        return takeLast(1).single();
+    public final Single<T> last() {
+        return RxJavaPlugins.onAssembly(new FlowableLastSingle<T>(this, null));
     }
 
     /**
@@ -8902,14 +8902,15 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param defaultItem
      *            the default item to emit if the source Publisher is empty
-     * @return a Flowable that emits only the last item emitted by the source Publisher, or a default item
+     * @return a Single that emits only the last item emitted by the source Publisher, or a default item
      *         if the source Publisher is empty
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX operators documentation: Last</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> last(T defaultItem) {
-        return takeLast(1).single(defaultItem);
+    public final Single<T> last(T defaultItem) {
+        ObjectHelper.requireNonNull(defaultItem, "defaultItem");
+        return RxJavaPlugins.onAssembly(new FlowableLastSingle<T>(this, defaultItem));
     }
 
     /**
@@ -9937,7 +9938,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> reduce(R seed, BiFunction<R, ? super T, R> reducer) {
-        return scan(seed, reducer).last();
+        return scan(seed, reducer).takeLast(1).single(); // TODO
     }
 
     /**
@@ -9987,7 +9988,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> reduceWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
-        return scanWith(seedSupplier, reducer).last();
+        return scanWith(seedSupplier, reducer).takeLast(1).single();
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -7659,8 +7659,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX operators documentation: Last</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> last() {
-        return takeLast(1).single();
+    public final Single<T> last() {
+        return RxJavaPlugins.onAssembly(new ObservableLastSingle<T>(this, null));
     }
 
     /**
@@ -7680,8 +7680,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/last.html">ReactiveX operators documentation: Last</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> last(T defaultItem) {
-        return takeLast(1).single(defaultItem);
+    public final Single<T> last(T defaultItem) {
+        ObjectHelper.requireNonNull(defaultItem, "defaultItem is null");
+        return RxJavaPlugins.onAssembly(new ObservableLastSingle<T>(this, defaultItem));
     }
 
     /**
@@ -8202,7 +8203,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> reduce(BiFunction<T, T, T> reducer) {
-        return scan(reducer).last();
+        return scan(reducer).takeLast(1).single();
     }
 
     /**
@@ -8248,7 +8249,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> reduce(R seed, BiFunction<R, ? super T, R> reducer) {
-        return scan(seed, reducer).last();
+        return scan(seed, reducer).takeLast(1).single();
     }
 
     /**
@@ -8294,7 +8295,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> reduceWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
-        return scanWith(seedSupplier, reducer).last();
+        return scanWith(seedSupplier, reducer).takeLast(1).single();
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastSingle.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.NoSuchElementException;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+/**
+ * Consumes the source Publisher and emits its last item, the defaultItem
+ * if empty or a NoSuchElementException if even the defaultItem is null.
+ * 
+ * @param <T> the value type
+ */
+public final class FlowableLastSingle<T> extends Single<T> {
+
+    final Publisher<T> source;
+    
+    final T defaultItem;
+    
+    public FlowableLastSingle(Publisher<T> source, T defaultItem) {
+        this.source = source;
+        this.defaultItem = defaultItem;
+    }
+
+    // TODO fuse back to Flowable
+    
+    @Override
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        source.subscribe(new LastSubscriber<T>(observer, defaultItem));
+    }
+    
+    static final class LastSubscriber<T> implements Subscriber<T>, Disposable {
+        
+        final SingleObserver<? super T> actual;
+        
+        final T defaultItem;
+
+        Subscription s;
+        
+        T item;
+        
+        public LastSubscriber(SingleObserver<? super T> actual, T defaultItem) {
+            this.actual = actual;
+            this.defaultItem = defaultItem;
+        }
+
+        @Override
+        public void dispose() {
+            s.cancel();
+            s = SubscriptionHelper.CANCELLED;
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return s == SubscriptionHelper.CANCELLED;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+                
+                actual.onSubscribe(this);
+                
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            item = t;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            s = SubscriptionHelper.CANCELLED;
+            item = null;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            s = SubscriptionHelper.CANCELLED;
+            T v = item;
+            if (v != null) {
+                item = null;
+                actual.onSuccess(v);
+            } else {
+                v = defaultItem;
+                if (v == null) {
+                    actual.onError(new NoSuchElementException());
+                } else {
+                    actual.onSuccess(v);
+                }
+            }
+        }
+        
+        
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableLastSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableLastSingle.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.NoSuchElementException;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Consumes the source ObservableSource and emits its last item, the defaultItem
+ * if empty or a NoSuchElementException if even the defaultItem is null.
+ * 
+ * @param <T> the value type
+ */
+public final class ObservableLastSingle<T> extends Single<T> {
+
+    final ObservableSource<T> source;
+    
+    final T defaultItem;
+    
+    public ObservableLastSingle(ObservableSource<T> source, T defaultItem) {
+        this.source = source;
+        this.defaultItem = defaultItem;
+    }
+
+    // TODO fuse back to Observable
+    
+    @Override
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        source.subscribe(new LastObserver<T>(observer, defaultItem));
+    }
+    
+    static final class LastObserver<T> implements Observer<T>, Disposable {
+        
+        final SingleObserver<? super T> actual;
+        
+        final T defaultItem;
+
+        Disposable s;
+        
+        T item;
+        
+        public LastObserver(SingleObserver<? super T> actual, T defaultItem) {
+            this.actual = actual;
+            this.defaultItem = defaultItem;
+        }
+
+        @Override
+        public void dispose() {
+            s.dispose();
+            s = DisposableHelper.DISPOSED;
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return s == DisposableHelper.DISPOSED;
+        }
+
+        @Override
+        public void onSubscribe(Disposable s) {
+            if (DisposableHelper.validate(this.s, s)) {
+                this.s = s;
+                
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            item = t;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            s = DisposableHelper.DISPOSED;
+            item = null;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            s = DisposableHelper.DISPOSED;
+            T v = item;
+            if (v != null) {
+                item = null;
+                actual.onSuccess(v);
+            } else {
+                v = defaultItem;
+                if (v == null) {
+                    actual.onError(new NoSuchElementException());
+                } else {
+                    actual.onSuccess(v);
+                }
+            }
+        }
+        
+        
+    }
+}

--- a/src/test/java/io/reactivex/InternalWrongNaming.java
+++ b/src/test/java/io/reactivex/InternalWrongNaming.java
@@ -158,6 +158,9 @@ public class InternalWrongNaming {
 
     @Test
     public void flowableNoObserver() throws Exception {
-        checkInternalOperatorNaming("Flowable", "Observer", "FlowableFromObservable");
+        checkInternalOperatorNaming("Flowable", "Observer", 
+                "FlowableFromObservable",
+                "FlowableLastSingle"
+        );
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableLastTest.java
@@ -21,7 +21,6 @@ import java.util.NoSuchElementException;
 
 import org.junit.Test;
 import org.mockito.InOrder;
-import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.functions.Predicate;
@@ -30,21 +29,21 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithElements() {
-        Flowable<Integer> last = Flowable.just(1, 2, 3).last();
-        assertEquals(3, last.blockingSingle().intValue());
+        Single<Integer> last = Flowable.just(1, 2, 3).last();
+        assertEquals(3, last.blockingGet().intValue());
     }
 
     @Test(expected = NoSuchElementException.class)
     public void testLastWithNoElements() {
-        Flowable<?> last = Flowable.empty().last();
-        last.blockingSingle();
+        Single<?> last = Flowable.empty().last();
+        last.blockingGet();
     }
 
     @Test
     public void testLastMultiSubscribe() {
-        Flowable<Integer> last = Flowable.just(1, 2, 3).last();
-        assertEquals(3, last.blockingSingle().intValue());
-        assertEquals(3, last.blockingSingle().intValue());
+        Single<Integer> last = Flowable.just(1, 2, 3).last();
+        assertEquals(3, last.blockingGet().intValue());
+        assertEquals(3, last.blockingGet().intValue());
     }
 
     @Test
@@ -54,35 +53,35 @@ public class FlowableLastTest {
 
     @Test
     public void testLast() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3).last();
+        Single<Integer> observable = Flowable.just(1, 2, 3).last();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(3);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(3);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastWithOneElement() {
-        Flowable<Integer> observable = Flowable.just(1).last();
+        Single<Integer> observable = Flowable.just(1).last();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(1);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastWithEmpty() {
-        Flowable<Integer> observable = Flowable.<Integer> empty().last();
+        Single<Integer> observable = Flowable.<Integer> empty().last();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -93,7 +92,7 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithPredicate() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
+        Single<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
 
                     @Override
@@ -103,18 +102,18 @@ public class FlowableLastTest {
                 })
                 .last();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(6);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(6);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastWithPredicateAndOneElement() {
-        Flowable<Integer> observable = Flowable.just(1, 2)
+        Single<Integer> observable = Flowable.just(1, 2)
             .filter(
                 new Predicate<Integer>() {
 
@@ -125,18 +124,18 @@ public class FlowableLastTest {
                 })
             .last();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(2);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastWithPredicateAndEmpty() {
-        Flowable<Integer> observable = Flowable.just(1)
+        Single<Integer> observable = Flowable.just(1)
             .filter(
                 new Predicate<Integer>() {
 
@@ -146,7 +145,7 @@ public class FlowableLastTest {
                     }
                 }).last();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -157,48 +156,48 @@ public class FlowableLastTest {
 
     @Test
     public void testLastOrDefault() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3)
+        Single<Integer> observable = Flowable.just(1, 2, 3)
                 .last(4);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(3);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(3);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastOrDefaultWithOneElement() {
-        Flowable<Integer> observable = Flowable.just(1).last(2);
+        Single<Integer> observable = Flowable.just(1).last(2);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(1);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastOrDefaultWithEmpty() {
-        Flowable<Integer> observable = Flowable.<Integer> empty()
+        Single<Integer> observable = Flowable.<Integer> empty()
                 .last(1);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(1);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastOrDefaultWithPredicate() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
+        Single<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
 
                     @Override
@@ -208,18 +207,18 @@ public class FlowableLastTest {
                 })
                 .last(8);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(6);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(6);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastOrDefaultWithPredicateAndOneElement() {
-        Flowable<Integer> observable = Flowable.just(1, 2)
+        Single<Integer> observable = Flowable.just(1, 2)
                 .filter(new Predicate<Integer>() {
 
                     @Override
@@ -229,18 +228,18 @@ public class FlowableLastTest {
                 })
                 .last(4);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(2);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastOrDefaultWithPredicateAndEmpty() {
-        Flowable<Integer> observable = Flowable.just(1)
+        Single<Integer> observable = Flowable.just(1)
                 .filter(
                 new Predicate<Integer>() {
 
@@ -251,12 +250,12 @@ public class FlowableLastTest {
                 })
                 .last(2);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(2);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
@@ -215,7 +215,7 @@ public class FlowableMapTest {
                 return i;
             }
 
-        }).blockingSingle();
+        }).blockingGet();
     }
 
     /**
@@ -246,7 +246,7 @@ public class FlowableMapTest {
                 return i / 0;
             }
 
-        }).blockingSingle();
+        }).blockingGet();
     }
 
     // FIXME RS subscribers can't throw

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableLastTest.java
@@ -29,21 +29,21 @@ public class ObservableLastTest {
 
     @Test
     public void testLastWithElements() {
-        Observable<Integer> last = Observable.just(1, 2, 3).last();
-        assertEquals(3, last.blockingSingle().intValue());
+        Single<Integer> last = Observable.just(1, 2, 3).last();
+        assertEquals(3, last.blockingGet().intValue());
     }
 
     @Test(expected = NoSuchElementException.class)
     public void testLastWithNoElements() {
-        Observable<?> last = Observable.empty().last();
-        last.blockingSingle();
+        Single<?> last = Observable.empty().last();
+        last.blockingGet();
     }
 
     @Test
     public void testLastMultiSubscribe() {
-        Observable<Integer> last = Observable.just(1, 2, 3).last();
-        assertEquals(3, last.blockingSingle().intValue());
-        assertEquals(3, last.blockingSingle().intValue());
+        Single<Integer> last = Observable.just(1, 2, 3).last();
+        assertEquals(3, last.blockingGet().intValue());
+        assertEquals(3, last.blockingGet().intValue());
     }
 
     @Test
@@ -53,35 +53,35 @@ public class ObservableLastTest {
 
     @Test
     public void testLast() {
-        Observable<Integer> o = Observable.just(1, 2, 3).last();
+        Single<Integer> o = Observable.just(1, 2, 3).last();
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(3);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(3);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastWithOneElement() {
-        Observable<Integer> o = Observable.just(1).last();
+        Single<Integer> o = Observable.just(1).last();
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(1);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastWithEmpty() {
-        Observable<Integer> o = Observable.<Integer> empty().last();
+        Single<Integer> o = Observable.<Integer> empty().last();
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -92,7 +92,7 @@ public class ObservableLastTest {
 
     @Test
     public void testLastWithPredicate() {
-        Observable<Integer> o = Observable.just(1, 2, 3, 4, 5, 6)
+        Single<Integer> o = Observable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
 
                     @Override
@@ -102,18 +102,18 @@ public class ObservableLastTest {
                 })
                 .last();
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(6);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(6);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastWithPredicateAndOneElement() {
-        Observable<Integer> o = Observable.just(1, 2)
+        Single<Integer> o = Observable.just(1, 2)
             .filter(
                 new Predicate<Integer>() {
 
@@ -124,18 +124,18 @@ public class ObservableLastTest {
                 })
             .last();
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(2);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastWithPredicateAndEmpty() {
-        Observable<Integer> o = Observable.just(1)
+        Single<Integer> o = Observable.just(1)
             .filter(
                 new Predicate<Integer>() {
 
@@ -145,7 +145,7 @@ public class ObservableLastTest {
                     }
                 }).last();
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -156,48 +156,48 @@ public class ObservableLastTest {
 
     @Test
     public void testLastOrDefault() {
-        Observable<Integer> o = Observable.just(1, 2, 3)
+        Single<Integer> o = Observable.just(1, 2, 3)
                 .last(4);
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(3);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(3);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastOrDefaultWithOneElement() {
-        Observable<Integer> o = Observable.just(1).last(2);
+        Single<Integer> o = Observable.just(1).last(2);
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(1);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastOrDefaultWithEmpty() {
-        Observable<Integer> o = Observable.<Integer> empty()
+        Single<Integer> o = Observable.<Integer> empty()
                 .last(1);
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(1);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastOrDefaultWithPredicate() {
-        Observable<Integer> o = Observable.just(1, 2, 3, 4, 5, 6)
+        Single<Integer> o = Observable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
 
                     @Override
@@ -207,18 +207,18 @@ public class ObservableLastTest {
                 })
                 .last(8);
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(6);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(6);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastOrDefaultWithPredicateAndOneElement() {
-        Observable<Integer> o = Observable.just(1, 2)
+        Single<Integer> o = Observable.just(1, 2)
                 .filter(new Predicate<Integer>() {
 
                     @Override
@@ -228,18 +228,18 @@ public class ObservableLastTest {
                 })
                 .last(4);
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(2);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastOrDefaultWithPredicateAndEmpty() {
-        Observable<Integer> o = Observable.just(1)
+        Single<Integer> o = Observable.just(1)
                 .filter(
                 new Predicate<Integer>() {
 
@@ -250,12 +250,12 @@ public class ObservableLastTest {
                 })
                 .last(2);
 
-        Observer<Integer> observer = TestHelper.mockObserver();
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(observer, times(1)).onSuccess(2);
+//        inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMapTest.java
@@ -213,7 +213,7 @@ public class ObservableMapTest {
                 return i;
             }
 
-        }).blockingSingle();
+        }).blockingGet();
     }
 
     /**
@@ -244,7 +244,7 @@ public class ObservableMapTest {
                 return i / 0;
             }
 
-        }).blockingSingle();
+        }).blockingGet();
     }
 
     // FIXME RS subscribers can't throw

--- a/src/test/java/io/reactivex/tck/LastTckTest.java
+++ b/src/test/java/io/reactivex/tck/LastTckTest.java
@@ -24,7 +24,7 @@ public class LastTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.range(1, 10).last()
+                Flowable.range(1, 10).last().hide().toFlowable()
             );
     }
 


### PR DESCRIPTION
This PR changes the return type of `last()` to `Single<T>` and updates the relevant locations.

Originally, it was implemented as `takeLast(1).single()` so to reduce impact, all other original uses now have this inlined.
