### PR TITLE
2.x: Factor out typical TestObserver/TestSubscriber methods

### DIFF
--- a/src/main/java/io/reactivex/internal/util/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/internal/util/BaseTestConsumer.java
@@ -1,0 +1,709 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.util;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import io.reactivex.Notification;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.CompositeException;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.functions.ObjectHelper;
+
+/**
+ * Base class with shared infrastructure to support TestSubscriber and TestObserver.
+ * @param <T> the value type consumed
+ * @param <U> the subclass of this BaseTestConsumer
+ */
+public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> implements Disposable {
+    /** The latch that indicates an onError or onComplete has been called. */
+    protected final CountDownLatch done;
+    /** The list of values received. */
+    protected final List<T> values;
+    /** The list of errors received. */
+    protected final List<Throwable> errors;
+    /** The number of completions. */
+    protected long completions;
+    /** The last thread seen by the observer. */
+    protected Thread lastThread;
+
+    protected boolean checkSubscriptionOnce;
+
+    protected int initialFusionMode;
+
+    protected int establishedFusionMode;
+
+    public BaseTestConsumer() {
+        this.values = new ArrayList<T>();
+        this.errors = new ArrayList<Throwable>();
+        this.done = new CountDownLatch(1);
+    }
+
+    /**
+     * Returns the last thread which called the onXXX methods of this TestObserver/TestSubscriber.
+     * @return the last thread which called the onXXX methods
+     */
+    public final Thread lastThread() {
+        return lastThread;
+    }
+
+    /**
+     * Returns a shared list of received onNext values.
+     * @return a list of received onNext values
+     */
+    public final List<T> values() {
+        return values;
+    }
+
+    /**
+     * Returns a shared list of received onError exceptions.
+     * @return a list of received events onError exceptions
+     */
+    public final List<Throwable> errors() {
+        return errors;
+    }
+
+    /**
+     * Returns the number of times onComplete was called.
+     * @return the number of times onComplete was called
+     */
+    public final long completions() {
+        return completions;
+    }
+
+    /**
+     * Returns true if TestObserver/TestSubscriber received any onError or onComplete events.
+     * @return true if TestObserver/TestSubscriber received any onError or onComplete events
+     */
+    public final boolean isTerminated() {
+        return done.getCount() == 0;
+    }
+
+    /**
+     * Returns the number of onNext values received.
+     * @return the number of onNext values received
+     */
+    public final int valueCount() {
+        return values.size();
+    }
+
+    /**
+     * Returns the number of onError exceptions received.
+     * @return the number of onError exceptions received
+     */
+    public final int errorCount() {
+        return errors.size();
+    }
+
+
+    /**
+     * Fail with the given message and add the sequence of errors as suppressed ones.
+     * <p>Note this is deliberately the only fail method. Most of the times an assertion
+     * would fail but it is possible it was due to an exception somewhere. This construct
+     * will capture those potential errors and report it along with the original failure.
+     *
+     * @param message the message to use
+     */
+    protected final AssertionError fail(String message) {
+        StringBuilder b = new StringBuilder(64 + message.length());
+        b.append(message);
+
+        b.append(" (")
+        .append("latch = ").append(done.getCount()).append(", ")
+        .append("values = ").append(values.size()).append(", ")
+        .append("errors = ").append(errors.size()).append(", ")
+        .append("completions = ").append(completions)
+        .append(')')
+        ;
+
+        AssertionError ae = new AssertionError(b.toString());
+        CompositeException ce = new CompositeException();
+        for (Throwable e : errors) {
+            ce.suppress(e);
+        }
+        if (!ce.isEmpty()) {
+            ae.initCause(ce);
+        }
+        return ae;
+    }
+
+    /**
+     * Awaits until this TestObserver/TestSubscriber receives an onError or onComplete events.
+     * @return this
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     * @see #awaitTerminalEvent()
+     */
+    @SuppressWarnings("unchecked")
+    public final U await() throws InterruptedException {
+        if (done.getCount() == 0) {
+            return (U)this;
+        }
+
+        done.await();
+        return (U)this;
+    }
+
+    /**
+     * Awaits the specified amount of time or until this TestObserver/TestSubscriber
+     * receives an onError or onComplete events, whichever happens first.
+     * @param time the waiting time
+     * @param unit the time unit of the waiting time
+     * @return true if the TestObserver/TestSubscriber terminated, false if timeout happened
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     * @see #awaitTerminalEvent(long, TimeUnit)
+     */
+    public final boolean await(long time, TimeUnit unit) throws InterruptedException {
+        return done.getCount() == 0 || done.await(time, unit);
+    }
+
+    // assertion methods
+
+    /**
+     * Assert that this TestObserver/TestSubscriber received exactly one onComplete event.
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertComplete() {
+        long c = completions;
+        if (c == 0) {
+            throw fail("Not completed");
+        } else
+        if (c > 1) {
+            throw fail("Multiple completions: " + c);
+        }
+        return (U)this;
+    }
+
+    /**
+     * Assert that this TestObserver/TestSubscriber has not received any onComplete event.
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertNotComplete() {
+        long c = completions;
+        if (c == 1) {
+            throw fail("Completed!");
+        } else
+        if (c > 1) {
+            throw fail("Multiple completions: " + c);
+        }
+        return (U)this;
+    }
+
+    /**
+     * Assert that this TestObserver/TestSubscriber has not received any onError event.
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertNoErrors() {
+        int s = errors.size();
+        if (s != 0) {
+            throw fail("Error(s) present: " + errors);
+        }
+        return (U)this;
+    }
+
+    /**
+     * Assert that this TestObserver/TestSubscriber received exactly the specified onError event value.
+     *
+     * <p>The comparison is performed via Objects.equals(); since most exceptions don't
+     * implement equals(), this assertion may fail. Use the {@link #assertError(Class)}
+     * overload to test against the class of an error instead of an instance of an error
+     * or {@link #assertError(Predicate)} to test with different condition.
+     * @param error the error to check
+     * @return this;
+     * @see #assertError(Class)
+     * @see #assertError(Predicate)
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertError(Throwable error) {
+        int s = errors.size();
+        if (s == 0) {
+            throw fail("No errors");
+        }
+        if (errors.contains(error)) {
+            if (s != 1) {
+                throw fail("Error present but other errors as well");
+            }
+        } else {
+            throw fail("Error not present");
+        }
+        return (U)this;
+    }
+
+    /**
+     * Asserts that this TestObserver/TestSubscriber received exactly one onError event which is an
+     * instance of the specified errorClass class.
+     * @param errorClass the error class to expect
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertError(Class<? extends Throwable> errorClass) {
+        int s = errors.size();
+        if (s == 0) {
+            throw fail("No errors");
+        }
+
+        boolean found = false;
+
+        for (Throwable e : errors) {
+            if (errorClass.isInstance(e)) {
+                found = true;
+                break;
+            }
+        }
+
+        if (found) {
+            if (s != 1) {
+                throw fail("Error present but other errors as well");
+            }
+        } else {
+            throw fail("Error not present");
+        }
+        return (U)this;
+    }
+
+    /**
+     * Asserts that this TestObserver/TestSubscriber received exactly one onError event for which
+     * the provided predicate returns true.
+     * @param errorPredicate
+     *            the predicate that receives the error Throwable
+     *            and should return true for expected errors.
+     * @return this
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertError(Predicate<Throwable> errorPredicate) {
+        int s = errors.size();
+        if (s == 0) {
+            throw fail("No errors");
+        }
+
+        boolean found = false;
+
+        for (Throwable e : errors) {
+            try {
+                if (errorPredicate.test(e)) {
+                    found = true;
+                    break;
+                }
+            } catch (Exception ex) {
+                throw ExceptionHelper.wrapOrThrow(ex);
+            }
+        }
+
+        if (found) {
+            if (s != 1) {
+                throw fail("Error present but other errors as well");
+            }
+        } else {
+            throw fail("Error not present");
+        }
+        return (U)this;
+    }
+
+    /**
+     * Assert that this TestObserver/TestSubscriber received exactly one onNext value which is equal to
+     * the given value with respect to Objects.equals.
+     * @param value the value to expect
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertValue(T value) {
+        int s = values.size();
+        if (s != 1) {
+            throw fail("Expected: " + valueAndClass(value) + ", Actual: " + values);
+        }
+        T v = values.get(0);
+        if (!ObjectHelper.equals(value, v)) {
+            throw fail("Expected: " + valueAndClass(value) + ", Actual: " + valueAndClass(v));
+        }
+        return (U)this;
+    }
+
+    /**
+     * Asserts that this TestObserver/TestSubscriber received exactly one onNext value for which
+     * the provided predicate returns true.
+     * @param valuePredicate
+     *            the predicate that receives the onNext value
+     *            and should return true for the expected value.
+     * @return this
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertValue(Predicate<T> valuePredicate) {
+        int s = values.size();
+        if (s == 0) {
+            throw fail("No values");
+        }
+
+        boolean found = false;
+
+        try {
+            if (valuePredicate.test(values.get(0))) {
+                found = true;
+            }
+        } catch (Exception ex) {
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
+
+        if (found) {
+            if (s != 1) {
+                throw fail("Value present but other values as well");
+            }
+        } else {
+            throw fail("Value not present");
+        }
+        return (U)this;
+    }
+
+    /**
+     * Appends the class name to a non-null value.
+     * @param o the object
+     * @return the string representation
+     */
+    public static String valueAndClass(Object o) {
+        if (o != null) {
+            return o + " (class: " + o.getClass().getSimpleName() + ")";
+        }
+        return "null";
+    }
+
+    /**
+     * Assert that this TestObserver/TestSubscriber received the specified number onNext events.
+     * @param count the expected number of onNext events
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertValueCount(int count) {
+        int s = values.size();
+        if (s != count) {
+            throw fail("Value counts differ; Expected: " + count + ", Actual: " + s);
+        }
+        return (U)this;
+    }
+
+    /**
+     * Assert that this TestObserver/TestSubscriber has not received any onNext events.
+     * @return this;
+     */
+    public final U assertNoValues() {
+        return assertValueCount(0);
+    }
+
+    /**
+     * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order.
+     * @param values the values expected
+     * @return this;
+     * @see #assertValueSet(Collection)
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertValues(T... values) {
+        int s = this.values.size();
+        if (s != values.length) {
+            throw fail("Value count differs; Expected: " + values.length + " " + Arrays.toString(values)
+            + ", Actual: " + s + " " + this.values);
+        }
+        for (int i = 0; i < s; i++) {
+            T v = this.values.get(i);
+            T u = values[i];
+            if (!ObjectHelper.equals(u, v)) {
+                throw fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
+            }
+        }
+        return (U)this;
+    }
+
+    /**
+     * Assert that the TestObserver/TestSubscriber received only the specified values in any order.
+     * <p>This helps asserting when the order of the values is not guaranteed, i.e., when merging
+     * asynchronous streams.
+     *
+     * @param expected the collection of values expected in any order
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertValueSet(Collection<? extends T> expected) {
+        if (expected.isEmpty()) {
+            assertNoValues();
+            return (U)this;
+        }
+        for (T v : this.values) {
+            if (!expected.contains(v)) {
+                throw fail("Value not in the expected collection: " + valueAndClass(v));
+            }
+        }
+        return (U)this;
+    }
+
+    /**
+     * Assert that the TestObserver/TestSubscriber received only the specified sequence of values in the same order.
+     * @param sequence the sequence of expected values in order
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertValueSequence(Iterable<? extends T> sequence) {
+        int i = 0;
+        Iterator<T> vit = values.iterator();
+        Iterator<? extends T> it = sequence.iterator();
+        boolean actualNext;
+        boolean expectedNext;
+        for (;;) {
+            actualNext = it.hasNext();
+            expectedNext = vit.hasNext();
+
+            if (!actualNext || !expectedNext) {
+                break;
+            }
+
+            T v = it.next();
+            T u = vit.next();
+
+            if (!ObjectHelper.equals(u, v)) {
+                throw fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
+            }
+            i++;
+        }
+
+        if (actualNext) {
+            throw fail("More values received than expected (" + i + ")");
+        }
+        if (expectedNext) {
+            throw fail("Fever values received than expected (" + i + ")");
+        }
+        return (U)this;
+    }
+
+    /**
+     * Assert that the TestObserver/TestSubscriber terminated (i.e., the terminal latch reached zero).
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertTerminated() {
+        if (done.getCount() != 0) {
+            throw fail("Subscriber still running!");
+        }
+        long c = completions;
+        if (c > 1) {
+            throw fail("Terminated with multiple completions: " + c);
+        }
+        int s = errors.size();
+        if (s > 1) {
+            throw fail("Terminated with multiple errors: " + s);
+        }
+
+        if (c != 0 && s != 0) {
+            throw fail("Terminated with multiple completions and errors: " + c);
+        }
+        return (U)this;
+    }
+
+    /**
+     * Assert that the TestObserver/TestSubscriber has not terminated (i.e., the terminal latch is still non-zero).
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertNotTerminated() {
+        if (done.getCount() == 0) {
+            throw fail("Subscriber terminated!");
+        }
+        return (U)this;
+    }
+
+    /**
+     * Waits until the any terminal event has been received by this TestObserver/TestSubscriber
+     * or returns false if the wait has been interrupted.
+     * @return true if the TestObserver/TestSubscriber terminated, false if the wait has been interrupted
+     */
+    public final boolean awaitTerminalEvent() {
+        try {
+            await();
+            return true;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    /**
+     * Awaits the specified amount of time or until this TestObserver/TestSubscriber
+     * receives an onError or onComplete events, whichever happens first.
+     * @param duration the waiting time
+     * @param unit the time unit of the waiting time
+     * @return true if the TestObserver/TestSubscriber terminated, false if timeout or interrupt happened
+     */
+    public final boolean awaitTerminalEvent(long duration, TimeUnit unit) {
+        try {
+            return await(duration, unit);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    /**
+     * Assert that there is a single error and it has the given message.
+     * @param message the message expected
+     * @return this
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertErrorMessage(String message) {
+        int s = errors.size();
+        if (s == 0) {
+            throw fail("No errors");
+        } else
+        if (s == 1) {
+            Throwable e = errors.get(0);
+            String errorMessage = e.getMessage();
+            if (!ObjectHelper.equals(message, errorMessage)) {
+                throw fail("Error message differs; Expected: " + message + ", Actual: " + errorMessage);
+            }
+        } else {
+            throw fail("Multiple errors");
+        }
+        return (U)this;
+    }
+
+    /**
+     * Returns a list of 3 other lists: the first inner list contains the plain
+     * values received; the second list contains the potential errors
+     * and the final list contains the potential completions as Notifications.
+     *
+     * @return a list of (values, errors, completion-notifications)
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public final List<List<Object>> getEvents() {
+        List<List<Object>> result = new ArrayList<List<Object>>();
+
+        result.add((List)values());
+
+        result.add((List)errors());
+
+        List<Object> completeList = new ArrayList<Object>();
+        for (long i = 0; i < completions; i++) {
+            completeList.add(Notification.createOnComplete());
+        }
+        result.add(completeList);
+
+        return result;
+    }
+
+    /**
+     * Assert that the onSubscribe method was called exactly once.
+     * @return this;
+     */
+    public abstract U assertSubscribed();
+
+    /**
+     * Assert that the onSubscribe method hasn't been called at all.
+     * @return this;
+     */
+    public abstract U assertNotSubscribed();
+
+    /**
+     * Assert that the upstream signalled the specified values in order and
+     * completed normally.
+     * @param values the expected values, asserted in order
+     * @return this
+     * @see #assertFailure(Class, Object...)
+     * @see #assertFailure(Predicate, Object...)
+     * @see #assertFailureAndMessage(Class, String, Object...)
+     */
+    public final U assertResult(T... values) {
+        return assertSubscribed()
+                .assertValues(values)
+                .assertNoErrors()
+                .assertComplete();
+    }
+
+    /**
+     * Assert that the upstream signalled the specified values in order
+     * and then failed with a specific class or subclass of Throwable.
+     * @param error the expected exception (parent) class
+     * @param values the expected values, asserted in order
+     * @return this
+     */
+    public final U assertFailure(Class<? extends Throwable> error, T... values) {
+        return assertSubscribed()
+                .assertValues(values)
+                .assertError(error)
+                .assertNotComplete();
+    }
+
+    /**
+     * Assert that the upstream signalled the specified values in order and then failed
+     * with a Throwable for which the provided predicate returns true.
+     * @param errorPredicate
+     *            the predicate that receives the error Throwable
+     *            and should return true for expected errors.
+     * @param values the expected values, asserted in order
+     * @return this
+     */
+    public final U assertFailure(Predicate<Throwable> errorPredicate, T... values) {
+        return assertSubscribed()
+                .assertValues(values)
+                .assertError(errorPredicate)
+                .assertNotComplete();
+    }
+
+    /**
+     * Assert that the upstream signalled the specified values in order,
+     * then failed with a specific class or subclass of Throwable
+     * and with the given exact error message.
+     * @param error the expected exception (parent) class
+     * @param message the expected failure message
+     * @param values the expected values, asserted in order
+     * @return this
+     */
+    public final U assertFailureAndMessage(Class<? extends Throwable> error,
+            String message, T... values) {
+        return assertSubscribed()
+                .assertValues(values)
+                .assertError(error)
+                .assertErrorMessage(message)
+                .assertNotComplete();
+    }
+
+    /**
+     * Awaits until the internal latch is counted down.
+     * <p>If the wait times out or gets interrupted, the TestObserver/TestSubscriber is cancelled.
+     * @param time the waiting time
+     * @param unit the time unit of the waiting time
+     * @return this
+     * @throws RuntimeException wrapping an InterruptedException if the wait is interrupted
+     */
+    @SuppressWarnings("unchecked")
+    public final U awaitDone(long time, TimeUnit unit) {
+        try {
+            if (!done.await(time, unit)) {
+                dispose();
+            }
+        } catch (InterruptedException ex) {
+            dispose();
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
+        return (U)this;
+    }
+
+
+    /**
+     * Assert that the TestObserver/TestSubscriber/TestSubscriber has received a Disposable but no other events.
+     * @return this
+     */
+    public final U assertEmpty() {
+        return assertSubscribed()
+                .assertNoValues()
+                .assertNoErrors()
+                .assertNotComplete();
+    }
+}

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -11,7 +11,7 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.util;
+package io.reactivex.observers;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -21,6 +21,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.util.ExceptionHelper;
 
 /**
  * Base class with shared infrastructure to support TestSubscriber and TestObserver.

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -21,6 +21,7 @@ import io.reactivex.functions.Consumer;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
+import io.reactivex.observers.BaseTestConsumer;
 
 /**
  * A subscriber that records events and allows making assertions about them.

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -12,18 +12,12 @@
  */
 package io.reactivex.subscribers;
 
-import java.util.*;
-import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Notification;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
-import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
@@ -41,19 +35,11 @@ import io.reactivex.internal.util.*;
  *
  * @param <T> the value type
  */
-public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposable {
+public class TestSubscriber<T>
+extends BaseTestConsumer<T, TestSubscriber<T>>
+implements Subscriber<T>, Subscription, Disposable {
     /** The actual subscriber to forward events to. */
     private final Subscriber<? super T> actual;
-    /** The latch that indicates an onError or onComplete has been called. */
-    private final CountDownLatch done;
-    /** The list of values received. */
-    private final List<T> values;
-    /** The list of errors received. */
-    private final List<Throwable> errors;
-    /** The number of completions. */
-    private long completions;
-    /** The last thread seen by the subscriber. */
-    private Thread lastThread;
 
     /** Makes sure the incoming Subscriptions get cancelled immediately. */
     private volatile boolean cancelled;
@@ -63,12 +49,6 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
 
     /** Holds the requested amount until a subscription arrives. */
     private final AtomicLong missedRequested;
-
-    private boolean checkSubscriptionOnce;
-
-    private int initialFusionMode;
-
-    private int establishedFusionMode;
 
     private QueueSubscription<T> qs;
 
@@ -134,10 +114,8 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
      * @param initialRequest the initial request value
      */
     public TestSubscriber(Subscriber<? super T> actual, long initialRequest) {
+        super();
         this.actual = actual;
-        this.values = new ArrayList<T>();
-        this.errors = new ArrayList<Throwable>();
-        this.done = new CountDownLatch(1);
         this.subscription = new AtomicReference<Subscription>();
         this.missedRequested = new AtomicLong(initialRequest);
     }
@@ -307,62 +285,6 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
     // state retrieval methods
 
     /**
-     * Returns the last thread which called the onXXX methods of this TestSubscriber.
-     * @return the last thread which called the onXXX methods
-     */
-    public final Thread lastThread() {
-        return lastThread;
-    }
-
-    /**
-     * Returns a shared list of received onNext values.
-     * @return a list of received onNext values
-     */
-    public final List<T> values() {
-        return values;
-    }
-
-    /**
-     * Returns a shared list of received onError exceptions.
-     * @return a list of received events onError exceptions
-     */
-    public final List<Throwable> errors() {
-        return errors;
-    }
-
-    /**
-     * Returns the number of times onComplete was called.
-     * @return the number of times onComplete was called
-     */
-    public final long completions() {
-        return completions;
-    }
-
-    /**
-     * Returns true if TestSubscriber received any onError or onComplete events.
-     * @return true if TestSubscriber received any onError or onComplete events
-     */
-    public final boolean isTerminated() {
-        return done.getCount() == 0;
-    }
-
-    /**
-     * Returns the number of onNext values received.
-     * @return the number of onNext values received
-     */
-    public final int valueCount() {
-        return values.size();
-    }
-
-    /**
-     * Returns the number of onError exceptions received.
-     * @return the number of onError exceptions received
-     */
-    public final int errorCount() {
-        return errors.size();
-    }
-
-    /**
      * Returns true if this TestSubscriber received a subscription.
      * @return true if this TestSubscriber received a subscription
      */
@@ -370,394 +292,13 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
         return subscription.get() != null;
     }
 
-    /**
-     * Awaits until this TestSubscriber receives an onError or onComplete events.
-     * @return this
-     * @throws InterruptedException if the current thread is interrupted while waiting
-     * @see #awaitTerminalEvent()
-     */
-    public final TestSubscriber<T> await() throws InterruptedException {
-        if (done.getCount() == 0) {
-            return this;
-        }
-
-        done.await();
-        return this;
-    }
-
     // assertion methods
-
-    /**
-     * Fail with the given message and add the sequence of errors as suppressed ones.
-     * <p>Note this is deliberately the only fail method. Most of the times an assertion
-     * would fail but it is possible it was due to an exception somewhere. This construct
-     * will capture those potential errors and report it along with the original failure.
-     *
-     * @param message the message to use
-     */
-    private AssertionError fail(String message) {
-        StringBuilder b = new StringBuilder(64 + message.length());
-        b.append(message);
-
-        b.append(" (")
-        .append("latch = ").append(done.getCount()).append(", ")
-        .append("values = ").append(values.size()).append(", ")
-        .append("errors = ").append(errors.size()).append(", ")
-        .append("completions = ").append(completions)
-        .append(')')
-        ;
-
-        AssertionError ae = new AssertionError(b.toString());
-        CompositeException ce = new CompositeException();
-        for (Throwable e : errors) {
-            if (e == null) {
-                ce.suppress(new NullPointerException("Throwable was null!"));
-            } else {
-                ce.suppress(e);
-            }
-        }
-        if (!ce.isEmpty()) {
-            ae.initCause(ce);
-        }
-        return ae;
-    }
-
-    /**
-     * Assert that this TestSubscriber received exactly one onComplete event.
-     * @return this
-     */
-    public final TestSubscriber<T> assertComplete() {
-        long c = completions;
-        if (c == 0) {
-            throw fail("Not completed");
-        } else
-        if (c > 1) {
-            throw fail("Multiple completions: " + c);
-        }
-        return this;
-    }
-
-    /**
-     * Assert that this TestSubscriber has not received any onComplete event.
-     * @return this
-     */
-    public final TestSubscriber<T> assertNotComplete() {
-        long c = completions;
-        if (c == 1) {
-            throw fail("Completed!");
-        } else
-        if (c > 1) {
-            throw fail("Multiple completions: " + c);
-        }
-        return this;
-    }
-
-    /**
-     * Assert that this TestSubscriber has not received any onError event.
-     * @return this
-     */
-    public final TestSubscriber<T> assertNoErrors() {
-        int s = errors.size();
-        if (s != 0) {
-            throw fail("Error(s) present: " + errors);
-        }
-        return this;
-    }
-
-    /**
-     * Assert that this TestSubscriber received exactly the specified onError event value.
-     *
-     * <p>The comparison is performed via Objects.equals(); since most exceptions don't
-     * implement equals(), this assertion may fail. Use the {@link #assertError(Class)}
-     * overload to test against the class of an error instead of an instance of an error
-     * or {@link #assertError(Predicate)} to test with different condition.
-     * @param error the error to check
-     * @return this
-     * @see #assertError(Class)
-     * @see #assertError(Predicate)
-     */
-    public final TestSubscriber<T> assertError(Throwable error) {
-        int s = errors.size();
-        if (s == 0) {
-            throw fail("No errors");
-        }
-        if (errors.contains(error)) {
-            if (s != 1) {
-                throw fail("Error present but other errors as well");
-            }
-        } else {
-            throw fail("Error not present");
-        }
-        return this;
-    }
-
-    /**
-     * Asserts that this TestSubscriber received exactly one onError event which is an
-     * instance of the specified errorClass class.
-     * @param errorClass the error class to expect
-     * @return this
-     */
-    public final TestSubscriber<T> assertError(Class<? extends Throwable> errorClass) {
-        int s = errors.size();
-        if (s == 0) {
-            throw fail("No errors");
-        }
-
-        boolean found = false;
-
-        for (Throwable e : errors) {
-            if (errorClass.isInstance(e)) {
-                found = true;
-                break;
-            }
-        }
-
-        if (found) {
-            if (s != 1) {
-                throw fail("Error present but other errors as well");
-            }
-        } else {
-            throw fail("Error not present");
-        }
-        return this;
-    }
-
-    /**
-     * Asserts that this TestSubscriber received exactly one onError event for which
-     * the provided predicate returns true.
-     * @param errorPredicate
-     *            the predicate that receives the error Throwable
-     *            and should return true for expected errors.
-     * @return this
-     */
-    public final TestSubscriber<T> assertError(Predicate<Throwable> errorPredicate) {
-        int s = errors.size();
-        if (s == 0) {
-            throw fail("No errors");
-        }
-
-        boolean found = false;
-
-        for (Throwable e : errors) {
-            try {
-                if (errorPredicate.test(e)) {
-                    found = true;
-                    break;
-                }
-            } catch (Exception ex) {
-                throw ExceptionHelper.wrapOrThrow(ex);
-            }
-        }
-
-        if (found) {
-            if (s != 1) {
-                throw fail("Error present but other errors as well");
-            }
-        } else {
-            throw fail("Error not present");
-        }
-        return this;
-    }
-
-    /**
-     * Assert that this TestSubscriber received exactly one onNext value which is equal to
-     * the given value with respect to Objects.equals.
-     * @param value the value to expect
-     * @return this
-     */
-    public final TestSubscriber<T> assertValue(T value) {
-        int s = values.size();
-        if (s != 1) {
-            throw fail("Expected: " + valueAndClass(value) + ", Actual: " + values);
-        }
-        T v = values.get(0);
-        if (!ObjectHelper.equals(value, v)) {
-            throw fail("Expected: " + valueAndClass(value) + ", Actual: " + valueAndClass(v));
-        }
-        return this;
-    }
-
-    /**
-     * Asserts that this TestSubscriber received exactly one onNext value for which
-     * the provided predicate returns true.
-     * @param valuePredicate
-     *            the predicate that receives the onNext value
-     *            and should return true for the expected value.
-     * @return this
-     */
-    public final TestSubscriber<T> assertValue(Predicate<T> valuePredicate) {
-        int s = values.size();
-        if (s == 0) {
-            throw fail("No values");
-        }
-
-        boolean found = false;
-
-        try {
-            if (valuePredicate.test(values.get(0))) {
-                found = true;
-            }
-        } catch (Exception ex) {
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
-
-        if (found) {
-            if (s != 1) {
-                throw fail("Value present but other values as well");
-            }
-        } else {
-            throw fail("Value not present");
-        }
-        return this;
-    }
-
-    /** Appends the class name to a non-null value. */
-    static String valueAndClass(Object o) {
-        if (o != null) {
-            return o + " (class: " + o.getClass().getSimpleName() + ")";
-        }
-        return "null";
-    }
-
-    /**
-     * Assert that this TestSubscriber received the specified number onNext events.
-     * @param count the expected number of onNext events
-     * @return this
-     */
-    public final TestSubscriber<T> assertValueCount(int count) {
-        int s = values.size();
-        if (s != count) {
-            throw fail("Value counts differ; Expected: " + count + ", Actual: " + s);
-        }
-        return this;
-    }
-
-    /**
-     * Assert that this TestSubscriber has not received any onNext events.
-     * @return this
-     */
-    public final TestSubscriber<T> assertNoValues() {
-        return assertValueCount(0);
-    }
-
-    /**
-     * Assert that the TestSubscriber received only the specified values in the specified order.
-     * @param values the values expected
-     * @return this
-     * @see #assertValueSet(Collection)
-     */
-    public final TestSubscriber<T> assertValues(T... values) {
-        int s = this.values.size();
-        if (s != values.length) {
-            throw fail("Value count differs; Expected: " + values.length + " " + Arrays.toString(values)
-            + ", Actual: " + s + " " + this.values);
-        }
-        for (int i = 0; i < s; i++) {
-            T v = this.values.get(i);
-            T u = values[i];
-            if (!ObjectHelper.equals(u, v)) {
-                throw fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
-            }
-        }
-        return this;
-    }
-
-    /**
-     * Assert that the TestSubscriber received only the specified values in any order.
-     * <p>This helps asserting when the order of the values is not guaranteed, i.e., when merging
-     * asynchronous streams.
-     *
-     * @param expected the collection of values expected in any order
-     * @return this
-     */
-    public final TestSubscriber<T> assertValueSet(Collection<? extends T> expected) {
-        if (expected.isEmpty()) {
-            assertNoValues();
-            return this;
-        }
-        for (T v : this.values) {
-            if (!expected.contains(v)) {
-                throw fail("Value not in the expected collection: " + valueAndClass(v));
-            }
-        }
-        return this;
-    }
-
-    /**
-     * Assert that the TestSubscriber received only the specified sequence of values in the same order.
-     * @param sequence the sequence of expected values in order
-     * @return this
-     */
-    public final TestSubscriber<T> assertValueSequence(Iterable<? extends T> sequence) {
-        int i = 0;
-        Iterator<T> vit = values.iterator();
-        Iterator<? extends T> it = sequence.iterator();
-        boolean actualNext;
-        boolean expectedNext;
-        for (;;) {
-            actualNext = it.hasNext();
-            expectedNext = vit.hasNext();
-
-            if (!actualNext || !expectedNext) {
-                break;
-            }
-
-            T v = it.next();
-            T u = vit.next();
-
-            if (!ObjectHelper.equals(u, v)) {
-                throw fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
-            }
-            i++;
-        }
-
-        if (actualNext) {
-            throw fail("More values received than expected (" + i + ")");
-        }
-        if (expectedNext) {
-            throw fail("Fever values received than expected (" + i + ")");
-        }
-        return this;
-    }
-
-    /**
-     * Assert that the TestSubscriber terminated (i.e., the terminal latch reached zero).
-     * @return this
-     */
-    public final TestSubscriber<T> assertTerminated() {
-        if (done.getCount() != 0) {
-            throw fail("Subscriber still running!");
-        }
-        long c = completions;
-        if (c > 1) {
-            throw fail("Terminated with multiple completions: " + c);
-        }
-        int s = errors.size();
-        if (s > 1) {
-            throw fail("Terminated with multiple errors: " + s);
-        }
-
-        if (c != 0 && s != 0) {
-            throw fail("Terminated with multiple completions and errors: " + c);
-        }
-        return this;
-    }
-
-    /**
-     * Assert that the TestSubscriber has not terminated (i.e., the terminal latch is still non-zero).
-     * @return this
-     */
-    public final TestSubscriber<T> assertNotTerminated() {
-        if (done.getCount() == 0) {
-            throw fail("Subscriber terminated!");
-        }
-        return this;
-    }
 
     /**
      * Assert that the onSubscribe method was called exactly once.
      * @return this
      */
+    @Override
     public final TestSubscriber<T> assertSubscribed() {
         if (subscription.get() == null) {
             throw fail("Not subscribed!");
@@ -769,6 +310,7 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
      * Assert that the onSubscribe method hasn't been called at all.
      * @return this
      */
+    @Override
     public final TestSubscriber<T> assertNotSubscribed() {
         if (subscription.get() != null) {
             throw fail("Subscribed!");
@@ -777,83 +319,6 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
             throw fail("Not subscribed but errors found");
         }
         return this;
-    }
-
-    /**
-     * Waits until the any terminal event has been received by this TestSubscriber
-     * or returns false if the wait has been interrupted.
-     * @return true if the TestSubscriber terminated, false if the wait has been interrupted
-     */
-    public final boolean awaitTerminalEvent() {
-        try {
-            await();
-            return true;
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            return false;
-        }
-    }
-
-    /**
-     * Awaits the specified amount of time or until this TestSubscriber
-     * receives an onError or onComplete events, whichever happens first.
-     * @param duration the waiting time
-     * @param unit the time unit of the waiting time
-     * @return true if the TestSubscriber terminated, false if timeout or interrupt happened
-     */
-    public final boolean awaitTerminalEvent(long duration, TimeUnit unit) {
-        try {
-            return await(duration, unit);
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            return false;
-        }
-    }
-
-    /**
-     * Assert that there is only a single error with the given message.
-     * @param message the message to check
-     * @return this
-     */
-    public final TestSubscriber<T> assertErrorMessage(String message) {
-        int s = errors.size();
-        if (s == 0) {
-            throw fail("No errors");
-        } else
-        if (s == 1) {
-            Throwable e = errors.get(0);
-            String errorMessage = e.getMessage();
-            if (!ObjectHelper.equals(message, errorMessage)) {
-                throw fail("Error message differs; Expected: " + message + ", Actual: " + errorMessage);
-            }
-        } else {
-            throw fail("Multiple errors");
-        }
-        return this;
-    }
-
-    /**
-     * Returns a list of 3 other lists: the first inner list contains the plain
-     * values received; the second list contains the potential errors
-     * and the final list contains the potential completions as Notifications.
-     *
-     * @return a list of (values, errors, completion-notifications)
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public final List<List<Object>> getEvents() {
-        List<List<Object>> result = new ArrayList<List<Object>>();
-
-        result.add((List)values());
-
-        result.add((List)errors());
-
-        List<Object> completeList = new ArrayList<Object>();
-        for (long i = 0; i < completions; i++) {
-            completeList.add(Notification.createOnComplete());
-        }
-        result.add(completeList);
-
-        return result;
     }
 
     /**
@@ -935,114 +400,6 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Disposabl
             throw ExceptionHelper.wrapOrThrow(ex);
         }
         return this;
-    }
-
-    /**
-     * Assert that the upstream signalled the specified values in order and
-     * completed normally.
-     * @param values the expected values, asserted in order
-     * @return this
-     * @see #assertFailure(Class, Object...)
-     * @see #assertFailure(Predicate, Object...)
-     * @see #assertFailureAndMessage(Class, String, Object...)
-     */
-    public final TestSubscriber<T> assertResult(T... values) {
-        return  assertSubscribed()
-                .assertValues(values)
-                .assertNoErrors()
-                .assertComplete();
-    }
-
-    /**
-     * Assert that the upstream signalled the specified values in order
-     * and then failed with a specific class or subclass of Throwable.
-     * @param error the expected exception (parent) class
-     * @param values the expected values, asserted in order
-     * @return this
-     */
-    public final TestSubscriber<T> assertFailure(Class<? extends Throwable> error, T... values) {
-        return assertSubscribed()
-                .assertValues(values)
-                .assertError(error)
-                .assertNotComplete();
-    }
-
-    /**
-     * Assert that the upstream signalled the specified values in order and then failed
-     * with a Throwable for which the provided predicate returns true.
-     * @param errorPredicate
-     *            the predicate that receives the error Throwable
-     *            and should return true for expected errors.
-     * @param values the expected values, asserted in order
-     * @return this
-     */
-    public final TestSubscriber<T> assertFailure(Predicate<Throwable> errorPredicate, T... values) {
-        return assertSubscribed()
-                .assertValues(values)
-                .assertError(errorPredicate)
-                .assertNotComplete();
-    }
-
-    /**
-     * Assert that the upstream signalled the specified values in order,
-     * then failed with a specific class or subclass of Throwable
-     * and with the given exact error message.
-     * @param error the expected exception (parent) class
-     * @param message the expected failure message
-     * @param values the expected values, asserted in order
-     * @return this
-     */
-    public final TestSubscriber<T> assertFailureAndMessage(Class<? extends Throwable> error,
-            String message, T... values) {
-        return assertSubscribed()
-                .assertValues(values)
-                .assertError(error)
-                .assertErrorMessage(message)
-                .assertNotComplete();
-    }
-
-    /**
-     * Awaits the specified amount of time or until this TestSubscriber
-     * receives an onError or onComplete events, whichever happens first.
-     * @param time the waiting time
-     * @param unit the time unit of the waiting time
-     * @return true if the TestSubscriber terminated, false if timeout happened
-     * @throws InterruptedException if the current thread is interrupted while waiting
-     * @see #awaitTerminalEvent(long, TimeUnit)
-     */
-    public final boolean await(long time, TimeUnit unit) throws InterruptedException {
-        return done.getCount() == 0 || done.await(time, unit);
-    }
-
-    /**
-     * Awaits until the internal latch is counted down for the specified duration.
-     * <p>If the wait times out or gets interrupted, the TestSubscriber is cancelled.
-     * @param time the waiting time
-     * @param unit the time unit of the waiting time
-     * @return this
-     * @throws RuntimeException wrapping an InterruptedException if the wait is interrupted
-     */
-    public final TestSubscriber<T> awaitDone(long time, TimeUnit unit) {
-        try {
-            if (!done.await(time, unit)) {
-                cancel();
-            }
-        } catch (InterruptedException ex) {
-            cancel();
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
-        return this;
-    }
-
-    /**
-     * Assert that the TestSubscriber has received a Subscription but no other events.
-     * @return this
-     */
-    public final TestSubscriber<T> assertEmpty() {
-        return assertSubscribed()
-                .assertNoValues()
-                .assertNoErrors()
-                .assertNotComplete();
     }
 
     /**

--- a/src/perf/java/io/reactivex/CallableAsyncPerf.java
+++ b/src/perf/java/io/reactivex/CallableAsyncPerf.java
@@ -30,53 +30,53 @@ import io.reactivex.schedulers.Schedulers;
 public class CallableAsyncPerf {
 
     Flowable<Integer> subscribeOnFlowable;
-    
+
     Flowable<Integer> observeOnFlowable;
 
     Flowable<Integer> pipelineFlowable;
 
     Observable<Integer> subscribeOnObservable;
-    
+
     Observable<Integer> observeOnObservable;
 
     Observable<Integer> pipelineObservable;
 
     Single<Integer> observeOnSingle;
-    
+
     Single<Integer> subscribeOnSingle;
 
     Single<Integer> pipelineSingle;
 
     Completable observeOnCompletable;
-    
+
     Completable subscribeOnCompletable;
 
     Completable pipelineCompletable;
 
     Maybe<Integer> observeOnMaybe;
-    
+
     Maybe<Integer> subscribeOnMaybe;
-    
+
     Maybe<Integer> pipelineMaybe;
 
     @Setup
     public void setup() {
-        
+
         Scheduler s = Schedulers.single();
-        
+
         Scheduler s2 = new SingleScheduler();
-        
+
         Callable<Integer> c = new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
                 return 1;
             }
         };
-        
+
         subscribeOnFlowable = Flowable.fromCallable(c).subscribeOn(s);
-        
+
         observeOnFlowable = Flowable.fromCallable(c).observeOn(s);
-        
+
         pipelineFlowable = Flowable.fromCallable(c).subscribeOn(s).observeOn(s2);
 
         // ----
@@ -86,11 +86,11 @@ public class CallableAsyncPerf {
         observeOnObservable = Observable.fromCallable(c).observeOn(s);
 
         pipelineObservable = Observable.fromCallable(c).subscribeOn(s).observeOn(s2);
-        
+
         // ----
 
         observeOnSingle = Single.fromCallable(c).observeOn(s);
-        
+
         subscribeOnSingle = Single.fromCallable(c).subscribeOn(s);
 
         pipelineSingle = Single.fromCallable(c).subscribeOn(s).observeOn(s2);
@@ -98,15 +98,15 @@ public class CallableAsyncPerf {
         // ----
 
         observeOnCompletable = Completable.fromCallable(c).observeOn(s);
-        
+
         subscribeOnCompletable = Completable.fromCallable(c).subscribeOn(s);
 
         pipelineCompletable = Completable.fromCallable(c).subscribeOn(s).observeOn(s2);
 
         // ----
-        
+
         observeOnMaybe = Maybe.fromCallable(c).observeOn(s);
-        
+
         subscribeOnMaybe = Maybe.fromCallable(c).subscribeOn(s);
 
         pipelineMaybe = Maybe.fromCallable(c).subscribeOn(s).observeOn(s2);
@@ -116,7 +116,7 @@ public class CallableAsyncPerf {
     public void subscribeOnFlowable(Blackhole bh) {
         subscribeOnFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     }
-    
+
     @Benchmark
     public void observeOnFlowable(Blackhole bh) {
         observeOnFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
@@ -131,7 +131,7 @@ public class CallableAsyncPerf {
     public void subscribeOnObservable(Blackhole bh) {
         subscribeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     };
-    
+
     @Benchmark
     public void observeOnObservable(Blackhole bh) {
         observeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
@@ -146,7 +146,7 @@ public class CallableAsyncPerf {
     public void observeOnSingle(Blackhole bh) {
         observeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     };
-    
+
     @Benchmark
     public void subscribeOnSingle(Blackhole bh) {
         subscribeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
@@ -161,7 +161,7 @@ public class CallableAsyncPerf {
     public void observeOnCompletable(Blackhole bh) {
         observeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     };
-    
+
     @Benchmark
     public void subscribeOnCompletable(Blackhole bh) {
         subscribeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
@@ -176,12 +176,12 @@ public class CallableAsyncPerf {
     public void observeOnMaybe(Blackhole bh) {
         observeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     };
-    
+
     @Benchmark
     public void subscribeOnMaybe(Blackhole bh) {
         subscribeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     };
-    
+
     @Benchmark
     public void pipelineMaybe(Blackhole bh) {
         pipelineMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);

--- a/src/perf/java/io/reactivex/JustAsyncPerf.java
+++ b/src/perf/java/io/reactivex/JustAsyncPerf.java
@@ -30,46 +30,46 @@ import io.reactivex.schedulers.Schedulers;
 public class JustAsyncPerf {
 
     Flowable<Integer> subscribeOnFlowable;
-    
+
     Flowable<Integer> observeOnFlowable;
 
     Flowable<Integer> pipelineFlowable;
 
     Observable<Integer> subscribeOnObservable;
-    
+
     Observable<Integer> observeOnObservable;
 
     Observable<Integer> pipelineObservable;
 
     Single<Integer> observeOnSingle;
-    
+
     Single<Integer> subscribeOnSingle;
 
     Single<Integer> pipelineSingle;
 
     Completable observeOnCompletable;
-    
+
     Completable subscribeOnCompletable;
 
     Completable pipelineCompletable;
 
     Maybe<Integer> observeOnMaybe;
-    
+
     Maybe<Integer> subscribeOnMaybe;
-    
+
     Maybe<Integer> pipelineMaybe;
 
     @Setup
     public void setup() {
-        
+
         Scheduler s = Schedulers.single();
-        
+
         Scheduler s2 = new SingleScheduler();
-        
+
         subscribeOnFlowable = Flowable.just(1).subscribeOn(s);
-        
+
         observeOnFlowable = Flowable.just(1).observeOn(s);
-        
+
         pipelineFlowable = Flowable.just(1).subscribeOn(s).observeOn(s2);
 
         // ----
@@ -79,11 +79,11 @@ public class JustAsyncPerf {
         observeOnObservable = Observable.just(1).observeOn(s);
 
         pipelineObservable = Observable.just(1).subscribeOn(s).observeOn(s2);
-        
+
         // ----
 
         observeOnSingle = Single.just(1).observeOn(s);
-        
+
         subscribeOnSingle = Single.just(1).subscribeOn(s);
 
         pipelineSingle = Single.just(1).subscribeOn(s).observeOn(s2);
@@ -91,15 +91,15 @@ public class JustAsyncPerf {
         // ----
 
         observeOnCompletable = Completable.complete().observeOn(s);
-        
+
         subscribeOnCompletable = Completable.complete().subscribeOn(s);
 
         pipelineCompletable = Completable.complete().subscribeOn(s).observeOn(s2);
 
         // ----
-        
+
         observeOnMaybe = Maybe.just(1).observeOn(s);
-        
+
         subscribeOnMaybe = Maybe.just(1).subscribeOn(s);
 
         pipelineMaybe = Maybe.just(1).subscribeOn(s).observeOn(s2);
@@ -109,7 +109,7 @@ public class JustAsyncPerf {
     public void subscribeOnFlowable(Blackhole bh) {
         subscribeOnFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     }
-    
+
     @Benchmark
     public void observeOnFlowable(Blackhole bh) {
         observeOnFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
@@ -124,7 +124,7 @@ public class JustAsyncPerf {
     public void subscribeOnObservable(Blackhole bh) {
         subscribeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     };
-    
+
     @Benchmark
     public void observeOnObservable(Blackhole bh) {
         observeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
@@ -139,7 +139,7 @@ public class JustAsyncPerf {
     public void observeOnSingle(Blackhole bh) {
         observeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     };
-    
+
     @Benchmark
     public void subscribeOnSingle(Blackhole bh) {
         subscribeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
@@ -154,7 +154,7 @@ public class JustAsyncPerf {
     public void observeOnCompletable(Blackhole bh) {
         observeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     };
-    
+
     @Benchmark
     public void subscribeOnCompletable(Blackhole bh) {
         subscribeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
@@ -169,12 +169,12 @@ public class JustAsyncPerf {
     public void observeOnMaybe(Blackhole bh) {
         observeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     };
-    
+
     @Benchmark
     public void subscribeOnMaybe(Blackhole bh) {
         subscribeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
     };
-    
+
     @Benchmark
     public void pipelineMaybe(Blackhole bh) {
         pipelineMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);

--- a/src/perf/java/io/reactivex/PerfAsyncConsumer.java
+++ b/src/perf/java/io/reactivex/PerfAsyncConsumer.java
@@ -21,18 +21,18 @@ import org.reactivestreams.*;
 import io.reactivex.disposables.Disposable;
 
 /**
- * A multi-type asynchronous consumer. 
+ * A multi-type asynchronous consumer.
  */
 public final class PerfAsyncConsumer extends CountDownLatch implements Subscriber<Object>, Observer<Object>,
 SingleObserver<Object>, CompletableObserver, MaybeObserver<Object> {
 
     final Blackhole bh;
-    
+
     public PerfAsyncConsumer(Blackhole bh) {
         super(1);
         this.bh = bh;
     }
-    
+
     @Override
     public void onSuccess(Object value) {
         bh.consume(value);
@@ -64,14 +64,14 @@ SingleObserver<Object>, CompletableObserver, MaybeObserver<Object> {
         bh.consume(true);
         countDown();
     }
-    
+
     /**
      * Wait for the terminal signal.
      * @param count if less than 1001, a spin-wait is used
      */
     public void await(int count) {
         if (count <= 1000) {
-            while (getCount() != 0) ;
+            while (getCount() != 0) { }
         } else {
             try {
                 await();

--- a/src/test/java/io/reactivex/subscribers/SafeSubscriberWithPluginTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeSubscriberWithPluginTest.java
@@ -231,11 +231,11 @@ public class SafeSubscriberWithPluginTest {
             }
         });
 
-        final AtomicInteger errors = new AtomicInteger();
+        final AtomicInteger errorCount = new AtomicInteger();
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onError(Throwable e) {
-                errors.incrementAndGet();
+                errorCount.incrementAndGet();
             }
         };
         final RuntimeException ex = new RuntimeException();
@@ -272,7 +272,7 @@ public class SafeSubscriberWithPluginTest {
             }
         });
 
-        final AtomicInteger errors = new AtomicInteger();
+        final AtomicInteger errorCount = new AtomicInteger();
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
 
             @Override
@@ -282,7 +282,7 @@ public class SafeSubscriberWithPluginTest {
 
             @Override
             public void onError(Throwable e) {
-                errors.incrementAndGet();
+                errorCount.incrementAndGet();
             }
         };
         SafeSubscriber<Integer> safe = new SafeSubscriber<Integer>(ts);


### PR DESCRIPTION
This PR introduces a new abstract internal class `BaseTestConsumer` which now hosts the `assertX` methods of `TestSubscriber` and `TestObserver` which were duplicates before.
