### PR TITLE
2.x: Evaluate Schedule initialization via Callable

### DIFF
--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -184,7 +184,7 @@ public final class RxJavaPlugins {
 
     /**
      * Calls the associated hook function.
-     * @param defaultScheduler the hook's input value
+     * @param defaultScheduler a {@link Callable} which returns the hook's input value
      * @return the value returned by the hook
      */
     public static Scheduler initComputationScheduler(Callable<Scheduler> defaultScheduler) {
@@ -197,7 +197,7 @@ public final class RxJavaPlugins {
 
     /**
      * Calls the associated hook function.
-     * @param defaultScheduler the hook's input value
+     * @param defaultScheduler a {@link Callable} which returns the hook's input value
      * @return the value returned by the hook
      */
     public static Scheduler initIoScheduler(Callable<Scheduler> defaultScheduler) {
@@ -210,7 +210,7 @@ public final class RxJavaPlugins {
 
     /**
      * Calls the associated hook function.
-     * @param defaultScheduler the hook's input value
+     * @param defaultScheduler a {@link Callable} which returns the hook's input value
      * @return the value returned by the hook
      */
     public static Scheduler initNewThreadScheduler(Callable<Scheduler> defaultScheduler) {
@@ -223,7 +223,7 @@ public final class RxJavaPlugins {
 
     /**
      * Calls the associated hook function.
-     * @param defaultScheduler the hook's input value
+     * @param defaultScheduler a {@link Callable} which returns the hook's input value
      * @return the value returned by the hook
      */
     public static Scheduler initSingleScheduler(Callable<Scheduler> defaultScheduler) {

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -190,7 +190,7 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initComputationScheduler(Callable<Scheduler> defaultScheduler) {
-        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Scheduler, Scheduler> f = onInitComputationHandler;
         if (f == null) {
             return call(defaultScheduler);
@@ -205,7 +205,7 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initIoScheduler(Callable<Scheduler> defaultScheduler) {
-        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Scheduler, Scheduler> f = onInitIoHandler;
         if (f == null) {
             return call(defaultScheduler);
@@ -220,7 +220,7 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initNewThreadScheduler(Callable<Scheduler> defaultScheduler) {
-        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Scheduler, Scheduler> f = onInitNewThreadHandler;
         if (f == null) {
             return call(defaultScheduler);
@@ -235,7 +235,7 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initSingleScheduler(Callable<Scheduler> defaultScheduler) {
-        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Scheduler, Scheduler> f = onInitSingleHandler;
         if (f == null) {
             return call(defaultScheduler);
@@ -957,7 +957,7 @@ public final class RxJavaPlugins {
     static <T, R> R apply(Function<T, R> f, Callable<T> t) {
         try {
             T value = t.call();
-            ObjectHelper.requireNonNull(t, "Callable result cannot be null.");
+            ObjectHelper.requireNonNull(t, "Callable result can't be null");
             return f.apply(value);
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
@@ -994,7 +994,7 @@ public final class RxJavaPlugins {
     static <T> T call(Callable<T> t) {
         try {
             T result = t.call();
-            ObjectHelper.requireNonNull(result, "Callable result cannot be null.");
+            ObjectHelper.requireNonNull(result, "Callable result can't be null");
             return result;
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -956,9 +956,9 @@ public final class RxJavaPlugins {
      */
     static <T, R> R apply(Function<T, R> f, Callable<T> t) {
         try {
-            T value = t.call();
-            ObjectHelper.requireNonNull(t, "Callable result can't be null");
-            return f.apply(value);
+            T result = t.call();
+            ObjectHelper.requireNonNull(result, "Callable result can't be null");
+            return f.apply(result);
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -33,13 +33,13 @@ public final class RxJavaPlugins {
 
     static volatile Function<Runnable, Runnable> onScheduleHandler;
 
-    static volatile Function<Scheduler, Scheduler> onInitComputationHandler;
+    static volatile Function<Callable<Scheduler>, Scheduler> onInitComputationHandler;
 
-    static volatile Function<Scheduler, Scheduler> onInitSingleHandler;
+    static volatile Function<Callable<Scheduler>, Scheduler> onInitSingleHandler;
 
-    static volatile Function<Scheduler, Scheduler> onInitIoHandler;
+    static volatile Function<Callable<Scheduler>, Scheduler> onInitIoHandler;
 
-    static volatile Function<Scheduler, Scheduler> onInitNewThreadHandler;
+    static volatile Function<Callable<Scheduler>, Scheduler> onInitNewThreadHandler;
 
     static volatile Function<Scheduler, Scheduler> onComputationHandler;
 
@@ -123,7 +123,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
-    public static Function<Scheduler, Scheduler> getInitComputationSchedulerHandler() {
+    public static Function<Callable<Scheduler>, Scheduler> getInitComputationSchedulerHandler() {
         return onInitComputationHandler;
     }
 
@@ -131,7 +131,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
-    public static Function<Scheduler, Scheduler> getInitIoSchedulerHandler() {
+    public static Function<Callable<Scheduler>, Scheduler> getInitIoSchedulerHandler() {
         return onInitIoHandler;
     }
 
@@ -139,7 +139,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
-    public static Function<Scheduler, Scheduler> getInitNewThreadSchedulerHandler() {
+    public static Function<Callable<Scheduler>, Scheduler> getInitNewThreadSchedulerHandler() {
         return onInitNewThreadHandler;
     }
 
@@ -147,7 +147,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
-    public static Function<Scheduler, Scheduler> getInitSingleSchedulerHandler() {
+    public static Function<Callable<Scheduler>, Scheduler> getInitSingleSchedulerHandler() {
         return onInitSingleHandler;
     }
 
@@ -186,61 +186,61 @@ public final class RxJavaPlugins {
     /**
      * Calls the associated hook function.
      * @param defaultScheduler a {@link Callable} which returns the hook's input value
-     * @return the value returned by the hook
+     * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initComputationScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<Scheduler, Scheduler> f = onInitComputationHandler;
+        Function<Callable<Scheduler>, Scheduler> f = onInitComputationHandler;
         if (f == null) {
-            return call(defaultScheduler);
+            return callRequireNonNull(defaultScheduler);
         }
-        return apply(f, defaultScheduler); // JIT will skip this
+        return applyRequireNonNull(f, defaultScheduler); // JIT will skip this
     }
 
     /**
      * Calls the associated hook function.
      * @param defaultScheduler a {@link Callable} which returns the hook's input value
-     * @return the value returned by the hook
+     * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initIoScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<Scheduler, Scheduler> f = onInitIoHandler;
+        Function<Callable<Scheduler>, Scheduler> f = onInitIoHandler;
         if (f == null) {
-            return call(defaultScheduler);
+            return callRequireNonNull(defaultScheduler);
         }
-        return apply(f, defaultScheduler);
+        return applyRequireNonNull(f, defaultScheduler);
     }
 
     /**
      * Calls the associated hook function.
      * @param defaultScheduler a {@link Callable} which returns the hook's input value
-     * @return the value returned by the hook
+     * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initNewThreadScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<Scheduler, Scheduler> f = onInitNewThreadHandler;
+        Function<Callable<Scheduler>, Scheduler> f = onInitNewThreadHandler;
         if (f == null) {
-            return call(defaultScheduler);
+            return callRequireNonNull(defaultScheduler);
         }
-        return apply(f, defaultScheduler);
+        return applyRequireNonNull(f, defaultScheduler);
     }
 
     /**
      * Calls the associated hook function.
      * @param defaultScheduler a {@link Callable} which returns the hook's input value
-     * @return the value returned by the hook
+     * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initSingleScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<Scheduler, Scheduler> f = onInitSingleHandler;
+        Function<Callable<Scheduler>, Scheduler> f = onInitSingleHandler;
         if (f == null) {
-            return call(defaultScheduler);
+            return callRequireNonNull(defaultScheduler);
         }
-        return apply(f, defaultScheduler);
+        return applyRequireNonNull(f, defaultScheduler);
     }
 
     /**
@@ -403,9 +403,9 @@ public final class RxJavaPlugins {
 
     /**
      * Sets the specific hook function.
-     * @param handler the hook function to set, null allowed
+     * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitComputationSchedulerHandler(Function<Scheduler, Scheduler> handler) {
+    public static void setInitComputationSchedulerHandler(Function<Callable<Scheduler>, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -414,9 +414,9 @@ public final class RxJavaPlugins {
 
     /**
      * Sets the specific hook function.
-     * @param handler the hook function to set, null allowed
+     * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitIoSchedulerHandler(Function<Scheduler, Scheduler> handler) {
+    public static void setInitIoSchedulerHandler(Function<Callable<Scheduler>, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -425,9 +425,9 @@ public final class RxJavaPlugins {
 
     /**
      * Sets the specific hook function.
-     * @param handler the hook function to set, null allowed
+     * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitNewThreadSchedulerHandler(Function<Scheduler, Scheduler> handler) {
+    public static void setInitNewThreadSchedulerHandler(Function<Callable<Scheduler>, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -436,9 +436,9 @@ public final class RxJavaPlugins {
 
     /**
      * Sets the specific hook function.
-     * @param handler the hook function to set, null allowed
+     * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitSingleSchedulerHandler(Function<Scheduler, Scheduler> handler) {
+    public static void setInitSingleSchedulerHandler(Function<Callable<Scheduler>, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -946,26 +946,6 @@ public final class RxJavaPlugins {
 
     /**
      * Wraps the call to the function in try-catch and propagates thrown
-     * checked exceptions as RuntimeException. Takes a {@link Callable} to provide the function input value.
-     * @param <T> the input type
-     * @param <R> the output type
-     * @param f the function to call, not null (not verified)
-     * @param t the {@link Callable} parameter value to the function, not null (not verified). Cannot return null.
-     * @return the result of the function call, not null
-     * @throws NullPointerException if the callable returns null
-     */
-    static <T, R> R apply(Function<T, R> f, Callable<T> t) {
-        try {
-            T result = t.call();
-            ObjectHelper.requireNonNull(result, "Callable result can't be null");
-            return f.apply(result);
-        } catch (Throwable ex) {
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
-    }
-
-    /**
-     * Wraps the call to the function in try-catch and propagates thrown
      * checked exceptions as RuntimeException.
      * @param <T> the first input type
      * @param <U> the second input type
@@ -984,20 +964,30 @@ public final class RxJavaPlugins {
     }
 
     /**
-     * Wraps the call to the callable in try-catch and propagates thrown
-     * checked exceptions as RuntimeException.
-     * @param <T> the input type
-     * @param t the callable, not null (not verified). Cannot return null.
+     * Wraps the call to the Scheduler creation callable in try-catch and propagates thrown
+     * checked exceptions as RuntimeException and enforces that result is not null.
+     * @param s the {@link Callable} which returns a {@link Scheduler}, not null (not verified). Cannot return null
      * @return the result of the callable call, not null
-     * @throws NullPointerException if the callable returns null
+     * @throws NullPointerException if the callable parameter returns null
      */
-    static <T> T call(Callable<T> t) {
+    static Scheduler callRequireNonNull(Callable<Scheduler> s) {
         try {
-            T result = t.call();
-            return ObjectHelper.requireNonNull(result, "Callable result can't be null");
+            return ObjectHelper.requireNonNull(s.call(), "Scheduler Callable result can't be null");
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }
+    }
+
+    /**
+     * Wraps the call to the Scheduler creation function in try-catch and propagates thrown
+     * checked exceptions as RuntimeException and enforces that result is not null.
+     * @param f the function to call, not null (not verified). Cannot return null
+     * @param s the parameter value to the function
+     * @return the result of the function call, not null
+     * @throws NullPointerException if the function parameter returns null
+     */
+    static Scheduler applyRequireNonNull(Function<Callable<Scheduler>, Scheduler> f, Callable<Scheduler> s) {
+        return ObjectHelper.requireNonNull(apply(f, s), "Scheduler Callable result can't be null");
     }
 
     /** Helper class, no instances. */

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -994,8 +994,7 @@ public final class RxJavaPlugins {
     static <T> T call(Callable<T> t) {
         try {
             T result = t.call();
-            ObjectHelper.requireNonNull(result, "Callable result can't be null");
-            return result;
+            return ObjectHelper.requireNonNull(result, "Callable result can't be null");
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -15,6 +15,7 @@ package io.reactivex.plugins;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.concurrent.Callable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
@@ -188,9 +189,10 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     public static Scheduler initComputationScheduler(Callable<Scheduler> defaultScheduler) {
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
         Function<Scheduler, Scheduler> f = onInitComputationHandler;
         if (f == null) {
-            return callOrNull(defaultScheduler);
+            return call(defaultScheduler);
         }
         return apply(f, defaultScheduler); // JIT will skip this
     }
@@ -201,9 +203,10 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     public static Scheduler initIoScheduler(Callable<Scheduler> defaultScheduler) {
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
         Function<Scheduler, Scheduler> f = onInitIoHandler;
         if (f == null) {
-            return callOrNull(defaultScheduler);
+            return call(defaultScheduler);
         }
         return apply(f, defaultScheduler);
     }
@@ -214,9 +217,10 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     public static Scheduler initNewThreadScheduler(Callable<Scheduler> defaultScheduler) {
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
         Function<Scheduler, Scheduler> f = onInitNewThreadHandler;
         if (f == null) {
-            return callOrNull(defaultScheduler);
+            return call(defaultScheduler);
         }
         return apply(f, defaultScheduler);
     }
@@ -227,9 +231,10 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     public static Scheduler initSingleScheduler(Callable<Scheduler> defaultScheduler) {
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
         Function<Scheduler, Scheduler> f = onInitSingleHandler;
         if (f == null) {
-            return callOrNull(defaultScheduler);
+            return call(defaultScheduler);
         }
         return apply(f, defaultScheduler);
     }
@@ -942,11 +947,13 @@ public final class RxJavaPlugins {
      * @param <R> the output type
      * @param f the function to call, not null (not verified)
      * @param t the {@link Callable} parameter value to the function
-     * @return the result of the function call
+     * @return the result of the function call, not null
      */
     static <T, R> R apply(Function<T, R> f, Callable<T> t) {
         try {
-            return f.apply(t.call());
+            T value = t.call();
+            ObjectHelper.requireNonNull(t, "Callable result cannot be null.");
+            return f.apply(value);
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }
@@ -975,27 +982,17 @@ public final class RxJavaPlugins {
      * Wraps the call to the callable in try-catch and propagates thrown
      * checked exceptions as RuntimeException.
      * @param <T> the input type
-     * @param <T> the output type
      * @param t the callable, not null (not verified)
-     * @return the result of the callable call
+     * @return the result of the callable call, not null
      */
     static <T> T call(Callable<T> t) {
         try {
-            return t.call();
+            T result = t.call();
+            ObjectHelper.requireNonNull(result, "Callable result cannot be null.");
+            return result;
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }
-    }
-
-    /**
-     * Wraps the call to the callable in try-catch and propagates thrown
-     * checked exceptions as RuntimeException.
-     * @param <T> the input and output type
-     * @param t the callable, nullable
-     * @return the callable result if the callable is nonnull, null otherwise.
-     */
-    static <T> T callOrNull(Callable<T> t) {
-        return t == null ? null : call(t);
     }
 
     /** Helper class, no instances. */

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -187,6 +187,7 @@ public final class RxJavaPlugins {
      * Calls the associated hook function.
      * @param defaultScheduler a {@link Callable} which returns the hook's input value
      * @return the value returned by the hook
+     * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initComputationScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
@@ -201,6 +202,7 @@ public final class RxJavaPlugins {
      * Calls the associated hook function.
      * @param defaultScheduler a {@link Callable} which returns the hook's input value
      * @return the value returned by the hook
+     * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initIoScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
@@ -215,6 +217,7 @@ public final class RxJavaPlugins {
      * Calls the associated hook function.
      * @param defaultScheduler a {@link Callable} which returns the hook's input value
      * @return the value returned by the hook
+     * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initNewThreadScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
@@ -229,6 +232,7 @@ public final class RxJavaPlugins {
      * Calls the associated hook function.
      * @param defaultScheduler a {@link Callable} which returns the hook's input value
      * @return the value returned by the hook
+     * @throws NullPointerException if the callable parameter or its result are null
      */
     public static Scheduler initSingleScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable cannot be null.");
@@ -942,12 +946,13 @@ public final class RxJavaPlugins {
 
     /**
      * Wraps the call to the function in try-catch and propagates thrown
-     * checked exceptions as RuntimeException.
+     * checked exceptions as RuntimeException. Takes a {@link Callable} to provide the function input value.
      * @param <T> the input type
      * @param <R> the output type
      * @param f the function to call, not null (not verified)
-     * @param t the {@link Callable} parameter value to the function
+     * @param t the {@link Callable} parameter value to the function, not null (not verified). Cannot return null.
      * @return the result of the function call, not null
+     * @throws NullPointerException if the callable returns null
      */
     static <T, R> R apply(Function<T, R> f, Callable<T> t) {
         try {
@@ -982,8 +987,9 @@ public final class RxJavaPlugins {
      * Wraps the call to the callable in try-catch and propagates thrown
      * checked exceptions as RuntimeException.
      * @param <T> the input type
-     * @param t the callable, not null (not verified)
+     * @param t the callable, not null (not verified). Cannot return null.
      * @return the result of the callable call, not null
+     * @throws NullPointerException if the callable returns null
      */
     static <T> T call(Callable<T> t) {
         try {

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -45,25 +45,41 @@ public final class Schedulers {
 
     static final Scheduler NEW_THREAD;
 
+    static final class SingleHolder {
+        static final Scheduler DEFAULT = new SingleScheduler();
+    }
+
+    static final class ComputationHolder {
+        static final Scheduler DEFAULT = new ComputationScheduler();
+    }
+
+    static final class IoHolder {
+        static final Scheduler DEFAULT = new IoScheduler();
+    }
+
+    static final class NewThreadHolder {
+        static final Scheduler DEFAULT = NewThreadScheduler.instance();
+    }
+
     static {
         SINGLE = RxJavaPlugins.initSingleScheduler(new Callable<Scheduler>() {
             @Override
             public Scheduler call() throws Exception {
-                return new SingleScheduler();
+                return SingleHolder.DEFAULT;
             }
         });
 
         COMPUTATION = RxJavaPlugins.initComputationScheduler(new Callable<Scheduler>() {
             @Override
             public Scheduler call() throws Exception {
-                return new ComputationScheduler();
+                return ComputationHolder.DEFAULT;
             }
         });
 
         IO = RxJavaPlugins.initIoScheduler(new Callable<Scheduler>() {
             @Override
             public Scheduler call() throws Exception {
-                return new IoScheduler();
+                return IoHolder.DEFAULT;
             }
         });
 
@@ -72,7 +88,7 @@ public final class Schedulers {
         NEW_THREAD = RxJavaPlugins.initNewThreadScheduler(new Callable<Scheduler>() {
             @Override
             public Scheduler call() throws Exception {
-                return NewThreadScheduler.instance();
+                return NewThreadHolder.DEFAULT;
             }
         });
     }

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.schedulers;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 
 import io.reactivex.Scheduler;
@@ -45,15 +46,35 @@ public final class Schedulers {
     static final Scheduler NEW_THREAD;
 
     static {
-        SINGLE = RxJavaPlugins.initSingleScheduler(new SingleScheduler());
+        SINGLE = RxJavaPlugins.initSingleScheduler(new Callable<Scheduler>() {
+            @Override
+            public Scheduler call() throws Exception {
+                return new SingleScheduler();
+            }
+        });
 
-        COMPUTATION = RxJavaPlugins.initComputationScheduler(new ComputationScheduler());
+        COMPUTATION = RxJavaPlugins.initComputationScheduler(new Callable<Scheduler>() {
+            @Override
+            public Scheduler call() throws Exception {
+                return new ComputationScheduler();
+            }
+        });
 
-        IO = RxJavaPlugins.initIoScheduler(new IoScheduler());
+        IO = RxJavaPlugins.initIoScheduler(new Callable<Scheduler>() {
+            @Override
+            public Scheduler call() throws Exception {
+                return new IoScheduler();
+            }
+        });
 
         TRAMPOLINE = TrampolineScheduler.instance();
 
-        NEW_THREAD = RxJavaPlugins.initNewThreadScheduler(NewThreadScheduler.instance());
+        NEW_THREAD = RxJavaPlugins.initNewThreadScheduler(new Callable<Scheduler>() {
+            @Override
+            public Scheduler call() throws Exception {
+                return NewThreadScheduler.instance();
+            }
+        });
     }
 
     /** Utility class. */

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -426,7 +426,7 @@ public class RxJavaPluginsTest {
 
     @Test
     public void overrideInitSingleSchedulerCrashes() {
-        // Fail when Callable is null
+        // fail when Callable is null
         try {
             RxJavaPlugins.initSingleScheduler(null);
             fail("Should have thrown NullPointerException");
@@ -434,18 +434,32 @@ public class RxJavaPluginsTest {
             assertEquals("Scheduler Callable can't be null", npe.getMessage());
         }
 
-        // Fail when Callable result is null
+        // fail when Callable result is null
         try {
             RxJavaPlugins.initSingleScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
             assertEquals("Callable result can't be null", npe.getMessage());
         }
+
+        // fail when Callable result is null and initHandler set
+        try {
+            RxJavaPlugins.setInitSingleSchedulerHandler(replaceWithImmediate);
+            RxJavaPlugins.initSingleScheduler(nullResultCallable);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException npe) {
+            assertEquals("Callable result can't be null", npe.getMessage());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+        // make sure the reset worked
+        assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.single());
     }
 
     @Test
     public void overrideInitComputationSchedulerCrashes() {
-        // Fail when Callable is null
+        // fail when Callable is null
         try {
             RxJavaPlugins.initComputationScheduler(null);
             fail("Should have thrown NullPointerException");
@@ -453,38 +467,65 @@ public class RxJavaPluginsTest {
             assertEquals("Scheduler Callable can't be null", npe.getMessage());
         }
 
-        // Fail when Callable result is null
+        // fail when Callable result is null
         try {
             RxJavaPlugins.initComputationScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
             assertEquals("Callable result can't be null", npe.getMessage());
         }
+
+        // fail when Callable result is null and initHandler set
+        try {
+            RxJavaPlugins.setInitComputationSchedulerHandler(replaceWithImmediate);
+            RxJavaPlugins.initComputationScheduler(nullResultCallable);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException npe) {
+            assertEquals("Callable result can't be null", npe.getMessage());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+        // make sure the reset worked
+        assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.computation());
     }
 
     @Test
     public void overrideInitIoSchedulerCrashes() {
-        // Fail when Callable is null
+        // fail when Callable is null
         try {
             RxJavaPlugins.initIoScheduler(null);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            // expected
             assertEquals("Scheduler Callable can't be null", npe.getMessage());
         }
 
-        // Fail when Callable result is null
+        // fail when Callable result is null
         try {
             RxJavaPlugins.initIoScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
             assertEquals("Callable result can't be null", npe.getMessage());
         }
+
+        // fail when Callable result is null and initHandler set
+        try {
+            RxJavaPlugins.setInitIoSchedulerHandler(replaceWithImmediate);
+            RxJavaPlugins.initIoScheduler(nullResultCallable);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException npe) {
+            assertEquals("Callable result can't be null", npe.getMessage());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+        // make sure the reset worked
+        assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.io());
     }
 
     @Test
     public void overrideInitNewThreadSchedulerCrashes() {
-        // Fail when Callable is null
+        // fail when Callable is null
         try {
             RxJavaPlugins.initNewThreadScheduler(null);
             fail("Should have thrown NullPointerException");
@@ -492,13 +533,28 @@ public class RxJavaPluginsTest {
             // expected
             assertEquals("Scheduler Callable can't be null", npe.getMessage());
         }
-        // Fail when Callable result is null
+
+        // fail when Callable result is null
         try {
             RxJavaPlugins.initNewThreadScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
             assertEquals("Callable result can't be null", npe.getMessage());
         }
+
+        // fail when Callable result is null and initHandler set
+        try {
+            RxJavaPlugins.setInitNewThreadSchedulerHandler(replaceWithImmediate);
+            RxJavaPlugins.initNewThreadScheduler(nullResultCallable);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException npe) {
+            assertEquals("Callable result can't be null", npe.getMessage());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+        // make sure the reset worked
+        assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.newThread());
     }
 
     @SuppressWarnings("rawtypes")

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -430,7 +430,7 @@ public class RxJavaPluginsTest {
         try {
             RxJavaPlugins.initSingleScheduler(null);
             fail("Should have thrown NullPointerException");
-        } catch (NullPointerException iae) {
+        } catch (NullPointerException npe) {
             // expected
         }
 
@@ -438,7 +438,7 @@ public class RxJavaPluginsTest {
         try {
             RxJavaPlugins.initSingleScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
-        } catch (NullPointerException iae) {
+        } catch (NullPointerException npe) {
             // expected
         }
     }
@@ -449,7 +449,7 @@ public class RxJavaPluginsTest {
         try {
             RxJavaPlugins.initComputationScheduler(null);
             fail("Should have thrown NullPointerException");
-        } catch (NullPointerException iae) {
+        } catch (NullPointerException npe) {
             // expected
         }
 
@@ -457,7 +457,7 @@ public class RxJavaPluginsTest {
         try {
             RxJavaPlugins.initComputationScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
-        } catch (NullPointerException iae) {
+        } catch (NullPointerException npe) {
             // expected
         }
     }
@@ -468,7 +468,7 @@ public class RxJavaPluginsTest {
         try {
             RxJavaPlugins.initIoScheduler(null);
             fail("Should have thrown NullPointerException");
-        } catch (NullPointerException iae) {
+        } catch (NullPointerException npe) {
             // expected
         }
 
@@ -476,7 +476,7 @@ public class RxJavaPluginsTest {
         try {
             RxJavaPlugins.initIoScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
-        } catch (NullPointerException iae) {
+        } catch (NullPointerException npe) {
             // expected
         }
     }
@@ -487,14 +487,14 @@ public class RxJavaPluginsTest {
         try {
             RxJavaPlugins.initNewThreadScheduler(null);
             fail("Should have thrown NullPointerException");
-        } catch (NullPointerException iae) {
+        } catch (NullPointerException npe) {
             // expected
         }
         // Fail when Callable result is null
         try {
             RxJavaPlugins.initNewThreadScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
-        } catch (NullPointerException iae) {
+        } catch (NullPointerException npe) {
             // expected
         }
     }

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -417,6 +417,36 @@ public class RxJavaPluginsTest {
         assertSame(s, RxJavaPlugins.initNewThreadScheduler(c));
     }
 
+    @Test
+    public void overrideInitSingleSchedulerCrashes() {
+        // Fail when Callable is null
+        try {
+            RxJavaPlugins.initSingleScheduler(null);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException iae) {
+            // ignore - expected
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+        // TODO Verify reset.
+
+        // Fail when Callable result is null
+        try {
+            RxJavaPlugins.initSingleScheduler(new Callable<Scheduler>() {
+                @Override
+                public Scheduler call() throws Exception {
+                    return null;
+                }
+            });
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException iae) {
+            // ignore - expected
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
     @SuppressWarnings("rawtypes")
     @Test
     public void observableCreate() {

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -295,7 +295,7 @@ public class RxJavaPluginsTest {
             RxJavaPlugins.reset();
         }
         // make sure the reset worked
-        assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.computation());
+        assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.single());
     }
 
     @Test

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -417,6 +417,13 @@ public class RxJavaPluginsTest {
         assertSame(s, RxJavaPlugins.initNewThreadScheduler(c));
     }
 
+    Callable<Scheduler> nullResultCallable = new Callable<Scheduler>() {
+        @Override
+        public Scheduler call() throws Exception {
+            return null;
+        }
+    };
+
     @Test
     public void overrideInitSingleSchedulerCrashes() {
         // Fail when Callable is null
@@ -424,26 +431,71 @@ public class RxJavaPluginsTest {
             RxJavaPlugins.initSingleScheduler(null);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException iae) {
-            // ignore - expected
-        } finally {
-            RxJavaPlugins.reset();
+            // expected
         }
-
-        // TODO Verify reset.
 
         // Fail when Callable result is null
         try {
-            RxJavaPlugins.initSingleScheduler(new Callable<Scheduler>() {
-                @Override
-                public Scheduler call() throws Exception {
-                    return null;
-                }
-            });
+            RxJavaPlugins.initSingleScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException iae) {
-            // ignore - expected
-        } finally {
-            RxJavaPlugins.reset();
+            // expected
+        }
+    }
+
+    @Test
+    public void overrideInitComputationSchedulerCrashes() {
+        // Fail when Callable is null
+        try {
+            RxJavaPlugins.initComputationScheduler(null);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException iae) {
+            // expected
+        }
+
+        // Fail when Callable result is null
+        try {
+            RxJavaPlugins.initComputationScheduler(nullResultCallable);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException iae) {
+            // expected
+        }
+    }
+
+    @Test
+    public void overrideInitIoSchedulerCrashes() {
+        // Fail when Callable is null
+        try {
+            RxJavaPlugins.initIoScheduler(null);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException iae) {
+            // expected
+        }
+
+        // Fail when Callable result is null
+        try {
+            RxJavaPlugins.initIoScheduler(nullResultCallable);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException iae) {
+            // expected
+        }
+    }
+
+    @Test
+    public void overrideInitNewThreadSchedulerCrashes() {
+        // Fail when Callable is null
+        try {
+            RxJavaPlugins.initNewThreadScheduler(null);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException iae) {
+            // expected
+        }
+        // Fail when Callable result is null
+        try {
+            RxJavaPlugins.initNewThreadScheduler(nullResultCallable);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException iae) {
+            // expected
         }
     }
 
@@ -1222,15 +1274,6 @@ public class RxJavaPluginsTest {
 
             assertSame(s, RxJavaPlugins.onSingleScheduler(s));
 
-
-            assertNull(RxJavaPlugins.initComputationScheduler(null));
-
-            assertNull(RxJavaPlugins.initIoScheduler(null));
-
-            assertNull(RxJavaPlugins.initNewThreadScheduler(null));
-
-            assertNull(RxJavaPlugins.initSingleScheduler(null));
-
             assertSame(s, RxJavaPlugins.initComputationScheduler(c));
 
             assertSame(s, RxJavaPlugins.initIoScheduler(c));
@@ -1238,7 +1281,6 @@ public class RxJavaPluginsTest {
             assertSame(s, RxJavaPlugins.initNewThreadScheduler(c));
 
             assertSame(s, RxJavaPlugins.initSingleScheduler(c));
-
 
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -431,7 +431,7 @@ public class RxJavaPluginsTest {
             RxJavaPlugins.initSingleScheduler(null);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            // expected
+            assertEquals("Scheduler Callable can't be null", npe.getMessage());
         }
 
         // Fail when Callable result is null
@@ -439,7 +439,7 @@ public class RxJavaPluginsTest {
             RxJavaPlugins.initSingleScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            // expected
+            assertEquals("Callable result can't be null", npe.getMessage());
         }
     }
 
@@ -450,7 +450,7 @@ public class RxJavaPluginsTest {
             RxJavaPlugins.initComputationScheduler(null);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            // expected
+            assertEquals("Scheduler Callable can't be null", npe.getMessage());
         }
 
         // Fail when Callable result is null
@@ -458,7 +458,7 @@ public class RxJavaPluginsTest {
             RxJavaPlugins.initComputationScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            // expected
+            assertEquals("Callable result can't be null", npe.getMessage());
         }
     }
 
@@ -470,6 +470,7 @@ public class RxJavaPluginsTest {
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
             // expected
+            assertEquals("Scheduler Callable can't be null", npe.getMessage());
         }
 
         // Fail when Callable result is null
@@ -477,7 +478,7 @@ public class RxJavaPluginsTest {
             RxJavaPlugins.initIoScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            // expected
+            assertEquals("Callable result can't be null", npe.getMessage());
         }
     }
 
@@ -489,13 +490,14 @@ public class RxJavaPluginsTest {
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
             // expected
+            assertEquals("Scheduler Callable can't be null", npe.getMessage());
         }
         // Fail when Callable result is null
         try {
             RxJavaPlugins.initNewThreadScheduler(nullResultCallable);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            // expected
+            assertEquals("Callable result can't be null", npe.getMessage());
         }
     }
 

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -339,58 +339,82 @@ public class RxJavaPluginsTest {
 
     @Test
     public void overrideInitSingleScheduler() {
-        Scheduler s = Schedulers.single(); // make sure the Schedulers is initialized
+        final Scheduler s = Schedulers.single(); // make sure the Schedulers is initialized
+        Callable<Scheduler> c = new Callable<Scheduler>() {
+            @Override
+            public Scheduler call() throws Exception {
+                return s;
+            }
+        };
         try {
             RxJavaPlugins.setInitSingleSchedulerHandler(replaceWithImmediate);
 
-            assertSame(ImmediateThinScheduler.INSTANCE, RxJavaPlugins.initSingleScheduler(s));
+            assertSame(ImmediateThinScheduler.INSTANCE, RxJavaPlugins.initSingleScheduler(c));
         } finally {
             RxJavaPlugins.reset();
         }
         // make sure the reset worked
-        assertSame(s, RxJavaPlugins.initSingleScheduler(s));
+        assertSame(s, RxJavaPlugins.initSingleScheduler(c));
     }
 
     @Test
     public void overrideInitComputationScheduler() {
-        Scheduler s = Schedulers.computation(); // make sure the Schedulers is initialized
+        final Scheduler s = Schedulers.computation(); // make sure the Schedulers is initialized
+        Callable<Scheduler> c = new Callable<Scheduler>() {
+            @Override
+            public Scheduler call() throws Exception {
+                return s;
+            }
+        };
         try {
             RxJavaPlugins.setInitComputationSchedulerHandler(replaceWithImmediate);
 
-            assertSame(ImmediateThinScheduler.INSTANCE, RxJavaPlugins.initComputationScheduler(s));
+            assertSame(ImmediateThinScheduler.INSTANCE, RxJavaPlugins.initComputationScheduler(c));
         } finally {
             RxJavaPlugins.reset();
         }
         // make sure the reset worked
-        assertSame(s, RxJavaPlugins.initComputationScheduler(s));
+        assertSame(s, RxJavaPlugins.initComputationScheduler(c));
     }
 
     @Test
     public void overrideInitIoScheduler() {
-        Scheduler s = Schedulers.io(); // make sure the Schedulers is initialized
+        final Scheduler s = Schedulers.io(); // make sure the Schedulers is initialized;
+        Callable<Scheduler> c = new Callable<Scheduler>() {
+            @Override
+            public Scheduler call() throws Exception {
+                return s;
+            }
+        };
         try {
             RxJavaPlugins.setInitIoSchedulerHandler(replaceWithImmediate);
 
-            assertSame(ImmediateThinScheduler.INSTANCE, RxJavaPlugins.initIoScheduler(s));
+            assertSame(ImmediateThinScheduler.INSTANCE, RxJavaPlugins.initIoScheduler(c));
         } finally {
             RxJavaPlugins.reset();
         }
         // make sure the reset worked
-        assertSame(s, RxJavaPlugins.initIoScheduler(s));
+        assertSame(s, RxJavaPlugins.initIoScheduler(c));
     }
 
     @Test
     public void overrideInitNewThreadScheduler() {
-        Scheduler s = Schedulers.newThread(); // make sure the Schedulers is initialized
+        final Scheduler s = Schedulers.newThread(); // make sure the Schedulers is initialized;
+        Callable<Scheduler> c = new Callable<Scheduler>() {
+            @Override
+            public Scheduler call() throws Exception {
+                return s;
+            }
+        };
         try {
             RxJavaPlugins.setInitNewThreadSchedulerHandler(replaceWithImmediate);
 
-            assertSame(ImmediateThinScheduler.INSTANCE, RxJavaPlugins.initNewThreadScheduler(s));
+            assertSame(ImmediateThinScheduler.INSTANCE, RxJavaPlugins.initNewThreadScheduler(c));
         } finally {
             RxJavaPlugins.reset();
         }
         // make sure the reset worked
-        assertSame(s, RxJavaPlugins.initNewThreadScheduler(s));
+        assertSame(s, RxJavaPlugins.initNewThreadScheduler(c));
     }
 
     @SuppressWarnings("rawtypes")
@@ -1153,8 +1177,13 @@ public class RxJavaPluginsTest {
 
             assertNull(RxJavaPlugins.onSingleScheduler(null));
 
-            Scheduler s = ImmediateThinScheduler.INSTANCE;
-
+            final Scheduler s = ImmediateThinScheduler.INSTANCE;
+            Callable<Scheduler> c = new Callable<Scheduler>() {
+                @Override
+                public Scheduler call() throws Exception {
+                    return s;
+                }
+            };
             assertSame(s, RxJavaPlugins.onComputationScheduler(s));
 
             assertSame(s, RxJavaPlugins.onIoScheduler(s));
@@ -1172,13 +1201,13 @@ public class RxJavaPluginsTest {
 
             assertNull(RxJavaPlugins.initSingleScheduler(null));
 
-            assertSame(s, RxJavaPlugins.initComputationScheduler(s));
+            assertSame(s, RxJavaPlugins.initComputationScheduler(c));
 
-            assertSame(s, RxJavaPlugins.initIoScheduler(s));
+            assertSame(s, RxJavaPlugins.initIoScheduler(c));
 
-            assertSame(s, RxJavaPlugins.initNewThreadScheduler(s));
+            assertSame(s, RxJavaPlugins.initNewThreadScheduler(c));
 
-            assertSame(s, RxJavaPlugins.initSingleScheduler(s));
+            assertSame(s, RxJavaPlugins.initSingleScheduler(c));
 
 
         } finally {


### PR DESCRIPTION
This implements the solution proposed in #4572 - to initialize the Schedulers via a Callable, rather than directly via a value.
