### PR TITLE
2.x: benchmark just() and fromCallable() throughput

### DIFF
--- a/src/perf/java/io/reactivex/CallableAsyncPerf.java
+++ b/src/perf/java/io/reactivex/CallableAsyncPerf.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.concurrent.*;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.internal.schedulers.SingleScheduler;
+import io.reactivex.schedulers.Schedulers;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class CallableAsyncPerf {
+
+    Flowable<Integer> subscribeOnFlowable;
+    
+    Flowable<Integer> observeOnFlowable;
+
+    Flowable<Integer> pipelineFlowable;
+
+    Observable<Integer> subscribeOnObservable;
+    
+    Observable<Integer> observeOnObservable;
+
+    Observable<Integer> pipelineObservable;
+
+    Single<Integer> observeOnSingle;
+    
+    Single<Integer> subscribeOnSingle;
+
+    Single<Integer> pipelineSingle;
+
+    Completable observeOnCompletable;
+    
+    Completable subscribeOnCompletable;
+
+    Completable pipelineCompletable;
+
+    Maybe<Integer> observeOnMaybe;
+    
+    Maybe<Integer> subscribeOnMaybe;
+    
+    Maybe<Integer> pipelineMaybe;
+
+    @Setup
+    public void setup() {
+        
+        Scheduler s = Schedulers.single();
+        
+        Scheduler s2 = new SingleScheduler();
+        
+        Callable<Integer> c = new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return 1;
+            }
+        };
+        
+        subscribeOnFlowable = Flowable.fromCallable(c).subscribeOn(s);
+        
+        observeOnFlowable = Flowable.fromCallable(c).observeOn(s);
+        
+        pipelineFlowable = Flowable.fromCallable(c).subscribeOn(s).observeOn(s2);
+
+        // ----
+
+        subscribeOnObservable = Observable.fromCallable(c).subscribeOn(s);
+
+        observeOnObservable = Observable.fromCallable(c).observeOn(s);
+
+        pipelineObservable = Observable.fromCallable(c).subscribeOn(s).observeOn(s2);
+        
+        // ----
+
+        observeOnSingle = Single.fromCallable(c).observeOn(s);
+        
+        subscribeOnSingle = Single.fromCallable(c).subscribeOn(s);
+
+        pipelineSingle = Single.fromCallable(c).subscribeOn(s).observeOn(s2);
+
+        // ----
+
+        observeOnCompletable = Completable.fromCallable(c).observeOn(s);
+        
+        subscribeOnCompletable = Completable.fromCallable(c).subscribeOn(s);
+
+        pipelineCompletable = Completable.fromCallable(c).subscribeOn(s).observeOn(s2);
+
+        // ----
+        
+        observeOnMaybe = Maybe.fromCallable(c).observeOn(s);
+        
+        subscribeOnMaybe = Maybe.fromCallable(c).subscribeOn(s);
+
+        pipelineMaybe = Maybe.fromCallable(c).subscribeOn(s).observeOn(s2);
+    }
+
+    @Benchmark
+    public void subscribeOnFlowable(Blackhole bh) {
+        subscribeOnFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    }
+    
+    @Benchmark
+    public void observeOnFlowable(Blackhole bh) {
+        observeOnFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void pipelineFlowable(Blackhole bh) {
+        pipelineFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void subscribeOnObservable(Blackhole bh) {
+        subscribeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+    
+    @Benchmark
+    public void observeOnObservable(Blackhole bh) {
+        observeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void pipelineObservable(Blackhole bh) {
+        pipelineObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void observeOnSingle(Blackhole bh) {
+        observeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+    
+    @Benchmark
+    public void subscribeOnSingle(Blackhole bh) {
+        subscribeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void pipelineSingle(Blackhole bh) {
+        pipelineSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void observeOnCompletable(Blackhole bh) {
+        observeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+    
+    @Benchmark
+    public void subscribeOnCompletable(Blackhole bh) {
+        subscribeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void pipelineCompletable(Blackhole bh) {
+        pipelineCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void observeOnMaybe(Blackhole bh) {
+        observeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+    
+    @Benchmark
+    public void subscribeOnMaybe(Blackhole bh) {
+        subscribeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+    
+    @Benchmark
+    public void pipelineMaybe(Blackhole bh) {
+        pipelineMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+}

--- a/src/perf/java/io/reactivex/JustAsyncPerf.java
+++ b/src/perf/java/io/reactivex/JustAsyncPerf.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.internal.schedulers.SingleScheduler;
+import io.reactivex.schedulers.Schedulers;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class JustAsyncPerf {
+
+    Flowable<Integer> subscribeOnFlowable;
+    
+    Flowable<Integer> observeOnFlowable;
+
+    Flowable<Integer> pipelineFlowable;
+
+    Observable<Integer> subscribeOnObservable;
+    
+    Observable<Integer> observeOnObservable;
+
+    Observable<Integer> pipelineObservable;
+
+    Single<Integer> observeOnSingle;
+    
+    Single<Integer> subscribeOnSingle;
+
+    Single<Integer> pipelineSingle;
+
+    Completable observeOnCompletable;
+    
+    Completable subscribeOnCompletable;
+
+    Completable pipelineCompletable;
+
+    Maybe<Integer> observeOnMaybe;
+    
+    Maybe<Integer> subscribeOnMaybe;
+    
+    Maybe<Integer> pipelineMaybe;
+
+    @Setup
+    public void setup() {
+        
+        Scheduler s = Schedulers.single();
+        
+        Scheduler s2 = new SingleScheduler();
+        
+        subscribeOnFlowable = Flowable.just(1).subscribeOn(s);
+        
+        observeOnFlowable = Flowable.just(1).observeOn(s);
+        
+        pipelineFlowable = Flowable.just(1).subscribeOn(s).observeOn(s2);
+
+        // ----
+
+        subscribeOnObservable = Observable.just(1).subscribeOn(s);
+
+        observeOnObservable = Observable.just(1).observeOn(s);
+
+        pipelineObservable = Observable.just(1).subscribeOn(s).observeOn(s2);
+        
+        // ----
+
+        observeOnSingle = Single.just(1).observeOn(s);
+        
+        subscribeOnSingle = Single.just(1).subscribeOn(s);
+
+        pipelineSingle = Single.just(1).subscribeOn(s).observeOn(s2);
+
+        // ----
+
+        observeOnCompletable = Completable.complete().observeOn(s);
+        
+        subscribeOnCompletable = Completable.complete().subscribeOn(s);
+
+        pipelineCompletable = Completable.complete().subscribeOn(s).observeOn(s2);
+
+        // ----
+        
+        observeOnMaybe = Maybe.just(1).observeOn(s);
+        
+        subscribeOnMaybe = Maybe.just(1).subscribeOn(s);
+
+        pipelineMaybe = Maybe.just(1).subscribeOn(s).observeOn(s2);
+    }
+
+    @Benchmark
+    public void subscribeOnFlowable(Blackhole bh) {
+        subscribeOnFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    }
+    
+    @Benchmark
+    public void observeOnFlowable(Blackhole bh) {
+        observeOnFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void pipelineFlowable(Blackhole bh) {
+        pipelineFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void subscribeOnObservable(Blackhole bh) {
+        subscribeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+    
+    @Benchmark
+    public void observeOnObservable(Blackhole bh) {
+        observeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void pipelineObservable(Blackhole bh) {
+        pipelineObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void observeOnSingle(Blackhole bh) {
+        observeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+    
+    @Benchmark
+    public void subscribeOnSingle(Blackhole bh) {
+        subscribeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void pipelineSingle(Blackhole bh) {
+        pipelineSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void observeOnCompletable(Blackhole bh) {
+        observeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+    
+    @Benchmark
+    public void subscribeOnCompletable(Blackhole bh) {
+        subscribeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void pipelineCompletable(Blackhole bh) {
+        pipelineCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+    @Benchmark
+    public void observeOnMaybe(Blackhole bh) {
+        observeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+    
+    @Benchmark
+    public void subscribeOnMaybe(Blackhole bh) {
+        subscribeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+    
+    @Benchmark
+    public void pipelineMaybe(Blackhole bh) {
+        pipelineMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
+    };
+
+}

--- a/src/perf/java/io/reactivex/PerfAsyncConsumer.java
+++ b/src/perf/java/io/reactivex/PerfAsyncConsumer.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.concurrent.*;
+
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.*;
+
+import io.reactivex.disposables.Disposable;
+
+/**
+ * A multi-type asynchronous consumer. 
+ */
+public final class PerfAsyncConsumer extends CountDownLatch implements Subscriber<Object>, Observer<Object>,
+SingleObserver<Object>, CompletableObserver, MaybeObserver<Object> {
+
+    final Blackhole bh;
+    
+    public PerfAsyncConsumer(Blackhole bh) {
+        super(1);
+        this.bh = bh;
+    }
+    
+    @Override
+    public void onSuccess(Object value) {
+        bh.consume(value);
+        countDown();
+    }
+
+    @Override
+    public void onSubscribe(Disposable d) {
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        s.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(Object t) {
+        bh.consume(t);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        t.printStackTrace();
+        countDown();
+    }
+
+    @Override
+    public void onComplete() {
+        bh.consume(true);
+        countDown();
+    }
+    
+    /**
+     * Wait for the terminal signal.
+     * @param count if less than 1001, a spin-wait is used
+     */
+    public void await(int count) {
+        if (count <= 1000) {
+            while (getCount() != 0) ;
+        } else {
+            try {
+                await();
+            } catch (InterruptedException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds benchmarks for measuring `just()` and `fromCallable()` when using `subscribeOn`, `observeOn` and `subscribeOn().observeOn()` with them.
# Benchmark baseline
- i7 4770K, Windows 7 x64, Java 8u102, JMH 1.13
- throughput ops/s, larger is better
## just

![image](https://cloud.githubusercontent.com/assets/1269832/18817630/bf4c4c9a-8365-11e6-87ea-13b9e2f5303c.png)

![image](https://cloud.githubusercontent.com/assets/1269832/18817657/69047e10-8366-11e6-9a63-6b0878e55097.png)
## fromCallable

![image](https://cloud.githubusercontent.com/assets/1269832/18817631/c850e922-8365-11e6-8e7b-f60c2b9bdbaa.png)

![image](https://cloud.githubusercontent.com/assets/1269832/18817654/5cfcd46e-8366-11e6-9eb7-50e1b872f377.png)
## just vs. fromCallable

![image](https://cloud.githubusercontent.com/assets/1269832/18817632/d7109ac0-8365-11e6-9936-e287477965e5.png)
