### PR TITLE
2.x: Make CompositeExcpetion thread-safe like 1.x and also fix some issues

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
@@ -299,9 +299,8 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
         void onError(Throwable e) {
             for (;;) {
                 Throwable curr = error.get();
-                if (curr instanceof CompositeException) {
-                    CompositeException ce = new CompositeException((CompositeException)curr);
-                    ce.suppress(e);
+                if (curr != null) {
+                    CompositeException ce = new CompositeException(curr, e);
                     e = ce;
                 }
                 Throwable next = e;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -486,39 +486,42 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
         }
 
         void reportError(SimpleQueue<Throwable> q) {
-            CompositeException composite = null;
+            List<Throwable> composite = null;
             Throwable ex = null;
 
-            Throwable t;
-            int count = 0;
             for (;;) {
+                Throwable t;
                 try {
                     t = q.poll();
                 } catch (Throwable exc) {
                     Exceptions.throwIfFatal(exc);
-                    if (composite == null) {
-                        composite = new CompositeException(exc);
+                    if (ex == null) {
+                        ex = exc;
+                    } else {
+                        if (composite == null) {
+                            composite = new ArrayList<Throwable>();
+                            composite.add(ex);
+                        }
+                        composite.add(exc);
                     }
-                    composite.suppress(exc);
                     break;
                 }
 
                 if (t == null) {
                     break;
                 }
-                if (count == 0) {
+                if (ex == null) {
                     ex = t;
                 } else {
                     if (composite == null) {
-                        composite = new CompositeException(ex);
+                        composite = new ArrayList<Throwable>();
+                        composite.add(ex);
                     }
-                    composite.suppress(t);
+                    composite.add(t);
                 }
-
-                count++;
             }
             if (composite != null) {
-                actual.onError(composite);
+                actual.onError(new CompositeException(composite));
             } else {
                 actual.onError(ex);
             }

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -130,11 +130,8 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
         ;
 
         AssertionError ae = new AssertionError(b.toString());
-        CompositeException ce = new CompositeException();
-        for (Throwable e : errors) {
-            ce.suppress(e);
-        }
-        if (!ce.isEmpty()) {
+        if (!errors.isEmpty()) {
+            CompositeException ce = new CompositeException(errors);
             ae.initCause(ce);
         }
         return ae;

--- a/src/main/java/io/reactivex/observers/SafeObserver.java
+++ b/src/main/java/io/reactivex/observers/SafeObserver.java
@@ -142,26 +142,22 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
         done = true;
 
         if (s == null) {
-            CompositeException t2 = new CompositeException(t, new NullPointerException("Subscription not set!"));
+            Throwable npe = new NullPointerException("Subscription not set!");
 
             try {
                 actual.onSubscribe(EmptyDisposable.INSTANCE);
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 // can't call onError because the actual's state may be corrupt at this point
-                t2.suppress(e);
-
-                RxJavaPlugins.onError(t2);
+                RxJavaPlugins.onError(new CompositeException(t, npe, e));
                 return;
             }
             try {
-                actual.onError(t2);
+                actual.onError(new CompositeException(t, npe));
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 // if onError failed, all that's left is to report the error to plugins
-                t2.suppress(e);
-
-                RxJavaPlugins.onError(t2);
+                RxJavaPlugins.onError(new CompositeException(t, npe, e));
             }
             return;
         }

--- a/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
@@ -130,26 +130,22 @@ public final class SafeSubscriber<T> implements Subscriber<T>, Subscription {
         done = true;
 
         if (s == null) {
-            CompositeException t2 = new CompositeException(t, new NullPointerException("Subscription not set!"));
+            Throwable npe = new NullPointerException("Subscription not set!");
 
             try {
                 actual.onSubscribe(EmptySubscription.INSTANCE);
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 // can't call onError because the actual's state may be corrupt at this point
-                t2.suppress(e);
-
-                RxJavaPlugins.onError(t2);
+                RxJavaPlugins.onError(new CompositeException(t, npe, e));
                 return;
             }
             try {
-                actual.onError(t2);
+                actual.onError(new CompositeException(t, npe));
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 // if onError failed, all that's left is to report the error to plugins
-                t2.suppress(e);
-
-                RxJavaPlugins.onError(t2);
+                RxJavaPlugins.onError(new CompositeException(t, npe, e));
             }
             return;
         }

--- a/src/test/java/io/reactivex/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/exceptions/CompositeExceptionTest.java
@@ -44,7 +44,7 @@ public class CompositeExceptionTest {
         Throwable e1 = new Throwable("1", rootCause);
         Throwable e2 = new Throwable("2", rootCause);
         Throwable e3 = new Throwable("3", rootCause);
-        CompositeException ce = new CompositeException(Arrays.asList(e1, e2, e3));
+        CompositeException ce = new CompositeException(e1, e2, e3);
 
         System.err.println("----------------------------- print composite stacktrace");
         ce.printStackTrace();
@@ -56,9 +56,25 @@ public class CompositeExceptionTest {
         ce.getCause().printStackTrace();
     }
 
+    @Test
+    public void testEmptyErrors() {
+        try {
+            new CompositeException();
+            fail("CompositeException should fail if errors is empty");
+        } catch(IllegalArgumentException e) {
+            assertEquals("errors is empty", e.getMessage());
+        }
+        try {
+            new CompositeException(new ArrayList<Throwable>());
+            fail("CompositeException should fail if errors is empty");
+        } catch(IllegalArgumentException e) {
+            assertEquals("errors is empty", e.getMessage());
+        }
+    }
+
     @Test(timeout = 1000)
     public void testCompositeExceptionFromParentThenChild() {
-        CompositeException cex = new CompositeException(Arrays.asList(ex1, ex2));
+        CompositeException cex = new CompositeException(ex1, ex2);
 
         System.err.println("----------------------------- print composite stacktrace");
         cex.printStackTrace();
@@ -73,7 +89,7 @@ public class CompositeExceptionTest {
 
     @Test(timeout = 1000)
     public void testCompositeExceptionFromChildThenParent() {
-        CompositeException cex = new CompositeException(Arrays.asList(ex2, ex1));
+        CompositeException cex = new CompositeException(ex2, ex1);
 
         System.err.println("----------------------------- print composite stacktrace");
         cex.printStackTrace();
@@ -88,7 +104,7 @@ public class CompositeExceptionTest {
 
     @Test(timeout = 1000)
     public void testCompositeExceptionFromChildAndComposite() {
-        CompositeException cex = new CompositeException(Arrays.asList(ex1, getNewCompositeExceptionWithEx123()));
+        CompositeException cex = new CompositeException(ex1, getNewCompositeExceptionWithEx123());
 
         System.err.println("----------------------------- print composite stacktrace");
         cex.printStackTrace();
@@ -103,7 +119,7 @@ public class CompositeExceptionTest {
 
     @Test(timeout = 1000)
     public void testCompositeExceptionFromCompositeAndChild() {
-        CompositeException cex = new CompositeException(Arrays.asList(getNewCompositeExceptionWithEx123(), ex1));
+        CompositeException cex = new CompositeException(getNewCompositeExceptionWithEx123(), ex1);
 
         System.err.println("----------------------------- print composite stacktrace");
         cex.printStackTrace();
@@ -184,7 +200,7 @@ public class CompositeExceptionTest {
                 throw new UnsupportedOperationException();
             }
         };
-        CompositeException cex = new CompositeException(Arrays.asList(t, ex1));
+        CompositeException cex = new CompositeException(t, ex1);
 
         System.err.println("----------------------------- print composite stacktrace");
         cex.printStackTrace();
@@ -208,7 +224,7 @@ public class CompositeExceptionTest {
                 return null;
             }
         };
-        CompositeException cex = new CompositeException(Arrays.asList(t, ex1));
+        CompositeException cex = new CompositeException(t, ex1);
 
         System.err.println("----------------------------- print composite stacktrace");
         cex.printStackTrace();
@@ -223,7 +239,7 @@ public class CompositeExceptionTest {
 
     @Test
     public void messageCollection() {
-        CompositeException compositeException = new CompositeException(Arrays.asList(ex1, ex3));
+        CompositeException compositeException = new CompositeException(ex1, ex3);
         assertEquals("2 exceptions occurred. ", compositeException.getMessage());
     }
 
@@ -275,27 +291,6 @@ public class CompositeExceptionTest {
         assertTrue(new CompositeException((Iterable<Throwable>)null).getExceptions().get(0) instanceof NullPointerException);
 
         assertTrue(new CompositeException(null, new TestException()).getExceptions().get(0) instanceof NullPointerException);
-
-        CompositeException ce1 = new CompositeException();
-        ce1.suppress(null);
-
-        assertTrue(ce1.getExceptions().get(0) instanceof NullPointerException);
-    }
-
-    @Test
-    public void isEmpty() {
-        assertTrue(new CompositeException().isEmpty());
-
-        assertFalse(new CompositeException(new TestException()).isEmpty());
-
-        CompositeException ce1 = new CompositeException();
-        ce1.initCause(new TestException());
-
-        assertTrue(ce1.isEmpty());
-
-        ce1.suppress(new TestException());
-
-        assertEquals(1, ce1.size());
     }
 
     @Test
@@ -348,4 +343,17 @@ public class CompositeExceptionTest {
         assertSame(te, new CompositeException(new RuntimeException(te)).getCause().getCause().getCause());
     }
 
+    @Test
+    public void badException() {
+        Throwable e = new BadException();
+        assertSame(e, new CompositeException(e).getCause().getCause());
+        assertSame(e, new CompositeException(new RuntimeException(e)).getCause().getCause().getCause());
+    }
+}
+
+class BadException extends Throwable {
+    @Override
+    public synchronized Throwable getCause() {
+        return this;
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatDelayErrorTest.java
@@ -245,16 +245,11 @@ public class FlowableConcatDelayErrorTest {
         CompositeException ce = (CompositeException)ts.errors().get(0);
         List<Throwable> cex = ce.getExceptions();
 
-        assertEquals(2, cex.size());
-
-        assertTrue(cex.get(0).toString(), cex.get(0) instanceof CompositeException);
-        assertTrue(cex.get(1).toString(), cex.get(1) instanceof TestException);
-
-        ce = (CompositeException)cex.get(0);
-        cex = ce.getExceptions();
+        assertEquals(3, cex.size());
 
         assertTrue(cex.get(0).toString(), cex.get(0) instanceof TestException);
         assertTrue(cex.get(1).toString(), cex.get(1) instanceof TestException);
+        assertTrue(cex.get(2).toString(), cex.get(2) instanceof TestException);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Right now CompositeExcpetion has several issues:
- `CompositeException(Throwable... exceptions)` doesn't deduplicate exceptions and flatten CompositeExceptions like `CompositeException(Iterable<? extends Throwable> errors)`
- If using `CompositeException(Iterable<? extends Throwable> errors)` to create CompositeException, `suppress` cannot be used.
- `suppress` doesn't update `cause`.
- `suppress` doesn't deduplicate exceptions and flatten CompositeExceptions.
- `suppress` and `Throwable.addSuppressed` are pretty confusing for Java 7+ users. Without looking at the implementation, it's hard to figure out the differences.

This PR made the following changes:
- Remove `CompositeException.suppress` so that it's easy to make CompositeException thread-safe.
  - This may cause some performance lost in some path rarely happening, e.g., an excpetion is thrown from `onError`, but that's not a big deal.
  - Since `suppress` is removed, it doesn't make sense to create an empty CompositeException, so `isEmpty` is removed and defense codes are added.
- Defense codes for bad exceptions.
- Deduplicate excepctions and flatten CompositeExceptions for `CompositeException(Throwable... exceptions)`.
