### PR TITLE
2.x: collect, toList, toSortedList, toMap, toMultimap to return Single

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -4000,7 +4000,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <T, R> Flowable<R> zip(Publisher<? extends Publisher<? extends T>> sources,
             final Function<? super Object[], ? extends R> zipper) {
         ObjectHelper.requireNonNull(zipper, "zipper is null");
-        return fromPublisher(sources).toList().flatMap(FlowableInternalHelper.<T, R>zipIterable(zipper));
+        return fromPublisher(sources).toList().flatMapPublisher(FlowableInternalHelper.<T, R>zipIterable(zipper));
     }
 
     /**
@@ -4848,7 +4848,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     // ***************************************************************************************************
 
     /**
-     * Returns a Flowable that emits a Boolean that indicates whether all of the items emitted by the source
+     * Returns a Single that emits a Boolean that indicates whether all of the items emitted by the source
      * Publisher satisfy a condition.
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/all.png" alt="">
@@ -4901,7 +4901,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits {@code true} if any item emitted by the source Publisher satisfies a
+     * Returns a Single that emits {@code true} if any item emitted by the source Publisher satisfies a
      * specified condition, otherwise {@code false}. <em>Note:</em> this always emits {@code false} if the
      * source Publisher is empty.
      * <p>
@@ -6192,8 +6192,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Collects items emitted by the source Publisher into a single mutable data structure and returns an
-     * Publisher that emits this structure.
+     * Collects items emitted by the source Publisher into a single mutable data structure and returns
+     * a Single that emits this structure.
      * <p>
      * <img width="640" height="330" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/collect.png" alt="">
      * <p>
@@ -6212,21 +6212,21 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param collector
      *           a function that accepts the {@code state} and an emitted item, and modifies {@code state}
      *           accordingly
-     * @return a Flowable that emits the result of collecting the values emitted by the source Publisher
+     * @return a Single that emits the result of collecting the values emitted by the source Publisher
      *         into a single mutable data structure
      * @see <a href="http://reactivex.io/documentation/operators/reduce.html">ReactiveX operators documentation: Reduce</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<U> collect(Callable<? extends U> initialItemSupplier, BiConsumer<? super U, ? super T> collector) {
+    public final <U> Single<U> collect(Callable<? extends U> initialItemSupplier, BiConsumer<? super U, ? super T> collector) {
         ObjectHelper.requireNonNull(initialItemSupplier, "initialItemSupplier is null");
         ObjectHelper.requireNonNull(collector, "collector is null");
-        return RxJavaPlugins.onAssembly(new FlowableCollect<T, U>(this, initialItemSupplier, collector));
+        return RxJavaPlugins.onAssembly(new FlowableCollectSingle<T, U>(this, initialItemSupplier, collector));
     }
 
     /**
-     * Collects items emitted by the source Publisher into a single mutable data structure and returns an
-     * Publisher that emits this structure.
+     * Collects items emitted by the source Publisher into a single mutable data structure and returns
+     * a Single that emits this structure.
      * <p>
      * <img width="640" height="330" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/collect.png" alt="">
      * <p>
@@ -6245,13 +6245,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param collector
      *           a function that accepts the {@code state} and an emitted item, and modifies {@code state}
      *           accordingly
-     * @return a Flowable that emits the result of collecting the values emitted by the source Publisher
+     * @return a Single that emits the result of collecting the values emitted by the source Publisher
      *         into a single mutable data structure
      * @see <a href="http://reactivex.io/documentation/operators/reduce.html">ReactiveX operators documentation: Reduce</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<U> collectInto(final U initialItem, BiConsumer<? super U, ? super T> collector) {
+    public final <U> Single<U> collectInto(final U initialItem, BiConsumer<? super U, ? super T> collector) {
         ObjectHelper.requireNonNull(initialItem, "initialItem is null");
         return collect(Functions.justCallable(initialItem), collector);
     }
@@ -6640,7 +6640,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits a Boolean that indicates whether the source Publisher emitted a
+     * Returns a Single that emits a Boolean that indicates whether the source Publisher emitted a
      * specified item.
      * <p>
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/contains.png" alt="">
@@ -8795,7 +8795,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits {@code true} if the source Publisher is empty, otherwise {@code false}.
+     * Returns a Single that emits {@code true} if the source Publisher is empty, otherwise {@code false}.
      * <p>
      * In Rx.Net this is negated as the {@code any} Subscriber but we renamed this in RxJava to better match Java
      * naming idioms.
@@ -8865,7 +8865,7 @@ public abstract class Flowable<T> implements Publisher<T> {
 
 
     /**
-     * Returns a Flowable that emits the last item emitted by the source Publisher or notifies Subscribers of
+     * Returns a Single that emits the last item emitted by the source Publisher or notifies Subscribers of
      * a {@code NoSuchElementException} if the source Publisher is empty.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/last.png" alt="">
@@ -8888,7 +8888,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits only the last item emitted by the source Publisher, or a default item
+     * Returns a Single that emits only the last item emitted by the source Publisher, or a default item
      * if the source Publisher completes without emitting any items.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/lastOrDefault.png" alt="">
@@ -9855,7 +9855,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that applies a specified accumulator function to the first item emitted by a source
+     * Returns a Single that applies a specified accumulator function to the first item emitted by a source
      * Publisher, then feeds the result of that function along with the second item emitted by the source
      * Publisher into the same function, and so on until all items have been emitted by the source Publisher,
      * and emits the final result from the final call to your function as its sole item.
@@ -9887,7 +9887,6 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> reduce(BiFunction<T, T, T> reducer) {
         ObjectHelper.requireNonNull(reducer, "reducer is null");
-//        return RxJavaPlugins.onAssembly(new FlowableReduce<T>(this, reducer));
         return RxJavaPlugins.onAssembly(new SingleReduceFlowable<T>(this, reducer));
     }
 
@@ -11593,7 +11592,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> sorted() {
-        return toSortedList().flatMapIterable(Functions.<List<T>>identity());
+        return toList().toFlowable().map(Functions.listSorter(Functions.<T>naturalComparator())).flatMapIterable(Functions.<List<T>>identity());
     }
 
     /**
@@ -11619,7 +11618,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> sorted(Comparator<? super T> sortFunction) {
-        return toSortedList(sortFunction).flatMapIterable(Functions.<List<T>>identity());
+        return toList().toFlowable().map(Functions.listSorter(sortFunction)).flatMapIterable(Functions.<List<T>>identity());
     }
 
     /**
@@ -13453,7 +13452,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits a single item, a list composed of all the items emitted by the source
+     * Returns a Single that emits a single item, a list composed of all the items emitted by the source
      * Publisher.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toList.png" alt="">
@@ -13474,18 +13473,18 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code toList} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a Flowable that emits a single item: a List containing all of the items emitted by the source
+     * @return a Single that emits a single item: a List containing all of the items emitted by the source
      *         Publisher
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<List<T>> toList() {
-        return RxJavaPlugins.onAssembly(new FlowableToList<T, List<T>>(this));
+    public final Single<List<T>> toList() {
+        return RxJavaPlugins.onAssembly(new FlowableToListSingle<T, List<T>>(this));
     }
 
     /**
-     * Returns a Flowable that emits a single item, a list composed of all the items emitted by the source
+     * Returns a Single that emits a single item, a list composed of all the items emitted by the source
      * Publisher.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toList.png" alt="">
@@ -13514,9 +13513,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<List<T>> toList(final int capacityHint) {
+    public final Single<List<T>> toList(final int capacityHint) {
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
-        return RxJavaPlugins.onAssembly(new FlowableToList<T, List<T>>(this, Functions.<T>createArrayList(capacityHint)));
+        return RxJavaPlugins.onAssembly(new FlowableToListSingle<T, List<T>>(this, Functions.<T>createArrayList(capacityHint)));
     }
 
     /**
@@ -13556,7 +13555,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits a single HashMap containing all items emitted by the source Publisher,
+     * Returns a Single that emits a single HashMap containing all items emitted by the source Publisher,
      * mapped by the keys returned by a specified {@code keySelector} function.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toMap.png" alt="">
@@ -13573,19 +13572,19 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <K> the key type of the Map
      * @param keySelector
      *            the function that extracts the key from a source item to be used in the HashMap
-     * @return a Flowable that emits a single item: a HashMap containing the mapped items from the source
+     * @return a Single that emits a single item: a HashMap containing the mapped items from the source
      *         Publisher
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Flowable<Map<K, T>> toMap(final Function<? super T, ? extends K> keySelector) {
+    public final <K> Single<Map<K, T>> toMap(final Function<? super T, ? extends K> keySelector) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         return collect(HashMapSupplier.<K, T>asCallable(), Functions.toMapKeySelector(keySelector));
     }
 
     /**
-     * Returns a Flowable that emits a single HashMap containing values corresponding to items emitted by the
+     * Returns a Single that emits a single HashMap containing values corresponding to items emitted by the
      * source Publisher, mapped by the keys returned by a specified {@code keySelector} function.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toMap.png" alt="">
@@ -13606,20 +13605,20 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the function that extracts the key from a source item to be used in the HashMap
      * @param valueSelector
      *            the function that extracts the value from a source item to be used in the HashMap
-     * @return a Flowable that emits a single item: a HashMap containing the mapped items from the source
+     * @return a Single that emits a single item: a HashMap containing the mapped items from the source
      *         Publisher
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Flowable<Map<K, V>> toMap(final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector) {
+    public final <K, V> Single<Map<K, V>> toMap(final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
         return collect(HashMapSupplier.<K, V>asCallable(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
     }
 
     /**
-     * Returns a Flowable that emits a single Map, returned by a specified {@code mapFactory} function, that
+     * Returns a Single that emits a single Map, returned by a specified {@code mapFactory} function, that
      * contains keys and values extracted from the items emitted by the source Publisher.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toMap.png" alt="">
@@ -13645,7 +13644,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Flowable<Map<K, V>> toMap(final Function<? super T, ? extends K> keySelector,
+    public final <K, V> Single<Map<K, V>> toMap(final Function<? super T, ? extends K> keySelector,
             final Function<? super T, ? extends V> valueSelector,
             final Callable<? extends Map<K, V>> mapSupplier) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
@@ -13654,7 +13653,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits a single HashMap that contains an ArrayList of items emitted by the
+     * Returns a Single that emits a single HashMap that contains an ArrayList of items emitted by the
      * source Publisher keyed by a specified {@code keySelector} function.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toMultiMap.png" alt="">
@@ -13668,13 +13667,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <K> the key type of the Map
      * @param keySelector
      *            the function that extracts the key from the source items to be used as key in the HashMap
-     * @return a Flowable that emits a single item: a HashMap that contains an ArrayList of items mapped from
+     * @return a Single that emits a single item: a HashMap that contains an ArrayList of items mapped from
      *         the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Flowable<Map<K, Collection<T>>> toMultimap(Function<? super T, ? extends K> keySelector) {
+    public final <K> Single<Map<K, Collection<T>>> toMultimap(Function<? super T, ? extends K> keySelector) {
         Function<T, T> valueSelector = Functions.identity();
         Callable<Map<K, Collection<T>>> mapSupplier = HashMapSupplier.asCallable();
         Function<K, List<T>> collectionFactory = ArrayListSupplier.asFunction();
@@ -13682,7 +13681,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits a single HashMap that contains an ArrayList of values extracted by a
+     * Returns a Single that emits a single HashMap that contains an ArrayList of values extracted by a
      * specified {@code valueSelector} function from items emitted by the source Publisher, keyed by a
      * specified {@code keySelector} function.
      * <p>
@@ -13701,20 +13700,20 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the function that extracts a key from the source items to be used as key in the HashMap
      * @param valueSelector
      *            the function that extracts a value from the source items to be used as value in the HashMap
-     * @return a Flowable that emits a single item: a HashMap that contains an ArrayList of items mapped from
+     * @return a Single that emits a single item: a HashMap that contains an ArrayList of items mapped from
      *         the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Flowable<Map<K, Collection<V>>> toMultimap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
+    public final <K, V> Single<Map<K, Collection<V>>> toMultimap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
         Callable<Map<K, Collection<V>>> mapSupplier = HashMapSupplier.asCallable();
         Function<K, List<V>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
     }
 
     /**
-     * Returns a Flowable that emits a single Map, returned by a specified {@code mapFactory} function, that
+     * Returns a Single that emits a single Map, returned by a specified {@code mapFactory} function, that
      * contains a custom collection of values, extracted by a specified {@code valueSelector} function from
      * items emitted by the source Publisher, and keyed by the {@code keySelector} function.
      * <p>
@@ -13737,13 +13736,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the function that returns a Map instance to be used
      * @param collectionFactory
      *            the function that returns a Collection instance for a particular key to be used in the Map
-     * @return a Flowable that emits a single item: a Map that contains the collection of mapped items from
+     * @return a Single that emits a single item: a Map that contains the collection of mapped items from
      *         the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Flowable<Map<K, Collection<V>>> toMultimap(
+    public final <K, V> Single<Map<K, Collection<V>>> toMultimap(
             final Function<? super T, ? extends K> keySelector,
             final Function<? super T, ? extends V> valueSelector,
             final Callable<? extends Map<K, Collection<V>>> mapSupplier,
@@ -13756,7 +13755,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits a single Map, returned by a specified {@code mapFactory} function, that
+     * Returns a Single that emits a single Map, returned by a specified {@code mapFactory} function, that
      * contains an ArrayList of values, extracted by a specified {@code valueSelector} function from items
      * emitted by the source Publisher and keyed by the {@code keySelector} function.
      * <p>
@@ -13777,13 +13776,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the function that extracts a value from the source items to be used as the value in the Map
      * @param mapSupplier
      *            the function that returns a Map instance to be used
-     * @return a Flowable that emits a single item: a Map that contains a list items mapped from the source
+     * @return a Single that emits a single item: a Map that contains a list items mapped from the source
      *         Publisher
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Flowable<Map<K, Collection<V>>> toMultimap(
+    public final <K, V> Single<Map<K, Collection<V>>> toMultimap(
             Function<? super T, ? extends K> keySelector,
             Function<? super T, ? extends V> valueSelector,
             Callable<Map<K, Collection<V>>> mapSupplier
@@ -13857,7 +13856,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits a list that contains the items emitted by the source Publisher, in a
+     * Returns a Single that emits a list that contains the items emitted by the source Publisher, in a
      * sorted order. Each item emitted by the Publisher must implement {@link Comparable} with respect to all
      * other items in the sequence.
      * <p>
@@ -13873,18 +13872,18 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @throws ClassCastException
      *             if any item emitted by the Publisher does not implement {@link Comparable} with respect to
      *             all other items emitted by the Publisher
-     * @return a Flowable that emits a list that contains the items emitted by the source Publisher in
+     * @return a Single that emits a list that contains the items emitted by the source Publisher in
      *         sorted order
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<List<T>> toSortedList() {
+    public final Single<List<T>> toSortedList() {
         return toSortedList(Functions.naturalComparator());
     }
 
     /**
-     * Returns a Flowable that emits a list that contains the items emitted by the source Publisher, in a
+     * Returns a Single that emits a list that contains the items emitted by the source Publisher, in a
      * sorted order based on a specified comparison function.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toSortedList.f.png" alt="">
@@ -13899,19 +13898,19 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param comparator
      *            a function that compares two items emitted by the source Publisher and returns an Integer
      *            that indicates their sort order
-     * @return a Flowable that emits a list that contains the items emitted by the source Publisher in
+     * @return a Single that emits a list that contains the items emitted by the source Publisher in
      *         sorted order
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<List<T>> toSortedList(final Comparator<? super T> comparator) {
+    public final Single<List<T>> toSortedList(final Comparator<? super T> comparator) {
         ObjectHelper.requireNonNull(comparator, "comparator is null");
         return toList().map(Functions.listSorter(comparator));
     }
 
     /**
-     * Returns a Flowable that emits a list that contains the items emitted by the source Publisher, in a
+     * Returns a Single that emits a list that contains the items emitted by the source Publisher, in a
      * sorted order based on a specified comparison function.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toSortedList.f.png" alt="">
@@ -13928,14 +13927,14 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            that indicates their sort order
      * @param capacityHint
      *             the initial capacity of the ArrayList used to accumulate items before sorting
-     * @return a Flowable that emits a list that contains the items emitted by the source Publisher in
+     * @return a Single that emits a list that contains the items emitted by the source Publisher in
      *         sorted order
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      * @since 2.0
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<List<T>> toSortedList(final Comparator<? super T> comparator, int capacityHint) {
+    public final Single<List<T>> toSortedList(final Comparator<? super T> comparator, int capacityHint) {
         ObjectHelper.requireNonNull(comparator, "comparator is null");
         return toList(capacityHint).map(Functions.listSorter(comparator));
     }
@@ -13966,7 +13965,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<List<T>> toSortedList(int capacityHint) {
+    public final Single<List<T>> toSortedList(int capacityHint) {
         return toSortedList(Functions.naturalComparator(), capacityHint);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAnySingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAnySingle.java
@@ -24,9 +24,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableAnySingle<T> extends Single<Boolean> implements FuseToFlowable<Boolean> {
     final Publisher<T> source;
-    
+
     final Predicate<? super T> predicate;
-    
+
     public FlowableAnySingle(Publisher<T> source, Predicate<? super T> predicate) {
         this.source = source;
         this.predicate = predicate;
@@ -36,7 +36,7 @@ public final class FlowableAnySingle<T> extends Single<Boolean> implements FuseT
     protected void subscribeActual(SingleObserver<? super Boolean> s) {
         source.subscribe(new AnySubscriber<T>(s, predicate));
     }
-    
+
     @Override
     public Flowable<Boolean> fuseToFlowable() {
         return RxJavaPlugins.onAssembly(new FlowableAny<T>(source, predicate));
@@ -45,7 +45,7 @@ public final class FlowableAnySingle<T> extends Single<Boolean> implements FuseT
     static final class AnySubscriber<T> implements Subscriber<T>, Disposable {
 
         final SingleObserver<? super Boolean> actual;
-        
+
         final Predicate<? super T> predicate;
 
         Subscription s;
@@ -111,7 +111,7 @@ public final class FlowableAnySingle<T> extends Single<Boolean> implements FuseT
             s.cancel();
             s = SubscriptionHelper.CANCELLED;
         }
-        
+
         @Override
         public boolean isDisposed() {
             return s == SubscriptionHelper.CANCELLED;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollectSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollectSingle.java
@@ -12,51 +12,69 @@
  */
 package io.reactivex.internal.operators.flowable;
 
+import java.util.concurrent.Callable;
+
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Predicate;
+import io.reactivex.functions.BiConsumer;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.FuseToFlowable;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableAllSingle<T> extends Single<Boolean> implements FuseToFlowable<Boolean> {
+public final class FlowableCollectSingle<T, U> extends Single<U> implements FuseToFlowable<U> {
 
     final Publisher<T> source;
 
-    final Predicate<? super T> predicate;
+    final Callable<? extends U> initialSupplier;
+    final BiConsumer<? super U, ? super T> collector;
 
-    public FlowableAllSingle(Publisher<T> source, Predicate<? super T> predicate) {
+    public FlowableCollectSingle(Publisher<T> source, Callable<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
         this.source = source;
-        this.predicate = predicate;
+        this.initialSupplier = initialSupplier;
+        this.collector = collector;
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super Boolean> s) {
-        source.subscribe(new AllSubscriber<T>(s, predicate));
+    protected void subscribeActual(SingleObserver<? super U> s) {
+        U u;
+        try {
+            u = ObjectHelper.requireNonNull(initialSupplier.call(), "The initialSupplier returned a null value");
+        } catch (Throwable e) {
+            EmptyDisposable.error(e, s);
+            return;
+        }
+
+        source.subscribe(new CollectSubscriber<T, U>(s, u, collector));
     }
 
     @Override
-    public Flowable<Boolean> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableAll<T>(source, predicate));
+    public Flowable<U> fuseToFlowable() {
+        return RxJavaPlugins.onAssembly(new FlowableCollect<T, U>(source, initialSupplier, collector));
     }
 
-    static final class AllSubscriber<T> implements Subscriber<T>, Disposable {
+    static final class CollectSubscriber<T, U> implements Subscriber<T>, Disposable {
 
-        final SingleObserver<? super Boolean> actual;
+        final SingleObserver<? super U> actual;
 
-        final Predicate<? super T> predicate;
+        final BiConsumer<? super U, ? super T> collector;
+
+        final U u;
 
         Subscription s;
 
         boolean done;
 
-        AllSubscriber(SingleObserver<? super Boolean> actual, Predicate<? super T> predicate) {
+        CollectSubscriber(SingleObserver<? super U> actual, U u, BiConsumer<? super U, ? super T> collector) {
             this.actual = actual;
-            this.predicate = predicate;
+            this.collector = collector;
+            this.u = u;
         }
+
         @Override
         public void onSubscribe(Subscription s) {
             if (SubscriptionHelper.validate(this.s, s)) {
@@ -71,21 +89,12 @@ public final class FlowableAllSingle<T> extends Single<Boolean> implements FuseT
             if (done) {
                 return;
             }
-            boolean b;
             try {
-                b = predicate.test(t);
+                collector.accept(u, t);
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 s.cancel();
-                s = SubscriptionHelper.CANCELLED;
                 onError(e);
-                return;
-            }
-            if (!b) {
-                done = true;
-                s.cancel();
-                s = SubscriptionHelper.CANCELLED;
-                actual.onSuccess(false);
             }
         }
 
@@ -107,8 +116,7 @@ public final class FlowableAllSingle<T> extends Single<Boolean> implements FuseT
             }
             done = true;
             s = SubscriptionHelper.CANCELLED;
-
-            actual.onSuccess(true);
+            actual.onSuccess(u);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastSingle.java
@@ -30,31 +30,31 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 public final class FlowableLastSingle<T> extends Single<T> {
 
     final Publisher<T> source;
-    
+
     final T defaultItem;
-    
+
     public FlowableLastSingle(Publisher<T> source, T defaultItem) {
         this.source = source;
         this.defaultItem = defaultItem;
     }
 
     // TODO fuse back to Flowable
-    
+
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
         source.subscribe(new LastSubscriber<T>(observer, defaultItem));
     }
-    
+
     static final class LastSubscriber<T> implements Subscriber<T>, Disposable {
-        
+
         final SingleObserver<? super T> actual;
-        
+
         final T defaultItem;
 
         Subscription s;
-        
+
         T item;
-        
+
         public LastSubscriber(SingleObserver<? super T> actual, T defaultItem) {
             this.actual = actual;
             this.defaultItem = defaultItem;
@@ -75,9 +75,9 @@ public final class FlowableLastSingle<T> extends Single<T> {
         public void onSubscribe(Subscription s) {
             if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
-                
+
                 actual.onSubscribe(this);
-                
+
                 s.request(Long.MAX_VALUE);
             }
         }
@@ -110,7 +110,5 @@ public final class FlowableLastSingle<T> extends Single<T> {
                 }
             }
         }
-        
-        
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAnySingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAnySingle.java
@@ -22,9 +22,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableAnySingle<T> extends Single<Boolean> implements FuseToObservable<Boolean> {
     final ObservableSource<T> source;
-    
+
     final Predicate<? super T> predicate;
-    
+
     public ObservableAnySingle(ObservableSource<T> source, Predicate<? super T> predicate) {
         this.source = source;
         this.predicate = predicate;
@@ -34,7 +34,7 @@ public final class ObservableAnySingle<T> extends Single<Boolean> implements Fus
     protected void subscribeActual(SingleObserver<? super Boolean> t) {
         source.subscribe(new AnyObserver<T>(t, predicate));
     }
-    
+
     @Override
     public Observable<Boolean> fuseToObservable() {
         return RxJavaPlugins.onAssembly(new ObservableAny<T>(source, predicate));

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableLastSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableLastSingle.java
@@ -28,31 +28,31 @@ import io.reactivex.internal.disposables.DisposableHelper;
 public final class ObservableLastSingle<T> extends Single<T> {
 
     final ObservableSource<T> source;
-    
+
     final T defaultItem;
-    
+
     public ObservableLastSingle(ObservableSource<T> source, T defaultItem) {
         this.source = source;
         this.defaultItem = defaultItem;
     }
 
     // TODO fuse back to Observable
-    
+
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
         source.subscribe(new LastObserver<T>(observer, defaultItem));
     }
-    
+
     static final class LastObserver<T> implements Observer<T>, Disposable {
-        
+
         final SingleObserver<? super T> actual;
-        
+
         final T defaultItem;
 
         Disposable s;
-        
+
         T item;
-        
+
         public LastObserver(SingleObserver<? super T> actual, T defaultItem) {
             this.actual = actual;
             this.defaultItem = defaultItem;
@@ -73,7 +73,7 @@ public final class ObservableLastSingle<T> extends Single<T> {
         public void onSubscribe(Disposable s) {
             if (DisposableHelper.validate(this.s, s)) {
                 this.s = s;
-                
+
                 actual.onSubscribe(this);
             }
         }
@@ -106,7 +106,5 @@ public final class ObservableLastSingle<T> extends Single<T> {
                 }
             }
         }
-        
-        
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableToListSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableToListSingle.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.*;
+import java.util.concurrent.Callable;
+
+import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.fuseable.FuseToObservable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class ObservableToListSingle<T, U extends Collection<? super T>>
+extends Single<U> implements FuseToObservable<U> {
+
+    final ObservableSource<T> source;
+
+    final Callable<U> collectionSupplier;
+
+    public ObservableToListSingle(ObservableSource<T> source, final int defaultCapacityHint) {
+        this.source = source;
+        this.collectionSupplier = new Callable<U>() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public U call() throws Exception {
+                return (U)new ArrayList<T>(defaultCapacityHint);
+            }
+        };
+    }
+
+    public ObservableToListSingle(ObservableSource<T> source, Callable<U> collectionSupplier) {
+        this.source = source;
+        this.collectionSupplier = collectionSupplier;
+    }
+
+    @Override
+    public void subscribeActual(SingleObserver<? super U> t) {
+        U coll;
+        try {
+            coll = collectionSupplier.call();
+        } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
+            EmptyDisposable.error(e, t);
+            return;
+        }
+        source.subscribe(new ToListObserver<T, U>(t, coll));
+    }
+
+    @Override
+    public Observable<U> fuseToObservable() {
+        return RxJavaPlugins.onAssembly(new ObservableToList<T, U>(source, collectionSupplier));
+    }
+
+    static final class ToListObserver<T, U extends Collection<? super T>> implements Observer<T>, Disposable {
+        final SingleObserver<? super U> actual;
+
+        U collection;
+
+        Disposable s;
+
+        ToListObserver(SingleObserver<? super U> actual, U collection) {
+            this.actual = actual;
+            this.collection = collection;
+        }
+
+        @Override
+        public void onSubscribe(Disposable s) {
+            if (DisposableHelper.validate(this.s, s)) {
+                this.s = s;
+                actual.onSubscribe(this);
+            }
+        }
+
+
+        @Override
+        public void dispose() {
+            s.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return s.isDisposed();
+        }
+
+
+        @Override
+        public void onNext(T t) {
+            collection.add(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            collection = null;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            U c = collection;
+            collection = null;
+            actual.onSuccess(c);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/observers/TestObserver.java
@@ -903,7 +903,7 @@ public class TestObserver<T> implements Observer<T>, Disposable, MaybeObserver<T
         onNext(value);
         onComplete();
     }
-    
+
     /**
      * An observer that ignores all events and does not report errors.
      */

--- a/src/perf/java/io/reactivex/RxVsStreamPerf.java
+++ b/src/perf/java/io/reactivex/RxVsStreamPerf.java
@@ -80,7 +80,7 @@ public class RxVsStreamPerf {
             }
         });
 
-        values = range.toList().blockingFirst();
+        values = range.toList().blockingGet();
     }
 
     @Benchmark

--- a/src/test/java/io/reactivex/InternalWrongNaming.java
+++ b/src/test/java/io/reactivex/InternalWrongNaming.java
@@ -158,11 +158,13 @@ public class InternalWrongNaming {
 
     @Test
     public void flowableNoObserver() throws Exception {
-        checkInternalOperatorNaming("Flowable", "Observer", 
+        checkInternalOperatorNaming("Flowable", "Observer",
                 "FlowableFromObservable",
                 "FlowableLastSingle",
                 "FlowableAnySingle",
-                "FlowableAllSingle"
+                "FlowableAllSingle",
+                "FlowableToListSingle",
+                "FlowableCollectSingle"
         );
     }
 }

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -1593,7 +1593,11 @@ public class CompletableTest {
 
         Assert.assertFalse("Already done", done.get());
 
-        Thread.sleep(200);
+        int timeout = 10;
+
+        while (timeout-- > 0 && !done.get()) {
+            Thread.sleep(100);
+        }
 
         Assert.assertTrue("Not done", done.get());
 

--- a/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
@@ -22,15 +22,168 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.functions.BiConsumer;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableCollectTest {
 
     @Test
-    public void testCollectToList() {
+    public void testCollectToListFlowable() {
         Flowable<List<Integer>> o = Flowable.just(1, 2, 3)
+        .collect(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() {
+                return new ArrayList<Integer>();
+            }
+        }, new BiConsumer<List<Integer>, Integer>() {
+            @Override
+            public void accept(List<Integer> list, Integer v) {
+                list.add(v);
+            }
+        }).toFlowable();
+
+        List<Integer> list =  o.blockingLast();
+
+        assertEquals(3, list.size());
+        assertEquals(1, list.get(0).intValue());
+        assertEquals(2, list.get(1).intValue());
+        assertEquals(3, list.get(2).intValue());
+
+        // test multiple subscribe
+        List<Integer> list2 =  o.blockingLast();
+
+        assertEquals(3, list2.size());
+        assertEquals(1, list2.get(0).intValue());
+        assertEquals(2, list2.get(1).intValue());
+        assertEquals(3, list2.get(2).intValue());
+    }
+
+    @Test
+    public void testCollectToStringFlowable() {
+        String value = Flowable.just(1, 2, 3)
+            .collect(
+                new Callable<StringBuilder>() {
+                    @Override
+                    public StringBuilder call() {
+                        return new StringBuilder();
+                    }
+                },
+                new BiConsumer<StringBuilder, Integer>() {
+                    @Override
+                    public void accept(StringBuilder sb, Integer v) {
+                    if (sb.length() > 0) {
+                        sb.append("-");
+                    }
+                    sb.append(v);
+                }
+            }).toFlowable().blockingLast().toString();
+
+        assertEquals("1-2-3", value);
+    }
+
+
+    @Test
+    public void testFactoryFailureResultsInErrorEmissionFlowable() {
+        final RuntimeException e = new RuntimeException();
+        Flowable.just(1).collect(new Callable<List<Integer>>() {
+
+            @Override
+            public List<Integer> call() throws Exception {
+                throw e;
+            }
+        }, new BiConsumer<List<Integer>, Integer>() {
+
+            @Override
+            public void accept(List<Integer> list, Integer t) {
+                list.add(t);
+            }
+        })
+        .test()
+        .assertNoValues()
+        .assertError(e)
+        .assertNotComplete();
+    }
+
+    @Test
+    public void testCollectorFailureDoesNotResultInTwoErrorEmissionsFlowable() {
+        try {
+            final List<Throwable> list = new CopyOnWriteArrayList<Throwable>();
+            RxJavaPlugins.setErrorHandler(addToList(list));
+            final RuntimeException e1 = new RuntimeException();
+            final RuntimeException e2 = new RuntimeException();
+
+            Burst.items(1).error(e2) //
+                    .collect(callableListCreator(), biConsumerThrows(e1))
+                    .toFlowable()
+                    .test() //
+                    .assertError(e1) //
+                    .assertNotComplete();
+            assertEquals(Arrays.asList(e2), list);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void testCollectorFailureDoesNotResultInErrorAndCompletedEmissionsFlowable() {
+        final RuntimeException e = new RuntimeException();
+        Burst.item(1).create() //
+                .collect(callableListCreator(), biConsumerThrows(e)) //
+                .toFlowable()
+                .test() //
+                .assertError(e) //
+                .assertNotComplete();
+    }
+
+    @Test
+    public void testCollectorFailureDoesNotResultInErrorAndOnNextEmissionsFlowable() {
+        final RuntimeException e = new RuntimeException();
+        final AtomicBoolean added = new AtomicBoolean();
+        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() {
+
+            boolean once = true;
+
+            @Override
+            public void accept(Object o, Integer t) {
+                if (once) {
+                    once = false;
+                    throw e;
+                } else {
+                    added.set(true);
+                }
+            }
+        };
+        Burst.items(1, 2).create() //
+                .collect(callableListCreator(), throwOnFirstOnly)//
+                .toFlowable()
+                .test() //
+                .assertError(e) //
+                .assertNoValues() //
+                .assertNotComplete();
+        assertFalse(added.get());
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void collectIntoFlowable() {
+        Flowable.just(1, 1, 1, 1, 2)
+        .collectInto(new HashSet<Integer>(), new BiConsumer<HashSet<Integer>, Integer>() {
+            @Override
+            public void accept(HashSet<Integer> s, Integer v) throws Exception {
+                s.add(v);
+            }
+        })
+        .toFlowable()
+        .test()
+        .assertResult(new HashSet<Integer>(Arrays.asList(1, 2)));
+    }
+
+
+    @Test
+    public void testCollectToList() {
+        Single<List<Integer>> o = Flowable.just(1, 2, 3)
         .collect(new Callable<List<Integer>>() {
             @Override
             public List<Integer> call() {
@@ -43,7 +196,7 @@ public final class FlowableCollectTest {
             }
         });
 
-        List<Integer> list =  o.blockingLast();
+        List<Integer> list =  o.blockingGet();
 
         assertEquals(3, list.size());
         assertEquals(1, list.get(0).intValue());
@@ -51,7 +204,7 @@ public final class FlowableCollectTest {
         assertEquals(3, list.get(2).intValue());
 
         // test multiple subscribe
-        List<Integer> list2 =  o.blockingLast();
+        List<Integer> list2 =  o.blockingGet();
 
         assertEquals(3, list2.size());
         assertEquals(1, list2.get(0).intValue());
@@ -77,7 +230,7 @@ public final class FlowableCollectTest {
                     }
                     sb.append(v);
                 }
-            }).blockingLast().toString();
+            }).blockingGet().toString();
 
         assertEquals("1-2-3", value);
     }

--- a/src/test/java/io/reactivex/flowable/FlowableConcatTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableConcatTests.java
@@ -29,7 +29,7 @@ public class FlowableConcatTests {
         Flowable<String> o1 = Flowable.just("one", "two");
         Flowable<String> o2 = Flowable.just("three", "four");
 
-        List<String> values = Flowable.concat(o1, o2).toList().blockingSingle();
+        List<String> values = Flowable.concat(o1, o2).toList().blockingGet();
 
         assertEquals("one", values.get(0));
         assertEquals("two", values.get(1));
@@ -45,7 +45,7 @@ public class FlowableConcatTests {
 
         Flowable<Flowable<String>> os = Flowable.just(o1, o2, o3);
 
-        List<String> values = Flowable.concat(os).toList().blockingSingle();
+        List<String> values = Flowable.concat(os).toList().blockingGet();
 
         assertEquals("one", values.get(0));
         assertEquals("two", values.get(1));
@@ -64,7 +64,7 @@ public class FlowableConcatTests {
         @SuppressWarnings("unchecked")
         Iterable<Flowable<String>> is = Arrays.asList(o1, o2, o3);
 
-        List<String> values = Flowable.concat(Flowable.fromIterable(is)).toList().blockingSingle();
+        List<String> values = Flowable.concat(Flowable.fromIterable(is)).toList().blockingGet();
 
         assertEquals("one", values.get(0));
         assertEquals("two", values.get(1));
@@ -86,7 +86,7 @@ public class FlowableConcatTests {
 
         Flowable<Flowable<Media>> os = Flowable.just(o1, o2);
 
-        List<Media> values = Flowable.concat(os).toList().blockingSingle();
+        List<Media> values = Flowable.concat(os).toList().blockingGet();
 
         assertEquals(horrorMovie1, values.get(0));
         assertEquals(movie, values.get(1));
@@ -108,7 +108,7 @@ public class FlowableConcatTests {
 
         Flowable<Flowable<Media>> os = Flowable.just(o1, o2);
 
-        List<Media> values = Flowable.concat(os).toList().blockingSingle();
+        List<Media> values = Flowable.concat(os).toList().blockingGet();
 
         assertEquals(horrorMovie1, values.get(0));
         assertEquals(movie, values.get(1));
@@ -128,7 +128,7 @@ public class FlowableConcatTests {
         Flowable<Movie> o1 = Flowable.just(horrorMovie1, movie);
         Flowable<Media> o2 = Flowable.just(media, horrorMovie2);
 
-        List<Media> values = Flowable.concat(o1, o2).toList().blockingSingle();
+        List<Media> values = Flowable.concat(o1, o2).toList().blockingGet();
 
         assertEquals(horrorMovie1, values.get(0));
         assertEquals(movie, values.get(1));
@@ -156,7 +156,7 @@ public class FlowableConcatTests {
 
         Flowable<Media> o2 = Flowable.just(media, horrorMovie2);
 
-        List<Media> values = Flowable.concat(o1, o2).toList().blockingSingle();
+        List<Media> values = Flowable.concat(o1, o2).toList().blockingGet();
 
         assertEquals(horrorMovie1, values.get(0));
         assertEquals(movie, values.get(1));

--- a/src/test/java/io/reactivex/flowable/FlowableMergeTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableMergeTests.java
@@ -43,7 +43,7 @@ public class FlowableMergeTests {
 
         Flowable<Flowable<Media>> os = Flowable.just(o1, o2);
 
-        List<Media> values = Flowable.merge(os).toList().blockingSingle();
+        List<Media> values = Flowable.merge(os).toList().blockingGet();
 
         assertEquals(4, values.size());
     }
@@ -55,7 +55,7 @@ public class FlowableMergeTests {
 
         Flowable<Flowable<Media>> os = Flowable.just(o1, o2);
 
-        List<Media> values = Flowable.merge(os).toList().blockingSingle();
+        List<Media> values = Flowable.merge(os).toList().blockingGet();
 
         assertEquals(5, values.size());
     }
@@ -65,7 +65,7 @@ public class FlowableMergeTests {
         Flowable<Movie> o1 = Flowable.just(new HorrorMovie(), new Movie());
         Flowable<Media> o2 = Flowable.just(new Media(), new HorrorMovie());
 
-        List<Media> values = Flowable.merge(o1, o2).toList().blockingSingle();
+        List<Media> values = Flowable.merge(o1, o2).toList().blockingGet();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);
@@ -88,7 +88,7 @@ public class FlowableMergeTests {
 
         Flowable<Media> o2 = Flowable.just(new Media(), new HorrorMovie());
 
-        List<Media> values = Flowable.merge(o1, o2).toList().blockingSingle();
+        List<Media> values = Flowable.merge(o1, o2).toList().blockingGet();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -918,7 +918,7 @@ public class FlowableNullTests {
         }, new BiConsumer<Object, Integer>() {
             @Override
             public void accept(Object a, Integer b) { }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2386,7 +2386,7 @@ public class FlowableNullTests {
             public Object apply(Integer v) {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2421,7 +2421,7 @@ public class FlowableNullTests {
             public Map<Object, Object> call() {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2451,7 +2451,7 @@ public class FlowableNullTests {
             public Object apply(Integer v) {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2486,7 +2486,7 @@ public class FlowableNullTests {
             public Map<Object, Collection<Object>> call() {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2531,7 +2531,7 @@ public class FlowableNullTests {
             public Collection<Integer> apply(Integer v) {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/flowable/FlowableStartWithTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableStartWithTests.java
@@ -26,7 +26,7 @@ public class FlowableStartWithTests {
     @Test
     public void startWith1() {
         List<String> values = Flowable.just("one", "two")
-                .startWithArray("zero").toList().blockingSingle();
+                .startWithArray("zero").toList().blockingGet();
 
         assertEquals("zero", values.get(0));
         assertEquals("two", values.get(2));
@@ -37,7 +37,7 @@ public class FlowableStartWithTests {
         List<String> li = new ArrayList<String>();
         li.add("alpha");
         li.add("beta");
-        List<String> values = Flowable.just("one", "two").startWith(li).toList().blockingSingle();
+        List<String> values = Flowable.just("one", "two").startWith(li).toList().blockingGet();
 
         assertEquals("alpha", values.get(0));
         assertEquals("beta", values.get(1));
@@ -53,7 +53,7 @@ public class FlowableStartWithTests {
         List<String> values = Flowable.just("one", "two")
                 .startWith(Flowable.fromIterable(li))
                 .toList()
-                .blockingSingle();
+                .blockingGet();
 
         assertEquals("alpha", values.get(0));
         assertEquals("beta", values.get(1));

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -992,7 +992,7 @@ public class FlowableTests {
                         }
                     })
                     .toList()
-                    .doOnNext(new Consumer<List<Boolean>>() {
+                    .doOnSuccess(new Consumer<List<Boolean>>() {
                         @Override
                         public void accept(List<Boolean> booleans) {
                             count.incrementAndGet();

--- a/src/test/java/io/reactivex/flowable/FlowableWindowTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableWindowTests.java
@@ -34,7 +34,7 @@ public class FlowableWindowTests {
             .map(new Function<Flowable<Integer>, Flowable<List<Integer>>>() {
                 @Override
                 public Flowable<List<Integer>> apply(Flowable<Integer> xs) {
-                    return xs.toList();
+                    return xs.toList().toFlowable();
                 }
             })
         )

--- a/src/test/java/io/reactivex/internal/operators/flowable/BufferUntilSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BufferUntilSubscriberTest.java
@@ -62,7 +62,7 @@ public class BufferUntilSubscriberTest {
                         }
                     })
                     .toList()
-                    .doOnNext(new Consumer<List<Object>>() {
+                    .doOnSuccess(new Consumer<List<Object>>() {
                         @Override
                         public void accept(List<Object> integers) {
                                 counter.incrementAndGet();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -622,9 +622,9 @@ public class FlowableConcatTest {
             }
         });
 
-        Flowable<List<Integer>> result = Flowable.concat(source).toList();
+        Single<List<Integer>> result = Flowable.concat(source).toList();
 
-        Subscriber<List<Integer>> o = TestHelper.mockSubscriber();
+        SingleObserver<List<Integer>> o = TestHelper.mockSingleObserver();
         InOrder inOrder = inOrder(o);
 
         result.subscribe(o);
@@ -633,8 +633,7 @@ public class FlowableConcatTest {
         for (int i = 0; i < n; i++) {
             list.add(i);
         }
-        inOrder.verify(o).onNext(list);
-        inOrder.verify(o).onComplete();
+        inOrder.verify(o).onSuccess(list);
         verify(o, never()).onError(any(Throwable.class));
     }
     @Test
@@ -647,9 +646,9 @@ public class FlowableConcatTest {
             }
         });
 
-        Flowable<List<Integer>> result = Flowable.concat(source).take(n / 2).toList();
+        Single<List<Integer>> result = Flowable.concat(source).take(n / 2).toList();
 
-        Subscriber<List<Integer>> o = TestHelper.mockSubscriber();
+        SingleObserver<List<Integer>> o = TestHelper.mockSingleObserver();
         InOrder inOrder = inOrder(o);
 
         result.subscribe(o);
@@ -658,8 +657,7 @@ public class FlowableConcatTest {
         for (int i = 0; i < n / 2; i++) {
             list.add(i);
         }
-        inOrder.verify(o).onNext(list);
-        inOrder.verify(o).onComplete();
+        inOrder.verify(o).onSuccess(list);
         verify(o, never()).onError(any(Throwable.class));
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
@@ -126,7 +126,7 @@ public class FlowableDoOnEachTest {
                         }
                     })
                     .toList()
-                    .doOnNext(new Consumer<List<Boolean>>() {
+                    .doOnSuccess(new Consumer<List<Boolean>>() {
                         @Override
                         public void accept(List<Boolean> booleans) {
                             count.incrementAndGet();
@@ -152,7 +152,7 @@ public class FlowableDoOnEachTest {
                         }
                     })
                     .toList()
-                    .doOnNext(new Consumer<List<Boolean>>() {
+                    .doOnSuccess(new Consumer<List<Boolean>>() {
                         @Override
                         public void accept(List<Boolean> booleans) {
                             count.incrementAndGet();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
@@ -54,7 +54,7 @@ public class FlowableRepeatTest {
     @Test(timeout = 2000)
     public void testRepeatTake() {
         Flowable<Integer> xs = Flowable.just(1, 2);
-        Object[] ys = xs.repeat().subscribeOn(Schedulers.newThread()).take(4).toList().blockingLast().toArray();
+        Object[] ys = xs.repeat().subscribeOn(Schedulers.newThread()).take(4).toList().blockingGet().toArray();
         assertArrayEquals(new Object[] { 1, 2, 1, 2 }, ys);
     }
 
@@ -91,7 +91,7 @@ public class FlowableRepeatTest {
                 return t1;
             }
 
-        }).take(4).toList().blockingLast().toArray();
+        }).take(4).toList().blockingGet().toArray();
 
         assertEquals(2, counter.get());
         assertArrayEquals(new Object[] { 1, 2, 1, 2 }, ys);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
@@ -253,6 +253,32 @@ public class FlowableScanTest {
      */
     @Test
     public void testSeedFactory() {
+        Single<List<Integer>> o = Flowable.range(1, 10)
+                .collect(new Callable<List<Integer>>() {
+
+                    @Override
+                    public List<Integer> call() {
+                        return new ArrayList<Integer>();
+                    }
+
+                }, new BiConsumer<List<Integer>, Integer>() {
+
+                    @Override
+                    public void accept(List<Integer> list, Integer t2) {
+                        list.add(t2);
+                    }
+
+                });
+
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.blockingGet());
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.blockingGet());
+    }
+
+    /**
+     * This uses the public API collect which uses scan under the covers.
+     */
+    @Test
+    public void testSeedFactoryFlowable() {
         Flowable<List<Integer>> o = Flowable.range(1, 10)
                 .collect(new Callable<List<Integer>>() {
 
@@ -268,7 +294,7 @@ public class FlowableScanTest {
                         list.add(t2);
                     }
 
-                }).takeLast(1);
+                }).toFlowable().takeLast(1);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.blockingSingle());
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.blockingSingle());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
@@ -154,7 +154,7 @@ public class FlowableTakeLastTest {
                     }
                 })
                 .toList()
-                .blockingSingle().size());
+                .blockingGet().size());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMultimapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMultimapTest.java
@@ -28,9 +28,12 @@ import io.reactivex.functions.Function;
 public class FlowableToMultimapTest {
     Subscriber<Object> objectObserver;
 
+    SingleObserver<Object> singleObserver;
+
     @Before
     public void before() {
         objectObserver = TestHelper.mockSubscriber();
+        singleObserver = TestHelper.mockSingleObserver();
     }
 
     Function<String, Integer> lengthFunc = new Function<String, Integer>() {
@@ -47,10 +50,10 @@ public class FlowableToMultimapTest {
     };
 
     @Test
-    public void testToMultimap() {
+    public void testToMultimapFlowable() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd");
 
-        Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc);
+        Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc).toFlowable();
 
         Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
         expected.put(1, Arrays.asList("a", "b"));
@@ -64,10 +67,10 @@ public class FlowableToMultimapTest {
     }
 
     @Test
-    public void testToMultimapWithValueSelector() {
+    public void testToMultimapWithValueSelectorFlowable() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd");
 
-        Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicate);
+        Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicate).toFlowable();
 
         Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
         expected.put(1, Arrays.asList("aa", "bb"));
@@ -81,7 +84,7 @@ public class FlowableToMultimapTest {
     }
 
     @Test
-    public void testToMultimapWithMapFactory() {
+    public void testToMultimapWithMapFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
         Callable<Map<Integer, Collection<String>>> mapFactory = new Callable<Map<Integer, Collection<String>>>() {
@@ -113,7 +116,7 @@ public class FlowableToMultimapTest {
                     public Collection<String> apply(Integer e) {
                         return new ArrayList<String>();
                     }
-                });
+                }).toFlowable();
 
         Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
         expected.put(2, Arrays.asList("cc", "dd"));
@@ -124,6 +127,252 @@ public class FlowableToMultimapTest {
         verify(objectObserver, never()).onError(any(Throwable.class));
         verify(objectObserver, times(1)).onNext(expected);
         verify(objectObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithCollectionFactoryFlowable() {
+        Flowable<String> source = Flowable.just("cc", "dd", "eee", "eee");
+
+        Function<Integer, Collection<String>> collectionFactory = new Function<Integer, Collection<String>>() {
+            @Override
+            public Collection<String> apply(Integer t1) {
+                if (t1 == 2) {
+                    return new ArrayList<String>();
+                } else {
+                    return new HashSet<String>();
+                }
+            }
+        };
+
+        Function<String, String> identity = new Function<String, String>() {
+            @Override
+            public String apply(String v) {
+                return v;
+            }
+        };
+        Callable<Map<Integer, Collection<String>>> mapSupplier = new Callable<Map<Integer, Collection<String>>>() {
+            @Override
+            public Map<Integer, Collection<String>> call() {
+                return new HashMap<Integer, Collection<String>>();
+            }
+        };
+
+        Flowable<Map<Integer, Collection<String>>> mapped = source
+                .toMultimap(lengthFunc, identity, mapSupplier, collectionFactory).toFlowable();
+
+        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        expected.put(2, Arrays.asList("cc", "dd"));
+        expected.put(3, new HashSet<String>(Arrays.asList("eee")));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, never()).onError(any(Throwable.class));
+        verify(objectObserver, times(1)).onNext(expected);
+        verify(objectObserver, times(1)).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithErrorFlowable() {
+        Flowable<String> source = Flowable.just("a", "b", "cc", "dd");
+
+        Function<String, Integer> lengthFuncErr = new Function<String, Integer>() {
+            @Override
+            public Integer apply(String t1) {
+                if ("b".equals(t1)) {
+                    throw new RuntimeException("Forced Failure");
+                }
+                return t1.length();
+            }
+        };
+
+        Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFuncErr).toFlowable();
+
+        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        expected.put(1, Arrays.asList("a", "b"));
+        expected.put(2, Arrays.asList("cc", "dd"));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, times(1)).onError(any(Throwable.class));
+        verify(objectObserver, never()).onNext(expected);
+        verify(objectObserver, never()).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithErrorInValueSelectorFlowable() {
+        Flowable<String> source = Flowable.just("a", "b", "cc", "dd");
+
+        Function<String, String> duplicateErr = new Function<String, String>() {
+            @Override
+            public String apply(String t1) {
+                if ("b".equals(t1)) {
+                    throw new RuntimeException("Forced failure");
+                }
+                return t1 + t1;
+            }
+        };
+
+        Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicateErr).toFlowable();
+
+        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        expected.put(1, Arrays.asList("aa", "bb"));
+        expected.put(2, Arrays.asList("cccc", "dddd"));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, times(1)).onError(any(Throwable.class));
+        verify(objectObserver, never()).onNext(expected);
+        verify(objectObserver, never()).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithMapThrowingFactoryFlowable() {
+        Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
+
+        Callable<Map<Integer, Collection<String>>> mapFactory = new Callable<Map<Integer, Collection<String>>>() {
+            @Override
+            public Map<Integer, Collection<String>> call() {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Flowable<Map<Integer, Collection<String>>> mapped = source
+                .toMultimap(lengthFunc, new Function<String, String>() {
+                    @Override
+                    public String apply(String v) {
+                        return v;
+                    }
+                }, mapFactory).toFlowable();
+
+        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        expected.put(2, Arrays.asList("cc", "dd"));
+        expected.put(3, Arrays.asList("eee", "fff"));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, times(1)).onError(any(Throwable.class));
+        verify(objectObserver, never()).onNext(expected);
+        verify(objectObserver, never()).onComplete();
+    }
+
+    @Test
+    public void testToMultimapWithThrowingCollectionFactoryFlowable() {
+        Flowable<String> source = Flowable.just("cc", "cc", "eee", "eee");
+
+        Function<Integer, Collection<String>> collectionFactory = new Function<Integer, Collection<String>>() {
+            @Override
+            public Collection<String> apply(Integer t1) {
+                if (t1 == 2) {
+                    throw new RuntimeException("Forced failure");
+                } else {
+                    return new HashSet<String>();
+                }
+            }
+        };
+
+        Function<String, String> identity = new Function<String, String>() {
+            @Override
+            public String apply(String v) {
+                return v;
+            }
+        };
+        Callable<Map<Integer, Collection<String>>> mapSupplier = new Callable<Map<Integer, Collection<String>>>() {
+            @Override
+            public Map<Integer, Collection<String>> call() {
+                return new HashMap<Integer, Collection<String>>();
+            }
+        };
+
+        Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc,
+                identity, mapSupplier, collectionFactory).toFlowable();
+
+        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        expected.put(2, Arrays.asList("cc", "dd"));
+        expected.put(3, Collections.singleton("eee"));
+
+        mapped.subscribe(objectObserver);
+
+        verify(objectObserver, times(1)).onError(any(Throwable.class));
+        verify(objectObserver, never()).onNext(expected);
+        verify(objectObserver, never()).onComplete();
+    }
+
+
+    @Test
+    public void testToMultimap() {
+        Flowable<String> source = Flowable.just("a", "b", "cc", "dd");
+
+        Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc);
+
+        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        expected.put(1, Arrays.asList("a", "b"));
+        expected.put(2, Arrays.asList("cc", "dd"));
+
+        mapped.subscribe(singleObserver);
+
+        verify(singleObserver, never()).onError(any(Throwable.class));
+        verify(singleObserver, times(1)).onSuccess(expected);
+    }
+
+    @Test
+    public void testToMultimapWithValueSelector() {
+        Flowable<String> source = Flowable.just("a", "b", "cc", "dd");
+
+        Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicate);
+
+        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        expected.put(1, Arrays.asList("aa", "bb"));
+        expected.put(2, Arrays.asList("cccc", "dddd"));
+
+        mapped.subscribe(singleObserver);
+
+        verify(singleObserver, never()).onError(any(Throwable.class));
+        verify(singleObserver, times(1)).onSuccess(expected);
+    }
+
+    @Test
+    public void testToMultimapWithMapFactory() {
+        Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
+
+        Callable<Map<Integer, Collection<String>>> mapFactory = new Callable<Map<Integer, Collection<String>>>() {
+            @Override
+            public Map<Integer, Collection<String>> call() {
+                return new LinkedHashMap<Integer, Collection<String>>() {
+
+                    private static final long serialVersionUID = -2084477070717362859L;
+
+                    @Override
+                    protected boolean removeEldestEntry(Map.Entry<Integer, Collection<String>> eldest) {
+                        return size() > 2;
+                    }
+                };
+            }
+        };
+
+        Function<String, String> identity = new Function<String, String>() {
+            @Override
+            public String apply(String v) {
+                return v;
+            }
+        };
+
+        Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(
+                lengthFunc, identity,
+                mapFactory, new Function<Integer, Collection<String>>() {
+                    @Override
+                    public Collection<String> apply(Integer e) {
+                        return new ArrayList<String>();
+                    }
+                });
+
+        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        expected.put(2, Arrays.asList("cc", "dd"));
+        expected.put(3, Arrays.asList("eee", "fff"));
+
+        mapped.subscribe(singleObserver);
+
+        verify(singleObserver, never()).onError(any(Throwable.class));
+        verify(singleObserver, times(1)).onSuccess(expected);
     }
 
     @Test
@@ -154,18 +403,17 @@ public class FlowableToMultimapTest {
             }
         };
 
-        Flowable<Map<Integer, Collection<String>>> mapped = source
+        Single<Map<Integer, Collection<String>>> mapped = source
                 .toMultimap(lengthFunc, identity, mapSupplier, collectionFactory);
 
         Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, new HashSet<String>(Arrays.asList("eee")));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(singleObserver);
 
-        verify(objectObserver, never()).onError(any(Throwable.class));
-        verify(objectObserver, times(1)).onNext(expected);
-        verify(objectObserver, times(1)).onComplete();
+        verify(singleObserver, never()).onError(any(Throwable.class));
+        verify(singleObserver, times(1)).onSuccess(expected);
     }
 
     @Test
@@ -182,17 +430,16 @@ public class FlowableToMultimapTest {
             }
         };
 
-        Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFuncErr);
+        Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFuncErr);
 
         Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
         expected.put(1, Arrays.asList("a", "b"));
         expected.put(2, Arrays.asList("cc", "dd"));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(singleObserver);
 
-        verify(objectObserver, times(1)).onError(any(Throwable.class));
-        verify(objectObserver, never()).onNext(expected);
-        verify(objectObserver, never()).onComplete();
+        verify(singleObserver, times(1)).onError(any(Throwable.class));
+        verify(singleObserver, never()).onSuccess(expected);
     }
 
     @Test
@@ -209,17 +456,16 @@ public class FlowableToMultimapTest {
             }
         };
 
-        Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicateErr);
+        Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicateErr);
 
         Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
         expected.put(1, Arrays.asList("aa", "bb"));
         expected.put(2, Arrays.asList("cccc", "dddd"));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(singleObserver);
 
-        verify(objectObserver, times(1)).onError(any(Throwable.class));
-        verify(objectObserver, never()).onNext(expected);
-        verify(objectObserver, never()).onComplete();
+        verify(singleObserver, times(1)).onError(any(Throwable.class));
+        verify(singleObserver, never()).onSuccess(expected);
     }
 
     @Test
@@ -233,7 +479,7 @@ public class FlowableToMultimapTest {
             }
         };
 
-        Flowable<Map<Integer, Collection<String>>> mapped = source
+        Single<Map<Integer, Collection<String>>> mapped = source
                 .toMultimap(lengthFunc, new Function<String, String>() {
                     @Override
                     public String apply(String v) {
@@ -245,11 +491,10 @@ public class FlowableToMultimapTest {
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Arrays.asList("eee", "fff"));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(singleObserver);
 
-        verify(objectObserver, times(1)).onError(any(Throwable.class));
-        verify(objectObserver, never()).onNext(expected);
-        verify(objectObserver, never()).onComplete();
+        verify(singleObserver, times(1)).onError(any(Throwable.class));
+        verify(singleObserver, never()).onSuccess(expected);
     }
 
     @Test
@@ -280,17 +525,17 @@ public class FlowableToMultimapTest {
             }
         };
 
-        Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc,
+        Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc,
                 identity, mapSupplier, collectionFactory);
 
         Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Collections.singleton("eee"));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(singleObserver);
 
-        verify(objectObserver, times(1)).onError(any(Throwable.class));
-        verify(objectObserver, never()).onNext(expected);
-        verify(objectObserver, never()).onComplete();
+        verify(singleObserver, times(1)).onError(any(Throwable.class));
+        verify(singleObserver, never()).onSuccess(expected);
     }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -38,7 +38,7 @@ public class FlowableWindowWithSizeTest {
         Flowable.concat(observables.map(new Function<Flowable<T>, Flowable<List<T>>>() {
             @Override
             public Flowable<List<T>> apply(Flowable<T> xs) {
-                return xs.toList();
+                return xs.toList().toFlowable();
             }
         }))
                 .blockingForEach(new Consumer<List<T>>() {
@@ -297,7 +297,7 @@ public class FlowableWindowWithSizeTest {
         .map(new Function<Flowable<Integer>, Flowable<List<Integer>>>() {
             @Override
             public Flowable<List<Integer>> apply(Flowable<Integer> t) {
-                return t.toList();
+                return t.toList().toFlowable();
             }
         })
         .concatMap(new Function<Flowable<List<Integer>>, Publisher<List<Integer>>>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
@@ -1220,7 +1220,7 @@ public class FlowableZipTest {
         for (int i = 0; i < 1026; i++) {
             expected.add(i * 3);
         }
-        assertEquals(expected, zip2.toList().blockingSingle());
+        assertEquals(expected, zip2.toList().blockingGet());
     }
     @Test
     public void testUnboundedDownstreamOverrequesting() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferUntilSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferUntilSubscriberTest.java
@@ -61,7 +61,7 @@ public class ObservableBufferUntilSubscriberTest {
                         }
                     })
                     .toList()
-                    .doOnNext(new Consumer<List<Object>>() {
+                    .doOnSuccess(new Consumer<List<Object>>() {
                         @Override
                         public void accept(List<Object> integers) {
                                 counter.incrementAndGet();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
@@ -23,14 +23,139 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
 import io.reactivex.Observable;
+import io.reactivex.Single;
 import io.reactivex.functions.BiConsumer;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableCollectTest {
 
     @Test
-    public void testCollectToList() {
+    public void testCollectToListObservable() {
         Observable<List<Integer>> o = Observable.just(1, 2, 3)
+        .collect(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() {
+                return new ArrayList<Integer>();
+            }
+        }, new BiConsumer<List<Integer>, Integer>() {
+            @Override
+            public void accept(List<Integer> list, Integer v) {
+                list.add(v);
+            }
+        }).toObservable();
+
+        List<Integer> list =  o.blockingLast();
+
+        assertEquals(3, list.size());
+        assertEquals(1, list.get(0).intValue());
+        assertEquals(2, list.get(1).intValue());
+        assertEquals(3, list.get(2).intValue());
+
+        // test multiple subscribe
+        List<Integer> list2 =  o.blockingLast();
+
+        assertEquals(3, list2.size());
+        assertEquals(1, list2.get(0).intValue());
+        assertEquals(2, list2.get(1).intValue());
+        assertEquals(3, list2.get(2).intValue());
+    }
+
+    @Test
+    public void testCollectToStringObservable() {
+        String value = Observable.just(1, 2, 3).collect(new Callable<StringBuilder>() {
+            @Override
+            public StringBuilder call() {
+                return new StringBuilder();
+            }
+        },
+            new BiConsumer<StringBuilder, Integer>() {
+                @Override
+                public void accept(StringBuilder sb, Integer v) {
+                if (sb.length() > 0) {
+                    sb.append("-");
+                }
+                sb.append(v);
+      }
+            }).toObservable().blockingLast().toString();
+
+        assertEquals("1-2-3", value);
+    }
+
+    @Test
+    public void testCollectorFailureDoesNotResultInTwoErrorEmissionsObservable() {
+        try {
+            final List<Throwable> list = new CopyOnWriteArrayList<Throwable>();
+            RxJavaPlugins.setErrorHandler(addToList(list));
+            final RuntimeException e1 = new RuntimeException();
+            final RuntimeException e2 = new RuntimeException();
+
+            Burst.items(1).error(e2) //
+                    .collect(callableListCreator(), biConsumerThrows(e1)) //
+                    .toObservable()
+                    .test() //
+                    .assertError(e1) //
+                    .assertNotComplete();
+            assertEquals(Arrays.asList(e2), list);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void testCollectorFailureDoesNotResultInErrorAndCompletedEmissionsObservable() {
+        final RuntimeException e = new RuntimeException();
+        Burst.item(1).create() //
+                .collect(callableListCreator(), biConsumerThrows(e)) //
+                .toObservable()
+                .test() //
+                .assertError(e) //
+                .assertNotComplete();
+    }
+
+    @Test
+    public void testCollectorFailureDoesNotResultInErrorAndOnNextEmissionsObservable() {
+        final RuntimeException e = new RuntimeException();
+        final AtomicBoolean added = new AtomicBoolean();
+        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() {
+
+            boolean once = true;
+
+            @Override
+            public void accept(Object o, Integer t) {
+                if (once) {
+                    once = false;
+                    throw e;
+                } else {
+                    added.set(true);
+                }
+            }
+        };
+        Burst.items(1, 2).create() //
+                .collect(callableListCreator(), throwOnFirstOnly)//
+                .test() //
+                .assertError(e) //
+                .assertNoValues() //
+                .assertNotComplete();
+        assertFalse(added.get());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void collectIntoObservable() {
+        Observable.just(1, 1, 1, 1, 2)
+        .collectInto(new HashSet<Integer>(), new BiConsumer<HashSet<Integer>, Integer>() {
+            @Override
+            public void accept(HashSet<Integer> s, Integer v) throws Exception {
+                s.add(v);
+            }
+        }).toObservable()
+        .test()
+        .assertResult(new HashSet<Integer>(Arrays.asList(1, 2)));
+    }
+
+    @Test
+    public void testCollectToList() {
+        Single<List<Integer>> o = Observable.just(1, 2, 3)
         .collect(new Callable<List<Integer>>() {
             @Override
             public List<Integer> call() {
@@ -43,7 +168,7 @@ public final class ObservableCollectTest {
             }
         });
 
-        List<Integer> list =  o.blockingLast();
+        List<Integer> list =  o.blockingGet();
 
         assertEquals(3, list.size());
         assertEquals(1, list.get(0).intValue());
@@ -51,7 +176,7 @@ public final class ObservableCollectTest {
         assertEquals(3, list.get(2).intValue());
 
         // test multiple subscribe
-        List<Integer> list2 =  o.blockingLast();
+        List<Integer> list2 =  o.blockingGet();
 
         assertEquals(3, list2.size());
         assertEquals(1, list2.get(0).intValue());
@@ -75,7 +200,7 @@ public final class ObservableCollectTest {
                 }
                 sb.append(v);
       }
-            }).blockingLast().toString();
+            }).blockingGet().toString();
 
         assertEquals("1-2-3", value);
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
@@ -610,9 +610,9 @@ public class ObservableConcatTest {
             }
         });
 
-        Observable<List<Integer>> result = Observable.concat(source).toList();
+        Single<List<Integer>> result = Observable.concat(source).toList();
 
-        Observer<List<Integer>> o = TestHelper.mockObserver();
+        SingleObserver<List<Integer>> o = TestHelper.mockSingleObserver();
         InOrder inOrder = inOrder(o);
 
         result.subscribe(o);
@@ -621,8 +621,7 @@ public class ObservableConcatTest {
         for (int i = 0; i < n; i++) {
             list.add(i);
         }
-        inOrder.verify(o).onNext(list);
-        inOrder.verify(o).onComplete();
+        inOrder.verify(o).onSuccess(list);
         verify(o, never()).onError(any(Throwable.class));
     }
     @Test
@@ -635,9 +634,9 @@ public class ObservableConcatTest {
             }
         });
 
-        Observable<List<Integer>> result = Observable.concat(source).take(n / 2).toList();
+        Single<List<Integer>> result = Observable.concat(source).take(n / 2).toList();
 
-        Observer<List<Integer>> o = TestHelper.mockObserver();
+        SingleObserver<List<Integer>> o = TestHelper.mockSingleObserver();
         InOrder inOrder = inOrder(o);
 
         result.subscribe(o);
@@ -646,8 +645,7 @@ public class ObservableConcatTest {
         for (int i = 0; i < n / 2; i++) {
             list.add(i);
         }
-        inOrder.verify(o).onNext(list);
-        inOrder.verify(o).onComplete();
+        inOrder.verify(o).onSuccess(list);
         verify(o, never()).onError(any(Throwable.class));
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
@@ -123,7 +123,7 @@ public class ObservableDoOnEachTest {
                         }
                     })
                     .toList()
-                    .doOnNext(new Consumer<List<Boolean>>() {
+                    .doOnSuccess(new Consumer<List<Boolean>>() {
                         @Override
                         public void accept(List<Boolean> booleans) {
                             count.incrementAndGet();
@@ -149,7 +149,7 @@ public class ObservableDoOnEachTest {
                         }
                     })
                     .toList()
-                    .doOnNext(new Consumer<List<Boolean>>() {
+                    .doOnSuccess(new Consumer<List<Boolean>>() {
                         @Override
                         public void accept(List<Boolean> booleans) {
                             count.incrementAndGet();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
@@ -54,7 +54,7 @@ public class ObservableRepeatTest {
     @Test(timeout = 2000)
     public void testRepeatTake() {
         Observable<Integer> xs = Observable.just(1, 2);
-        Object[] ys = xs.repeat().subscribeOn(Schedulers.newThread()).take(4).toList().blockingLast().toArray();
+        Object[] ys = xs.repeat().subscribeOn(Schedulers.newThread()).take(4).toList().blockingGet().toArray();
         assertArrayEquals(new Object[] { 1, 2, 1, 2 }, ys);
     }
 
@@ -91,7 +91,7 @@ public class ObservableRepeatTest {
                 return t1;
             }
 
-        }).take(4).toList().blockingLast().toArray();
+        }).take(4).toList().blockingGet().toArray();
 
         assertEquals(2, counter.get());
         assertArrayEquals(new Object[] { 1, 2, 1, 2 }, ys);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableScanTest.java
@@ -187,7 +187,7 @@ public class ObservableScanTest {
                         list.add(t2);
                     }
 
-                }).takeLast(1);
+                }).toObservable().takeLast(1);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.blockingSingle());
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.blockingSingle());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTest.java
@@ -152,7 +152,7 @@ public class ObservableTakeLastTest {
                     }
                 })
                 .toList()
-                .blockingSingle().size());
+                .blockingGet().size());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
@@ -22,16 +22,16 @@ import java.util.concurrent.*;
 import org.junit.*;
 import org.mockito.Mockito;
 
+import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.TestHelper;
 
 public class ObservableToListTest {
 
     @Test
-    public void testList() {
+    public void testListObservable() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
-        Observable<List<String>> observable = w.toList();
+        Observable<List<String>> observable = w.toList().toObservable();
 
         Observer<List<String>> observer = TestHelper.mockObserver();
         observable.subscribe(observer);
@@ -41,9 +41,9 @@ public class ObservableToListTest {
     }
 
     @Test
-    public void testListViaObservable() {
+    public void testListViaObservableObservable() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
-        Observable<List<String>> observable = w.toList();
+        Observable<List<String>> observable = w.toList().toObservable();
 
         Observer<List<String>> observer = TestHelper.mockObserver();
         observable.subscribe(observer);
@@ -53,9 +53,9 @@ public class ObservableToListTest {
     }
 
     @Test
-    public void testListMultipleSubscribers() {
+    public void testListMultipleSubscribersObservable() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
-        Observable<List<String>> observable = w.toList();
+        Observable<List<String>> observable = w.toList().toObservable();
 
         Observer<List<String>> o1 = TestHelper.mockObserver();
         observable.subscribe(o1);
@@ -76,9 +76,9 @@ public class ObservableToListTest {
 
     @Test
     @Ignore("Null values are not allowed")
-    public void testListWithNullValue() {
+    public void testListWithNullValueObservable() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", null, "three"));
-        Observable<List<String>> observable = w.toList();
+        Observable<List<String>> observable = w.toList().toObservable();
 
         Observer<List<String>> observer = TestHelper.mockObserver();
         observable.subscribe(observer);
@@ -88,9 +88,80 @@ public class ObservableToListTest {
     }
 
     @Test
+    public void testListWithBlockingFirstObservable() {
+        Observable<String> o = Observable.fromIterable(Arrays.asList("one", "two", "three"));
+        List<String> actual = o.toList().toObservable().blockingFirst();
+        Assert.assertEquals(Arrays.asList("one", "two", "three"), actual);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void capacityHintObservable() {
+        Observable.range(1, 10)
+        .toList(4)
+        .toObservable()
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+    }
+
+    @Test
+    public void testList() {
+        Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
+        Single<List<String>> observable = w.toList();
+
+        SingleObserver<List<String>> observer = TestHelper.mockSingleObserver();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onSuccess(Arrays.asList("one", "two", "three"));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testListViaObservable() {
+        Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
+        Single<List<String>> observable = w.toList();
+
+        SingleObserver<List<String>> observer = TestHelper.mockSingleObserver();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onSuccess(Arrays.asList("one", "two", "three"));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testListMultipleSubscribers() {
+        Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
+        Single<List<String>> observable = w.toList();
+
+        SingleObserver<List<String>> o1 = TestHelper.mockSingleObserver();
+        observable.subscribe(o1);
+
+        SingleObserver<List<String>> o2 = TestHelper.mockSingleObserver();
+        observable.subscribe(o2);
+
+        List<String> expected = Arrays.asList("one", "two", "three");
+
+        verify(o1, times(1)).onSuccess(expected);
+        verify(o1, Mockito.never()).onError(any(Throwable.class));
+
+        verify(o2, times(1)).onSuccess(expected);
+        verify(o2, Mockito.never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    @Ignore("Null values are not allowed")
+    public void testListWithNullValue() {
+        Observable<String> w = Observable.fromIterable(Arrays.asList("one", null, "three"));
+        Single<List<String>> observable = w.toList();
+
+        SingleObserver<List<String>> observer = TestHelper.mockSingleObserver();
+        observable.subscribe(observer);
+        verify(observer, times(1)).onSuccess(Arrays.asList("one", null, "three"));
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+    }
+
+    @Test
     public void testListWithBlockingFirst() {
         Observable<String> o = Observable.fromIterable(Arrays.asList("one", "two", "three"));
-        List<String> actual = o.toList().blockingFirst();
+        List<String> actual = o.toList().blockingGet();
         Assert.assertEquals(Arrays.asList("one", "two", "three"), actual);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToMapTest.java
@@ -21,17 +21,19 @@ import java.util.concurrent.Callable;
 
 import org.junit.*;
 
+import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.TestHelper;
 import io.reactivex.functions.Function;
 
 public class ObservableToMapTest {
     Observer<Object> objectObserver;
+    SingleObserver<Object> singleObserver;
 
     @Before
     public void before() {
         objectObserver = TestHelper.mockObserver();
+        singleObserver = TestHelper.mockSingleObserver();
     }
 
     Function<String, Integer> lengthFunc = new Function<String, Integer>() {
@@ -48,10 +50,10 @@ public class ObservableToMapTest {
     };
 
     @Test
-    public void testToMap() {
+    public void testToMapObservable() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
-        Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc);
+        Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc).toObservable();
 
         Map<Integer, String> expected = new HashMap<Integer, String>();
         expected.put(1, "a");
@@ -67,10 +69,10 @@ public class ObservableToMapTest {
     }
 
     @Test
-    public void testToMapWithValueSelector() {
+    public void testToMapWithValueSelectorObservable() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
-        Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicate);
+        Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicate).toObservable();
 
         Map<Integer, String> expected = new HashMap<Integer, String>();
         expected.put(1, "aa");
@@ -86,7 +88,7 @@ public class ObservableToMapTest {
     }
 
     @Test
-    public void testToMapWithError() {
+    public void testToMapWithErrorObservable() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
         Function<String, Integer> lengthFuncErr = new Function<String, Integer>() {
@@ -98,7 +100,7 @@ public class ObservableToMapTest {
                 return t1.length();
             }
         };
-        Observable<Map<Integer, String>> mapped = source.toMap(lengthFuncErr);
+        Observable<Map<Integer, String>> mapped = source.toMap(lengthFuncErr).toObservable();
 
         Map<Integer, String> expected = new HashMap<Integer, String>();
         expected.put(1, "a");
@@ -115,7 +117,7 @@ public class ObservableToMapTest {
     }
 
     @Test
-    public void testToMapWithErrorInValueSelector() {
+    public void testToMapWithErrorInValueSelectorObservable() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
         Function<String, String> duplicateErr = new Function<String, String>() {
@@ -128,7 +130,7 @@ public class ObservableToMapTest {
             }
         };
 
-        Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicateErr);
+        Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicateErr).toObservable();
 
         Map<Integer, String> expected = new HashMap<Integer, String>();
         expected.put(1, "aa");
@@ -145,7 +147,7 @@ public class ObservableToMapTest {
     }
 
     @Test
-    public void testToMapWithFactory() {
+    public void testToMapWithFactoryObservable() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
         Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
@@ -174,7 +176,7 @@ public class ObservableToMapTest {
             public String apply(String v) {
                 return v;
             }
-        }, mapFactory);
+        }, mapFactory).toObservable();
 
         Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
         expected.put(2, "bb");
@@ -189,7 +191,7 @@ public class ObservableToMapTest {
     }
 
     @Test
-    public void testToMapWithErrorThrowingFactory() {
+    public void testToMapWithErrorThrowingFactoryObservable() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
         Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
@@ -210,7 +212,7 @@ public class ObservableToMapTest {
             public String apply(String v) {
                 return v;
             }
-        }, mapFactory);
+        }, mapFactory).toObservable();
 
         Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
         expected.put(2, "bb");
@@ -222,6 +224,178 @@ public class ObservableToMapTest {
         verify(objectObserver, never()).onNext(expected);
         verify(objectObserver, never()).onComplete();
         verify(objectObserver, times(1)).onError(any(Throwable.class));
+    }
+
+
+    @Test
+    public void testToMap() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Single<Map<Integer, String>> mapped = source.toMap(lengthFunc);
+
+        Map<Integer, String> expected = new HashMap<Integer, String>();
+        expected.put(1, "a");
+        expected.put(2, "bb");
+        expected.put(3, "ccc");
+        expected.put(4, "dddd");
+
+        mapped.subscribe(singleObserver);
+
+        verify(singleObserver, never()).onError(any(Throwable.class));
+        verify(singleObserver, times(1)).onSuccess(expected);
+    }
+
+    @Test
+    public void testToMapWithValueSelector() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicate);
+
+        Map<Integer, String> expected = new HashMap<Integer, String>();
+        expected.put(1, "aa");
+        expected.put(2, "bbbb");
+        expected.put(3, "cccccc");
+        expected.put(4, "dddddddd");
+
+        mapped.subscribe(singleObserver);
+
+        verify(singleObserver, never()).onError(any(Throwable.class));
+        verify(singleObserver, times(1)).onSuccess(expected);
+    }
+
+    @Test
+    public void testToMapWithError() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Function<String, Integer> lengthFuncErr = new Function<String, Integer>() {
+            @Override
+            public Integer apply(String t1) {
+                if ("bb".equals(t1)) {
+                    throw new RuntimeException("Forced Failure");
+                }
+                return t1.length();
+            }
+        };
+        Single<Map<Integer, String>> mapped = source.toMap(lengthFuncErr);
+
+        Map<Integer, String> expected = new HashMap<Integer, String>();
+        expected.put(1, "a");
+        expected.put(2, "bb");
+        expected.put(3, "ccc");
+        expected.put(4, "dddd");
+
+        mapped.subscribe(singleObserver);
+
+        verify(singleObserver, never()).onSuccess(expected);
+        verify(singleObserver, times(1)).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testToMapWithErrorInValueSelector() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Function<String, String> duplicateErr = new Function<String, String>() {
+            @Override
+            public String apply(String t1) {
+                if ("bb".equals(t1)) {
+                    throw new RuntimeException("Forced failure");
+                }
+                return t1 + t1;
+            }
+        };
+
+        Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicateErr);
+
+        Map<Integer, String> expected = new HashMap<Integer, String>();
+        expected.put(1, "aa");
+        expected.put(2, "bbbb");
+        expected.put(3, "cccccc");
+        expected.put(4, "dddddddd");
+
+        mapped.subscribe(singleObserver);
+
+        verify(singleObserver, never()).onSuccess(expected);
+        verify(singleObserver, times(1)).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testToMapWithFactory() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
+            @Override
+            public Map<Integer, String> call() {
+                return new LinkedHashMap<Integer, String>() {
+
+                    private static final long serialVersionUID = -3296811238780863394L;
+
+                    @Override
+                    protected boolean removeEldestEntry(Map.Entry<Integer, String> eldest) {
+                        return size() > 3;
+                    }
+                };
+            }
+        };
+
+        Function<String, Integer> lengthFunc = new Function<String, Integer>() {
+            @Override
+            public Integer apply(String t1) {
+                return t1.length();
+            }
+        };
+        Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, new Function<String, String>() {
+            @Override
+            public String apply(String v) {
+                return v;
+            }
+        }, mapFactory);
+
+        Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
+        expected.put(2, "bb");
+        expected.put(3, "ccc");
+        expected.put(4, "dddd");
+
+        mapped.subscribe(singleObserver);
+
+        verify(singleObserver, never()).onError(any(Throwable.class));
+        verify(singleObserver, times(1)).onSuccess(expected);
+    }
+
+    @Test
+    public void testToMapWithErrorThrowingFactory() {
+        Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
+
+        Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
+            @Override
+            public Map<Integer, String> call() {
+                throw new RuntimeException("Forced failure");
+            }
+        };
+
+        Function<String, Integer> lengthFunc = new Function<String, Integer>() {
+            @Override
+            public Integer apply(String t1) {
+                return t1.length();
+            }
+        };
+        Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, new Function<String, String>() {
+            @Override
+            public String apply(String v) {
+                return v;
+            }
+        }, mapFactory);
+
+        Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
+        expected.put(2, "bb");
+        expected.put(3, "ccc");
+        expected.put(4, "dddd");
+
+        mapped.subscribe(singleObserver);
+
+        verify(singleObserver, never()).onSuccess(expected);
+        verify(singleObserver, times(1)).onError(any(Throwable.class));
     }
 
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -37,7 +37,7 @@ public class ObservableWindowWithSizeTest {
         Observable.concat(observables.map(new Function<Observable<T>, Observable<List<T>>>() {
             @Override
             public Observable<List<T>> apply(Observable<T> xs) {
-                return xs.toList();
+                return xs.toList().toObservable();
             }
         }))
                 .blockingForEach(new Consumer<List<T>>() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
@@ -1122,7 +1122,7 @@ public class ObservableZipTest {
         for (int i = 0; i < 1026; i++) {
             expected.add(i * 3);
         }
-        assertEquals(expected, zip2.toList().blockingSingle());
+        assertEquals(expected, zip2.toList().blockingGet());
     }
 
     @Test(timeout = 10000)

--- a/src/test/java/io/reactivex/observable/ObservableConcatTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableConcatTests.java
@@ -30,7 +30,7 @@ public class ObservableConcatTests {
         Observable<String> o1 = Observable.just("one", "two");
         Observable<String> o2 = Observable.just("three", "four");
 
-        List<String> values = Observable.concat(o1, o2).toList().blockingSingle();
+        List<String> values = Observable.concat(o1, o2).toList().blockingGet();
 
         assertEquals("one", values.get(0));
         assertEquals("two", values.get(1));
@@ -46,7 +46,7 @@ public class ObservableConcatTests {
 
         Observable<Observable<String>> os = Observable.just(o1, o2, o3);
 
-        List<String> values = Observable.concat(os).toList().blockingSingle();
+        List<String> values = Observable.concat(os).toList().blockingGet();
 
         assertEquals("one", values.get(0));
         assertEquals("two", values.get(1));
@@ -65,7 +65,7 @@ public class ObservableConcatTests {
         @SuppressWarnings("unchecked")
         Iterable<Observable<String>> is = Arrays.asList(o1, o2, o3);
 
-        List<String> values = Observable.concat(Observable.fromIterable(is)).toList().blockingSingle();
+        List<String> values = Observable.concat(Observable.fromIterable(is)).toList().blockingGet();
 
         assertEquals("one", values.get(0));
         assertEquals("two", values.get(1));
@@ -87,7 +87,7 @@ public class ObservableConcatTests {
 
         Observable<Observable<Media>> os = Observable.just(o1, o2);
 
-        List<Media> values = Observable.concat(os).toList().blockingSingle();
+        List<Media> values = Observable.concat(os).toList().blockingGet();
 
         assertEquals(horrorMovie1, values.get(0));
         assertEquals(movie, values.get(1));
@@ -109,7 +109,7 @@ public class ObservableConcatTests {
 
         Observable<Observable<Media>> os = Observable.just(o1, o2);
 
-        List<Media> values = Observable.concat(os).toList().blockingSingle();
+        List<Media> values = Observable.concat(os).toList().blockingGet();
 
         assertEquals(horrorMovie1, values.get(0));
         assertEquals(movie, values.get(1));
@@ -129,7 +129,7 @@ public class ObservableConcatTests {
         Observable<Movie> o1 = Observable.just(horrorMovie1, movie);
         Observable<Media> o2 = Observable.just(media, horrorMovie2);
 
-        List<Media> values = Observable.concat(o1, o2).toList().blockingSingle();
+        List<Media> values = Observable.concat(o1, o2).toList().blockingGet();
 
         assertEquals(horrorMovie1, values.get(0));
         assertEquals(movie, values.get(1));
@@ -157,7 +157,7 @@ public class ObservableConcatTests {
 
         Observable<Media> o2 = Observable.just(media, horrorMovie2);
 
-        List<Media> values = Observable.concat(o1, o2).toList().blockingSingle();
+        List<Media> values = Observable.concat(o1, o2).toList().blockingGet();
 
         assertEquals(horrorMovie1, values.get(0));
         assertEquals(movie, values.get(1));

--- a/src/test/java/io/reactivex/observable/ObservableMergeTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableMergeTests.java
@@ -42,7 +42,7 @@ public class ObservableMergeTests {
 
         Observable<Observable<Media>> os = Observable.just(o1, o2);
 
-        List<Media> values = Observable.merge(os).toList().blockingSingle();
+        List<Media> values = Observable.merge(os).toList().blockingGet();
 
         assertEquals(4, values.size());
     }
@@ -54,7 +54,7 @@ public class ObservableMergeTests {
 
         Observable<Observable<Media>> os = Observable.just(o1, o2);
 
-        List<Media> values = Observable.merge(os).toList().blockingSingle();
+        List<Media> values = Observable.merge(os).toList().blockingGet();
 
         assertEquals(5, values.size());
     }
@@ -64,7 +64,7 @@ public class ObservableMergeTests {
         Observable<Movie> o1 = Observable.just(new HorrorMovie(), new Movie());
         Observable<Media> o2 = Observable.just(new Media(), new HorrorMovie());
 
-        List<Media> values = Observable.merge(o1, o2).toList().blockingSingle();
+        List<Media> values = Observable.merge(o1, o2).toList().blockingGet();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);
@@ -87,7 +87,7 @@ public class ObservableMergeTests {
 
         Observable<Media> o2 = Observable.just(new Media(), new HorrorMovie());
 
-        List<Media> values = Observable.merge(o1, o2).toList().blockingSingle();
+        List<Media> values = Observable.merge(o1, o2).toList().blockingGet();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1008,7 +1008,7 @@ public class ObservableNullTests {
         }, new BiConsumer<Object, Integer>() {
             @Override
             public void accept(Object a, Integer b) { }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2422,7 +2422,7 @@ public class ObservableNullTests {
             public Collection<Integer> call() {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2457,7 +2457,7 @@ public class ObservableNullTests {
             public Object apply(Integer v) {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2492,7 +2492,7 @@ public class ObservableNullTests {
             public Map<Object, Object> call() {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2522,7 +2522,7 @@ public class ObservableNullTests {
             public Object apply(Integer v) {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2557,7 +2557,7 @@ public class ObservableNullTests {
             public Map<Object, Collection<Object>> call() {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2602,7 +2602,7 @@ public class ObservableNullTests {
             public Collection<Integer> apply(Integer v) {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/observable/ObservableStartWithTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableStartWithTests.java
@@ -26,7 +26,7 @@ public class ObservableStartWithTests {
     @Test
     public void startWith1() {
         List<String> values = Observable.just("one", "two")
-                .startWithArray("zero").toList().blockingSingle();
+                .startWithArray("zero").toList().blockingGet();
 
         assertEquals("zero", values.get(0));
         assertEquals("two", values.get(2));
@@ -37,7 +37,7 @@ public class ObservableStartWithTests {
         List<String> li = new ArrayList<String>();
         li.add("alpha");
         li.add("beta");
-        List<String> values = Observable.just("one", "two").startWith(li).toList().blockingSingle();
+        List<String> values = Observable.just("one", "two").startWith(li).toList().blockingGet();
 
         assertEquals("alpha", values.get(0));
         assertEquals("beta", values.get(1));
@@ -53,7 +53,7 @@ public class ObservableStartWithTests {
         List<String> values = Observable.just("one", "two")
                 .startWith(Observable.fromIterable(li))
                 .toList()
-                .blockingSingle();
+                .blockingGet();
 
         assertEquals("alpha", values.get(0));
         assertEquals("beta", values.get(1));

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -989,7 +989,7 @@ public class ObservableTest {
                         }
                     })
                     .toList()
-                    .doOnNext(new Consumer<List<Boolean>>() {
+                    .doOnSuccess(new Consumer<List<Boolean>>() {
                         @Override
                         public void accept(List<Boolean> booleans) {
                             count.incrementAndGet();
@@ -1102,7 +1102,7 @@ public class ObservableTest {
             public Observable<Integer> apply(Integer v) {
                 return Observable.range(v, 2);
             }
-        }).toList().blockingFirst();
+        }).toList().blockingGet();
 
         Assert.assertEquals(Arrays.asList(1, 2, 2, 3, 3, 4, 4, 5, 5, 6), list);
     }

--- a/src/test/java/io/reactivex/observable/ObservableWindowTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableWindowTests.java
@@ -34,7 +34,7 @@ public class ObservableWindowTests {
             .map(new Function<Observable<Integer>, Observable<List<Integer>>>() {
                 @Override
                 public Observable<List<Integer>> apply(Observable<Integer> xs) {
-                    return xs.toList();
+                    return xs.toList().toObservable();
                 }
             })
         )

--- a/src/test/java/io/reactivex/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -179,7 +179,7 @@ public class ReplayProcessorBoundedConcurrencyTest {
 
                 @Override
                 public void run() {
-                    List<Long> values = replay.toList().blockingLast();
+                    List<Long> values = replay.toList().blockingGet();
                     listOfListsOfValues.add(values);
                     System.out.println("Finished thread: " + count);
                 }

--- a/src/test/java/io/reactivex/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorConcurrencyTest.java
@@ -179,7 +179,7 @@ public class ReplayProcessorConcurrencyTest {
 
                 @Override
                 public void run() {
-                    List<Long> values = replay.toList().blockingLast();
+                    List<Long> values = replay.toList().blockingGet();
                     listOfListsOfValues.add(values);
                     System.out.println("Finished thread: " + count);
                 }

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
@@ -121,7 +121,7 @@ public abstract class AbstractSchedulerTests {
 
         });
 
-        List<String> strings = m.toList().blockingLast();
+        List<String> strings = m.toList().blockingGet();
 
         assertEquals(4, strings.size());
         // because flatMap does a merge there is no guarantee of order

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -183,7 +183,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
 
                 @Override
                 public void run() {
-                    List<Long> values = replay.toList().blockingLast();
+                    List<Long> values = replay.toList().blockingGet();
                     listOfListsOfValues.add(values);
                     System.out.println("Finished thread: " + count);
                 }

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
@@ -183,7 +183,7 @@ public class ReplaySubjectConcurrencyTest {
 
                 @Override
                 public void run() {
-                    List<Long> values = replay.toList().blockingLast();
+                    List<Long> values = replay.toList().blockingGet();
                     listOfListsOfValues.add(values);
                     System.out.println("Finished thread: " + count);
                 }

--- a/src/test/java/io/reactivex/tck/CollectTckTest.java
+++ b/src/test/java/io/reactivex/tck/CollectTckTest.java
@@ -33,7 +33,7 @@ public class CollectTckTest extends BaseTck<List<Integer>> {
                     public void accept(List<Integer> a, Integer b) throws Exception {
                         a.add(b);
                     }
-                })
+                }).toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/ToListTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToListTckTest.java
@@ -26,7 +26,7 @@ public class ToListTckTest extends BaseTck<List<Integer>> {
     @Override
     public Publisher<List<Integer>> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.range(1, 1000).toList()
+                Flowable.range(1, 1000).toList().toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/ToMapTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToMapTckTest.java
@@ -27,7 +27,7 @@ public class ToMapTckTest extends BaseTck<Map<Integer, Integer>> {
     @Override
     public Publisher<Map<Integer, Integer>> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.range(1, 1000).toMap(Functions.<Integer>identity())
+                Flowable.range(1, 1000).toMap(Functions.<Integer>identity()).toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/ToMultimapTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToMultimapTckTest.java
@@ -27,7 +27,7 @@ public class ToMultimapTckTest extends BaseTck<Map<Integer, Collection<Integer>>
     @Override
     public Publisher<Map<Integer, Collection<Integer>>> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.range(1, 1000).toMultimap(Functions.<Integer>identity())
+                Flowable.range(1, 1000).toMultimap(Functions.<Integer>identity()).toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/ToSortedListTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToSortedListTckTest.java
@@ -26,7 +26,7 @@ public class ToSortedListTckTest extends BaseTck<List<Integer>> {
     @Override
     public Publisher<List<Integer>> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.range(1, 1000).toSortedList()
+                Flowable.range(1, 1000).toSortedList().toFlowable()
             );
     }
 


### PR DESCRIPTION
This PR makes the following operators return `Single`:
- `collect`
- `collectInto`
- `toList`
- `toSortedList`
- `toMap`
- `toMultimap`

and changes the documentation to mention `Single` instead as well. (There are some whitespace removals I forgot previously).
