### PR TITLE
2.x: make any() and all() return Single, patch up tests

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -29,9 +29,9 @@ import io.reactivex.internal.operators.maybe.MaybeFromCompletable;
 import io.reactivex.internal.operators.observable.ObservableDelaySubscriptionOther;
 import io.reactivex.internal.operators.single.SingleDelayWithCompletable;
 import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.TestSubscriber;
 
 /**
  * Represents a deferred computation without any value but only indication for completion or exception.
@@ -1804,41 +1804,41 @@ public abstract class Completable implements CompletableSource {
     // -------------------------------------------------------------------------
 
     /**
-     * Creates a TestSubscriber and subscribes
+     * Creates a TestObserver and subscribes
      * it to this Completable.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the new TestSubscriber instance
+     * @return the new TestObserver instance
      * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final TestSubscriber<Void> test() {
-        TestSubscriber<Void> ts = new TestSubscriber<Void>();
-        subscribe(new SubscriberCompletableObserver<Void>(ts));
+    public final TestObserver<Void> test() {
+        TestObserver<Void> ts = new TestObserver<Void>();
+        subscribe(ts);
         return ts;
     }
 
     /**
-     * Creates a TestSubscriber optionally in cancelled state, then subscribes it to this Completable.
-     * @param cancelled if true, the TestSubscriber will be cancelled before subscribing to this
+     * Creates a TestObserver optionally in cancelled state, then subscribes it to this Completable.
+     * @param cancelled if true, the TestObserver will be cancelled before subscribing to this
      * Completable.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the new TestSubscriber instance
+     * @return the new TestObserver instance
      * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final TestSubscriber<Void> test(boolean cancelled) {
-        TestSubscriber<Void> ts = new TestSubscriber<Void>();
+    public final TestObserver<Void> test(boolean cancelled) {
+        TestObserver<Void> ts = new TestObserver<Void>();
 
         if (cancelled) {
             ts.cancel();
         }
-        subscribe(new SubscriberCompletableObserver<Void>(ts));
+        subscribe(ts);
         return ts;
     }
 }

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -4862,15 +4862,15 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param predicate
      *            a function that evaluates an item and returns a Boolean
-     * @return a Flowable that emits {@code true} if all items emitted by the source Publisher satisfy the
+     * @return a Single that emits {@code true} if all items emitted by the source Publisher satisfy the
      *         predicate; otherwise, {@code false}
      * @see <a href="http://reactivex.io/documentation/operators/all.html">ReactiveX operators documentation: All</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<Boolean> all(Predicate<? super T> predicate) {
+    public final Single<Boolean> all(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new FlowableAll<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new FlowableAllSingle<T>(this, predicate));
     }
 
     /**
@@ -4919,15 +4919,15 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param predicate
      *            the condition to test items emitted by the source Publisher
-     * @return a Flowable that emits a Boolean that indicates whether any item emitted by the source
+     * @return a Single that emits a Boolean that indicates whether any item emitted by the source
      *         Publisher satisfies the {@code predicate}
      * @see <a href="http://reactivex.io/documentation/operators/contains.html">ReactiveX operators documentation: Contains</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<Boolean> any(Predicate<? super T> predicate) {
+    public final Single<Boolean> any(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new FlowableAny<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new FlowableAnySingle<T>(this, predicate));
     }
 
     /**
@@ -6660,7 +6660,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<Boolean> contains(final Object item) {
+    public final Single<Boolean> contains(final Object item) {
         ObjectHelper.requireNonNull(item, "item is null");
         return any(Functions.equalsWith(item));
     }
@@ -8814,7 +8814,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<Boolean> isEmpty() {
+    public final Single<Boolean> isEmpty() {
         return all(Functions.alwaysFalse());
     }
 

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -26,9 +26,9 @@ import io.reactivex.internal.observers.BlockingMultiObserver;
 import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.operators.maybe.*;
 import io.reactivex.internal.util.*;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.TestSubscriber;
 
 /**
  * Represents a deferred computation and emission of a maybe value or exception.
@@ -3776,40 +3776,40 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     // ------------------------------------------------------------------
 
     /**
-     * Creates a TestSubscriber and subscribes
+     * Creates a TestObserver and subscribes
      * it to this Maybe.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the new TestSubscriber instance
+     * @return the new TestObserver instance
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final TestSubscriber<T> test() {
-        TestSubscriber<T> ts = new TestSubscriber<T>();
-        toFlowable().subscribe(ts);
+    public final TestObserver<T> test() {
+        TestObserver<T> ts = new TestObserver<T>();
+        subscribe(ts);
         return ts;
     }
 
     /**
-     * Creates a TestSubscriber optionally in cancelled state, then subscribes it to this Maybe.
+     * Creates a TestObserver optionally in cancelled state, then subscribes it to this Maybe.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param cancelled if true, the TestSubscriber will be cancelled before subscribing to this
+     * @param cancelled if true, the TestObserver will be cancelled before subscribing to this
      * Maybe.
-     * @return the new TestSubscriber instance
+     * @return the new TestObserver instance
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final TestSubscriber<T> test(boolean cancelled) {
-        TestSubscriber<T> ts = new TestSubscriber<T>();
+    public final TestObserver<T> test(boolean cancelled) {
+        TestObserver<T> ts = new TestObserver<T>();
 
         if (cancelled) {
             ts.cancel();
         }
 
-        toFlowable().subscribe(ts);
+        subscribe(ts);
         return ts;
     }
 }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -4260,14 +4260,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param predicate
      *            a function that evaluates an item and returns a Boolean
-     * @return an Observable that emits {@code true} if all items emitted by the source ObservableSource satisfy the
+     * @return a Single that emits {@code true} if all items emitted by the source ObservableSource satisfy the
      *         predicate; otherwise, {@code false}
      * @see <a href="http://reactivex.io/documentation/operators/all.html">ReactiveX operators documentation: All</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<Boolean> all(Predicate<? super T> predicate) {
+    public final Single<Boolean> all(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new ObservableAll<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new ObservableAllSingle<T>(this, predicate));
     }
 
     /**
@@ -4309,14 +4309,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param predicate
      *            the condition to test items emitted by the source ObservableSource
-     * @return an Observable that emits a Boolean that indicates whether any item emitted by the source
+     * @return a Single that emits a Boolean that indicates whether any item emitted by the source
      *         ObservableSource satisfies the {@code predicate}
      * @see <a href="http://reactivex.io/documentation/operators/contains.html">ReactiveX operators documentation: Contains</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<Boolean> any(Predicate<? super T> predicate) {
+    public final Single<Boolean> any(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new ObservableAny<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new ObservableAnySingle<T>(this, predicate));
     }
 
     /**
@@ -5798,12 +5798,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param element
      *            the item to search for in the emissions from the source ObservableSource
-     * @return an Observable that emits {@code true} if the specified item is emitted by the source ObservableSource,
+     * @return a Single that emits {@code true} if the specified item is emitted by the source ObservableSource,
      *         or {@code false} if the source ObservableSource completes without emitting that item
      * @see <a href="http://reactivex.io/documentation/operators/contains.html">ReactiveX operators documentation: Contains</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<Boolean> contains(final Object element) {
+    public final Single<Boolean> contains(final Object element) {
         ObjectHelper.requireNonNull(element, "element is null");
         return any(Functions.equalsWith(element));
     }
@@ -7594,11 +7594,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code isEmpty} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an Observable that emits a Boolean
+     * @return a Single that emits a Boolean
      * @see <a href="http://reactivex.io/documentation/operators/contains.html">ReactiveX operators documentation: Contains</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<Boolean> isEmpty() {
+    public final Single<Boolean> isEmpty() {
         return all(Functions.alwaysFalse());
     }
 

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -15,7 +15,7 @@ package io.reactivex;
 
 import java.util.concurrent.*;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Publisher;
 
 import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
@@ -30,9 +30,9 @@ import io.reactivex.internal.operators.maybe.*;
 import io.reactivex.internal.operators.observable.ObservableConcatMap;
 import io.reactivex.internal.operators.single.*;
 import io.reactivex.internal.util.*;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.TestSubscriber;
 
 /**
  * The Single class implements the Reactive Pattern for a single value response.
@@ -2806,42 +2806,42 @@ public abstract class Single<T> implements SingleSource<T> {
     // Fluent test support, super handy and reduces test preparation boilerplate
     // -------------------------------------------------------------------------
     /**
-     * Creates a TestSubscriber and subscribes
+     * Creates a TestObserver and subscribes
      * it to this Single.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the new TestSubscriber instance
+     * @return the new TestObserver instance
      * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final TestSubscriber<T> test() {
-        TestSubscriber<T> ts = new TestSubscriber<T>();
-        toFlowable().subscribe(ts);
+    public final TestObserver<T> test() {
+        TestObserver<T> ts = new TestObserver<T>();
+        subscribe(ts);
         return ts;
     }
 
     /**
-     * Creates a TestSubscriber optionally in cancelled state, then subscribes it to this Single.
+     * Creates a TestObserver optionally in cancelled state, then subscribes it to this Single.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param cancelled if true, the TestSubscriber will be cancelled before subscribing to this
+     * @param cancelled if true, the TestObserver will be cancelled before subscribing to this
      * Single.
-     * @return the new TestSubscriber instance
+     * @return the new TestObserver instance
      * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final TestSubscriber<T> test(boolean cancelled) {
-        TestSubscriber<T> ts = new TestSubscriber<T>();
+    public final TestObserver<T> test(boolean cancelled) {
+        TestObserver<T> ts = new TestObserver<T>();
 
         if (cancelled) {
             ts.cancel();
         }
 
-        toFlowable().subscribe(ts);
+        subscribe(ts);
         return ts;
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAllSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAllSingle.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.fuseable.FuseToFlowable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class FlowableAllSingle<T> extends Single<Boolean> implements FuseToFlowable<Boolean> {
+
+    final Publisher<T> source;
+    
+    final Predicate<? super T> predicate;
+
+    public FlowableAllSingle(Publisher<T> source, Predicate<? super T> predicate) {
+        this.source = source;
+        this.predicate = predicate;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super Boolean> s) {
+        source.subscribe(new AllSubscriber<T>(s, predicate));
+    }
+
+    @Override
+    public Flowable<Boolean> fuseToFlowable() {
+        return RxJavaPlugins.onAssembly(new FlowableAll<T>(source, predicate));
+    }
+    
+    static final class AllSubscriber<T> implements Subscriber<T>, Disposable {
+        
+        final SingleObserver<? super Boolean> actual;
+        
+        final Predicate<? super T> predicate;
+
+        Subscription s;
+
+        boolean done;
+
+        AllSubscriber(SingleObserver<? super Boolean> actual, Predicate<? super T> predicate) {
+            this.actual = actual;
+            this.predicate = predicate;
+        }
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+                actual.onSubscribe(this);
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            boolean b;
+            try {
+                b = predicate.test(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                s.cancel();
+                s = SubscriptionHelper.CANCELLED;
+                onError(e);
+                return;
+            }
+            if (!b) {
+                done = true;
+                s.cancel();
+                s = SubscriptionHelper.CANCELLED;
+                actual.onSuccess(false);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            s = SubscriptionHelper.CANCELLED;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            s = SubscriptionHelper.CANCELLED;
+
+            actual.onSuccess(true);
+        }
+
+        @Override
+        public void dispose() {
+            s.cancel();
+            s = SubscriptionHelper.CANCELLED;
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return s == SubscriptionHelper.CANCELLED;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAnySingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAnySingle.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.fuseable.FuseToFlowable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class FlowableAnySingle<T> extends Single<Boolean> implements FuseToFlowable<Boolean> {
+    final Publisher<T> source;
+    
+    final Predicate<? super T> predicate;
+    
+    public FlowableAnySingle(Publisher<T> source, Predicate<? super T> predicate) {
+        this.source = source;
+        this.predicate = predicate;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super Boolean> s) {
+        source.subscribe(new AnySubscriber<T>(s, predicate));
+    }
+    
+    @Override
+    public Flowable<Boolean> fuseToFlowable() {
+        return RxJavaPlugins.onAssembly(new FlowableAny<T>(source, predicate));
+    }
+
+    static final class AnySubscriber<T> implements Subscriber<T>, Disposable {
+
+        final SingleObserver<? super Boolean> actual;
+        
+        final Predicate<? super T> predicate;
+
+        Subscription s;
+
+        boolean done;
+
+        AnySubscriber(SingleObserver<? super Boolean> actual, Predicate<? super T> predicate) {
+            this.actual = actual;
+            this.predicate = predicate;
+        }
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+                actual.onSubscribe(this);
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            boolean b;
+            try {
+                b = predicate.test(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                s.cancel();
+                s = SubscriptionHelper.CANCELLED;
+                onError(e);
+                return;
+            }
+            if (b) {
+                done = true;
+                s.cancel();
+                s = SubscriptionHelper.CANCELLED;
+                actual.onSuccess(true);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (!done) {
+                done = true;
+                s = SubscriptionHelper.CANCELLED;
+                actual.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (!done) {
+                done = true;
+                s = SubscriptionHelper.CANCELLED;
+                actual.onSuccess(false);
+            }
+        }
+
+        @Override
+        public void dispose() {
+            s.cancel();
+            s = SubscriptionHelper.CANCELLED;
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return s == SubscriptionHelper.CANCELLED;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAllSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAllSingle.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.FuseToObservable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class ObservableAllSingle<T> extends Single<Boolean> implements FuseToObservable<Boolean>{
+    final ObservableSource<T> source;
+    
+    final Predicate<? super T> predicate;
+    public ObservableAllSingle(ObservableSource<T> source, Predicate<? super T> predicate) {
+        this.source = source;
+        this.predicate = predicate;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super Boolean> t) {
+        source.subscribe(new AllObserver<T>(t, predicate));
+    }
+    
+    @Override
+    public Observable<Boolean> fuseToObservable() {
+        return RxJavaPlugins.onAssembly(new ObservableAll<T>(source, predicate));
+    }
+
+    static final class AllObserver<T> implements Observer<T>, Disposable {
+        final SingleObserver<? super Boolean> actual;
+        final Predicate<? super T> predicate;
+
+        Disposable s;
+
+        boolean done;
+
+        AllObserver(SingleObserver<? super Boolean> actual, Predicate<? super T> predicate) {
+            this.actual = actual;
+            this.predicate = predicate;
+        }
+        @Override
+        public void onSubscribe(Disposable s) {
+            if (DisposableHelper.validate(this.s, s)) {
+                this.s = s;
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            boolean b;
+            try {
+                b = predicate.test(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                s.dispose();
+                onError(e);
+                return;
+            }
+            if (!b) {
+                done = true;
+                s.dispose();
+                actual.onSuccess(false);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            actual.onSuccess(true);
+        }
+
+        @Override
+        public void dispose() {
+            s.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return s.isDisposed();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAnySingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAnySingle.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.FuseToObservable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class ObservableAnySingle<T> extends Single<Boolean> implements FuseToObservable<Boolean> {
+    final ObservableSource<T> source;
+    
+    final Predicate<? super T> predicate;
+    
+    public ObservableAnySingle(ObservableSource<T> source, Predicate<? super T> predicate) {
+        this.source = source;
+        this.predicate = predicate;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super Boolean> t) {
+        source.subscribe(new AnyObserver<T>(t, predicate));
+    }
+    
+    @Override
+    public Observable<Boolean> fuseToObservable() {
+        return RxJavaPlugins.onAssembly(new ObservableAny<T>(source, predicate));
+    }
+
+    static final class AnyObserver<T> implements Observer<T>, Disposable {
+
+        final SingleObserver<? super Boolean> actual;
+        final Predicate<? super T> predicate;
+
+        Disposable s;
+
+        boolean done;
+
+        AnyObserver(SingleObserver<? super Boolean> actual, Predicate<? super T> predicate) {
+            this.actual = actual;
+            this.predicate = predicate;
+        }
+        @Override
+        public void onSubscribe(Disposable s) {
+            if (DisposableHelper.validate(this.s, s)) {
+                this.s = s;
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            boolean b;
+            try {
+                b = predicate.test(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                s.dispose();
+                onError(e);
+                return;
+            }
+            if (b) {
+                done = true;
+                s.dispose();
+                actual.onSuccess(true);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (!done) {
+                done = true;
+                actual.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (!done) {
+                done = true;
+                actual.onSuccess(false);
+            }
+        }
+
+        @Override
+        public void dispose() {
+            s.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return s.isDisposed();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/observers/TestObserver.java
@@ -16,7 +16,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.Notification;
+import io.reactivex.*;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
@@ -29,14 +29,14 @@ import io.reactivex.internal.util.ExceptionHelper;
 /**
  * An Observer that records events and allows making assertions about them.
  *
- * <p>You can override the onSubscribe, onNext, onError, onComplete and
+ * <p>You can override the onSubscribe, onNext, onError, onComplete, onSuccess and
  * cancel methods but not the others (this is by design).
  *
  * <p>The TestObserver implements Disposable for convenience where dispose calls cancel.
  *
  * @param <T> the value type
  */
-public class TestObserver<T> implements Observer<T>, Disposable {
+public class TestObserver<T> implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, CompletableObserver {
     /** The actual observer to forward events to. */
     private final Observer<? super T> actual;
     /** The latch that indicates an onError or onComplete has been called. */
@@ -898,6 +898,12 @@ public class TestObserver<T> implements Observer<T>, Disposable {
                 .assertNotComplete();
     }
 
+    @Override
+    public void onSuccess(T value) {
+        onNext(value);
+        onComplete();
+    }
+    
     /**
      * An observer that ignores all events and does not report errors.
      */

--- a/src/test/java/io/reactivex/InternalWrongNaming.java
+++ b/src/test/java/io/reactivex/InternalWrongNaming.java
@@ -160,7 +160,9 @@ public class InternalWrongNaming {
     public void flowableNoObserver() throws Exception {
         checkInternalOperatorNaming("Flowable", "Observer", 
                 "FlowableFromObservable",
-                "FlowableLastSingle"
+                "FlowableLastSingle",
+                "FlowableAnySingle",
+                "FlowableAllSingle"
         );
     }
 }

--- a/src/test/java/io/reactivex/JavadocWording.java
+++ b/src/test/java/io/reactivex/JavadocWording.java
@@ -101,7 +101,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Observer", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("ObservableSource")
-                                && !m.signature.contains("Observable")) {
+                                && !m.signature.contains("Observable")
+                                && !m.signature.contains("TestObserver")) {
 
                             if (idx < 5 || !m.javadoc.substring(idx - 5, idx + 8).equals("MaybeObserver")) {
                                 e.append("java.lang.RuntimeException: Maybe doc mentions Observer but not using Observable\r\n at io.reactivex.")
@@ -483,7 +484,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Observer", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("ObservableSource")
-                                && !m.signature.contains("Observable")) {
+                                && !m.signature.contains("Observable")
+                                && !m.signature.contains("TestObserver")) {
 
                             if (idx < 6 || !m.javadoc.substring(idx - 6, idx + 8).equals("SingleObserver")) {
                                 e.append("java.lang.RuntimeException: Single doc mentions Observer but not using Observable\r\n at io.reactivex.")
@@ -656,7 +658,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Observer", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("ObservableSource")
-                                && !m.signature.contains("Observable")) {
+                                && !m.signature.contains("Observable")
+                                && !m.signature.contains("TestObserver")) {
 
                             if (idx < 11 || !m.javadoc.substring(idx - 11, idx + 8).equals("CompletableObserver")) {
                                 e.append("java.lang.RuntimeException: Maybe doc mentions Observer but not using Observable\r\n at io.reactivex.")

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -757,8 +757,8 @@ public class FlowableTests {
     }
 
     @Test
-    public void testContains() {
-        Flowable<Boolean> observable = Flowable.just("a", "b", "c").contains("b"); // FIXME nulls not allowed, changed to "c"
+    public void testContainsFlowable() {
+        Flowable<Boolean> observable = Flowable.just("a", "b", "c").contains("b").toFlowable();
 
         Subscriber<Boolean> observer = TestHelper.mockSubscriber();
 
@@ -772,8 +772,8 @@ public class FlowableTests {
     }
 
     @Test
-    public void testContainsWithInexistence() {
-        Flowable<Boolean> observable = Flowable.just("a", "b").contains("c"); // FIXME null values are not allowed, removed
+    public void testContainsWithInexistenceFlowable() {
+        Flowable<Boolean> observable = Flowable.just("a", "b").contains("c").toFlowable();
 
         Subscriber<Object> observer = TestHelper.mockSubscriber();
 
@@ -788,8 +788,8 @@ public class FlowableTests {
 
     @Test
     @Ignore("null values are not allowed")
-    public void testContainsWithNull() {
-        Flowable<Boolean> observable = Flowable.just("a", "b", null).contains(null);
+    public void testContainsWithNullFlowable() {
+        Flowable<Boolean> observable = Flowable.just("a", "b", null).contains(null).toFlowable();
 
         Subscriber<Object> observer = TestHelper.mockSubscriber();
 
@@ -803,8 +803,8 @@ public class FlowableTests {
     }
 
     @Test
-    public void testContainsWithEmptyObservable() {
-        Flowable<Boolean> observable = Flowable.<String> empty().contains("a");
+    public void testContainsWithEmptyObservableFlowable() {
+        Flowable<Boolean> observable = Flowable.<String> empty().contains("a").toFlowable();
 
         Subscriber<Object> observer = TestHelper.mockSubscriber();
 
@@ -815,6 +815,64 @@ public class FlowableTests {
         verify(observer, never()).onError(
                 org.mockito.Matchers.any(Throwable.class));
         verify(observer, times(1)).onComplete();
+    }
+
+
+    @Test
+    public void testContains() {
+        Single<Boolean> observable = Flowable.just("a", "b", "c").contains("b"); // FIXME nulls not allowed, changed to "c"
+
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
+
+        observable.subscribe(observer);
+
+        verify(observer, times(1)).onSuccess(true);
+        verify(observer, never()).onSuccess(false);
+        verify(observer, never()).onError(
+                org.mockito.Matchers.any(Throwable.class));
+    }
+
+    @Test
+    public void testContainsWithInexistence() {
+        Single<Boolean> observable = Flowable.just("a", "b").contains("c"); // FIXME null values are not allowed, removed
+
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
+
+        observable.subscribe(observer);
+
+        verify(observer, times(1)).onSuccess(false);
+        verify(observer, never()).onSuccess(true);
+        verify(observer, never()).onError(
+                org.mockito.Matchers.any(Throwable.class));
+    }
+
+    @Test
+    @Ignore("null values are not allowed")
+    public void testContainsWithNull() {
+        Single<Boolean> observable = Flowable.just("a", "b", null).contains(null);
+
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
+
+        observable.subscribe(observer);
+
+        verify(observer, times(1)).onSuccess(true);
+        verify(observer, never()).onSuccess(false);
+        verify(observer, never()).onError(
+                org.mockito.Matchers.any(Throwable.class));
+    }
+
+    @Test
+    public void testContainsWithEmptyObservable() {
+        Single<Boolean> observable = Flowable.<String> empty().contains("a");
+
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
+
+        observable.subscribe(observer);
+
+        verify(observer, times(1)).onSuccess(false);
+        verify(observer, never()).onSuccess(true);
+        verify(observer, never()).onError(
+                org.mockito.Matchers.any(Throwable.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeOnTest.java
@@ -21,9 +21,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import io.reactivex.*;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class CompletableSubscribeOnTest {
 
@@ -33,7 +33,7 @@ public class CompletableSubscribeOnTest {
         try {
             TestScheduler scheduler = new TestScheduler();
 
-            TestSubscriber<Void> ts = Completable.complete()
+            TestObserver<Void> ts = Completable.complete()
             .subscribeOn(scheduler)
             .test();
 

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
@@ -13,20 +13,17 @@
 
 package io.reactivex.internal.operators.completable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.concurrent.*;
 
-import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subjects.PublishSubject;
-import io.reactivex.subscribers.TestSubscriber;
 import org.junit.Test;
 
 import io.reactivex.Completable;
 import io.reactivex.functions.Action;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.*;
+import io.reactivex.subjects.PublishSubject;
 
 public class CompletableTimeoutTest {
 
@@ -66,7 +63,7 @@ public class CompletableTimeoutTest {
         final PublishSubject<String> subject = PublishSubject.create();
         final TestScheduler scheduler = new TestScheduler();
 
-        final TestSubscriber<Void> observer = subject.toCompletable()
+        final TestObserver<Void> observer = subject.toCompletable()
                 .timeout(100, TimeUnit.MILLISECONDS, scheduler)
                 .test();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
@@ -18,11 +18,12 @@ import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.functions.*;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableAnyTest {
@@ -30,205 +31,195 @@ public class FlowableAnyTest {
     @Test
     public void testAnyWithTwoItems() {
         Flowable<Integer> w = Flowable.just(1, 2);
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
             }
         });
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
         observable.subscribe(observer);
 
-        verify(observer, never()).onNext(false);
-        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onSuccess(false);
+        verify(observer, times(1)).onSuccess(true);
         verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testIsEmptyWithTwoItems() {
         Flowable<Integer> w = Flowable.just(1, 2);
-        Flowable<Boolean> observable = w.isEmpty();
+        Single<Boolean> observable = w.isEmpty();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
         observable.subscribe(observer);
 
-        verify(observer, never()).onNext(true);
-        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onSuccess(true);
+        verify(observer, times(1)).onSuccess(false);
         verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAnyWithOneItem() {
         Flowable<Integer> w = Flowable.just(1);
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
             }
         });
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
         observable.subscribe(observer);
 
-        verify(observer, never()).onNext(false);
-        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onSuccess(false);
+        verify(observer, times(1)).onSuccess(true);
         verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testIsEmptyWithOneItem() {
         Flowable<Integer> w = Flowable.just(1);
-        Flowable<Boolean> observable = w.isEmpty();
+        Single<Boolean> observable = w.isEmpty();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
         observable.subscribe(observer);
 
-        verify(observer, never()).onNext(true);
-        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onSuccess(true);
+        verify(observer, times(1)).onSuccess(false);
         verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAnyWithEmpty() {
         Flowable<Integer> w = Flowable.empty();
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
             }
         });
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
         observable.subscribe(observer);
 
-        verify(observer, times(1)).onNext(false);
-        verify(observer, never()).onNext(true);
+        verify(observer, times(1)).onSuccess(false);
+        verify(observer, never()).onSuccess(true);
         verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testIsEmptyWithEmpty() {
         Flowable<Integer> w = Flowable.empty();
-        Flowable<Boolean> observable = w.isEmpty();
+        Single<Boolean> observable = w.isEmpty();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
         observable.subscribe(observer);
 
-        verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onSuccess(true);
+        verify(observer, never()).onSuccess(false);
         verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAnyWithPredicate1() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 2;
             }
         });
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
         observable.subscribe(observer);
 
-        verify(observer, never()).onNext(false);
-        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onSuccess(false);
+        verify(observer, times(1)).onSuccess(true);
         verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testExists1() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 2;
             }
         });
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
         observable.subscribe(observer);
 
-        verify(observer, never()).onNext(false);
-        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onSuccess(false);
+        verify(observer, times(1)).onSuccess(true);
         verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAnyWithPredicate2() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 1;
             }
         });
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
         observable.subscribe(observer);
 
-        verify(observer, times(1)).onNext(false);
-        verify(observer, never()).onNext(true);
+        verify(observer, times(1)).onSuccess(false);
+        verify(observer, never()).onSuccess(true);
         verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testAnyWithEmptyAndPredicate() {
         // If the source is empty, always output false.
         Flowable<Integer> w = Flowable.empty();
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> observable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t) {
                 return true;
             }
         });
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
         observable.subscribe(observer);
 
-        verify(observer, times(1)).onNext(false);
-        verify(observer, never()).onNext(true);
+        verify(observer, times(1)).onSuccess(false);
+        verify(observer, never()).onSuccess(true);
         verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
-        verify(observer, times(1)).onComplete();
     }
 
     @Test
     public void testWithFollowingFirst() {
         Flowable<Integer> o = Flowable.fromArray(1, 3, 5, 6);
-        Flowable<Boolean> anyEven = o.any(new Predicate<Integer>() {
+        Single<Boolean> anyEven = o.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer i) {
                 return i % 2 == 0;
             }
         });
 
-        assertTrue(anyEven.blockingFirst());
+        assertTrue(anyEven.blockingGet());
     }
     @Test(timeout = 5000)
     public void testIssue1935NoUnsubscribeDownstream() {
         Flowable<Integer> source = Flowable.just(1).isEmpty()
-            .flatMap(new Function<Boolean, Publisher<Integer>>() {
+            .flatMapPublisher(new Function<Boolean, Publisher<Integer>>() {
                 @Override
                 public Publisher<Integer> apply(Boolean t1) {
                     return Flowable.just(2).delay(500, TimeUnit.MILLISECONDS);
@@ -239,8 +230,9 @@ public class FlowableAnyTest {
     }
 
     @Test
+    @Ignore("Single doesn't do backpressure")
     public void testBackpressureIfNoneRequestedNoneShouldBeDelivered() {
-        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>(0L);
+        TestObserver<Boolean> ts = new TestObserver<Boolean>();
 
         Flowable.just(1).any(new Predicate<Integer>() {
             @Override
@@ -257,7 +249,7 @@ public class FlowableAnyTest {
 
     @Test
     public void testBackpressureIfOneRequestedOneShouldBeDelivered() {
-        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>(1L);
+        TestObserver<Boolean> ts = new TestObserver<Boolean>();
         Flowable.just(1).any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
@@ -273,7 +265,7 @@ public class FlowableAnyTest {
 
     @Test
     public void testPredicateThrowsExceptionAndValueInCauseMessage() {
-        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>();
+        TestObserver<Boolean> ts = new TestObserver<Boolean>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
         Flowable.just("Boo!").any(new Predicate<String>() {
@@ -282,6 +274,271 @@ public class FlowableAnyTest {
                 throw ex;
             }
         }).subscribe(ts);
+
+        ts.assertTerminated();
+        ts.assertNoValues();
+        ts.assertNotComplete();
+        ts.assertError(ex);
+        // FIXME value as last cause?
+//        assertTrue(ex.getCause().getMessage().contains("Boo!"));
+    }
+
+    @Test
+    public void testAnyWithTwoItemsFlowable() {
+        Flowable<Integer> w = Flowable.just(1, 2);
+        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) {
+                return true;
+            }
+        })
+        .toFlowable()
+        ;
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testIsEmptyWithTwoItemsFlowable() {
+        Flowable<Integer> w = Flowable.just(1, 2);
+        Flowable<Boolean> observable = w.isEmpty().toFlowable();
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+
+        verify(observer, never()).onNext(true);
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testAnyWithOneItemFlowable() {
+        Flowable<Integer> w = Flowable.just(1);
+        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) {
+                return true;
+            }
+        }).toFlowable();
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testIsEmptyWithOneItemFlowable() {
+        Flowable<Integer> w = Flowable.just(1);
+        Single<Boolean> observable = w.isEmpty();
+
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
+
+        observable.subscribe(observer);
+
+        verify(observer, never()).onSuccess(true);
+        verify(observer, times(1)).onSuccess(false);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+    }
+
+    @Test
+    public void testAnyWithEmptyFlowable() {
+        Flowable<Integer> w = Flowable.empty();
+        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) {
+                return true;
+            }
+        }).toFlowable();
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testIsEmptyWithEmptyFlowable() {
+        Flowable<Integer> w = Flowable.empty();
+        Flowable<Boolean> observable = w.isEmpty().toFlowable();
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onNext(false);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testAnyWithPredicate1Flowable() {
+        Flowable<Integer> w = Flowable.just(1, 2, 3);
+        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer t1) {
+                return t1 < 2;
+            }
+        }).toFlowable();
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testExists1Flowable() {
+        Flowable<Integer> w = Flowable.just(1, 2, 3);
+        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer t1) {
+                return t1 < 2;
+            }
+        }).toFlowable();
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+
+        verify(observer, never()).onNext(false);
+        verify(observer, times(1)).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testAnyWithPredicate2Flowable() {
+        Flowable<Integer> w = Flowable.just(1, 2, 3);
+        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer t1) {
+                return t1 < 1;
+            }
+        }).toFlowable();
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testAnyWithEmptyAndPredicateFlowable() {
+        // If the source is empty, always output false.
+        Flowable<Integer> w = Flowable.empty();
+        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer t) {
+                return true;
+            }
+        }).toFlowable();
+
+        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+
+        observable.subscribe(observer);
+
+        verify(observer, times(1)).onNext(false);
+        verify(observer, never()).onNext(true);
+        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testWithFollowingFirstFlowable() {
+        Flowable<Integer> o = Flowable.fromArray(1, 3, 5, 6);
+        Flowable<Boolean> anyEven = o.any(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer i) {
+                return i % 2 == 0;
+            }
+        }).toFlowable();
+
+        assertTrue(anyEven.blockingFirst());
+    }
+    @Test(timeout = 5000)
+    public void testIssue1935NoUnsubscribeDownstreamFlowable() {
+        Flowable<Integer> source = Flowable.just(1).isEmpty()
+            .flatMapPublisher(new Function<Boolean, Publisher<Integer>>() {
+                @Override
+                public Publisher<Integer> apply(Boolean t1) {
+                    return Flowable.just(2).delay(500, TimeUnit.MILLISECONDS);
+                }
+            });
+
+        assertEquals((Object)2, source.blockingFirst());
+    }
+
+    @Test
+    public void testBackpressureIfNoneRequestedNoneShouldBeDeliveredFlowable() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>(0L);
+
+        Flowable.just(1).any(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer t) {
+                return true;
+            }
+        }).toFlowable()
+        .subscribe(ts);
+
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void testBackpressureIfOneRequestedOneShouldBeDeliveredFlowable() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>(1L);
+        Flowable.just(1).any(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) {
+                return true;
+            }
+        }).toFlowable().subscribe(ts);
+
+        ts.assertTerminated();
+        ts.assertNoErrors();
+        ts.assertComplete();
+        ts.assertValue(true);
+    }
+
+    @Test
+    public void testPredicateThrowsExceptionAndValueInCauseMessageFlowable() {
+        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>();
+        final IllegalArgumentException ex = new IllegalArgumentException();
+
+        Flowable.just("Boo!").any(new Predicate<String>() {
+            @Override
+            public boolean test(String v) {
+                throw ex;
+            }
+        }).toFlowable().subscribe(ts);
 
         ts.assertTerminated();
         ts.assertNoValues();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -28,12 +28,12 @@ public class FlowableIgnoreElementsTest {
 
     @Test
     public void testWithEmpty() {
-        assertTrue(Flowable.empty().ignoreElements().isEmpty().blockingSingle());
+        assertTrue(Flowable.empty().ignoreElements().isEmpty().blockingGet());
     }
 
     @Test
     public void testWithNonEmpty() {
-        assertTrue(Flowable.just(1, 2, 3).ignoreElements().isEmpty().blockingSingle());
+        assertTrue(Flowable.just(1, 2, 3).ignoreElements().isEmpty().blockingGet());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
@@ -22,6 +22,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
@@ -73,7 +74,7 @@ public class MaybeCacheTest {
 
         assertNotNull(((MaybeCache<Integer>)source).source.get());
 
-        TestSubscriber<Integer> ts = source.test();
+        TestObserver<Integer> ts = source.test();
 
         assertNull(((MaybeCache<Integer>)source).source.get());
 
@@ -103,7 +104,7 @@ public class MaybeCacheTest {
 
         assertNotNull(((MaybeCache<Integer>)source).source.get());
 
-        TestSubscriber<Integer> ts = source.test();
+        TestObserver<Integer> ts = source.test();
 
         assertNull(((MaybeCache<Integer>)source).source.get());
 
@@ -132,7 +133,7 @@ public class MaybeCacheTest {
 
         assertNotNull(((MaybeCache<Integer>)source).source.get());
 
-        TestSubscriber<Integer> ts = source.test();
+        TestObserver<Integer> ts = source.test();
 
         assertNull(((MaybeCache<Integer>)source).source.get());
 
@@ -246,8 +247,8 @@ public class MaybeCacheTest {
 
             final Maybe<Integer> source = pp.toMaybe().cache();
 
-            final TestSubscriber<Integer> ts1 = source.test();
-            final TestSubscriber<Integer> ts2 = source.test();
+            final TestObserver<Integer> ts1 = source.test();
+            final TestObserver<Integer> ts2 = source.test();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
@@ -21,8 +21,8 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class MaybeContainsTest {
 
@@ -50,7 +50,7 @@ public class MaybeContainsTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Boolean> ts = pp.toMaybe().contains(1).test();
+        TestObserver<Boolean> ts = pp.toMaybe().contains(1).test();
 
         assertTrue(pp.hasSubscribers());
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCountTest.java
@@ -21,8 +21,8 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class MaybeCountTest {
 
@@ -45,7 +45,7 @@ public class MaybeCountTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Long> ts = pp.toMaybe().count().test();
+        TestObserver<Long> ts = pp.toMaybe().count().test();
 
         assertTrue(pp.hasSubscribers());
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherTest.java
@@ -21,8 +21,8 @@ import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.*;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class MaybeDelayOtherTest {
 
@@ -30,7 +30,7 @@ public class MaybeDelayOtherTest {
     public void justWithOnNext() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.just(1)
+        TestObserver<Integer> ts = Maybe.just(1)
         .delay(pp).test();
 
         ts.assertEmpty();
@@ -48,7 +48,7 @@ public class MaybeDelayOtherTest {
     public void justWithOnComplete() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.just(1)
+        TestObserver<Integer> ts = Maybe.just(1)
         .delay(pp).test();
 
         ts.assertEmpty();
@@ -67,7 +67,7 @@ public class MaybeDelayOtherTest {
     public void justWithOnError() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.just(1)
+        TestObserver<Integer> ts = Maybe.just(1)
         .delay(pp).test();
 
         ts.assertEmpty();
@@ -85,7 +85,7 @@ public class MaybeDelayOtherTest {
     public void emptyWithOnNext() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.<Integer>empty()
+        TestObserver<Integer> ts = Maybe.<Integer>empty()
         .delay(pp).test();
 
         ts.assertEmpty();
@@ -104,7 +104,7 @@ public class MaybeDelayOtherTest {
     public void emptyWithOnComplete() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.<Integer>empty()
+        TestObserver<Integer> ts = Maybe.<Integer>empty()
         .delay(pp).test();
 
         ts.assertEmpty();
@@ -122,7 +122,7 @@ public class MaybeDelayOtherTest {
     public void emptyWithOnError() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.<Integer>empty()
+        TestObserver<Integer> ts = Maybe.<Integer>empty()
         .delay(pp).test();
 
         ts.assertEmpty();
@@ -140,7 +140,7 @@ public class MaybeDelayOtherTest {
     public void errorWithOnNext() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
+        TestObserver<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
         .delay(pp).test();
 
         ts.assertEmpty();
@@ -158,7 +158,7 @@ public class MaybeDelayOtherTest {
     public void errorWithOnComplete() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
+        TestObserver<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
         .delay(pp).test();
 
         ts.assertEmpty();
@@ -176,7 +176,7 @@ public class MaybeDelayOtherTest {
     public void errorWithOnError() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
+        TestObserver<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
         .delay(pp).test();
 
         ts.assertEmpty();

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
@@ -21,9 +21,9 @@ import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class MaybeDelaySubscriptionTest {
 
@@ -31,7 +31,7 @@ public class MaybeDelaySubscriptionTest {
     public void normal() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.just(1).delaySubscription(pp)
+        TestObserver<Integer> ts = Maybe.just(1).delaySubscription(pp)
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -65,7 +65,7 @@ public class MaybeDelaySubscriptionTest {
     public void timedTestScheduler() {
         TestScheduler scheduler = new TestScheduler();
 
-        TestSubscriber<Integer> ts = Maybe.just(1)
+        TestObserver<Integer> ts = Maybe.just(1)
         .delaySubscription(100, TimeUnit.MILLISECONDS, scheduler)
         .test();
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayTest.java
@@ -22,9 +22,9 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class MaybeDelayTest {
 
@@ -66,7 +66,7 @@ public class MaybeDelayTest {
     public void disposeDuringDelay() {
         TestScheduler scheduler = new TestScheduler();
 
-        TestSubscriber<Integer> ts = Maybe.just(1).delay(100, TimeUnit.MILLISECONDS, scheduler)
+        TestObserver<Integer> ts = Maybe.just(1).delay(100, TimeUnit.MILLISECONDS, scheduler)
         .test();
 
         ts.cancel();
@@ -80,7 +80,7 @@ public class MaybeDelayTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = pp.toMaybe().delay(100, TimeUnit.MILLISECONDS).test();
+        TestObserver<Integer> ts = pp.toMaybe().delay(100, TimeUnit.MILLISECONDS).test();
 
         assertTrue(pp.hasSubscribers());
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeOfTypeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeOfTypeTest.java
@@ -18,8 +18,8 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class MaybeOfTypeTest {
 
@@ -32,7 +32,7 @@ public class MaybeOfTypeTest {
 
     @Test
     public void normalDowncast() {
-        TestSubscriber<Number> ts = Maybe.just(1)
+        TestObserver<Number> ts = Maybe.just(1)
         .ofType(Number.class)
         .test();
         // don't make this fluent, target type required!
@@ -41,7 +41,7 @@ public class MaybeOfTypeTest {
 
     @Test
     public void notInstance() {
-        TestSubscriber<String> ts = Maybe.just(1)
+        TestObserver<String> ts = Maybe.just(1)
         .ofType(String.class)
         .test();
         // don't make this fluent, target type required!
@@ -50,7 +50,7 @@ public class MaybeOfTypeTest {
 
     @Test
     public void error() {
-        TestSubscriber<Number> ts = Maybe.<Integer>error(new TestException())
+        TestObserver<Number> ts = Maybe.<Integer>error(new TestException())
         .ofType(Number.class)
         .test();
         // don't make this fluent, target type required!
@@ -59,7 +59,7 @@ public class MaybeOfTypeTest {
 
     @Test
     public void errorNotInstance() {
-        TestSubscriber<String> ts = Maybe.<Integer>error(new TestException())
+        TestObserver<String> ts = Maybe.<Integer>error(new TestException())
         .ofType(String.class)
         .test();
         // don't make this fluent, target type required!

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
@@ -20,9 +20,9 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class MaybeSwitchIfEmptyTest {
 
@@ -68,7 +68,7 @@ public class MaybeSwitchIfEmptyTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = pp.toMaybe().switchIfEmpty(Maybe.just(2)).test();
+        TestObserver<Integer> ts = pp.toMaybe().switchIfEmpty(Maybe.just(2)).test();
 
         assertTrue(pp.hasSubscribers());
 
@@ -100,7 +100,7 @@ public class MaybeSwitchIfEmptyTest {
         for (int i = 0; i < 500; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestSubscriber<Integer> ts = pp.toMaybe().switchIfEmpty(Maybe.just(2)).test();
+            final TestObserver<Integer> ts = pp.toMaybe().switchIfEmpty(Maybe.just(2)).test();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
@@ -28,12 +28,12 @@ public class ObservableIgnoreElementsTest {
 
     @Test
     public void testWithEmpty() {
-        assertTrue(Observable.empty().ignoreElements().isEmpty().blockingSingle());
+        assertTrue(Observable.empty().ignoreElements().isEmpty().blockingGet());
     }
 
     @Test
     public void testWithNonEmpty() {
-        assertTrue(Observable.just(1, 2, 3).ignoreElements().isEmpty().blockingSingle());
+        assertTrue(Observable.just(1, 2, 3).ignoreElements().isEmpty().blockingGet());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
@@ -20,8 +20,8 @@ import java.util.NoSuchElementException;
 import org.junit.Test;
 
 import io.reactivex.Single;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class SingleAmbTest {
     @Test
@@ -29,7 +29,7 @@ public class SingleAmbTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = pp1.toSingle().ambWith(pp2.toSingle()).test();
+        TestObserver<Integer> ts = pp1.toSingle().ambWith(pp2.toSingle()).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -49,7 +49,7 @@ public class SingleAmbTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = pp1.toSingle().ambWith(pp2.toSingle()).test();
+        TestObserver<Integer> ts = pp1.toSingle().ambWith(pp2.toSingle()).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());

--- a/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
@@ -17,9 +17,9 @@ import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class SingleCacheTest {
 
@@ -29,7 +29,7 @@ public class SingleCacheTest {
 
         Single<Integer> cached = pp.toSingle().cache();
 
-        TestSubscriber<Integer> ts = cached.test(true);
+        TestObserver<Integer> ts = cached.test(true);
 
         pp.onNext(1);
         pp.onComplete();
@@ -46,7 +46,7 @@ public class SingleCacheTest {
 
             final Single<Integer> cached = pp.toSingle().cache();
 
-            final TestSubscriber<Integer> ts1 = cached.test();
+            final TestObserver<Integer> ts1 = cached.test();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/single/SingleSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleSubscribeOnTest.java
@@ -21,9 +21,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import io.reactivex.*;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class SingleSubscribeOnTest {
 
@@ -33,7 +33,7 @@ public class SingleSubscribeOnTest {
         try {
             TestScheduler scheduler = new TestScheduler();
 
-            TestSubscriber<Integer> ts = Single.just(1)
+            TestObserver<Integer> ts = Single.just(1)
             .subscribeOn(scheduler)
             .test();
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
@@ -18,8 +18,8 @@ import java.util.concurrent.CancellationException;
 import org.junit.Test;
 
 import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class SingleTakeUntilTest {
 
@@ -28,7 +28,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp)
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp)
         .test();
 
         source.onNext(1);
@@ -42,7 +42,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
         .test();
 
         source.onNext(1);
@@ -57,7 +57,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
         .test();
 
         source.onNext(1);
@@ -71,7 +71,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp)
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp)
         .test();
 
         source.onError(new TestException());
@@ -84,7 +84,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
         .test();
 
         source.onError(new TestException());
@@ -97,7 +97,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
         .test();
 
         source.onError(new TestException());
@@ -110,7 +110,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp)
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp)
         .test();
 
         pp.onNext(1);
@@ -123,7 +123,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
         .test();
 
         pp.onNext(1);
@@ -137,7 +137,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
         .test();
 
         pp.onNext(1);
@@ -151,7 +151,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp)
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp)
         .test();
 
         pp.onComplete();
@@ -164,7 +164,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
         .test();
 
         pp.onComplete();
@@ -177,7 +177,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp)
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp)
         .test();
 
         pp.onError(new TestException());
@@ -190,7 +190,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
         .test();
 
         pp.onError(new TestException());
@@ -203,7 +203,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
+        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
         .test();
 
         pp.onError(new TestException());

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTests.java
@@ -13,15 +13,15 @@
 
 package io.reactivex.internal.operators.single;
 
-import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subjects.PublishSubject;
-import io.reactivex.subscribers.TestSubscriber;
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subjects.PublishSubject;
 
 public class SingleTimeoutTests {
 
@@ -30,7 +30,7 @@ public class SingleTimeoutTests {
         final PublishSubject<String> subject = PublishSubject.create();
         final TestScheduler scheduler = new TestScheduler();
 
-        final TestSubscriber<String> observer = subject.toSingle()
+        final TestObserver<String> observer = subject.toSingle()
                 .timeout(100, TimeUnit.MILLISECONDS, scheduler)
                 .test();
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
@@ -13,10 +13,11 @@
 
 package io.reactivex.internal.operators.single;
 
+import static org.junit.Assert.*;
+
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.*;
@@ -24,10 +25,10 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.TestSubscriber;
 
 public class SingleUsingTest {
 
@@ -101,7 +102,7 @@ public class SingleUsingTest {
 
     @Test
     public void eagerMapperThrowsDisposerThrows() {
-        TestSubscriber<Integer> ts = Single.using(Functions.justCallable(Disposables.empty()), mapperThrows, disposerThrows)
+        TestObserver<Integer> ts = Single.using(Functions.justCallable(Disposables.empty()), mapperThrows, disposerThrows)
         .test()
         .assertFailure(CompositeException.class);
 
@@ -182,7 +183,7 @@ public class SingleUsingTest {
 
     @Test
     public void errorAndDisposerThrowsEager() {
-        TestSubscriber<Integer> ts = Single.using(Functions.justCallable(Disposables.empty()),
+        TestObserver<Integer> ts = Single.using(Functions.justCallable(Disposables.empty()),
         new Function<Disposable, SingleSource<Integer>>() {
             @Override
             public SingleSource<Integer> apply(Disposable v) throws Exception {
@@ -224,7 +225,7 @@ public class SingleUsingTest {
 
             Disposable d = Disposables.empty();
 
-            final TestSubscriber<Integer> ts = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
+            final TestObserver<Integer> ts = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Disposable v) throws Exception {
                     return pp.toSingle();
@@ -299,7 +300,7 @@ public class SingleUsingTest {
 
             Disposable d = Disposables.empty();
 
-            final TestSubscriber<Integer> ts = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
+            final TestObserver<Integer> ts = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Disposable v) throws Exception {
                     return pp.toSingle();

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -33,6 +33,7 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.operators.flowable.FlowableZipTest.ArgsToString;
 import io.reactivex.internal.operators.maybe.*;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
@@ -88,7 +89,7 @@ public class MaybeTest {
     public void fromFlowableDisposeComposesThrough() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = pp.toMaybe().test();
+        TestObserver<Integer> ts = pp.toMaybe().test();
 
         assertTrue(pp.hasSubscribers());
 
@@ -145,7 +146,7 @@ public class MaybeTest {
     public void fromObservableDisposeComposesThrough() {
         PublishSubject<Integer> pp = PublishSubject.create();
 
-        TestSubscriber<Integer> ts = pp.toMaybe().test(false);
+        TestObserver<Integer> ts = pp.toMaybe().test(false);
 
         assertTrue(pp.hasObservers());
 
@@ -514,7 +515,7 @@ public class MaybeTest {
 
     @Test
     public void cast() {
-        TestSubscriber<Number> ts = Maybe.just(1).cast(Number.class).test();
+        TestObserver<Number> ts = Maybe.just(1).cast(Number.class).test();
         // don'n inline this due to the generic type
         ts.assertResult((Number)1);
     }
@@ -542,7 +543,7 @@ public class MaybeTest {
         })
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
-        .assertOf(TestHelper.subscriberSingleNot("1: " + main))
+        .assertOf(TestHelper.observerSingleNot("1: " + main))
         ;
     }
 
@@ -578,7 +579,7 @@ public class MaybeTest {
         .subscribeOn(Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
-        .assertOf(TestHelper.subscriberSingleNot(main))
+        .assertOf(TestHelper.observerSingleNot(main))
         ;
     }
 
@@ -827,7 +828,7 @@ public class MaybeTest {
         try {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            TestSubscriber<Integer> ts = pp.toMaybe().doOnDispose(new Action() {
+            TestObserver<Integer> ts = pp.toMaybe().doOnDispose(new Action() {
                 @Override
                 public void run() throws Exception {
                     throw new TestException();
@@ -1526,7 +1527,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
         .test();
 
         ts.assertEmpty();
@@ -1549,7 +1550,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
         .test();
 
         ts.assertEmpty();
@@ -1572,7 +1573,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
         .test();
 
         ts.assertEmpty();
@@ -1594,7 +1595,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
         .test();
 
         ts.assertEmpty();
@@ -1616,7 +1617,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
         .test();
 
         ts.assertEmpty();
@@ -1638,7 +1639,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
         .test();
 
         ts.assertEmpty();
@@ -1660,7 +1661,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
         .test();
 
         ts.assertEmpty();
@@ -1683,7 +1684,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
         .test();
 
         ts.assertEmpty();
@@ -1706,7 +1707,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
                 .test();
 
         ts.assertEmpty();
@@ -1730,7 +1731,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
         .test();
 
         ts.assertEmpty();
@@ -1752,7 +1753,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
         .test();
 
         ts.assertEmpty();
@@ -1774,7 +1775,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
                 .test();
 
         ts.assertEmpty();
@@ -1797,7 +1798,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
         .test();
 
         ts.assertEmpty();
@@ -1819,7 +1820,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
         .test();
 
         ts.assertEmpty();
@@ -2298,7 +2299,7 @@ public class MaybeTest {
 
     @Test
     public void doOnEventErrorThrows() {
-        TestSubscriber<Integer> ts = Maybe.<Integer>error(new TestException("Outer"))
+        TestObserver<Integer> ts = Maybe.<Integer>error(new TestException("Outer"))
         .doOnEvent(new BiConsumer<Integer, Throwable>() {
             @Override
             public void accept(Integer v, Throwable e) throws Exception {
@@ -2867,7 +2868,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = pp1.toMaybe().ambWith(pp2.toMaybe())
+        TestObserver<Integer> ts = pp1.toMaybe().ambWith(pp2.toMaybe())
         .test();
 
         ts.assertEmpty();
@@ -2889,7 +2890,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = pp1.toMaybe().ambWith(pp2.toMaybe())
+        TestObserver<Integer> ts = pp1.toMaybe().ambWith(pp2.toMaybe())
         .test();
 
         ts.assertEmpty();

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -755,8 +755,8 @@ public class ObservableTest {
     }
 
     @Test
-    public void testContains() {
-        Observable<Boolean> o = Observable.just("a", "b", "c").contains("b"); // FIXME nulls not allowed, changed to "c"
+    public void testContainsObservable() {
+        Observable<Boolean> o = Observable.just("a", "b", "c").contains("b").toObservable();
 
         Observer<Boolean> observer = TestHelper.mockObserver();
 
@@ -770,8 +770,8 @@ public class ObservableTest {
     }
 
     @Test
-    public void testContainsWithInexistence() {
-        Observable<Boolean> o = Observable.just("a", "b").contains("c"); // FIXME null values are not allowed, removed
+    public void testContainsWithInexistenceObservable() {
+        Observable<Boolean> o = Observable.just("a", "b").contains("c").toObservable();
 
         Observer<Object> observer = TestHelper.mockObserver();
 
@@ -786,8 +786,8 @@ public class ObservableTest {
 
     @Test
     @Ignore("null values are not allowed")
-    public void testContainsWithNull() {
-        Observable<Boolean> o = Observable.just("a", "b", null).contains(null);
+    public void testContainsWithNullObservable() {
+        Observable<Boolean> o = Observable.just("a", "b", null).contains(null).toObservable();
 
         Observer<Object> observer = TestHelper.mockObserver();
 
@@ -801,8 +801,8 @@ public class ObservableTest {
     }
 
     @Test
-    public void testContainsWithEmptyObservable() {
-        Observable<Boolean> o = Observable.<String> empty().contains("a");
+    public void testContainsWithEmptyObservableObservable() {
+        Observable<Boolean> o = Observable.<String> empty().contains("a").toObservable();
 
         Observer<Object> observer = TestHelper.mockObserver();
 
@@ -813,6 +813,63 @@ public class ObservableTest {
         verify(observer, never()).onError(
                 org.mockito.Matchers.any(Throwable.class));
         verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testContains() {
+        Single<Boolean> o = Observable.just("a", "b", "c").contains("b"); // FIXME nulls not allowed, changed to "c"
+
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
+
+        o.subscribe(observer);
+
+        verify(observer, times(1)).onSuccess(true);
+        verify(observer, never()).onSuccess(false);
+        verify(observer, never()).onError(
+                org.mockito.Matchers.any(Throwable.class));
+    }
+
+    @Test
+    public void testContainsWithInexistence() {
+        Single<Boolean> o = Observable.just("a", "b").contains("c"); // FIXME null values are not allowed, removed
+
+        SingleObserver<Object> observer = TestHelper.mockSingleObserver();
+
+        o.subscribe(observer);
+
+        verify(observer, times(1)).onSuccess(false);
+        verify(observer, never()).onSuccess(true);
+        verify(observer, never()).onError(
+                org.mockito.Matchers.any(Throwable.class));
+    }
+
+    @Test
+    @Ignore("null values are not allowed")
+    public void testContainsWithNull() {
+        Single<Boolean> o = Observable.just("a", "b", null).contains(null);
+
+        SingleObserver<Object> observer = TestHelper.mockSingleObserver();
+
+        o.subscribe(observer);
+
+        verify(observer, times(1)).onSuccess(true);
+        verify(observer, never()).onSuccess(false);
+        verify(observer, never()).onError(
+                org.mockito.Matchers.any(Throwable.class));
+    }
+
+    @Test
+    public void testContainsWithEmptyObservable() {
+        Single<Boolean> o = Observable.<String> empty().contains("a");
+
+        SingleObserver<Object> observer = TestHelper.mockSingleObserver();
+
+        o.subscribe(observer);
+
+        verify(observer, times(1)).onSuccess(false);
+        verify(observer, never()).onSuccess(true);
+        verify(observer, never()).onError(
+                org.mockito.Matchers.any(Throwable.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/single/SingleCacheTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import io.reactivex.Single;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -54,9 +55,9 @@ public class SingleCacheTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         Single<Integer> cache = ps.toSingle().cache();
 
-        TestSubscriber<Integer> ts1 = cache.test();
+        TestObserver<Integer> ts1 = cache.test();
 
-        TestSubscriber<Integer> ts2 = cache.test();
+        TestObserver<Integer> ts2 = cache.test();
 
         ps.onNext(1);
         ps.onComplete();
@@ -70,9 +71,9 @@ public class SingleCacheTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         Single<Integer> cache = ps.toSingle().cache();
 
-        TestSubscriber<Integer> ts1 = cache.test();
+        TestObserver<Integer> ts1 = cache.test();
 
-        TestSubscriber<Integer> ts2 = cache.test();
+        TestObserver<Integer> ts2 = cache.test();
 
         ts1.cancel();
 

--- a/src/test/java/io/reactivex/tck/AllTckTest.java
+++ b/src/test/java/io/reactivex/tck/AllTckTest.java
@@ -30,7 +30,7 @@ public class AllTckTest extends BaseTck<Boolean> {
                     public boolean test(Integer e) throws Exception {
                         return e < 800;
                     }
-                })
+                }).toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/AnyTckTest.java
+++ b/src/test/java/io/reactivex/tck/AnyTckTest.java
@@ -30,7 +30,7 @@ public class AnyTckTest extends BaseTck<Boolean> {
                     public boolean test(Integer e) throws Exception {
                         return e == 500;
                     }
-                })
+                }).toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/IsEmptyTckTest.java
+++ b/src/test/java/io/reactivex/tck/IsEmptyTckTest.java
@@ -24,7 +24,7 @@ public class IsEmptyTckTest extends BaseTck<Boolean> {
     @Override
     public Publisher<Boolean> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.range(1, 10).isEmpty()
+                Flowable.range(1, 10).isEmpty().toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/LastTckTest.java
+++ b/src/test/java/io/reactivex/tck/LastTckTest.java
@@ -24,7 +24,7 @@ public class LastTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.range(1, 10).last().hide().toFlowable()
+                Flowable.range(1, 10).last().toFlowable()
             );
     }
 


### PR DESCRIPTION
This PR changes the return type of `any()` and `all()` to `Single`.

I've also did a small change to `TestObserver` by having it implement the other `XObserver` types. This resulted in one extra method `onSuccess` to be added but now you can subscribe `TestObserver` to `Single`, `Maybe` and `Completable` without conversion yet still `test()` them with the same convenient API.

``` java
Flowable.range(1, 10).any(v -> true).test().assertResult(true);
```
