### PR TITLE
2.x: count, elementAt, ingoreElements, last, single, reduce, reduceWith to return non-Flowable

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3159,7 +3159,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
-        return toFlowable().retry(predicate).toMaybe();
+        return toFlowable().retry(predicate).singleElement();
     }
 
     /**
@@ -3199,7 +3199,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> retry(long times, Predicate<? super Throwable> predicate) {
-        return toFlowable().retry(times, predicate).toMaybe();
+        return toFlowable().retry(times, predicate).singleElement();
     }
 
     /**
@@ -3283,7 +3283,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> retryWhen(
             final Function<? super Flowable<? extends Throwable>, ? extends Publisher<?>> handler) {
-        return toFlowable().retryWhen(handler).toMaybe();
+        return toFlowable().retryWhen(handler).singleElement();
     }
 
     /**

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -453,7 +453,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> fromFuture(Future<? extends T> future) {
-        return Flowable.<T>fromFuture(future).toSingle();
+        return toSingle(Flowable.<T>fromFuture(future));
     }
 
     /**
@@ -485,7 +485,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
-        return Flowable.<T>fromFuture(future, timeout, unit).toSingle();
+        return toSingle(Flowable.<T>fromFuture(future, timeout, unit));
     }
 
     /**
@@ -519,7 +519,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Single<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit, Scheduler scheduler) {
-        return Flowable.<T>fromFuture(future, timeout, unit, scheduler).toSingle();
+        return toSingle(Flowable.<T>fromFuture(future, timeout, unit, scheduler));
     }
 
     /**
@@ -548,7 +548,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Single<T> fromFuture(Future<? extends T> future, Scheduler scheduler) {
-        return Flowable.<T>fromFuture(future, scheduler).toSingle();
+        return toSingle(Flowable.<T>fromFuture(future, scheduler));
     }
 
     /**
@@ -978,7 +978,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Single<R> zip(final Iterable<? extends SingleSource<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return Flowable.zipIterable(SingleInternalHelper.iterableToFlowable(sources), zipper, false, 1).toSingle();
+        return toSingle(Flowable.zipIterable(SingleInternalHelper.iterableToFlowable(sources), zipper, false, 1));
     }
 
     /**
@@ -1418,7 +1418,7 @@ public abstract class Single<T> implements SingleSource<T> {
             sourcePublishers[i] = RxJavaPlugins.onAssembly(new SingleToFlowable<T>(s));
             i++;
         }
-        return Flowable.zipArray(zipper, false, 1, sourcePublishers).toSingle();
+        return toSingle(Flowable.zipArray(zipper, false, 1, sourcePublishers));
     }
 
     /**
@@ -2252,7 +2252,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> retry() {
-        return toFlowable().retry().toSingle();
+        return toSingle(toFlowable().retry());
     }
 
     /**
@@ -2268,7 +2268,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> retry(long times) {
-        return toFlowable().retry(times).toSingle();
+        return toSingle(toFlowable().retry(times));
     }
 
     /**
@@ -2285,7 +2285,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
-        return toFlowable().retry(predicate).toSingle();
+        return toSingle(toFlowable().retry(predicate));
     }
 
     /**
@@ -2302,7 +2302,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> retry(Predicate<? super Throwable> predicate) {
-        return toFlowable().retry(predicate).toSingle();
+        return toSingle(toFlowable().retry(predicate));
     }
 
     /**
@@ -2323,7 +2323,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> retryWhen(Function<? super Flowable<? extends Throwable>, ? extends Publisher<Object>> handler) {
-        return toFlowable().retryWhen(handler).toSingle();
+        return toSingle(toFlowable().retryWhen(handler));
     }
 
     /**
@@ -2843,5 +2843,9 @@ public abstract class Single<T> implements SingleSource<T> {
 
         subscribe(ts);
         return ts;
+    }
+
+    private static <T> Single<T> toSingle(Flowable<T> source) {
+        return RxJavaPlugins.onAssembly(new FlowableSingleSingle<T>(source, null));
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtMaybe.java
@@ -15,29 +15,37 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
-import io.reactivex.internal.subscriptions.*;
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.fuseable.FuseToFlowable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, T> {
+public final class FlowableElementAtMaybe<T> extends Maybe<T> implements FuseToFlowable<T> {
+    final Publisher<T> source;
+
     final long index;
-    final T defaultValue;
-    public FlowableElementAt(Publisher<T> source, long index, T defaultValue) {
-        super(source);
+
+    public FlowableElementAtMaybe(Publisher<T> source, long index) {
+        this.source = source;
         this.index = index;
-        this.defaultValue = defaultValue;
     }
 
     @Override
-    protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new ElementAtSubscriber<T>(s, index, defaultValue));
+    protected void subscribeActual(MaybeObserver<? super T> s) {
+        source.subscribe(new ElementAtSubscriber<T>(s, index));
     }
 
-    static final class ElementAtSubscriber<T> extends DeferredScalarSubscription<T> implements Subscriber<T> {
+    @Override
+    public Flowable<T> fuseToFlowable() {
+        return RxJavaPlugins.onAssembly(new FlowableElementAt<T>(source, index, null));
+    }
 
-        private static final long serialVersionUID = 4066607327284737757L;
+    static final class ElementAtSubscriber<T> implements Subscriber<T>, Disposable {
+
+        final MaybeObserver<? super T> actual;
 
         final long index;
-        final T defaultValue;
 
         Subscription s;
 
@@ -45,10 +53,9 @@ public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, 
 
         boolean done;
 
-        ElementAtSubscriber(Subscriber<? super T> actual, long index, T defaultValue) {
-            super(actual);
+        ElementAtSubscriber(MaybeObserver<? super T> actual, long index) {
+            this.actual = actual;
             this.index = index;
-            this.defaultValue = defaultValue;
         }
 
         @Override
@@ -69,7 +76,8 @@ public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, 
             if (c == index) {
                 done = true;
                 s.cancel();
-                complete(t);
+                s = SubscriptionHelper.CANCELLED;
+                actual.onSuccess(t);
                 return;
             }
             count = c + 1;
@@ -82,26 +90,29 @@ public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, 
                 return;
             }
             done = true;
+            s = SubscriptionHelper.CANCELLED;
             actual.onError(t);
         }
 
         @Override
         public void onComplete() {
+            s = SubscriptionHelper.CANCELLED;
             if (index <= count && !done) {
                 done = true;
-                T v = defaultValue;
-                if (v == null) {
-                    actual.onComplete();
-                } else {
-                    complete(v);
-                }
+                actual.onComplete();
             }
         }
 
         @Override
-        public void cancel() {
-            super.cancel();
+        public void dispose() {
             s.cancel();
+            s = SubscriptionHelper.CANCELLED;
         }
+
+        @Override
+        public boolean isDisposed() {
+            return s == SubscriptionHelper.CANCELLED;
+        }
+
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtSingle.java
@@ -15,26 +15,38 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
-import io.reactivex.internal.subscriptions.*;
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.fuseable.FuseToFlowable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, T> {
+public final class FlowableElementAtSingle<T> extends Single<T> implements FuseToFlowable<T> {
+    final Publisher<T> source;
+
     final long index;
+
     final T defaultValue;
-    public FlowableElementAt(Publisher<T> source, long index, T defaultValue) {
-        super(source);
+
+    public FlowableElementAtSingle(Publisher<T> source, long index, T defaultValue) {
+        this.source = source;
         this.index = index;
         this.defaultValue = defaultValue;
     }
 
     @Override
-    protected void subscribeActual(Subscriber<? super T> s) {
+    protected void subscribeActual(SingleObserver<? super T> s) {
         source.subscribe(new ElementAtSubscriber<T>(s, index, defaultValue));
     }
 
-    static final class ElementAtSubscriber<T> extends DeferredScalarSubscription<T> implements Subscriber<T> {
+    @Override
+    public Flowable<T> fuseToFlowable() {
+        return RxJavaPlugins.onAssembly(new FlowableElementAt<T>(source, index, defaultValue));
+    }
 
-        private static final long serialVersionUID = 4066607327284737757L;
+    static final class ElementAtSubscriber<T> implements Subscriber<T>, Disposable {
+
+        final SingleObserver<? super T> actual;
 
         final long index;
         final T defaultValue;
@@ -45,8 +57,8 @@ public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, 
 
         boolean done;
 
-        ElementAtSubscriber(Subscriber<? super T> actual, long index, T defaultValue) {
-            super(actual);
+        ElementAtSubscriber(SingleObserver<? super T> actual, long index, T defaultValue) {
+            this.actual = actual;
             this.index = index;
             this.defaultValue = defaultValue;
         }
@@ -69,7 +81,8 @@ public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, 
             if (c == index) {
                 done = true;
                 s.cancel();
-                complete(t);
+                s = SubscriptionHelper.CANCELLED;
+                actual.onSuccess(t);
                 return;
             }
             count = c + 1;
@@ -82,26 +95,28 @@ public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, 
                 return;
             }
             done = true;
+            s = SubscriptionHelper.CANCELLED;
             actual.onError(t);
         }
 
         @Override
         public void onComplete() {
+            s = SubscriptionHelper.CANCELLED;
             if (index <= count && !done) {
                 done = true;
-                T v = defaultValue;
-                if (v == null) {
-                    actual.onComplete();
-                } else {
-                    complete(v);
-                }
+                actual.onSuccess(defaultValue);
             }
         }
 
         @Override
-        public void cancel() {
-            super.cancel();
+        public void dispose() {
             s.cancel();
+            s = SubscriptionHelper.CANCELLED;
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return s == SubscriptionHelper.CANCELLED;
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsCompletable.java
@@ -17,45 +17,61 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.fuseable.FuseToFlowable;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
 
-/**
- * Consumes the source Publisher and emits its last item or the defaultItem
- * if empty.
- * 
- * @param <T> the value type
- */
-public final class FlowableLastSingle<T> extends Single<T> {
+public final class FlowableIgnoreElementsCompletable<T> extends Completable implements FuseToFlowable<T> {
 
     final Publisher<T> source;
 
-    final T defaultItem;
-
-    public FlowableLastSingle(Publisher<T> source, T defaultItem) {
+    public FlowableIgnoreElementsCompletable(Publisher<T> source) {
         this.source = source;
-        this.defaultItem = defaultItem;
     }
-
-    // TODO fuse back to Flowable
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new LastSubscriber<T>(observer, defaultItem));
+    protected void subscribeActual(final CompletableObserver t) {
+        source.subscribe(new IgnoreElementsSubscriber<T>(t));
     }
 
-    static final class LastSubscriber<T> implements Subscriber<T>, Disposable {
+    @Override
+    public Flowable<T> fuseToFlowable() {
+        return RxJavaPlugins.onAssembly(new FlowableIgnoreElements<T>(source));
+    }
 
-        final SingleObserver<? super T> actual;
-
-        final T defaultItem;
+    static final class IgnoreElementsSubscriber<T> implements Subscriber<T>, Disposable {
+        final CompletableObserver actual;
 
         Subscription s;
 
-        T item;
-
-        public LastSubscriber(SingleObserver<? super T> actual, T defaultItem) {
+        IgnoreElementsSubscriber(CompletableObserver actual) {
             this.actual = actual;
-            this.defaultItem = defaultItem;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+                actual.onSubscribe(this);
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            // deliberately ignored
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            s = SubscriptionHelper.CANCELLED;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            s = SubscriptionHelper.CANCELLED;
+            actual.onComplete();
         }
 
         @Override
@@ -67,41 +83,6 @@ public final class FlowableLastSingle<T> extends Single<T> {
         @Override
         public boolean isDisposed() {
             return s == SubscriptionHelper.CANCELLED;
-        }
-
-        @Override
-        public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validate(this.s, s)) {
-                this.s = s;
-
-                actual.onSubscribe(this);
-
-                s.request(Long.MAX_VALUE);
-            }
-        }
-
-        @Override
-        public void onNext(T t) {
-            item = t;
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            s = SubscriptionHelper.CANCELLED;
-            item = null;
-            actual.onError(t);
-        }
-
-        @Override
-        public void onComplete() {
-            s = SubscriptionHelper.CANCELLED;
-            T v = item;
-            if (v != null) {
-                item = null;
-                actual.onSuccess(v);
-            } else {
-                actual.onSuccess(defaultItem);
-            }
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastMaybe.java
@@ -20,42 +20,35 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 /**
- * Consumes the source Publisher and emits its last item or the defaultItem
- * if empty.
+ * Consumes the source Publisher and emits its last item or completes.
  * 
  * @param <T> the value type
  */
-public final class FlowableLastSingle<T> extends Single<T> {
+public final class FlowableLastMaybe<T> extends Maybe<T> {
 
     final Publisher<T> source;
 
-    final T defaultItem;
-
-    public FlowableLastSingle(Publisher<T> source, T defaultItem) {
+    public FlowableLastMaybe(Publisher<T> source) {
         this.source = source;
-        this.defaultItem = defaultItem;
     }
 
     // TODO fuse back to Flowable
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new LastSubscriber<T>(observer, defaultItem));
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new LastSubscriber<T>(observer));
     }
 
     static final class LastSubscriber<T> implements Subscriber<T>, Disposable {
 
-        final SingleObserver<? super T> actual;
-
-        final T defaultItem;
+        final MaybeObserver<? super T> actual;
 
         Subscription s;
 
         T item;
 
-        public LastSubscriber(SingleObserver<? super T> actual, T defaultItem) {
+        public LastSubscriber(MaybeObserver<? super T> actual) {
             this.actual = actual;
-            this.defaultItem = defaultItem;
         }
 
         @Override
@@ -100,7 +93,7 @@ public final class FlowableLastSingle<T> extends Single<T> {
                 item = null;
                 actual.onSuccess(v);
             } else {
-                actual.onSuccess(defaultItem);
+                actual.onComplete();
             }
         }
     }

--- a/src/test/java/io/reactivex/InternalWrongNaming.java
+++ b/src/test/java/io/reactivex/InternalWrongNaming.java
@@ -164,7 +164,14 @@ public class InternalWrongNaming {
                 "FlowableAnySingle",
                 "FlowableAllSingle",
                 "FlowableToListSingle",
-                "FlowableCollectSingle"
+                "FlowableCollectSingle",
+                "FlowableCountSingle",
+                "FlowableElementAtMaybe",
+                "FlowableElementAtSingle",
+                "FlowableSingleSingle",
+                "FlowableSingleMaybe",
+                "FlowableLastMaybe",
+                "FlowableIgnoreElementsCompletable"
         );
     }
 }

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -97,6 +97,14 @@ public enum TestHelper {
     }
 
     /**
+     * Mocks an CompletableObserver.
+     * @return the mocked observer
+     */
+    public static CompletableObserver mockCompletableObserver() {
+        return mock(CompletableObserver.class);
+    }
+
+    /**
      * Validates that the given class, when forcefully instantiated throws
      * an IllegalArgumentException("No instances!") exception.
      * @param clazz the class to test, not null
@@ -958,7 +966,7 @@ public enum TestHelper {
         TestSubscriber<U> ts = new TestSubscriber<U>();
 
         try {
-            new MaybeToFlowable<U>(composer.apply(pp.toMaybe())).subscribe(ts);
+            new MaybeToFlowable<U>(composer.apply(pp.singleElement())).subscribe(ts);
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }
@@ -982,7 +990,7 @@ public enum TestHelper {
         TestSubscriber<U> ts = new TestSubscriber<U>();
 
         try {
-            new SingleToFlowable<U>(composer.apply(pp.toMaybe())).subscribe(ts);
+            new SingleToFlowable<U>(composer.apply(pp.singleElement())).subscribe(ts);
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -4544,7 +4544,7 @@ public class CompletableTest {
     @Test(timeout = 1000)
     public void subscribeTwoCallbacksDispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
-        Disposable d = pp.toCompletable().subscribe(Functions.EMPTY_ACTION, Functions.emptyConsumer());
+        Disposable d = pp.ignoreElements().subscribe(Functions.EMPTY_ACTION, Functions.emptyConsumer());
 
         assertFalse(d.isDisposed());
         assertTrue(pp.hasSubscribers());

--- a/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
@@ -24,8 +24,9 @@ import io.reactivex.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.*;
+import io.reactivex.subscribers.DefaultSubscriber;
 
 public class FlowableConversionTest {
 
@@ -146,7 +147,7 @@ public class FlowableConversionTest {
 
     @Test
     public void testConversionBetweenObservableClasses() {
-        final TestSubscriber<String> subscriber = new TestSubscriber<String>(new DefaultSubscriber<String>() {
+        final TestObserver<String> subscriber = new TestObserver<String>(new DefaultObserver<String>() {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -1736,7 +1736,7 @@ public class FlowableNullTests {
             public Integer apply(Integer a, Integer b) {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -1761,7 +1761,7 @@ public class FlowableNullTests {
             public Object apply(Object a, Integer b) {
                 return 1;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableAwaitTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableAwaitTest.java
@@ -31,7 +31,7 @@ public class CompletableAwaitTest {
         Thread.currentThread().interrupt();
 
         try {
-            PublishProcessor.create().toCompletable().blockingAwait();
+            PublishProcessor.create().ignoreElements().blockingAwait();
             fail("Should have thrown RuntimeException");
         } catch (RuntimeException ex) {
             if (!(ex.getCause() instanceof InterruptedException)) {
@@ -47,7 +47,7 @@ public class CompletableAwaitTest {
         Thread.currentThread().interrupt();
 
         try {
-            PublishProcessor.create().toCompletable().blockingAwait(1, TimeUnit.SECONDS);
+            PublishProcessor.create().ignoreElements().blockingAwait(1, TimeUnit.SECONDS);
             fail("Should have thrown RuntimeException");
         } catch (RuntimeException ex) {
             if (!(ex.getCause() instanceof InterruptedException)) {
@@ -59,7 +59,7 @@ public class CompletableAwaitTest {
 
     @Test
     public void awaitTimeout() {
-        assertFalse(PublishProcessor.create().toCompletable().blockingAwait(100, TimeUnit.MILLISECONDS));
+        assertFalse(PublishProcessor.create().ignoreElements().blockingAwait(100, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeTest.java
@@ -25,7 +25,7 @@ public class CompletableSubscribeTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        pp.toCompletable().test(true);
+        pp.ignoreElements().test(true);
 
         assertFalse(pp.hasSubscribers());
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCountTest.java
@@ -19,12 +19,22 @@ import io.reactivex.Flowable;
 
 public class FlowableCountTest {
     @Test
+    public void simpleFlowable() {
+        Assert.assertEquals(0, Flowable.empty().count().toFlowable().blockingLast().intValue());
+
+        Assert.assertEquals(1, Flowable.just(1).count().toFlowable().blockingLast().intValue());
+
+        Assert.assertEquals(10, Flowable.range(1, 10).count().toFlowable().blockingLast().intValue());
+
+    }
+
+    @Test
     public void simple() {
-        Assert.assertEquals(0, Flowable.empty().count().blockingLast().intValue());
+        Assert.assertEquals(0, Flowable.empty().count().blockingGet().intValue());
 
-        Assert.assertEquals(1, Flowable.just(1).count().blockingLast().intValue());
+        Assert.assertEquals(1, Flowable.just(1).count().blockingGet().intValue());
 
-        Assert.assertEquals(10, Flowable.range(1, 10).count().blockingLast().intValue());
+        Assert.assertEquals(10, Flowable.range(1, 10).count().blockingGet().intValue());
 
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
@@ -38,7 +38,7 @@ public class FlowableDetachTest {
 
         TestSubscriber<Object> ts = new TestSubscriber<Object>();
 
-        Flowable.just(o).count().onTerminateDetach().subscribe(ts);
+        Flowable.just(o).count().toFlowable().onTerminateDetach().subscribe(ts);
 
         ts.assertValue(1L);
         ts.assertComplete();
@@ -95,7 +95,7 @@ public class FlowableDetachTest {
 
         TestSubscriber<Object> ts = new TestSubscriber<Object>(0L);
 
-        Flowable.just(o).count().onTerminateDetach().subscribe(ts);
+        Flowable.just(o).count().toFlowable().onTerminateDetach().subscribe(ts);
 
         ts.assertNoValues();
 
@@ -121,7 +121,7 @@ public class FlowableDetachTest {
 
         TestSubscriber<Object> ts = new TestSubscriber<Object>(0);
 
-        Flowable.just(o).count().onTerminateDetach().subscribe(ts);
+        Flowable.just(o).count().toFlowable().onTerminateDetach().subscribe(ts);
 
         ts.cancel();
         o = null;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
@@ -22,8 +22,39 @@ import io.reactivex.Flowable;
 public class FlowableElementAtTest {
 
     @Test
+    public void testElementAtFlowable() {
+        assertEquals(2, Flowable.fromArray(1, 2).elementAt(1).toFlowable().blockingSingle()
+                .intValue());
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testElementAtWithMinusIndexFlowable() {
+        Flowable.fromArray(1, 2).elementAt(-1);
+    }
+
+    @Test
+    public void testElementAtWithIndexOutOfBoundsFlowable() {
+        assertEquals(-100, Flowable.fromArray(1, 2).elementAt(2).toFlowable().blockingFirst(-100).intValue());
+    }
+
+    @Test
+    public void testElementAtOrDefaultFlowable() {
+        assertEquals(2, Flowable.fromArray(1, 2).elementAt(1, 0).toFlowable().blockingSingle().intValue());
+    }
+
+    @Test
+    public void testElementAtOrDefaultWithIndexOutOfBoundsFlowable() {
+        assertEquals(0, Flowable.fromArray(1, 2).elementAt(2, 0).toFlowable().blockingSingle().intValue());
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testElementAtOrDefaultWithMinusIndexFlowable() {
+        Flowable.fromArray(1, 2).elementAt(-1, 0);
+    }
+
+    @Test
     public void testElementAt() {
-        assertEquals(2, Flowable.fromArray(1, 2).elementAt(1).blockingSingle()
+        assertEquals(2, Flowable.fromArray(1, 2).elementAt(1).blockingGet()
                 .intValue());
     }
 
@@ -32,19 +63,19 @@ public class FlowableElementAtTest {
         Flowable.fromArray(1, 2).elementAt(-1);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testElementAtWithIndexOutOfBounds() {
-        Flowable.fromArray(1, 2).elementAt(2).blockingSingle();
+        assertNull(Flowable.fromArray(1, 2).elementAt(2).blockingGet());
     }
 
     @Test
     public void testElementAtOrDefault() {
-        assertEquals(2, Flowable.fromArray(1, 2).elementAt(1, 0).blockingSingle().intValue());
+        assertEquals(2, Flowable.fromArray(1, 2).elementAt(1, 0).blockingGet().intValue());
     }
 
     @Test
     public void testElementAtOrDefaultWithIndexOutOfBounds() {
-        assertEquals(0, Flowable.fromArray(1, 2).elementAt(2, 0).blockingSingle().intValue());
+        assertEquals(0, Flowable.fromArray(1, 2).elementAt(2, 0).blockingGet().intValue());
     }
 
     @Test(expected = IndexOutOfBoundsException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableLastTest.java
@@ -13,11 +13,9 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.isA;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
-
-import java.util.NoSuchElementException;
 
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -29,33 +27,33 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithElements() {
-        Single<Integer> last = Flowable.just(1, 2, 3).last();
+        Maybe<Integer> last = Flowable.just(1, 2, 3).lastElement();
         assertEquals(3, last.blockingGet().intValue());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testLastWithNoElements() {
-        Single<?> last = Flowable.empty().last();
-        last.blockingGet();
+        Maybe<?> last = Flowable.empty().lastElement();
+        assertNull(last.blockingGet());
     }
 
     @Test
     public void testLastMultiSubscribe() {
-        Single<Integer> last = Flowable.just(1, 2, 3).last();
+        Maybe<Integer> last = Flowable.just(1, 2, 3).lastElement();
         assertEquals(3, last.blockingGet().intValue());
         assertEquals(3, last.blockingGet().intValue());
     }
 
     @Test
     public void testLastViaObservable() {
-        Flowable.just(1, 2, 3).last();
+        Flowable.just(1, 2, 3).lastElement();
     }
 
     @Test
     public void testLast() {
-        Single<Integer> observable = Flowable.just(1, 2, 3).last();
+        Maybe<Integer> observable = Flowable.just(1, 2, 3).lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -66,9 +64,9 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithOneElement() {
-        Single<Integer> observable = Flowable.just(1).last();
+        Maybe<Integer> observable = Flowable.just(1).lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -79,20 +77,20 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithEmpty() {
-        Single<Integer> observable = Flowable.<Integer> empty().last();
+        Maybe<Integer> observable = Flowable.<Integer> empty().lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(
-                isA(NoSuchElementException.class));
+        inOrder.verify(observer).onComplete();
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastWithPredicate() {
-        Single<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
+        Maybe<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
 
                     @Override
@@ -100,9 +98,9 @@ public class FlowableLastTest {
                         return t1 % 2 == 0;
                     }
                 })
-                .last();
+                .lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -113,7 +111,7 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithPredicateAndOneElement() {
-        Single<Integer> observable = Flowable.just(1, 2)
+        Maybe<Integer> observable = Flowable.just(1, 2)
             .filter(
                 new Predicate<Integer>() {
 
@@ -122,9 +120,9 @@ public class FlowableLastTest {
                         return t1 % 2 == 0;
                     }
                 })
-            .last();
+            .lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -135,7 +133,7 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithPredicateAndEmpty() {
-        Single<Integer> observable = Flowable.just(1)
+        Maybe<Integer> observable = Flowable.just(1)
             .filter(
                 new Predicate<Integer>() {
 
@@ -143,14 +141,14 @@ public class FlowableLastTest {
                     public boolean test(Integer t1) {
                         return t1 % 2 == 0;
                     }
-                }).last();
+                }).lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         observable.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(
-                isA(NoSuchElementException.class));
+        inOrder.verify(observer).onComplete();
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
 
 import java.util.*;
 
@@ -206,16 +207,16 @@ public class FlowableMapTest {
     /**
      * While mapping over range(1,0).last() we expect NoSuchElementException since the sequence is empty.
      */
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testErrorPassesThruMap() {
-        Flowable.range(1, 0).last().map(new Function<Integer, Integer>() {
+        assertNull(Flowable.range(1, 0).lastElement().map(new Function<Integer, Integer>() {
 
             @Override
             public Integer apply(Integer i) {
                 return i;
             }
 
-        }).blockingGet();
+        }).blockingGet());
     }
 
     /**
@@ -239,7 +240,7 @@ public class FlowableMapTest {
      */
     @Test(expected = ArithmeticException.class)
     public void testMapWithErrorInFunc() {
-        Flowable.range(1, 1).last().map(new Function<Integer, Integer>() {
+        Flowable.range(1, 1).lastElement().map(new Function<Integer, Integer>() {
 
             @Override
             public Integer apply(Integer i) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOneTest.java
@@ -92,7 +92,7 @@ public class FlowableTakeLastOneTest {
             public void accept(Integer t) {
                 upstreamCount.incrementAndGet();
             }})
-            .takeLast(0).count().blockingSingle();
+            .takeLast(0).count().blockingGet();
         assertEquals(num, upstreamCount.get());
         assertEquals(0L, count);
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
@@ -147,6 +147,7 @@ public class FlowableTakeLastTest {
         assertEquals(0, Flowable
                 .empty()
                 .count()
+                .toFlowable()
                 .filter(new Predicate<Long>() {
                     @Override
                     public boolean test(Long v) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToCompletableTest.java
@@ -30,7 +30,7 @@ public class FlowableToCompletableTest {
     @Test
     public void testJustSingleItemObservable() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
-        Completable cmp = Flowable.just("Hello World!").toCompletable();
+        Completable cmp = Flowable.just("Hello World!").ignoreElements();
         cmp.<String>toFlowable().subscribe(subscriber);
 
         subscriber.assertNoValues();
@@ -42,7 +42,7 @@ public class FlowableToCompletableTest {
     public void testErrorObservable() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
         IllegalArgumentException error = new IllegalArgumentException("Error");
-        Completable cmp = Flowable.<String>error(error).toCompletable();
+        Completable cmp = Flowable.<String>error(error).ignoreElements();
         cmp.<String>toFlowable().subscribe(subscriber);
 
         subscriber.assertError(error);
@@ -52,7 +52,7 @@ public class FlowableToCompletableTest {
     @Test
     public void testJustTwoEmissionsObservableThrowsError() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
-        Completable cmp = Flowable.just("First", "Second").toCompletable();
+        Completable cmp = Flowable.just("First", "Second").ignoreElements();
         cmp.<String>toFlowable().subscribe(subscriber);
 
         subscriber.assertNoErrors();
@@ -62,7 +62,7 @@ public class FlowableToCompletableTest {
     @Test
     public void testEmptyObservable() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
-        Completable cmp = Flowable.<String>empty().toCompletable();
+        Completable cmp = Flowable.<String>empty().ignoreElements();
         cmp.<String>toFlowable().subscribe(subscriber);
 
         subscriber.assertNoErrors();
@@ -73,7 +73,7 @@ public class FlowableToCompletableTest {
     @Test
     public void testNeverObservable() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
-        Completable cmp = Flowable.<String>never().toCompletable();
+        Completable cmp = Flowable.<String>never().ignoreElements();
         cmp.<String>toFlowable().subscribe(subscriber);
 
         subscriber.assertNotTerminated();
@@ -89,7 +89,7 @@ public class FlowableToCompletableTest {
             @Override
             public void run() {
                 unsubscribed.set(true);
-            }}).toCompletable();
+            }}).ignoreElements();
 
         cmp.<String>toFlowable().subscribe(subscriber);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSingleTest.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.*;
@@ -27,7 +26,7 @@ public class FlowableToSingleTest {
     @Test
     public void testJustSingleItemObservable() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
-        Single<String> single = Flowable.just("Hello World!").toSingle();
+        Single<String> single = Flowable.just("Hello World!").single("");
         single.toFlowable().subscribe(subscriber);
 
         subscriber.assertResult("Hello World!");
@@ -37,7 +36,7 @@ public class FlowableToSingleTest {
     public void testErrorObservable() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
         IllegalArgumentException error = new IllegalArgumentException("Error");
-        Single<String> single = Flowable.<String>error(error).toSingle();
+        Single<String> single = Flowable.<String>error(error).single("");
         single.toFlowable().subscribe(subscriber);
 
         subscriber.assertError(error);
@@ -46,28 +45,28 @@ public class FlowableToSingleTest {
     @Test
     public void testJustTwoEmissionsObservableThrowsError() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
-        Single<String> single = Flowable.just("First", "Second").toSingle();
+        Single<String> single = Flowable.just("First", "Second").single("");
         single.toFlowable().subscribe(subscriber);
 
-        subscriber.assertError(IndexOutOfBoundsException.class);
+        subscriber.assertError(IllegalArgumentException.class);
     }
 
     @Test
     public void testEmptyObservable() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
-        Single<String> single = Flowable.<String>empty().toSingle();
+        Single<String> single = Flowable.<String>empty().single("");
         single.toFlowable().subscribe(subscriber);
 
-        subscriber.assertError(NoSuchElementException.class);
+        subscriber.assertResult("");
     }
 
     @Test
     public void testRepeatObservableThrowsError() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
-        Single<String> single = Flowable.just("First", "Second").repeat().toSingle();
+        Single<String> single = Flowable.just("First", "Second").repeat().single("");
         single.toFlowable().subscribe(subscriber);
 
-        subscriber.assertError(IndexOutOfBoundsException.class);
+        subscriber.assertError(IllegalArgumentException.class);
     }
 
     @Test
@@ -79,7 +78,7 @@ public class FlowableToSingleTest {
             @Override
             public void run() {
                 unsubscribed.set(true);
-            }}).toSingle();
+            }}).single("");
         single.toFlowable().subscribe(subscriber);
         subscriber.assertComplete();
         Assert.assertFalse(unsubscribed.get());

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
@@ -68,7 +68,7 @@ public class MaybeCacheTest {
     public void onlineSuccess() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        Maybe<Integer> source = pp.toMaybe().cache();
+        Maybe<Integer> source = pp.singleElement().cache();
 
         assertFalse(pp.hasSubscribers());
 
@@ -98,7 +98,7 @@ public class MaybeCacheTest {
     public void onlineError() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        Maybe<Integer> source = pp.toMaybe().cache();
+        Maybe<Integer> source = pp.singleElement().cache();
 
         assertFalse(pp.hasSubscribers());
 
@@ -127,7 +127,7 @@ public class MaybeCacheTest {
     public void onlineComplete() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        Maybe<Integer> source = pp.toMaybe().cache();
+        Maybe<Integer> source = pp.singleElement().cache();
 
         assertFalse(pp.hasSubscribers());
 
@@ -159,7 +159,7 @@ public class MaybeCacheTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        Maybe<Integer> source = pp.toMaybe().cache();
+        Maybe<Integer> source = pp.singleElement().cache();
 
         source.subscribe(new Consumer<Integer>() {
             @Override
@@ -183,7 +183,7 @@ public class MaybeCacheTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        Maybe<Integer> source = pp.toMaybe().cache();
+        Maybe<Integer> source = pp.singleElement().cache();
 
         source.subscribe(Functions.emptyConsumer(), new Consumer<Object>() {
             @Override
@@ -206,7 +206,7 @@ public class MaybeCacheTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        Maybe<Integer> source = pp.toMaybe().cache();
+        Maybe<Integer> source = pp.singleElement().cache();
 
         source.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), new Action() {
             @Override
@@ -227,7 +227,7 @@ public class MaybeCacheTest {
         for (int i = 0; i < 500; i++) {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final Maybe<Integer> source = pp.toMaybe().cache();
+            final Maybe<Integer> source = pp.singleElement().cache();
 
             Runnable r = new Runnable() {
                 @Override
@@ -245,7 +245,7 @@ public class MaybeCacheTest {
         for (int i = 0; i < 500; i++) {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final Maybe<Integer> source = pp.toMaybe().cache();
+            final Maybe<Integer> source = pp.singleElement().cache();
 
             final TestObserver<Integer> ts1 = source.test();
             final TestObserver<Integer> ts2 = source.test();
@@ -272,7 +272,7 @@ public class MaybeCacheTest {
     public void doubleDispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final Maybe<Integer> source = pp.toMaybe().cache();
+        final Maybe<Integer> source = pp.singleElement().cache();
 
         final Disposable[] dout = { null };
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
@@ -50,7 +50,7 @@ public class MaybeContainsTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Boolean> ts = pp.toMaybe().contains(1).test();
+        TestObserver<Boolean> ts = pp.singleElement().contains(1).test();
 
         assertTrue(pp.hasSubscribers());
 
@@ -64,7 +64,7 @@ public class MaybeContainsTest {
     public void isDisposed() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestHelper.checkDisposed(pp.toMaybe().contains(1));
+        TestHelper.checkDisposed(pp.singleElement().contains(1));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCountTest.java
@@ -45,7 +45,7 @@ public class MaybeCountTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Long> ts = pp.toMaybe().count().test();
+        TestObserver<Long> ts = pp.singleElement().count().test();
 
         assertTrue(pp.hasSubscribers());
 
@@ -58,7 +58,7 @@ public class MaybeCountTest {
     public void isDisposed() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestHelper.checkDisposed(pp.toMaybe().count());
+        TestHelper.checkDisposed(pp.singleElement().count());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayTest.java
@@ -80,7 +80,7 @@ public class MaybeDelayTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp.toMaybe().delay(100, TimeUnit.MILLISECONDS).test();
+        TestObserver<Integer> ts = pp.singleElement().delay(100, TimeUnit.MILLISECONDS).test();
 
         assertTrue(pp.hasSubscribers());
 
@@ -93,7 +93,7 @@ public class MaybeDelayTest {
     public void isDisposed() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestHelper.checkDisposed(pp.toMaybe().delay(100, TimeUnit.MILLISECONDS));
+        TestHelper.checkDisposed(pp.singleElement().delay(100, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeHideTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeHideTest.java
@@ -70,7 +70,7 @@ public class MaybeHideTest {
     public void isDisposed() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestHelper.checkDisposed(pp.toMaybe().hide());
+        TestHelper.checkDisposed(pp.singleElement().hide());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptyTest.java
@@ -68,7 +68,7 @@ public class MaybeIsEmptyTest {
     public void isDisposed() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestHelper.checkDisposed(pp.toMaybe().isEmpty());
+        TestHelper.checkDisposed(pp.singleElement().isEmpty());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeOfTypeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeOfTypeTest.java
@@ -80,7 +80,7 @@ public class MaybeOfTypeTest {
     public void isDisposed() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestHelper.checkDisposed(pp.toMaybe().ofType(Object.class));
+        TestHelper.checkDisposed(pp.singleElement().ofType(Object.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
@@ -68,7 +68,7 @@ public class MaybeSwitchIfEmptyTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp.toMaybe().switchIfEmpty(Maybe.just(2)).test();
+        TestObserver<Integer> ts = pp.singleElement().switchIfEmpty(Maybe.just(2)).test();
 
         assertTrue(pp.hasSubscribers());
 
@@ -82,7 +82,7 @@ public class MaybeSwitchIfEmptyTest {
     public void isDisposed() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestHelper.checkDisposed(pp.toMaybe().switchIfEmpty(Maybe.just(2)));
+        TestHelper.checkDisposed(pp.singleElement().switchIfEmpty(Maybe.just(2)));
     }
 
     @Test
@@ -100,7 +100,7 @@ public class MaybeSwitchIfEmptyTest {
         for (int i = 0; i < 500; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestObserver<Integer> ts = pp.toMaybe().switchIfEmpty(Maybe.just(2)).test();
+            final TestObserver<Integer> ts = pp.singleElement().switchIfEmpty(Maybe.just(2)).test();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeUnsubscribeOnTest.java
@@ -40,7 +40,7 @@ public class MaybeUnsubscribeOnTest {
                 cdl.countDown();
             }
         })
-        .toMaybe()
+        .singleElement()
         .unsubscribeOn(Schedulers.single())
         .test(true)
         ;

--- a/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
@@ -29,7 +29,7 @@ public class SingleAmbTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp1.toSingle().ambWith(pp2.toSingle()).test();
+        TestObserver<Integer> ts = pp1.single(-99).ambWith(pp2.single(-99)).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -49,7 +49,7 @@ public class SingleAmbTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp1.toSingle().ambWith(pp2.toSingle()).test();
+        TestObserver<Integer> ts = pp1.single(-99).ambWith(pp2.single(-99)).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());

--- a/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
@@ -27,7 +27,7 @@ public class SingleCacheTest {
     public void cancelImmediately() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        Single<Integer> cached = pp.toSingle().cache();
+        Single<Integer> cached = pp.single(-99).cache();
 
         TestObserver<Integer> ts = cached.test(true);
 
@@ -44,7 +44,7 @@ public class SingleCacheTest {
         for (int i = 0; i < 500; i++) {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final Single<Integer> cached = pp.toSingle().cache();
+            final Single<Integer> cached = pp.single(-99).cache();
 
             final TestObserver<Integer> ts1 = cached.test();
 
@@ -70,7 +70,7 @@ public class SingleCacheTest {
     public void doubleDispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final Single<Integer> cached = pp.toSingle().cache();
+        final Single<Integer> cached = pp.single(-99).cache();
 
         SingleObserver<Integer> doubleDisposer = new SingleObserver<Integer>() {
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
@@ -28,7 +28,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp)
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp)
         .test();
 
         source.onNext(1);
@@ -42,7 +42,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.single(-99))
         .test();
 
         source.onNext(1);
@@ -57,7 +57,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.ignoreElements())
         .test();
 
         source.onNext(1);
@@ -71,7 +71,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp)
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp)
         .test();
 
         source.onError(new TestException());
@@ -84,7 +84,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.single(-99))
         .test();
 
         source.onError(new TestException());
@@ -97,7 +97,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.ignoreElements())
         .test();
 
         source.onError(new TestException());
@@ -110,7 +110,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp)
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp)
         .test();
 
         pp.onNext(1);
@@ -123,7 +123,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.single(-99))
         .test();
 
         pp.onNext(1);
@@ -137,7 +137,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.ignoreElements())
         .test();
 
         pp.onNext(1);
@@ -151,7 +151,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp)
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp)
         .test();
 
         pp.onComplete();
@@ -164,7 +164,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.ignoreElements())
         .test();
 
         pp.onComplete();
@@ -177,7 +177,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp)
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp)
         .test();
 
         pp.onError(new TestException());
@@ -190,7 +190,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toSingle())
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.single(-99))
         .test();
 
         pp.onError(new TestException());
@@ -203,7 +203,7 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.toSingle().takeUntil(pp.toCompletable())
+        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.ignoreElements())
         .test();
 
         pp.onError(new TestException());

--- a/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
@@ -228,7 +228,7 @@ public class SingleUsingTest {
             final TestObserver<Integer> ts = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Disposable v) throws Exception {
-                    return pp.toSingle();
+                    return pp.single(-99);
                 }
             }, disposer)
             .test();
@@ -303,7 +303,7 @@ public class SingleUsingTest {
             final TestObserver<Integer> ts = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Disposable v) throws Exception {
-                    return pp.toSingle();
+                    return pp.single(-99);
                 }
             }, disposer)
             .test();

--- a/src/test/java/io/reactivex/internal/subscribers/DeferredScalarSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/DeferredScalarSubscriberTest.java
@@ -134,7 +134,7 @@ public class DeferredScalarSubscriberTest {
     public void emptySource() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0L);
         TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
-        Flowable.just(1).ignoreElements().subscribe(ds); // we need a producer from upstream
+        Flowable.just(1).ignoreElements().<Integer>toFlowable().subscribe(ds); // we need a producer from upstream
 
         ts.assertNoValues();
 

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -45,7 +45,7 @@ public class MaybeTest {
     public void fromFlowableEmpty() {
 
         Flowable.empty()
-        .toMaybe()
+        .singleElement()
         .test()
         .assertResult();
     }
@@ -54,7 +54,7 @@ public class MaybeTest {
     public void fromFlowableJust() {
 
         Flowable.just(1)
-        .toMaybe()
+        .singleElement()
         .test()
         .assertResult(1);
     }
@@ -63,7 +63,7 @@ public class MaybeTest {
     public void fromFlowableError() {
 
         Flowable.error(new TestException())
-        .toMaybe()
+        .singleElement()
         .test()
         .assertFailure(TestException.class);
     }
@@ -71,7 +71,7 @@ public class MaybeTest {
     @Test
     public void fromFlowableValueAndError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
-        .toMaybe()
+        .singleElement()
         .test()
         .assertFailure(TestException.class);
     }
@@ -80,16 +80,16 @@ public class MaybeTest {
     public void fromFlowableMany() {
 
         Flowable.range(1, 2)
-        .toMaybe()
+        .singleElement()
         .test()
-        .assertFailure(IndexOutOfBoundsException.class);
+        .assertFailure(IllegalArgumentException.class);
     }
 
     @Test
     public void fromFlowableDisposeComposesThrough() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp.toMaybe().test();
+        TestObserver<Integer> ts = pp.singleElement().test();
 
         assertTrue(pp.hasSubscribers());
 
@@ -128,7 +128,7 @@ public class MaybeTest {
     @Test
     public void fromObservableValueAndError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
-        .toMaybe()
+        .singleElement()
         .test()
         .assertFailure(TestException.class);
     }
@@ -332,7 +332,7 @@ public class MaybeTest {
 
     @Test
     public void flowableMaybeFlowable() {
-        Flowable.just(1).toMaybe().toFlowable().test().assertResult(1);
+        Flowable.just(1).singleElement().toFlowable().test().assertResult(1);
     }
 
     @Test
@@ -828,7 +828,7 @@ public class MaybeTest {
         try {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            TestObserver<Integer> ts = pp.toMaybe().doOnDispose(new Action() {
+            TestObserver<Integer> ts = pp.singleElement().doOnDispose(new Action() {
                 @Override
                 public void run() throws Exception {
                     throw new TestException();
@@ -1238,7 +1238,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.concat(pp1.toMaybe(), pp2.toMaybe())
+        TestSubscriber<Integer> ts = Maybe.concat(pp1.singleElement(), pp2.singleElement())
         .test(0L);
 
         assertTrue(pp1.hasSubscribers());
@@ -1374,7 +1374,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.concat(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestSubscriber<Integer> ts = Maybe.concat(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test(0L);
 
         assertTrue(pp1.hasSubscribers());
@@ -1527,7 +1527,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
         ts.assertEmpty();
@@ -1550,7 +1550,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
         ts.assertEmpty();
@@ -1573,7 +1573,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
         ts.assertEmpty();
@@ -1595,7 +1595,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
         ts.assertEmpty();
@@ -1617,7 +1617,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
         ts.assertEmpty();
@@ -1639,7 +1639,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.toMaybe(), pp2.toMaybe())
+        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
         ts.assertEmpty();
@@ -1661,7 +1661,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
         ts.assertEmpty();
@@ -1684,7 +1684,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
         ts.assertEmpty();
@@ -1707,7 +1707,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
                 .test();
 
         ts.assertEmpty();
@@ -1731,7 +1731,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
         ts.assertEmpty();
@@ -1753,7 +1753,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
         ts.assertEmpty();
@@ -1775,7 +1775,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
                 .test();
 
         ts.assertEmpty();
@@ -1798,7 +1798,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
         ts.assertEmpty();
@@ -1820,7 +1820,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.toMaybe(), pp2.toMaybe()))
+        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
         ts.assertEmpty();
@@ -1976,7 +1976,7 @@ public class MaybeTest {
 
             TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
 
-            Maybe.mergeArray(pp1.toMaybe(), pp2.toMaybe()).subscribe(ts);
+            Maybe.mergeArray(pp1.singleElement(), pp2.singleElement()).subscribe(ts);
 
             ts.assertSubscribed()
             .assertOf(SubscriberFusion.<Integer>assertFuseable())
@@ -2027,7 +2027,7 @@ public class MaybeTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.merge(Flowable.just(pp1.toMaybe(), pp2.toMaybe()), 1).test(0L);
+        TestSubscriber<Integer> ts = Maybe.merge(Flowable.just(pp1.singleElement(), pp2.singleElement()), 1).test(0L);
 
         assertTrue(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
@@ -2374,7 +2374,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.concatArrayEager(pp1.toMaybe(), pp2.toMaybe()).test();
+        TestSubscriber<Integer> ts = Maybe.concatArrayEager(pp1.singleElement(), pp2.singleElement()).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -2397,7 +2397,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.concatEager(Arrays.asList(pp1.toMaybe(), pp2.toMaybe())).test();
+        TestSubscriber<Integer> ts = Maybe.concatEager(Arrays.asList(pp1.singleElement(), pp2.singleElement())).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -2419,7 +2419,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.concatEager(Flowable.just(pp1.toMaybe(), pp2.toMaybe())).test();
+        TestSubscriber<Integer> ts = Maybe.concatEager(Flowable.just(pp1.singleElement(), pp2.singleElement())).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -2868,7 +2868,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp1.toMaybe().ambWith(pp2.toMaybe())
+        TestObserver<Integer> ts = pp1.singleElement().ambWith(pp2.singleElement())
         .test();
 
         ts.assertEmpty();
@@ -2890,7 +2890,7 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp1.toMaybe().ambWith(pp2.toMaybe())
+        TestObserver<Integer> ts = pp1.singleElement().ambWith(pp2.singleElement())
         .test();
 
         ts.assertEmpty();
@@ -2939,7 +2939,7 @@ public class MaybeTest {
 
         long before = usedMemoryNow();
 
-        Maybe<Object> source = Flowable.just((Object)new Object[10000000]).toMaybe();
+        Maybe<Object> source = Flowable.just((Object)new Object[10000000]).singleElement();
 
         long middle = usedMemoryNow();
 

--- a/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
@@ -244,7 +244,7 @@ public class BehaviorProcessorTest {
             String v = "" + i;
             src.onNext(v);
             System.out.printf("Turn: %d%n", i);
-            src.first()
+            src.firstElement().toFlowable()
                 .flatMap(new Function<String, Flowable<String>>() {
 
                     @Override

--- a/src/test/java/io/reactivex/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/PublishProcessorTest.java
@@ -301,7 +301,7 @@ public class PublishProcessorTest {
             InOrder inOrder = inOrder(o);
             String v = "" + i;
             System.out.printf("Turn: %d%n", i);
-            src.first()
+            src.firstElement().toFlowable()
                 .flatMap(new Function<String, Flowable<String>>() {
 
                     @Override

--- a/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
@@ -365,7 +365,7 @@ public class ReplayProcessorTest {
             String v = "" + i;
             src.onNext(v);
             System.out.printf("Turn: %d%n", i);
-            src.first()
+            src.firstElement().toFlowable()
                 .flatMap(new Function<String, Flowable<String>>() {
 
                     @Override

--- a/src/test/java/io/reactivex/tck/ElementAtTckTest.java
+++ b/src/test/java/io/reactivex/tck/ElementAtTckTest.java
@@ -24,7 +24,7 @@ public class ElementAtTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.range(1, 10).elementAt(5)
+                Flowable.range(1, 10).elementAt(5).toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/FirstTckTest.java
+++ b/src/test/java/io/reactivex/tck/FirstTckTest.java
@@ -24,7 +24,7 @@ public class FirstTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.range(1, 10).first()
+                Flowable.range(1, 10).firstElement().toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/IgnoreElementsTckTest.java
+++ b/src/test/java/io/reactivex/tck/IgnoreElementsTckTest.java
@@ -24,7 +24,7 @@ public class IgnoreElementsTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.range(1, 1000).ignoreElements()
+                Flowable.range(1, 1000).ignoreElements().<Integer>toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/LastTckTest.java
+++ b/src/test/java/io/reactivex/tck/LastTckTest.java
@@ -24,7 +24,7 @@ public class LastTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.range(1, 10).last().toFlowable()
+                Flowable.range(1, 10).lastElement().toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/ReduceWithTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReduceWithTckTest.java
@@ -32,7 +32,7 @@ public class ReduceWithTckTest extends BaseTck<Integer> {
                     public Integer apply(Integer a, Integer b) throws Exception {
                         return a + b;
                     }
-                })
+                }).toFlowable()
             );
     }
 

--- a/src/test/java/io/reactivex/tck/SingleTckTest.java
+++ b/src/test/java/io/reactivex/tck/SingleTckTest.java
@@ -24,7 +24,7 @@ public class SingleTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
         return FlowableTck.wrap(
-                Flowable.just(1).single()
+                Flowable.just(1).singleElement().toFlowable()
             );
     }
 


### PR DESCRIPTION
This PR updates many `Flowable` operators to return `Single`, `Maybe` or `Completable`:
- `count()` -> `Single`
- `elementAt()` -> `Maybe`
- `elementAt(T)` -> `Single`
- `first(T)` -> `Single`
- `firstElement()` -> `Maybe`
- `ignoreElements()` -> `Completable`
- `reduce(Callable, BiFunction)` -> `Single`
- `reduceWith(U, BiFunction)` -> `Single`
- `single(T)` -> `Single`
- `singleElement()` -> `Maybe`

and deletes `Flowable.toSingle`, `Flowable.toMaybe` and `Flowable.toCompletable`.

`Flowble.reduce(BiFunction)` was not yet changed from `Single` to `Maybe` (to allow empty sources to be reduced to empty Maybe).

Related: #4321
