### PR TITLE
2.x: don't show started unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,21 +68,45 @@ if (project.hasProperty('release.useLastTag')) {
 }
 
 test {
+    
+    testLogging  {
+        // showing skipped occasionally should prevent CI timeout due to lack of standard output
+        events=['skipped', 'failed'] // "started", "passed"
+        // showStandardStreams = true
+        exceptionFormat="full"
+
+        debug.events = ["skipped", "failed"]
+        debug.exceptionFormat="full"
+
+        info.events = ["failed", "skipped"]
+        info.exceptionFormat="full"
+        
+        warn.events = ["failed", "skipped"]
+        warn.exceptionFormat="full"
+    }
+
     maxHeapSize = "1200m"
 
     if (System.getenv('CI') == null) {
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     }
-    
-    testLogging  {
-        // showing skipped occasionally should prevent CI timeout due to long running tests
-        events "skipped", "failed" // "started", "passed"
-    //    showStandardStreams = true
-    }
 }
 
 task testng(type: Test) { 
-     useTestNG() 
+     useTestNG()
+     testLogging  {
+        events=['skipped', 'failed']
+        exceptionFormat="full"
+
+        debug.events = ["skipped", "failed"]
+        debug.exceptionFormat="full"
+
+        info.events = ["failed", "skipped"]
+        info.exceptionFormat="full"
+        
+        warn.events = ["failed", "skipped"]
+        warn.exceptionFormat="full"
+     }
 } 
 
 check.dependsOn testng 

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,12 @@ test {
     if (System.getenv('CI') == null) {
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     }
+    
+    testLogging  {
+        // showing skipped occasionally should prevent CI timeout due to long running tests
+        events "skipped", "failed" // "started", "passed"
+    //    showStandardStreams = true
+    }
 }
 
 task testng(type: Test) { 


### PR DESCRIPTION
Unfortunately, test reporting can't be coalesced so our almost 6000 tests overflow the Travis' window and making it more difficult to see what went wrong (especially from mobile). 

However, Travis times the build out if it doesn't detect standard output emission for more than 10 minutes; our tests take 12 minutes on average.

By not showing started but showing skipped (of which we have 200 scattered around), the timeout should not happen and the output is not bloated.
