### PR TITLE
2.x fix Flowable.create() not reporting null values properly, unify

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableCreate.java
@@ -74,7 +74,7 @@ public final class CompletableCreate extends Completable {
         @Override
         public void onError(Throwable t) {
             if (t == null) {
-                t = new NullPointerException("Emitter got a null throwable. Null values are generally not allowed in 2.x operators and sources.");
+                t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
             }
             if (get() != DisposableHelper.DISPOSED) {
                 Disposable d = getAndSet(DisposableHelper.DISPOSED);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCreate.java
@@ -107,7 +107,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
                 return;
             }
             if (t == null) {
-                onError(new NullPointerException("Emitter got a null value. Null values are generally not allowed in 2.x operators and sources."));
+                onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
                 return;
             }
             if (get() == 0 && compareAndSet(0, 1)) {
@@ -134,7 +134,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
                 return;
             }
             if (t == null) {
-                t = new NullPointerException("Emitter got a null throwable. Null values are generally not allowed in 2.x operators and sources.");
+                t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
             }
             if (error.addThrowable(t)) {
                 done = true;
@@ -265,6 +265,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
         @Override
         public void onError(Throwable e) {
             if (isCancelled()) {
+                RxJavaPlugins.onError(e);
                 return;
             }
             try {
@@ -337,7 +338,12 @@ public final class FlowableCreate<T> extends Flowable<T> {
                 return;
             }
 
-            actual.onNext(t);
+            if (t != null) {
+                actual.onNext(t);
+            } else {
+                onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
+                return;
+            }
 
             for (;;) {
                 long r = get();
@@ -360,6 +366,11 @@ public final class FlowableCreate<T> extends Flowable<T> {
         @Override
         public final void onNext(T t) {
             if (isCancelled()) {
+                return;
+            }
+
+            if (t == null) {
+                onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
                 return;
             }
 
@@ -426,12 +437,29 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
         @Override
         public void onNext(T t) {
+            if (done || isCancelled()) {
+                return;
+            }
+
+            if (t == null) {
+                onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
+                return;
+            }
             queue.offer(t);
             drain();
         }
 
         @Override
         public void onError(Throwable e) {
+            if (done || isCancelled()) {
+                RxJavaPlugins.onError(e);
+                return;
+            }
+
+            if (e == null) {
+                e = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+            }
+
             error = e;
             done = true;
             drain();
@@ -552,12 +580,27 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
         @Override
         public void onNext(T t) {
+            if (done || isCancelled()) {
+                return;
+            }
+
+            if (t == null) {
+                onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
+                return;
+            }
             queue.set(t);
             drain();
         }
 
         @Override
         public void onError(Throwable e) {
+            if (done || isCancelled()) {
+                RxJavaPlugins.onError(e);
+                return;
+            }
+            if (e == null) {
+                onError(new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources."));
+            }
             error = e;
             done = true;
             drain();

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeCreate.java
@@ -69,7 +69,7 @@ public final class MaybeCreate<T> extends Maybe<T> {
                 if (d != DisposableHelper.DISPOSED) {
                     try {
                         if (value == null) {
-                            actual.onError(new NullPointerException("Emitter got a null value. Null values are generally not allowed in 2.x operators and sources."));
+                            actual.onError(new NullPointerException("onSuccess called with null. Null values are generally not allowed in 2.x operators and sources."));
                         } else {
                             actual.onSuccess(value);
                         }
@@ -85,7 +85,7 @@ public final class MaybeCreate<T> extends Maybe<T> {
         @Override
         public void onError(Throwable t) {
             if (t == null) {
-                t = new NullPointerException("Emitter got a null throwable. Null values are generally not allowed in 2.x operators and sources.");
+                t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
             }
             if (get() != DisposableHelper.DISPOSED) {
                 Disposable d = getAndSet(DisposableHelper.DISPOSED);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCreate.java
@@ -60,7 +60,8 @@ public final class ObservableCreate<T> extends Observable<T> {
         @Override
         public void onNext(T t) {
             if (t == null) {
-                onError(new NullPointerException("Emitter got a null value. Null values are generally not allowed in 2.x operators and sources."));
+                onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
+                return;
             }
             if (!isDisposed()) {
                 observer.onNext(t);
@@ -70,7 +71,7 @@ public final class ObservableCreate<T> extends Observable<T> {
         @Override
         public void onError(Throwable t) {
             if (t == null) {
-                t = new NullPointerException("Emitter got a null throwable. Null values are generally not allowed in 2.x operators and sources.");
+                t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
             }
             if (!isDisposed()) {
                 try {
@@ -151,7 +152,7 @@ public final class ObservableCreate<T> extends Observable<T> {
                 return;
             }
             if (t == null) {
-                onError(new NullPointerException("t is null"));
+                onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
                 return;
             }
             if (get() == 0 && compareAndSet(0, 1)) {
@@ -178,7 +179,7 @@ public final class ObservableCreate<T> extends Observable<T> {
                 return;
             }
             if (t == null) {
-                t = new NullPointerException("t is null");
+                t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
             }
             if (error.addThrowable(t)) {
                 done = true;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleCreate.java
@@ -63,7 +63,7 @@ public final class SingleCreate<T> extends Single<T> {
                 if (d != DisposableHelper.DISPOSED) {
                     try {
                         if (value == null) {
-                            actual.onError(new NullPointerException("Emitter got a null value. Null values are generally not allowed in 2.x operators and sources."));
+                            actual.onError(new NullPointerException("onSuccess called with null. Null values are generally not allowed in 2.x operators and sources."));
                         } else {
                             actual.onSuccess(value);
                         }
@@ -79,7 +79,7 @@ public final class SingleCreate<T> extends Single<T> {
         @Override
         public void onError(Throwable t) {
             if (t == null) {
-                t = new NullPointerException("Emitter got a null throwable. Null values are generally not allowed in 2.x operators and sources.");
+                t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
             }
             if (get() != DisposableHelper.DISPOSED) {
                 Disposable d = getAndSet(DisposableHelper.DISPOSED);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 import org.reactivestreams.*;
@@ -213,6 +213,241 @@ public class FlowableCreateTest {
     @Test(expected = IllegalArgumentException.class)
     public void unsafeWithFlowable() {
         Flowable.unsafeCreate(Flowable.just(1));
+    }
+
+    @Test
+    public void createNullValueBuffer() {
+        final Throwable[] error = { null };
+
+        Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        }, FlowableEmitter.BackpressureMode.BUFFER)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
+    }
+
+    @Test
+    public void createNullValueLatest() {
+        final Throwable[] error = { null };
+
+        Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        }, FlowableEmitter.BackpressureMode.LATEST)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
+    }
+
+    @Test
+    public void createNullValueError() {
+        final Throwable[] error = { null };
+
+        Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        }, FlowableEmitter.BackpressureMode.ERROR)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
+    }
+
+    @Test
+    public void createNullValueDrop() {
+        final Throwable[] error = { null };
+
+        Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        }, FlowableEmitter.BackpressureMode.DROP)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
+    }
+
+    @Test
+    public void createNullValueNone() {
+        final Throwable[] error = { null };
+
+        Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        }, FlowableEmitter.BackpressureMode.NONE)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
+    }
+
+    @Test
+    public void createNullValueBufferSerialized() {
+        final Throwable[] error = { null };
+
+        Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                e = e.serialize();
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        }, FlowableEmitter.BackpressureMode.BUFFER)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
+    }
+
+    @Test
+    public void createNullValueLatestSerialized() {
+        final Throwable[] error = { null };
+
+        Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                e = e.serialize();
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        }, FlowableEmitter.BackpressureMode.LATEST)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
+    }
+
+    @Test
+    public void createNullValueErrorSerialized() {
+        final Throwable[] error = { null };
+
+        Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                e = e.serialize();
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        }, FlowableEmitter.BackpressureMode.ERROR)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
+    }
+
+    @Test
+    public void createNullValueDropSerialized() {
+        final Throwable[] error = { null };
+
+        Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                e = e.serialize();
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        }, FlowableEmitter.BackpressureMode.DROP)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
+    }
+
+    @Test
+    public void createNullValueNoneSerialized() {
+        final Throwable[] error = { null };
+
+        Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                e = e.serialize();
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        }, FlowableEmitter.BackpressureMode.NONE)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
     }
 
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
@@ -205,4 +205,50 @@ public class ObservableCreateTest {
         Observable.unsafeCreate(Observable.just(1));
     }
 
+    @Test
+    public void createNullValue() {
+        final Throwable[] error = { null };
+
+        Observable.create(new ObservableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(ObservableEmitter<Integer> e) throws Exception {
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
+    }
+
+    @Test
+    public void createNullValueSerialized() {
+        final Throwable[] error = { null };
+
+        Observable.create(new ObservableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(ObservableEmitter<Integer> e) throws Exception {
+                e = e.serialize();
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
+                }
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertNull(error[0]);
+    }
 }


### PR DESCRIPTION
exception msg across

Reported on [Stackoverflow](http://stackoverflow.com/questions/39622458/flowableemitter-doesnt-signal-error-when-onnext-got-null).

There was no proper null check in the various emitters. I've also unified the message pattern across all `create()` emitters.
