### PR TITLE
2.x: convert the Observable operators to return Single/Maybe

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -26,7 +26,6 @@ import io.reactivex.internal.functions.*;
 import io.reactivex.internal.fuseable.ScalarCallable;
 import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.operators.observable.ObservableFromPublisher;
-import io.reactivex.internal.operators.single.SingleReduceFlowable;
 import io.reactivex.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.internal.subscribers.*;
 import io.reactivex.internal.util.*;
@@ -9847,7 +9846,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Single that applies a specified accumulator function to the first item emitted by a source
+     * Returns a Maybe that applies a specified accumulator function to the first item emitted by a source
      * Publisher, then feeds the result of that function along with the second item emitted by the source
      * Publisher into the same function, and so on until all items have been emitted by the source Publisher,
      * and emits the final result from the final call to your function as its sole item.
@@ -9870,16 +9869,16 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param reducer
      *            an accumulator function to be invoked on each item emitted by the source Publisher, whose
      *            result will be used in the next accumulator call
-     * @return a Single that emits a single item that is the result of accumulating the items emitted by
+     * @return a Maybe that emits a single item that is the result of accumulating the items emitted by
      *         the source Flowable
      * @see <a href="http://reactivex.io/documentation/operators/reduce.html">ReactiveX operators documentation: Reduce</a>
      * @see <a href="http://en.wikipedia.org/wiki/Fold_(higher-order_function)">Wikipedia: Fold (higher-order function)</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> reduce(BiFunction<T, T, T> reducer) {
+    public final Maybe<T> reduce(BiFunction<T, T, T> reducer) {
         ObjectHelper.requireNonNull(reducer, "reducer is null");
-        return RxJavaPlugins.onAssembly(new SingleReduceFlowable<T>(this, reducer));
+        return RxJavaPlugins.onAssembly(new FlowableReduceMaybe<T>(this, reducer));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastSingle.java
@@ -53,7 +53,7 @@ public final class FlowableLastSingle<T> extends Single<T> {
 
         T item;
 
-        public LastSubscriber(SingleObserver<? super T> actual, T defaultItem) {
+        LastSubscriber(SingleObserver<? super T> actual, T defaultItem) {
             this.actual = actual;
             this.defaultItem = defaultItem;
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceMaybe.java
@@ -11,9 +11,7 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.operators.single;
-
-import java.util.NoSuchElementException;
+package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
@@ -23,7 +21,6 @@ import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
-import io.reactivex.internal.operators.flowable.FlowableReduce;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -32,15 +29,15 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the value type
  */
-public final class SingleReduceFlowable<T>
-extends Single<T>
+public final class FlowableReduceMaybe<T>
+extends Maybe<T>
 implements HasUpstreamPublisher<T>, FuseToFlowable<T> {
 
     final Flowable<T> source;
 
     final BiFunction<T, T, T> reducer;
 
-    public SingleReduceFlowable(Flowable<T> source, BiFunction<T, T, T> reducer) {
+    public FlowableReduceMaybe(Flowable<T> source, BiFunction<T, T, T> reducer) {
         this.source = source;
         this.reducer = reducer;
     }
@@ -52,17 +49,16 @@ implements HasUpstreamPublisher<T>, FuseToFlowable<T> {
 
     @Override
     public Flowable<T> fuseToFlowable() {
-//        return RxJavaPlugins.onAssembly(new SingleToFlowable<T>(this));
         return RxJavaPlugins.onAssembly(new FlowableReduce<T>(source, reducer));
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> observer) {
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
         source.subscribe(new ReduceSubscriber<T>(observer, reducer));
     }
 
     static final class ReduceSubscriber<T> implements Subscriber<T>, Disposable {
-        final SingleObserver<? super T> actual;
+        final MaybeObserver<? super T> actual;
 
         final BiFunction<T, T, T> reducer;
 
@@ -72,7 +68,7 @@ implements HasUpstreamPublisher<T>, FuseToFlowable<T> {
 
         boolean done;
 
-        ReduceSubscriber(SingleObserver<? super T> actual, BiFunction<T, T, T> reducer) {
+        ReduceSubscriber(MaybeObserver<? super T> actual, BiFunction<T, T, T> reducer) {
             this.actual = actual;
             this.reducer = reducer;
         }
@@ -139,7 +135,7 @@ implements HasUpstreamPublisher<T>, FuseToFlowable<T> {
 //                value = null;
                 actual.onSuccess(v);
             } else {
-                actual.onError(new NoSuchElementException());
+                actual.onComplete();
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCountSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCountSingle.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.FuseToObservable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class ObservableCountSingle<T> extends Single<Long> implements FuseToObservable<Long> {
+    final ObservableSource<T> source;
+    public ObservableCountSingle(ObservableSource<T> source) {
+        this.source = source;
+    }
+
+    @Override
+    public void subscribeActual(SingleObserver<? super Long> t) {
+        source.subscribe(new CountObserver(t));
+    }
+
+    @Override
+    public Observable<Long> fuseToObservable() {
+        return RxJavaPlugins.onAssembly(new ObservableCount<T>(source));
+    }
+
+    static final class CountObserver implements Observer<Object>, Disposable {
+        final SingleObserver<? super Long> actual;
+
+        Disposable d;
+
+        long count;
+
+        CountObserver(SingleObserver<? super Long> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+                actual.onSubscribe(this);
+            }
+        }
+
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            d = DisposableHelper.DISPOSED;
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void onNext(Object t) {
+            count++;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            d = DisposableHelper.DISPOSED;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            d = DisposableHelper.DISPOSED;
+            actual.onSuccess(count);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAt.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAt.java
@@ -97,12 +97,10 @@ public final class ObservableElementAt<T> extends AbstractObservableWithUpstream
             if (index <= count && !done) {
                 done = true;
                 T v = defaultValue;
-                if (v == null) {
-                    actual.onError(new IndexOutOfBoundsException());
-                } else {
+                if (v != null) {
                     actual.onNext(v);
-                    actual.onComplete();
                 }
+                actual.onComplete();
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsCompletable.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.fuseable.FuseToObservable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class ObservableIgnoreElementsCompletable<T> extends Completable implements FuseToObservable<T> {
+
+    final ObservableSource<T> source;
+
+    public ObservableIgnoreElementsCompletable(ObservableSource<T> source) {
+        this.source = source;
+    }
+
+    @Override
+    public void subscribeActual(final CompletableObserver t) {
+        source.subscribe(new IgnoreObservable<T>(t));
+    }
+
+    @Override
+    public Observable<T> fuseToObservable() {
+        return RxJavaPlugins.onAssembly(new ObservableIgnoreElements<T>(source));
+    }
+
+    static final class IgnoreObservable<T> implements Observer<T>, Disposable {
+        final CompletableObserver actual;
+
+        Disposable d;
+
+        IgnoreObservable(CompletableObserver t) {
+            this.actual = t;
+        }
+
+        @Override
+        public void onSubscribe(Disposable s) {
+            this.d = s;
+            actual.onSubscribe(this);
+        }
+
+        @Override
+        public void onNext(T v) {
+            // deliberately ignored
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableLastSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableLastSingle.java
@@ -53,7 +53,7 @@ public final class ObservableLastSingle<T> extends Single<T> {
 
         T item;
 
-        public LastObserver(SingleObserver<? super T> actual, T defaultItem) {
+        LastObserver(SingleObserver<? super T> actual, T defaultItem) {
             this.actual = actual;
             this.defaultItem = defaultItem;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSingleMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSingleMaybe.java
@@ -17,22 +17,20 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableSingle<T> extends AbstractObservableWithUpstream<T, T> {
+public final class ObservableSingleMaybe<T> extends Maybe<T> {
 
-    final T defaultValue;
+    final ObservableSource<T> source;
 
-    public ObservableSingle(ObservableSource<T> source, T defaultValue) {
-        super(source);
-        this.defaultValue = defaultValue;
+    public ObservableSingleMaybe(ObservableSource<T> source) {
+        this.source = source;
     }
     @Override
-    public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new SingleElementObserver<T>(t, defaultValue));
+    public void subscribeActual(MaybeObserver<? super T> t) {
+        source.subscribe(new SingleElementObserver<T>(t));
     }
 
     static final class SingleElementObserver<T> implements Observer<T>, Disposable {
-        final Observer<? super T> actual;
-        final T defaultValue;
+        final MaybeObserver<? super T> actual;
 
         Disposable s;
 
@@ -40,9 +38,8 @@ public final class ObservableSingle<T> extends AbstractObservableWithUpstream<T,
 
         boolean done;
 
-        SingleElementObserver(Observer<? super T> actual, T defaultValue) {
+        SingleElementObserver(MaybeObserver<? super T> actual) {
             this.actual = actual;
-            this.defaultValue = defaultValue;
         }
 
         @Override
@@ -97,12 +94,10 @@ public final class ObservableSingle<T> extends AbstractObservableWithUpstream<T,
             T v = value;
             value = null;
             if (v == null) {
-                v = defaultValue;
+                actual.onComplete();
+            } else {
+                actual.onSuccess(v);
             }
-            if (v != null) {
-                actual.onNext(v);
-            }
-            actual.onComplete();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSingleSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSingleSingle.java
@@ -17,21 +17,24 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
-public final class ObservableSingle<T> extends AbstractObservableWithUpstream<T, T> {
+public final class ObservableSingleSingle<T> extends Single<T> {
+
+    final ObservableSource<T> source;
 
     final T defaultValue;
 
-    public ObservableSingle(ObservableSource<T> source, T defaultValue) {
-        super(source);
+    public ObservableSingleSingle(ObservableSource<T> source, T defaultValue) {
+        this.source = source;
         this.defaultValue = defaultValue;
     }
     @Override
-    public void subscribeActual(Observer<? super T> t) {
+    public void subscribeActual(SingleObserver<? super T> t) {
         source.subscribe(new SingleElementObserver<T>(t, defaultValue));
     }
 
     static final class SingleElementObserver<T> implements Observer<T>, Disposable {
-        final Observer<? super T> actual;
+        final SingleObserver<? super T> actual;
+
         final T defaultValue;
 
         Disposable s;
@@ -40,7 +43,7 @@ public final class ObservableSingle<T> extends AbstractObservableWithUpstream<T,
 
         boolean done;
 
-        SingleElementObserver(Observer<? super T> actual, T defaultValue) {
+        SingleElementObserver(SingleObserver<? super T> actual, T defaultValue) {
             this.actual = actual;
             this.defaultValue = defaultValue;
         }
@@ -99,10 +102,7 @@ public final class ObservableSingle<T> extends AbstractObservableWithUpstream<T,
             if (v == null) {
                 v = defaultValue;
             }
-            if (v != null) {
-                actual.onNext(v);
-            }
-            actual.onComplete();
+            actual.onSuccess(v);
         }
     }
 }

--- a/src/perf/java/io/reactivex/ToFlowablePerf.java
+++ b/src/perf/java/io/reactivex/ToFlowablePerf.java
@@ -31,7 +31,7 @@ public class ToFlowablePerf {
     @Param({ "1", "1000", "1000000" })
     public int times;
 
-    Single<Integer> flowable;
+    Maybe<Integer> flowable;
 
     Flowable<Integer> flowableInner;
 
@@ -64,12 +64,12 @@ public class ToFlowablePerf {
 
         Observable<Integer> sourceObs = Observable.fromArray(array);
 
-        observable = sourceObs.reduce(second);
+        observable = sourceObs.reduce(second).toObservable();
 
         observableInner = sourceObs.concatMap(new Function<Integer, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Integer v) throws Exception {
-                return Observable.range(1, 50).reduce(second);
+                return Observable.range(1, 50).reduce(second).toObservable();
             }
         });
     }

--- a/src/test/java/io/reactivex/InternalWrongNaming.java
+++ b/src/test/java/io/reactivex/InternalWrongNaming.java
@@ -171,7 +171,8 @@ public class InternalWrongNaming {
                 "FlowableSingleSingle",
                 "FlowableSingleMaybe",
                 "FlowableLastMaybe",
-                "FlowableIgnoreElementsCompletable"
+                "FlowableIgnoreElementsCompletable",
+                "FlowableReduceMaybe"
         );
     }
 }

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -3546,7 +3546,7 @@ public class CompletableTest {
     @Test
     public void subscribeReportsUnsubscribedOnError() {
         PublishSubject<String> stringSubject = PublishSubject.create();
-        Completable completable = stringSubject.toCompletable();
+        Completable completable = stringSubject.ignoreElements();
 
         Disposable completableSubscription = completable.subscribe();
 
@@ -3558,7 +3558,7 @@ public class CompletableTest {
     @Test
     public void subscribeActionReportsUnsubscribed() {
         PublishSubject<String> stringSubject = PublishSubject.create();
-        Completable completable = stringSubject.toCompletable();
+        Completable completable = stringSubject.ignoreElements();
 
         Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
@@ -3575,7 +3575,7 @@ public class CompletableTest {
     @Test
     public void subscribeActionReportsUnsubscribedAfter() {
         PublishSubject<String> stringSubject = PublishSubject.create();
-        Completable completable = stringSubject.toCompletable();
+        Completable completable = stringSubject.ignoreElements();
 
         final AtomicReference<Disposable> subscriptionRef = new AtomicReference<Disposable>();
         Disposable completableSubscription = completable.subscribe(new Action() {
@@ -3597,7 +3597,7 @@ public class CompletableTest {
     @Test
     public void subscribeActionReportsUnsubscribedOnError() {
         PublishSubject<String> stringSubject = PublishSubject.create();
-        Completable completable = stringSubject.toCompletable();
+        Completable completable = stringSubject.ignoreElements();
 
         Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
@@ -3613,7 +3613,7 @@ public class CompletableTest {
     @Test
     public void subscribeAction2ReportsUnsubscribed() {
         PublishSubject<String> stringSubject = PublishSubject.create();
-        Completable completable = stringSubject.toCompletable();
+        Completable completable = stringSubject.ignoreElements();
 
         Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
@@ -3635,7 +3635,7 @@ public class CompletableTest {
     @Test
     public void subscribeAction2ReportsUnsubscribedOnError() {
         PublishSubject<String> stringSubject = PublishSubject.create();
-        Completable completable = stringSubject.toCompletable();
+        Completable completable = stringSubject.ignoreElements();
 
         Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
@@ -4072,7 +4072,7 @@ public class CompletableTest {
     @Test
     public void subscribeReportsUnsubscribed() {
         PublishSubject<String> stringSubject = PublishSubject.create();
-        Completable completable = stringSubject.toCompletable();
+        Completable completable = stringSubject.ignoreElements();
 
         Disposable completableSubscription = completable.subscribe();
 
@@ -4250,7 +4250,7 @@ public class CompletableTest {
     @Test
     public void subscribeAction2ReportsUnsubscribedAfter() {
         PublishSubject<String> stringSubject = PublishSubject.create();
-        Completable completable = stringSubject.toCompletable();
+        Completable completable = stringSubject.ignoreElements();
 
         final AtomicReference<Disposable> subscriptionRef = new AtomicReference<Disposable>();
         Disposable completableSubscription = completable.subscribe(new Action() {
@@ -4272,7 +4272,7 @@ public class CompletableTest {
     @Test
     public void subscribeAction2ReportsUnsubscribedOnErrorAfter() {
         PublishSubject<String> stringSubject = PublishSubject.create();
-        Completable completable = stringSubject.toCompletable();
+        Completable completable = stringSubject.ignoreElements();
 
         final AtomicReference<Disposable> subscriptionRef = new AtomicReference<Disposable>();
         Disposable completableSubscription = completable.subscribe(Functions.EMPTY_ACTION,

--- a/src/test/java/io/reactivex/flowable/FlowableReduceTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableReduceTests.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.flowable;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
@@ -22,6 +22,61 @@ import io.reactivex.flowable.FlowableCovarianceTest.*;
 import io.reactivex.functions.BiFunction;
 
 public class FlowableReduceTests {
+
+    @Test
+    public void reduceIntsFlowable() {
+        Flowable<Integer> o = Flowable.just(1, 2, 3);
+        int value = o.reduce(new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t1, Integer t2) {
+                return t1 + t2;
+            }
+        }).toFlowable().blockingSingle();
+
+        assertEquals(6, value);
+    }
+
+    @SuppressWarnings("unused")
+    @Test
+    public void reduceWithObjectsFlowable() {
+        Flowable<Movie> horrorMovies = Flowable.<Movie> just(new HorrorMovie());
+
+        Flowable<Movie> reduceResult = horrorMovies.scan(new BiFunction<Movie, Movie, Movie>() {
+            @Override
+            public Movie apply(Movie t1, Movie t2) {
+                return t2;
+            }
+        }).takeLast(1);
+
+        Flowable<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
+            @Override
+            public Movie apply(Movie t1, Movie t2) {
+                return t2;
+            }
+        }).toFlowable();
+
+        assertNotNull(reduceResult2);
+    }
+
+    /**
+     * Reduce consumes and produces T so can't do covariance.
+     *
+     * https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016
+     */
+    @Test
+    public void reduceWithCovariantObjectsFlowable() {
+        Flowable<Movie> horrorMovies = Flowable.<Movie> just(new HorrorMovie());
+
+        Flowable<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
+            @Override
+            public Movie apply(Movie t1, Movie t2) {
+                return t2;
+            }
+        }).toFlowable();
+
+        assertNotNull(reduceResult2);
+    }
+
 
     @Test
     public void reduceInts() {
@@ -48,12 +103,14 @@ public class FlowableReduceTests {
             }
         }).takeLast(1);
 
-        Single<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
+        Maybe<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
             @Override
             public Movie apply(Movie t1, Movie t2) {
                 return t2;
             }
         });
+
+        assertNotNull(reduceResult2);
     }
 
     /**
@@ -61,17 +118,18 @@ public class FlowableReduceTests {
      *
      * https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016
      */
-    @SuppressWarnings("unused")
     @Test
     public void reduceWithCovariantObjects() {
         Flowable<Movie> horrorMovies = Flowable.<Movie> just(new HorrorMovie());
 
-        Single<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
+        Maybe<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
             @Override
             public Movie apply(Movie t1, Movie t2) {
                 return t2;
             }
         });
+
+        assertNotNull(reduceResult2);
     }
 
     /**

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -274,7 +274,7 @@ public class FlowableTests {
     /**
      * A reduce should fail with an NoSuchElementException if done on an empty Observable.
      */
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testReduceWithEmptyObservable() {
         Flowable<Integer> observable = Flowable.range(1, 0);
         observable.reduce(new BiFunction<Integer, Integer, Integer>() {
@@ -290,8 +290,6 @@ public class FlowableTests {
                 // do nothing ... we expect an exception instead
             }
         });
-
-        fail("Expected an exception to be thrown");
     }
 
     /**

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeTest.java
@@ -35,7 +35,7 @@ public class CompletableSubscribeTest {
     public void methodTestNoCancel() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        ps.toCompletable().test(false);
+        ps.ignoreElements().test(false);
 
         assertTrue(ps.hasObservers());
     }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
@@ -63,7 +63,7 @@ public class CompletableTimeoutTest {
         final PublishSubject<String> subject = PublishSubject.create();
         final TestScheduler scheduler = new TestScheduler();
 
-        final TestObserver<Void> observer = subject.toCompletable()
+        final TestObserver<Void> observer = subject.ignoreElements()
                 .timeout(100, TimeUnit.MILLISECONDS, scheduler)
                 .test();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
@@ -213,7 +213,7 @@ public class FlowableReduceTest {
     @Test
     public void testBackpressureWithNoInitialValue() throws InterruptedException {
         Flowable<Integer> source = Flowable.just(1, 2, 3, 4, 5, 6);
-        Single<Integer> reduced = source.reduce(sum);
+        Maybe<Integer> reduced = source.reduce(sum);
 
         Integer r = reduced.blockingGet();
         assertEquals(21, r.intValue());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
@@ -293,6 +293,11 @@ public class FlowableSerializeTest {
                                             // force an error
                                             throw npe;
                                         } else {
+                                            try {
+                                                Thread.sleep(10);
+                                            } catch (InterruptedException ex) {
+                                                // ignored
+                                            }
                                             System.out.println("TestMultiThreadedObservable onNext: " + s);
                                         }
                                         observer.onNext(s);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
@@ -637,7 +637,7 @@ public class FlowableSingleTest {
     public void testIssue1527() throws InterruptedException {
         //https://github.com/ReactiveX/RxJava/pull/1527
         Flowable<Integer> source = Flowable.just(1, 2, 3, 4, 5, 6);
-        Single<Integer> reduced = source.reduce(new BiFunction<Integer, Integer, Integer>() {
+        Maybe<Integer> reduced = source.reduce(new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer i1, Integer i2) {
                 return i1 + i2;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDetachTest.java
@@ -36,7 +36,7 @@ public class ObservableDetachTest {
 
         TestObserver<Object> ts = new TestObserver<Object>();
 
-        Observable.just(o).count().onTerminateDetach().subscribe(ts);
+        Observable.just(o).count().toObservable().onTerminateDetach().subscribe(ts);
 
         ts.assertValue(1L);
         ts.assertComplete();
@@ -118,7 +118,7 @@ public class ObservableDetachTest {
 
         WeakReference<Object> wr = new WeakReference<Object>(o);
 
-        TestObserver<Long> ts = Observable.just(o).count().onTerminateDetach().test();
+        TestObserver<Long> ts = Observable.just(o).count().toObservable().onTerminateDetach().test();
 
         o = null;
         ts.cancel();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableElementAtTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
@@ -22,8 +22,29 @@ import io.reactivex.Observable;
 public class ObservableElementAtTest {
 
     @Test
+    public void testElementAtObservable() {
+        assertEquals(2, Observable.fromArray(1, 2).elementAt(1).toObservable().blockingSingle()
+                .intValue());
+    }
+
+    @Test
+    public void testElementAtWithIndexOutOfBoundsObservable() {
+        assertEquals(-99, Observable.fromArray(1, 2).elementAt(2).toObservable().blockingSingle(-99).intValue());
+    }
+
+    @Test
+    public void testElementAtOrDefaultObservable() {
+        assertEquals(2, Observable.fromArray(1, 2).elementAt(1, 0).toObservable().blockingSingle().intValue());
+    }
+
+    @Test
+    public void testElementAtOrDefaultWithIndexOutOfBoundsObservable() {
+        assertEquals(0, Observable.fromArray(1, 2).elementAt(2, 0).toObservable().blockingSingle().intValue());
+    }
+
+    @Test
     public void testElementAt() {
-        assertEquals(2, Observable.fromArray(1, 2).elementAt(1).blockingSingle()
+        assertEquals(2, Observable.fromArray(1, 2).elementAt(1).blockingGet()
                 .intValue());
     }
 
@@ -32,19 +53,19 @@ public class ObservableElementAtTest {
         Observable.fromArray(1, 2).elementAt(-1);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testElementAtWithIndexOutOfBounds() {
-        Observable.fromArray(1, 2).elementAt(2).blockingSingle();
+        assertNull(Observable.fromArray(1, 2).elementAt(2).blockingGet());
     }
 
     @Test
     public void testElementAtOrDefault() {
-        assertEquals(2, Observable.fromArray(1, 2).elementAt(1, 0).blockingSingle().intValue());
+        assertEquals(2, Observable.fromArray(1, 2).elementAt(1, 0).blockingGet().intValue());
     }
 
     @Test
     public void testElementAtOrDefaultWithIndexOutOfBounds() {
-        assertEquals(0, Observable.fromArray(1, 2).elementAt(2, 0).blockingSingle().intValue());
+        assertEquals(0, Observable.fromArray(1, 2).elementAt(2, 0).blockingGet().intValue());
     }
 
     @Test(expected = IndexOutOfBoundsException.class)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableLastTest.java
@@ -13,11 +13,9 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.isA;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
-
-import java.util.NoSuchElementException;
 
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -29,33 +27,33 @@ public class ObservableLastTest {
 
     @Test
     public void testLastWithElements() {
-        Single<Integer> last = Observable.just(1, 2, 3).last();
+        Maybe<Integer> last = Observable.just(1, 2, 3).lastElement();
         assertEquals(3, last.blockingGet().intValue());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testLastWithNoElements() {
-        Single<?> last = Observable.empty().last();
-        last.blockingGet();
+        Maybe<?> last = Observable.empty().lastElement();
+        assertNull(last.blockingGet());
     }
 
     @Test
     public void testLastMultiSubscribe() {
-        Single<Integer> last = Observable.just(1, 2, 3).last();
+        Maybe<Integer> last = Observable.just(1, 2, 3).lastElement();
         assertEquals(3, last.blockingGet().intValue());
         assertEquals(3, last.blockingGet().intValue());
     }
 
     @Test
     public void testLastViaObservable() {
-        Observable.just(1, 2, 3).last();
+        Observable.just(1, 2, 3).lastElement();
     }
 
     @Test
     public void testLast() {
-        Single<Integer> o = Observable.just(1, 2, 3).last();
+        Maybe<Integer> o = Observable.just(1, 2, 3).lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -66,9 +64,9 @@ public class ObservableLastTest {
 
     @Test
     public void testLastWithOneElement() {
-        Single<Integer> o = Observable.just(1).last();
+        Maybe<Integer> o = Observable.just(1).lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -79,20 +77,20 @@ public class ObservableLastTest {
 
     @Test
     public void testLastWithEmpty() {
-        Single<Integer> o = Observable.<Integer> empty().last();
+        Maybe<Integer> o = Observable.<Integer> empty().lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(
-                isA(NoSuchElementException.class));
+        inOrder.verify(observer).onComplete();
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testLastWithPredicate() {
-        Single<Integer> o = Observable.just(1, 2, 3, 4, 5, 6)
+        Maybe<Integer> o = Observable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
 
                     @Override
@@ -100,9 +98,9 @@ public class ObservableLastTest {
                         return t1 % 2 == 0;
                     }
                 })
-                .last();
+                .lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -113,7 +111,7 @@ public class ObservableLastTest {
 
     @Test
     public void testLastWithPredicateAndOneElement() {
-        Single<Integer> o = Observable.just(1, 2)
+        Maybe<Integer> o = Observable.just(1, 2)
             .filter(
                 new Predicate<Integer>() {
 
@@ -122,9 +120,9 @@ public class ObservableLastTest {
                         return t1 % 2 == 0;
                     }
                 })
-            .last();
+            .lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -135,7 +133,7 @@ public class ObservableLastTest {
 
     @Test
     public void testLastWithPredicateAndEmpty() {
-        Single<Integer> o = Observable.just(1)
+        Maybe<Integer> o = Observable.just(1)
             .filter(
                 new Predicate<Integer>() {
 
@@ -143,14 +141,14 @@ public class ObservableLastTest {
                     public boolean test(Integer t1) {
                         return t1 % 2 == 0;
                     }
-                }).last();
+                }).lastElement();
 
-        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(
-                isA(NoSuchElementException.class));
+        inOrder.verify(observer).onComplete();
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMapTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -204,16 +205,16 @@ public class ObservableMapTest {
     /**
      * While mapping over range(1,0).last() we expect NoSuchElementException since the sequence is empty.
      */
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testErrorPassesThruMap() {
-        Observable.range(1, 0).last().map(new Function<Integer, Integer>() {
+        assertNull(Observable.range(1, 0).lastElement().map(new Function<Integer, Integer>() {
 
             @Override
             public Integer apply(Integer i) {
                 return i;
             }
 
-        }).blockingGet();
+        }).blockingGet());
     }
 
     /**
@@ -237,7 +238,7 @@ public class ObservableMapTest {
      */
     @Test(expected = ArithmeticException.class)
     public void testMapWithErrorInFunc() {
-        Observable.range(1, 1).last().map(new Function<Integer, Integer>() {
+        Observable.range(1, 1).lastElement().map(new Function<Integer, Integer>() {
 
             @Override
             public Integer apply(Integer i) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
@@ -17,8 +17,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.*;
 
-import java.util.NoSuchElementException;
-
 import org.junit.Test;
 import org.mockito.InOrder;
 
@@ -28,8 +26,8 @@ import io.reactivex.functions.*;
 public class ObservableSingleTest {
 
     @Test
-    public void testSingle() {
-        Observable<Integer> o = Observable.just(1).single();
+    public void testSingleObservable() {
+        Observable<Integer> o = Observable.just(1).singleElement().toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
@@ -41,8 +39,8 @@ public class ObservableSingleTest {
     }
 
     @Test
-    public void testSingleWithTooManyElements() {
-        Observable<Integer> o = Observable.just(1, 2).single();
+    public void testSingleWithTooManyElementsObservable() {
+        Observable<Integer> o = Observable.just(1, 2).singleElement().toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
@@ -54,20 +52,20 @@ public class ObservableSingleTest {
     }
 
     @Test
-    public void testSingleWithEmpty() {
-        Observable<Integer> o = Observable.<Integer> empty().single();
+    public void testSingleWithEmptyObservable() {
+        Observable<Integer> o = Observable.<Integer> empty().singleElement().toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(
-                isA(NoSuchElementException.class));
+        inOrder.verify(observer).onComplete();
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void testSingleWithPredicate() {
+    public void testSingleWithPredicateObservable() {
         Observable<Integer> o = Observable.just(1, 2)
                 .filter(
                 new Predicate<Integer>() {
@@ -77,7 +75,7 @@ public class ObservableSingleTest {
                         return t1 % 2 == 0;
                     }
                 })
-                .single();
+                .singleElement().toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
@@ -89,7 +87,7 @@ public class ObservableSingleTest {
     }
 
     @Test
-    public void testSingleWithPredicateAndTooManyElements() {
+    public void testSingleWithPredicateAndTooManyElementsObservable() {
         Observable<Integer> o = Observable.just(1, 2, 3, 4)
                 .filter(
                 new Predicate<Integer>() {
@@ -99,7 +97,7 @@ public class ObservableSingleTest {
                         return t1 % 2 == 0;
                     }
                 })
-                .single();
+                .singleElement().toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
@@ -111,7 +109,7 @@ public class ObservableSingleTest {
     }
 
     @Test
-    public void testSingleWithPredicateAndEmpty() {
+    public void testSingleWithPredicateAndEmptyObservable() {
         Observable<Integer> o = Observable.just(1)
                 .filter(
                 new Predicate<Integer>() {
@@ -121,19 +119,19 @@ public class ObservableSingleTest {
                         return t1 % 2 == 0;
                     }
                 })
-                .single();
+                .singleElement().toObservable();
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(
-                isA(NoSuchElementException.class));
+        inOrder.verify(observer).onComplete();
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void testSingleOrDefault() {
-        Observable<Integer> o = Observable.just(1).single(2);
+    public void testSingleOrDefaultObservable() {
+        Observable<Integer> o = Observable.just(1).single(2).toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
@@ -145,8 +143,8 @@ public class ObservableSingleTest {
     }
 
     @Test
-    public void testSingleOrDefaultWithTooManyElements() {
-        Observable<Integer> o = Observable.just(1, 2).single(3);
+    public void testSingleOrDefaultWithTooManyElementsObservable() {
+        Observable<Integer> o = Observable.just(1, 2).single(3).toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
@@ -158,9 +156,9 @@ public class ObservableSingleTest {
     }
 
     @Test
-    public void testSingleOrDefaultWithEmpty() {
+    public void testSingleOrDefaultWithEmptyObservable() {
         Observable<Integer> o = Observable.<Integer> empty()
-                .single(1);
+                .single(1).toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
@@ -172,7 +170,7 @@ public class ObservableSingleTest {
     }
 
     @Test
-    public void testSingleOrDefaultWithPredicate() {
+    public void testSingleOrDefaultWithPredicateObservable() {
         Observable<Integer> o = Observable.just(1, 2)
                 .filter(new Predicate<Integer>() {
                     @Override
@@ -180,7 +178,7 @@ public class ObservableSingleTest {
                         return t1 % 2 == 0;
                     }
                 })
-                .single(4);
+                .single(4).toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
@@ -192,7 +190,7 @@ public class ObservableSingleTest {
     }
 
     @Test
-    public void testSingleOrDefaultWithPredicateAndTooManyElements() {
+    public void testSingleOrDefaultWithPredicateAndTooManyElementsObservable() {
         Observable<Integer> o = Observable.just(1, 2, 3, 4)
                 .filter(new Predicate<Integer>() {
                     @Override
@@ -200,7 +198,7 @@ public class ObservableSingleTest {
                         return t1 % 2 == 0;
                     }
                 })
-                .single(6);
+                .single(6).toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
@@ -212,7 +210,7 @@ public class ObservableSingleTest {
     }
 
     @Test
-    public void testSingleOrDefaultWithPredicateAndEmpty() {
+    public void testSingleOrDefaultWithPredicateAndEmptyObservable() {
         Observable<Integer> o = Observable.just(1)
                 .filter(new Predicate<Integer>() {
                     @Override
@@ -220,7 +218,7 @@ public class ObservableSingleTest {
                         return t1 % 2 == 0;
                     }
                 })
-                .single(2);
+                .single(2).toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
         o.subscribe(observer);
@@ -232,7 +230,7 @@ public class ObservableSingleTest {
     }
 
     @Test(timeout = 30000)
-    public void testIssue1527() throws InterruptedException {
+    public void testIssue1527Observable() throws InterruptedException {
         //https://github.com/ReactiveX/RxJava/pull/1527
         Observable<Integer> source = Observable.just(1, 2, 3, 4, 5, 6);
         Observable<Integer> reduced = source.reduce(new BiFunction<Integer, Integer, Integer>() {
@@ -240,9 +238,221 @@ public class ObservableSingleTest {
             public Integer apply(Integer i1, Integer i2) {
                 return i1 + i2;
             }
-        });
+        }).toObservable();
 
         Integer r = reduced.blockingFirst();
+        assertEquals(21, r.intValue());
+    }
+
+    @Test
+    public void testSingle() {
+        Maybe<Integer> o = Observable.just(1).singleElement();
+
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onSuccess(1);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleWithTooManyElements() {
+        Maybe<Integer> o = Observable.just(1, 2).singleElement();
+
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
+                isA(IllegalArgumentException.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleWithEmpty() {
+        Maybe<Integer> o = Observable.<Integer> empty().singleElement();
+
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer).onComplete();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleWithPredicate() {
+        Maybe<Integer> o = Observable.just(1, 2)
+                .filter(
+                new Predicate<Integer>() {
+
+                    @Override
+                    public boolean test(Integer t1) {
+                        return t1 % 2 == 0;
+                    }
+                })
+                .singleElement();
+
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onSuccess(2);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleWithPredicateAndTooManyElements() {
+        Maybe<Integer> o = Observable.just(1, 2, 3, 4)
+                .filter(
+                new Predicate<Integer>() {
+
+                    @Override
+                    public boolean test(Integer t1) {
+                        return t1 % 2 == 0;
+                    }
+                })
+                .singleElement();
+
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
+                isA(IllegalArgumentException.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleWithPredicateAndEmpty() {
+        Maybe<Integer> o = Observable.just(1)
+                .filter(
+                new Predicate<Integer>() {
+
+                    @Override
+                    public boolean test(Integer t1) {
+                        return t1 % 2 == 0;
+                    }
+                })
+                .singleElement();
+        MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer).onComplete();
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleOrDefault() {
+        Single<Integer> o = Observable.just(1).single(2);
+
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onSuccess(1);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleOrDefaultWithTooManyElements() {
+        Single<Integer> o = Observable.just(1, 2).single(3);
+
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
+                isA(IllegalArgumentException.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleOrDefaultWithEmpty() {
+        Single<Integer> o = Observable.<Integer> empty()
+                .single(1);
+
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onSuccess(1);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleOrDefaultWithPredicate() {
+        Single<Integer> o = Observable.just(1, 2)
+                .filter(new Predicate<Integer>() {
+                    @Override
+                    public boolean test(Integer t1) {
+                        return t1 % 2 == 0;
+                    }
+                })
+                .single(4);
+
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onSuccess(2);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleOrDefaultWithPredicateAndTooManyElements() {
+        Single<Integer> o = Observable.just(1, 2, 3, 4)
+                .filter(new Predicate<Integer>() {
+                    @Override
+                    public boolean test(Integer t1) {
+                        return t1 % 2 == 0;
+                    }
+                })
+                .single(6);
+
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(
+                isA(IllegalArgumentException.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSingleOrDefaultWithPredicateAndEmpty() {
+        Single<Integer> o = Observable.just(1)
+                .filter(new Predicate<Integer>() {
+                    @Override
+                    public boolean test(Integer t1) {
+                        return t1 % 2 == 0;
+                    }
+                })
+                .single(2);
+
+        SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onSuccess(2);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test(timeout = 30000)
+    public void testIssue1527() throws InterruptedException {
+        //https://github.com/ReactiveX/RxJava/pull/1527
+        Observable<Integer> source = Observable.just(1, 2, 3, 4, 5, 6);
+        Maybe<Integer> reduced = source.reduce(new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer i1, Integer i2) {
+                return i1 + i2;
+            }
+        });
+
+        Integer r = reduced.blockingGet();
         assertEquals(21, r.intValue());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
@@ -82,7 +82,7 @@ public class ObservableTakeLastOneTest {
             public void accept(Integer t) {
                 upstreamCount.incrementAndGet();
             }})
-            .takeLast(0).count().blockingSingle();
+            .takeLast(0).count().blockingGet();
         assertEquals(num, upstreamCount.get());
         assertEquals(0L, count);
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -142,7 +142,7 @@ public class ObservableTakeLastTest {
     @Test
     public void testIssue1522() {
         // https://github.com/ReactiveX/RxJava/issues/1522
-        assertEquals(0, Observable
+        assertNull(Observable
                 .empty()
                 .count()
                 .filter(new Predicate<Long>() {
@@ -151,8 +151,7 @@ public class ObservableTakeLastTest {
                         return false;
                     }
                 })
-                .toList()
-                .blockingGet().size());
+                .blockingGet());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTests.java
@@ -30,7 +30,7 @@ public class SingleTimeoutTests {
         final PublishSubject<String> subject = PublishSubject.create();
         final TestScheduler scheduler = new TestScheduler();
 
-        final TestObserver<String> observer = subject.toSingle()
+        final TestObserver<String> observer = subject.single("")
                 .timeout(100, TimeUnit.MILLISECONDS, scheduler)
                 .test();
 

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -102,7 +102,7 @@ public class MaybeTest {
     public void fromObservableEmpty() {
 
         Observable.empty()
-        .toMaybe()
+        .singleElement()
         .test()
         .assertResult();
     }
@@ -111,7 +111,7 @@ public class MaybeTest {
     public void fromObservableJust() {
 
         Observable.just(1)
-        .toMaybe()
+        .singleElement()
         .test()
         .assertResult(1);
     }
@@ -120,7 +120,7 @@ public class MaybeTest {
     public void fromObservableError() {
 
         Observable.error(new TestException())
-        .toMaybe()
+        .singleElement()
         .test()
         .assertFailure(TestException.class);
     }
@@ -137,16 +137,16 @@ public class MaybeTest {
     public void fromObservableMany() {
 
         Observable.range(1, 2)
-        .toMaybe()
+        .singleElement()
         .test()
-        .assertFailure(IndexOutOfBoundsException.class);
+        .assertFailure(IllegalArgumentException.class);
     }
 
     @Test
     public void fromObservableDisposeComposesThrough() {
         PublishSubject<Integer> pp = PublishSubject.create();
 
-        TestObserver<Integer> ts = pp.toMaybe().test(false);
+        TestObserver<Integer> ts = pp.singleElement().test(false);
 
         assertTrue(pp.hasObservers());
 
@@ -159,7 +159,7 @@ public class MaybeTest {
     public void fromObservableDisposeComposesThroughImmediatelyCancelled() {
         PublishSubject<Integer> pp = PublishSubject.create();
 
-        pp.toMaybe().test(true);
+        pp.singleElement().test(true);
 
         assertFalse(pp.hasObservers());
     }
@@ -337,7 +337,7 @@ public class MaybeTest {
 
     @Test
     public void obervableMaybeobervable() {
-        Observable.just(1).toMaybe().toObservable().test().assertResult(1);
+        Observable.just(1).singleElement().toObservable().test().assertResult(1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1767,7 +1767,7 @@ public class ObservableNullTests {
             public Integer apply(Integer a, Integer b) {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -1792,7 +1792,7 @@ public class ObservableNullTests {
             public Integer apply(Integer a, Integer b) {
                 return null;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -1817,7 +1817,7 @@ public class ObservableNullTests {
             public Object apply(Object a, Integer b) {
                 return 1;
             }
-        }).blockingSubscribe();
+        }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/observable/ObservableReduceTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableReduceTests.java
@@ -13,15 +13,70 @@
 
 package io.reactivex.observable;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-import io.reactivex.Observable;
+import io.reactivex.*;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.observable.ObservableCovarianceTest.*;
 
 public class ObservableReduceTests {
+
+    @Test
+    public void reduceIntsObservable() {
+        Observable<Integer> o = Observable.just(1, 2, 3);
+        int value = o.reduce(new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t1, Integer t2) {
+                return t1 + t2;
+            }
+        }).toObservable().blockingSingle();
+
+        assertEquals(6, value);
+    }
+
+    @SuppressWarnings("unused")
+    @Test
+    public void reduceWithObjectsObservable() {
+        Observable<Movie> horrorMovies = Observable.<Movie> just(new HorrorMovie());
+
+        Observable<Movie> reduceResult = horrorMovies.scan(new BiFunction<Movie, Movie, Movie>() {
+            @Override
+            public Movie apply(Movie t1, Movie t2) {
+                return t2;
+            }
+        }).takeLast(1);
+
+        Observable<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
+            @Override
+            public Movie apply(Movie t1, Movie t2) {
+                return t2;
+            }
+        }).toObservable();
+
+        assertNotNull(reduceResult2);
+    }
+
+    /**
+     * Reduce consumes and produces T so can't do covariance.
+     *
+     * https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016
+     */
+    @Test
+    public void reduceWithCovariantObjectsObservable() {
+        Observable<Movie> horrorMovies = Observable.<Movie> just(new HorrorMovie());
+
+        Observable<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
+            @Override
+            public Movie apply(Movie t1, Movie t2) {
+                return t2;
+            }
+        }).toObservable();
+
+        assertNotNull(reduceResult2);
+    }
+
 
     @Test
     public void reduceInts() {
@@ -31,7 +86,7 @@ public class ObservableReduceTests {
             public Integer apply(Integer t1, Integer t2) {
                 return t1 + t2;
             }
-        }).blockingSingle();
+        }).blockingGet();
 
         assertEquals(6, value);
     }
@@ -48,12 +103,14 @@ public class ObservableReduceTests {
             }
         }).takeLast(1);
 
-        Observable<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
+        Maybe<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
             @Override
             public Movie apply(Movie t1, Movie t2) {
                 return t2;
             }
         });
+
+        assertNotNull(reduceResult2);
     }
 
     /**
@@ -61,17 +118,18 @@ public class ObservableReduceTests {
      *
      * https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016
      */
-    @SuppressWarnings("unused")
     @Test
     public void reduceWithCovariantObjects() {
         Observable<Movie> horrorMovies = Observable.<Movie> just(new HorrorMovie());
 
-        Observable<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
+        Maybe<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
             @Override
             public Movie apply(Movie t1, Movie t2) {
                 return t2;
             }
         });
+
+        assertNotNull(reduceResult2);
     }
 
     /**

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -79,7 +79,12 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         latch.await(1000, TimeUnit.MILLISECONDS);
 
         System.out.println("----------- it thinks it is finished ------------------ ");
-        Thread.sleep(100);
+
+        int timeout = 10;
+
+        while (timeout-- > 0 && countGenerated.get() != 2) {
+            Thread.sleep(100);
+        }
 
         assertEquals(2, countGenerated.get());
     }

--- a/src/test/java/io/reactivex/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/single/SingleCacheTest.java
@@ -53,7 +53,7 @@ public class SingleCacheTest {
     @Test
     public void delayed() {
         PublishSubject<Integer> ps = PublishSubject.create();
-        Single<Integer> cache = ps.toSingle().cache();
+        Single<Integer> cache = ps.single(-99).cache();
 
         TestObserver<Integer> ts1 = cache.test();
 
@@ -69,7 +69,7 @@ public class SingleCacheTest {
     @Test
     public void delayedDisposed() {
         PublishSubject<Integer> ps = PublishSubject.create();
-        Single<Integer> cache = ps.toSingle().cache();
+        Single<Integer> cache = ps.single(-99).cache();
 
         TestObserver<Integer> ts1 = cache.test();
 
@@ -87,7 +87,7 @@ public class SingleCacheTest {
     @Test
     public void crossCancel() {
         PublishSubject<Integer> ps = PublishSubject.create();
-        Single<Integer> cache = ps.toSingle().cache();
+        Single<Integer> cache = ps.single(-99).cache();
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
 
@@ -112,7 +112,7 @@ public class SingleCacheTest {
     @Test
     public void crossCancelOnError() {
         PublishSubject<Integer> ps = PublishSubject.create();
-        Single<Integer> cache = ps.toSingle().cache();
+        Single<Integer> cache = ps.single(-99).cache();
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
 

--- a/src/test/java/io/reactivex/single/SingleSubscribeTest.java
+++ b/src/test/java/io/reactivex/single/SingleSubscribeTest.java
@@ -97,7 +97,7 @@ public class SingleSubscribeTest {
     public void biConsumerDispose() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        Disposable d = ps.toSingle().subscribe(new BiConsumer<Object, Object>() {
+        Disposable d = ps.single(-99).subscribe(new BiConsumer<Object, Object>() {
             @Override
             public void accept(Object t1, Object t2) throws Exception {
 
@@ -117,7 +117,7 @@ public class SingleSubscribeTest {
     public void consumerDispose() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        Disposable d = ps.toSingle().subscribe(Functions.<Integer>emptyConsumer());
+        Disposable d = ps.single(-99).subscribe(Functions.<Integer>emptyConsumer());
 
         assertFalse(d.isDisposed());
 
@@ -213,7 +213,7 @@ public class SingleSubscribeTest {
     public void methodTestNoCancel() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        ps.toSingle().test(false);
+        ps.single(-99).test(false);
 
         assertTrue(ps.hasObservers());
     }

--- a/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
@@ -243,7 +243,8 @@ public class BehaviorSubjectTest {
             String v = "" + i;
             src.onNext(v);
             System.out.printf("Turn: %d%n", i);
-            src.first()
+            src.firstElement()
+                .toObservable()
                 .flatMap(new Function<String, Observable<String>>() {
 
                     @Override

--- a/src/test/java/io/reactivex/subjects/PublishSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/PublishSubjectTest.java
@@ -301,7 +301,8 @@ public class PublishSubjectTest {
             InOrder inOrder = inOrder(o);
             String v = "" + i;
             System.out.printf("Turn: %d%n", i);
-            src.first()
+            src.firstElement()
+                .toObservable()
                 .flatMap(new Function<String, Observable<String>>() {
 
                     @Override

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
@@ -364,7 +364,8 @@ public class ReplaySubjectTest {
             String v = "" + i;
             src.onNext(v);
             System.out.printf("Turn: %d%n", i);
-            src.first()
+            src.firstElement()
+                .toObservable()
                 .flatMap(new Function<String, Observable<String>>() {
 
                     @Override


### PR DESCRIPTION
This PR updates many `Observable` operators to return `Single`, `Maybe` or `Completable`:
- count() -> Single
- elementAt() -> Maybe
- elementAt(T) -> Single
- first(T) -> Single
- firstElement() -> Maybe
- ignoreElements() -> Completable
- lastElement() -> Maybe
- reduce(BiFunction) -> Maybe
- reduce(Callable, BiFunction) -> Single
- reduceWith(U, BiFunction) -> Single
- single(T) -> Single
- singleElement() -> Maybe

and deletes Observable.toSingle, Observable.toMaybe and Observable.toCompletable.

In addition, `Flowable.reduce(BiFunction)` now returns `Maybe<T>`.

Related: #4321
