### PR TITLE
1.x: NotificationLite - reduce allocations

### DIFF
--- a/src/main/java/rx/internal/operators/BlockingOperatorMostRecent.java
+++ b/src/main/java/rx/internal/operators/BlockingOperatorMostRecent.java
@@ -62,26 +62,25 @@ public final class BlockingOperatorMostRecent {
     }
 
     static final class MostRecentObserver<T> extends Subscriber<T> {
-        final NotificationLite<T> nl = NotificationLite.instance();
         volatile Object value;
 
         MostRecentObserver(T value) {
-            this.value = nl.next(value);
+            this.value = NotificationLite.next(value);
         }
 
         @Override
         public void onCompleted() {
-            value = nl.completed();
+            value = NotificationLite.completed();
         }
 
         @Override
         public void onError(Throwable e) {
-            value = nl.error(e);
+            value = NotificationLite.error(e);
         }
 
         @Override
         public void onNext(T args) {
-            value = nl.next(args);
+            value = NotificationLite.next(args);
         }
 
         /**
@@ -99,7 +98,7 @@ public final class BlockingOperatorMostRecent {
                 @Override
                 public boolean hasNext() {
                     buf = value;
-                    return !nl.isCompleted(buf);
+                    return !NotificationLite.isCompleted(buf);
                 }
 
                 @Override
@@ -109,13 +108,13 @@ public final class BlockingOperatorMostRecent {
                         if (buf == null) {
                             buf = value;
                         }
-                        if (nl.isCompleted(buf)) {
+                        if (NotificationLite.isCompleted(buf)) {
                             throw new NoSuchElementException();
                         }
-                        if (nl.isError(buf)) {
-                            throw Exceptions.propagate(nl.getError(buf));
+                        if (NotificationLite.isError(buf)) {
+                            throw Exceptions.propagate(NotificationLite.getError(buf));
                         }
-                        return nl.getValue(buf);
+                        return NotificationLite.getValue(buf);
                     }
                     finally {
                         buf = null;

--- a/src/main/java/rx/internal/operators/BufferUntilSubscriber.java
+++ b/src/main/java/rx/internal/operators/BufferUntilSubscriber.java
@@ -71,7 +71,6 @@ public final class BufferUntilSubscriber<T> extends Subject<T, T> {
         boolean emitting;
 
         final ConcurrentLinkedQueue<Object> buffer = new ConcurrentLinkedQueue<Object>();
-        final NotificationLite<T> nl = NotificationLite.instance();
 
         boolean casObserverRef(Observer<? super T>  expected, Observer<? super T>  next) {
             return compareAndSet(expected, next);
@@ -103,11 +102,10 @@ public final class BufferUntilSubscriber<T> extends Subject<T, T> {
                     }
                 }
                 if (win) {
-                    final NotificationLite<T> nl = NotificationLite.instance();
                     while(true) {
                         Object o;
                         while ((o = state.buffer.poll()) != null) {
-                            nl.accept(state.get(), o);
+                            NotificationLite.accept(state.get(), o);
                         }
                         synchronized (state.guard) {
                             if (state.buffer.isEmpty()) {
@@ -145,7 +143,7 @@ public final class BufferUntilSubscriber<T> extends Subject<T, T> {
         if (forward) {
             Object o;
             while ((o = state.buffer.poll()) != null) {
-                state.nl.accept(state.get(), o);
+                NotificationLite.accept(state.get(), o);
             }
             // Because `emit(Object v)` will be called in sequence,
             // no event will be put into `buffer` after we drain it.
@@ -158,7 +156,7 @@ public final class BufferUntilSubscriber<T> extends Subject<T, T> {
             state.get().onCompleted();
         }
         else {
-            emit(state.nl.completed());
+            emit(NotificationLite.completed());
         }
     }
 
@@ -168,7 +166,7 @@ public final class BufferUntilSubscriber<T> extends Subject<T, T> {
             state.get().onError(e);
         }
         else {
-            emit(state.nl.error(e));
+            emit(NotificationLite.error(e));
         }
     }
 
@@ -178,7 +176,7 @@ public final class BufferUntilSubscriber<T> extends Subject<T, T> {
             state.get().onNext(t);
         }
         else {
-            emit(state.nl.next(t));
+            emit(NotificationLite.next(t));
         }
     }
 

--- a/src/main/java/rx/internal/operators/NotificationLite.java
+++ b/src/main/java/rx/internal/operators/NotificationLite.java
@@ -34,22 +34,9 @@ import rx.Observer;
  * @param <T> the element type
  */
 public final class NotificationLite<T> {
-    @SuppressWarnings("rawtypes")
-    private static final NotificationLite INSTANCE = new NotificationLite();
 
     private NotificationLite() {
         // singleton
-    }
-
-    /**
-     * Gets the {@code NotificationLite} singleton.
-     *
-     * @param <T> the value type
-     * @return the sole {@code NotificationLite} object
-     */
-    @SuppressWarnings("unchecked")
-    public static <T> NotificationLite<T> instance() {
-        return INSTANCE;
     }
 
     private static final Object ON_COMPLETED_SENTINEL = new Serializable() {
@@ -92,7 +79,7 @@ public final class NotificationLite<T> {
      *          the item emitted to {@code onNext}
      * @return the item, or a null token representing the item if the item is {@code null}
      */
-    public Object next(T t) {
+    public static <T> Object next(T t) {
         if (t == null) {
             return ON_NEXT_NULL_SENTINEL;
         } else {
@@ -106,7 +93,7 @@ public final class NotificationLite<T> {
      *
      * @return a completion token
      */
-    public Object completed() {
+    public static Object completed() {
         return ON_COMPLETED_SENTINEL;
     }
 
@@ -119,7 +106,7 @@ public final class NotificationLite<T> {
      *           the {@code Throwable} in the {@code onError} notification
      * @return an object encapsulating the exception
      */
-    public Object error(Throwable e) {
+    public static Object error(Throwable e) {
         return new OnErrorSentinel(e);
     }
 
@@ -137,7 +124,7 @@ public final class NotificationLite<T> {
      *             if the {@link Observer} is null.
      */
     @SuppressWarnings("unchecked")
-    public boolean accept(Observer<? super T> o, Object n) {
+    public static <T> boolean accept(Observer<? super T> o, Object n) {
         if (n == ON_COMPLETED_SENTINEL) {
             o.onCompleted();
             return true;
@@ -163,7 +150,7 @@ public final class NotificationLite<T> {
      *            the lite notification
      * @return {@code true} if {@code n} represents an {@code onCompleted} event; {@code false} otherwise
      */
-    public boolean isCompleted(Object n) {
+    public static boolean isCompleted(Object n) {
         return n == ON_COMPLETED_SENTINEL;
     }
 
@@ -174,7 +161,7 @@ public final class NotificationLite<T> {
      *            the lite notification
      * @return {@code true} if {@code n} represents an {@code onError} event; {@code false} otherwise
      */
-    public boolean isError(Object n) {
+    public static boolean isError(Object n) {
         return n instanceof OnErrorSentinel;
     }
 
@@ -183,7 +170,7 @@ public final class NotificationLite<T> {
      * @param n the lite notification
      * @return {@code true} if {@code n} represents a wrapped {@code null} {@code onNext} event, {@code false} otherwise
      */
-    public boolean isNull(Object n) {
+    public static boolean isNull(Object n) {
         return n == ON_NEXT_NULL_SENTINEL;
     }
 
@@ -192,7 +179,7 @@ public final class NotificationLite<T> {
      * @param n the lite notification
      * @return {@code true} if {@code n} represents an {@code onNext} event, {@code false} otherwise
      */
-    public boolean isNext(Object n) {
+    public static boolean isNext(Object n) {
         return n != null && !isError(n) && !isCompleted(n);
     }
     /**
@@ -207,7 +194,7 @@ public final class NotificationLite<T> {
      * @return the {@link Kind} of lite notification {@code n} is: either {@code Kind.OnCompleted},
      *         {@code Kind.OnError}, or {@code Kind.OnNext}
      */
-    public Kind kind(Object n) {
+    public static Kind kind(Object n) {
         if (n == null) {
             throw new IllegalArgumentException("The lite notification can not be null");
         } else if (n == ON_COMPLETED_SENTINEL) {
@@ -230,7 +217,7 @@ public final class NotificationLite<T> {
      * @return the unwrapped value, which can be null
      */
     @SuppressWarnings("unchecked")
-    public T getValue(Object n) {
+    public static <T> T getValue(Object n) {
         return n == ON_NEXT_NULL_SENTINEL ? null : (T) n;
     }
 
@@ -243,7 +230,7 @@ public final class NotificationLite<T> {
      *            the lite notification (of type {@code Kind.OnError})
      * @return the {@link Throwable} wrapped inside {@code n}
      */
-    public Throwable getError(Object n) {
+    public static Throwable getError(Object n) {
         return ((OnErrorSentinel) n).e;
     }
 }

--- a/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCombineLatest.java
@@ -202,7 +202,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
                 if (value == null) {
                     complete = ++completedCount;
                 } else {
-                    latest[index] = combinerSubscriber.nl.getValue(value);
+                    latest[index] = NotificationLite.getValue(value);
                 }
                 allSourcesFinished = activeCount == sourceCount;
                 // see if either all sources completed
@@ -358,14 +358,12 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
     static final class CombinerSubscriber<T, R> extends Subscriber<T> {
         final LatestCoordinator<T, R> parent;
         final int index;
-        final NotificationLite<T> nl;
 
         boolean done;
 
         public CombinerSubscriber(LatestCoordinator<T, R> parent, int index) {
             this.parent = parent;
             this.index = index;
-            this.nl = NotificationLite.instance();
             request(parent.bufferSize);
         }
 
@@ -374,7 +372,7 @@ public final class OnSubscribeCombineLatest<T, R> implements OnSubscribe<R> {
             if (done) {
                 return;
             }
-            parent.combine(nl.next(t), index);
+            parent.combine(NotificationLite.next(t), index);
         }
 
         @Override

--- a/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeConcatMap.java
@@ -137,7 +137,7 @@ public final class OnSubscribeConcatMap<T, R> implements OnSubscribe<R> {
 
         @Override
         public void onNext(T t) {
-            if (!queue.offer(NotificationLite.instance().next(t))) {
+            if (!queue.offer(NotificationLite.next(t))) {
                 unsubscribe();
                 onError(new MissingBackpressureException());
             } else {
@@ -256,7 +256,7 @@ public final class OnSubscribeConcatMap<T, R> implements OnSubscribe<R> {
                         Observable<? extends R> source;
 
                         try {
-                            source = mapper.call(NotificationLite.<T>instance().getValue(v));
+                            source = mapper.call(NotificationLite.<T>getValue(v));
                         } catch (Throwable mapperError) {
                             Exceptions.throwIfFatal(mapperError);
                             drainError(mapperError);

--- a/src/main/java/rx/internal/operators/OnSubscribeFlattenIterable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFlattenIterable.java
@@ -90,8 +90,6 @@ public final class OnSubscribeFlattenIterable<T, R> implements OnSubscribe<R> {
 
         final AtomicInteger wip;
 
-        final NotificationLite<T> nl;
-
         volatile boolean done;
 
         long produced;
@@ -105,7 +103,6 @@ public final class OnSubscribeFlattenIterable<T, R> implements OnSubscribe<R> {
             this.error = new AtomicReference<Throwable>();
             this.wip = new AtomicInteger();
             this.requested = new AtomicLong();
-            this.nl = NotificationLite.instance();
             if (prefetch == Integer.MAX_VALUE) {
                 this.limit = Long.MAX_VALUE;
                 this.queue = new SpscLinkedArrayQueue<Object>(RxRingBuffer.SIZE);
@@ -123,7 +120,7 @@ public final class OnSubscribeFlattenIterable<T, R> implements OnSubscribe<R> {
 
         @Override
         public void onNext(T t) {
-            if (!queue.offer(nl.next(t))) {
+            if (!queue.offer(NotificationLite.next(t))) {
                 unsubscribe();
                 onError(new MissingBackpressureException());
                 return;
@@ -194,7 +191,7 @@ public final class OnSubscribeFlattenIterable<T, R> implements OnSubscribe<R> {
                         boolean b;
 
                         try {
-                            Iterable<? extends R> iterable = mapper.call(nl.getValue(v));
+                            Iterable<? extends R> iterable = mapper.call(NotificationLite.<T>getValue(v));
 
                             it = iterable.iterator();
 

--- a/src/main/java/rx/internal/operators/OnSubscribeFromAsyncEmitter.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromAsyncEmitter.java
@@ -320,20 +320,17 @@ public final class OnSubscribeFromAsyncEmitter<T> implements OnSubscribe<T> {
 
         final AtomicInteger wip;
 
-        final NotificationLite<T> nl;
-
         public BufferAsyncEmitter(Subscriber<? super T> actual, int capacityHint) {
             super(actual);
             this.queue = UnsafeAccess.isUnsafeAvailable()
                     ? new SpscUnboundedArrayQueue<Object>(capacityHint)
                     : new SpscUnboundedAtomicArrayQueue<Object>(capacityHint);
             this.wip = new AtomicInteger();
-            this.nl = NotificationLite.instance();
         }
 
         @Override
         public void onNext(T t) {
-            queue.offer(nl.next(t));
+            queue.offer(NotificationLite.next(t));
             drain();
         }
 
@@ -401,7 +398,7 @@ public final class OnSubscribeFromAsyncEmitter<T> implements OnSubscribe<T> {
                         break;
                     }
 
-                    a.onNext(nl.getValue(o));
+                    a.onNext(NotificationLite.<T>getValue(o));
 
                     e++;
                 }
@@ -451,18 +448,15 @@ public final class OnSubscribeFromAsyncEmitter<T> implements OnSubscribe<T> {
 
         final AtomicInteger wip;
 
-        final NotificationLite<T> nl;
-
         public LatestAsyncEmitter(Subscriber<? super T> actual) {
             super(actual);
             this.queue = new AtomicReference<Object>();
             this.wip = new AtomicInteger();
-            this.nl = NotificationLite.instance();
         }
 
         @Override
         public void onNext(T t) {
-            queue.set(nl.next(t));
+            queue.set(NotificationLite.next(t));
             drain();
         }
 
@@ -530,7 +524,7 @@ public final class OnSubscribeFromAsyncEmitter<T> implements OnSubscribe<T> {
                         break;
                     }
 
-                    a.onNext(nl.getValue(o));
+                    a.onNext(NotificationLite.<T>getValue(o));
 
                     e++;
                 }

--- a/src/main/java/rx/internal/operators/OnSubscribeFromEmitter.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromEmitter.java
@@ -320,20 +320,17 @@ public final class OnSubscribeFromEmitter<T> implements OnSubscribe<T> {
 
         final AtomicInteger wip;
 
-        final NotificationLite<T> nl;
-
         public BufferEmitter(Subscriber<? super T> actual, int capacityHint) {
             super(actual);
             this.queue = UnsafeAccess.isUnsafeAvailable()
                     ? new SpscUnboundedArrayQueue<Object>(capacityHint)
                     : new SpscUnboundedAtomicArrayQueue<Object>(capacityHint);
             this.wip = new AtomicInteger();
-            this.nl = NotificationLite.instance();
         }
 
         @Override
         public void onNext(T t) {
-            queue.offer(nl.next(t));
+            queue.offer(NotificationLite.next(t));
             drain();
         }
 
@@ -401,7 +398,7 @@ public final class OnSubscribeFromEmitter<T> implements OnSubscribe<T> {
                         break;
                     }
 
-                    a.onNext(nl.getValue(o));
+                    a.onNext(NotificationLite.<T>getValue(o));
 
                     e++;
                 }
@@ -451,18 +448,15 @@ public final class OnSubscribeFromEmitter<T> implements OnSubscribe<T> {
 
         final AtomicInteger wip;
 
-        final NotificationLite<T> nl;
-
         public LatestEmitter(Subscriber<? super T> actual) {
             super(actual);
             this.queue = new AtomicReference<Object>();
             this.wip = new AtomicInteger();
-            this.nl = NotificationLite.instance();
         }
 
         @Override
         public void onNext(T t) {
-            queue.set(nl.next(t));
+            queue.set(NotificationLite.next(t));
             drain();
         }
 
@@ -530,7 +524,7 @@ public final class OnSubscribeFromEmitter<T> implements OnSubscribe<T> {
                         break;
                     }
 
-                    a.onNext(nl.getValue(o));
+                    a.onNext(NotificationLite.<T>getValue(o));
 
                     e++;
                 }

--- a/src/main/java/rx/internal/operators/OperatorEagerConcatMap.java
+++ b/src/main/java/rx/internal/operators/OperatorEagerConcatMap.java
@@ -171,7 +171,6 @@ public final class OperatorEagerConcatMap<T, R> implements Operator<R, T> {
 
             final AtomicLong requested = sharedProducer;
             final Subscriber<? super R> actualSubscriber = this.actual;
-            final NotificationLite<R> nl = NotificationLite.instance();
 
             for (;;) {
 
@@ -243,7 +242,7 @@ public final class OperatorEagerConcatMap<T, R> implements Operator<R, T> {
                         innerQueue.poll();
 
                         try {
-                            actualSubscriber.onNext(nl.getValue(v));
+                            actualSubscriber.onNext(NotificationLite.<R>getValue(v));
                         } catch (Throwable ex) {
                             Exceptions.throwOrReport(ex, actualSubscriber, v);
                             return;
@@ -277,7 +276,6 @@ public final class OperatorEagerConcatMap<T, R> implements Operator<R, T> {
     static final class EagerInnerSubscriber<T> extends Subscriber<T> {
         final EagerOuterSubscriber<?, T> parent;
         final Queue<Object> queue;
-        final NotificationLite<T> nl;
 
         volatile boolean done;
         Throwable error;
@@ -292,13 +290,12 @@ public final class OperatorEagerConcatMap<T, R> implements Operator<R, T> {
                 q = new SpscAtomicArrayQueue<Object>(bufferSize);
             }
             this.queue = q;
-            this.nl = NotificationLite.instance();
             request(bufferSize);
         }
 
         @Override
         public void onNext(T t) {
-            queue.offer(nl.next(t));
+            queue.offer(NotificationLite.next(t));
             parent.drain();
         }
 

--- a/src/main/java/rx/internal/operators/OperatorGroupBy.java
+++ b/src/main/java/rx/internal/operators/OperatorGroupBy.java
@@ -493,7 +493,7 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 error = new NullPointerException();
                 done = true;
             } else {
-                queue.offer(NotificationLite.instance().next(t));
+                queue.offer(NotificationLite.next(t));
             }
             drain();
         }
@@ -518,7 +518,6 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
             final Queue<Object> q = queue;
             final boolean delayError = this.delayError;
             Subscriber<? super T> a = actual.get();
-            NotificationLite<T> nl = NotificationLite.instance();
             for (;;) {
                 if (a != null) {
                     if (checkTerminated(done, q.isEmpty(), a, delayError)) {
@@ -541,7 +540,7 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                             break;
                         }
 
-                        a.onNext(nl.getValue(v));
+                        a.onNext(NotificationLite.<T>getValue(v));
 
                         e++;
                     }

--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -159,8 +159,6 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
         /** Due to the emission loop, we need to store errors somewhere if !delayErrors. */
         volatile ConcurrentLinkedQueue<Throwable> errors;
 
-        final NotificationLite<T> nl;
-
         volatile boolean done;
 
         /** Guarded by this. */
@@ -191,7 +189,6 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
             this.child = child;
             this.delayErrors = delayErrors;
             this.maxConcurrent = maxConcurrent;
-            this.nl = NotificationLite.instance();
             this.innerGuard = new Object();
             this.innerSubscribers = EMPTY;
             if (maxConcurrent == Integer.MAX_VALUE) {
@@ -379,7 +376,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                 subscriber.queue = q;
             }
             try {
-                q.onNext(nl.next(value));
+                q.onNext(NotificationLite.next(value));
             } catch (MissingBackpressureException ex) {
                 subscriber.unsubscribe();
                 subscriber.onError(ex);
@@ -501,7 +498,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                 }
                 this.queue = q;
             }
-            if (!q.offer(nl.next(value))) {
+            if (!q.offer(NotificationLite.next(value))) {
                 unsubscribe();
                 onError(OnErrorThrowable.addValueAsLastCause(new MissingBackpressureException(), value));
             }
@@ -606,7 +603,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                                 if (o == null) {
                                     break;
                                 }
-                                T v = nl.getValue(o);
+                                T v = NotificationLite.getValue(o);
                                 // if child throws, report bounce it back immediately
                                 try {
                                     child.onNext(v);
@@ -723,7 +720,7 @@ public final class OperatorMerge<T> implements Operator<T, Observable<? extends 
                                     if (o == null) {
                                         break;
                                     }
-                                    T v = nl.getValue(o);
+                                    T v = NotificationLite.getValue(o);
                                     // if child throws, report bounce it back immediately
                                     try {
                                         child.onNext(v);

--- a/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
+++ b/src/main/java/rx/internal/operators/OperatorOnBackpressureBuffer.java
@@ -111,7 +111,6 @@ public class OperatorOnBackpressureBuffer<T> implements Operator<T, T> {
         private final Subscriber<? super T> child;
         private final AtomicBoolean saturated = new AtomicBoolean(false);
         private final BackpressureDrainManager manager;
-        private final NotificationLite<T> on = NotificationLite.instance();
         private final Action0 onOverflow;
         private final Strategy overflowStrategy;
 
@@ -148,13 +147,13 @@ public class OperatorOnBackpressureBuffer<T> implements Operator<T, T> {
             if (!assertCapacity()) {
                 return;
             }
-            queue.offer(on.next(t));
+            queue.offer(NotificationLite.next(t));
             manager.drain();
         }
 
         @Override
         public boolean accept(Object value) {
-            return on.accept(child, value);
+            return NotificationLite.accept(child, value);
         }
         @Override
         public void complete(Throwable exception) {

--- a/src/main/java/rx/internal/operators/OperatorScan.java
+++ b/src/main/java/rx/internal/operators/OperatorScan.java
@@ -192,13 +192,13 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
                 q = new SpscLinkedAtomicQueue<Object>();  // new SpscUnboundedAtomicArrayQueue<R>(8);
             }
             this.queue = q;
-            q.offer(NotificationLite.instance().next(initialValue));
+            q.offer(NotificationLite.next(initialValue));
             this.requested = new AtomicLong();
         }
 
         @Override
         public void onNext(R t) {
-            queue.offer(NotificationLite.instance().next(t));
+            queue.offer(NotificationLite.next(t));
             emit();
         }
 
@@ -298,7 +298,6 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
         void emitLoop() {
             final Subscriber<? super R> child = this.child;
             final Queue<Object> queue = this.queue;
-            final NotificationLite<R> nl = NotificationLite.instance();
             AtomicLong requested = this.requested;
 
             long r = requested.get();
@@ -319,7 +318,7 @@ public final class OperatorScan<R, T> implements Operator<R, T> {
                     if (empty) {
                         break;
                     }
-                    R v = nl.getValue(o);
+                    R v = NotificationLite.getValue(o);
                     try {
                         child.onNext(v);
                     } catch (Throwable ex) {

--- a/src/main/java/rx/internal/operators/OperatorSkipLast.java
+++ b/src/main/java/rx/internal/operators/OperatorSkipLast.java
@@ -39,8 +39,6 @@ public class OperatorSkipLast<T> implements Operator<T, T> {
     public Subscriber<? super T> call(final Subscriber<? super T> subscriber) {
         return new Subscriber<T>(subscriber) {
 
-            private final NotificationLite<T> on = NotificationLite.instance();
-
             /**
              * Store the last count elements until now.
              */
@@ -66,11 +64,11 @@ public class OperatorSkipLast<T> implements Operator<T, T> {
                     return;
                 }
                 if (deque.size() == count) {
-                    subscriber.onNext(on.getValue(deque.removeFirst()));
+                    subscriber.onNext(NotificationLite.<T>getValue(deque.removeFirst()));
                 } else {
                     request(1);
                 }
-                deque.offerLast(on.next(value));
+                deque.offerLast(NotificationLite.next(value));
             }
 
         };

--- a/src/main/java/rx/internal/operators/OperatorSwitch.java
+++ b/src/main/java/rx/internal/operators/OperatorSwitch.java
@@ -80,7 +80,6 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
         final boolean delayError;
         final AtomicLong index;
         final SpscLinkedArrayQueue<Object> queue;
-        final NotificationLite<T> nl;
 
         boolean emitting;
 
@@ -104,7 +103,6 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
             this.delayError = delayError;
             this.index = new AtomicLong();
             this.queue = new SpscLinkedArrayQueue<Object>(RxRingBuffer.SIZE);
-            this.nl = NotificationLite.instance();
         }
 
         void init() {
@@ -202,7 +200,7 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
                     return;
                 }
 
-                queue.offer(inner, nl.next(value));
+                queue.offer(inner, NotificationLite.next(value));
             }
             drain();
         }
@@ -310,7 +308,7 @@ public final class OperatorSwitch<T> implements Operator<T, Observable<? extends
 
                     @SuppressWarnings("unchecked")
                     InnerSubscriber<T> inner = (InnerSubscriber<T>)localQueue.poll();
-                    T value = nl.getValue(localQueue.poll());
+                    T value = NotificationLite.getValue(localQueue.poll());
 
                     if (localIndex.get() == inner.id) {
                         localChild.onNext(value);

--- a/src/main/java/rx/internal/operators/OperatorTakeLast.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeLast.java
@@ -60,14 +60,12 @@ public final class OperatorTakeLast<T> implements Operator<T, T> {
         final AtomicLong requested;
         final ArrayDeque<Object> queue;
         final int count;
-        final NotificationLite<T> nl;
 
         public TakeLastSubscriber(Subscriber<? super T> actual, int count) {
             this.actual = actual;
             this.count = count;
             this.requested = new AtomicLong();
             this.queue = new ArrayDeque<Object>();
-            this.nl = NotificationLite.instance();
         }
 
         @Override
@@ -75,7 +73,7 @@ public final class OperatorTakeLast<T> implements Operator<T, T> {
             if (queue.size() == count) {
                 queue.poll();
             }
-            queue.offer(nl.next(t));
+            queue.offer(NotificationLite.next(t));
         }
 
         @Override
@@ -91,7 +89,7 @@ public final class OperatorTakeLast<T> implements Operator<T, T> {
 
         @Override
         public T call(Object t) {
-            return nl.getValue(t);
+            return NotificationLite.getValue(t);
         }
 
         void requestMore(long n) {

--- a/src/main/java/rx/internal/operators/OperatorTakeLastTimed.java
+++ b/src/main/java/rx/internal/operators/OperatorTakeLastTimed.java
@@ -74,7 +74,6 @@ public final class OperatorTakeLastTimed<T> implements Operator<T, T> {
         final AtomicLong requested;
         final ArrayDeque<Object> queue;
         final ArrayDeque<Long> queueTimes;
-        final NotificationLite<T> nl;
 
         public TakeLastTimedSubscriber(Subscriber<? super T> actual, int count, long ageMillis, Scheduler scheduler) {
             this.actual = actual;
@@ -84,7 +83,6 @@ public final class OperatorTakeLastTimed<T> implements Operator<T, T> {
             this.requested = new AtomicLong();
             this.queue = new ArrayDeque<Object>();
             this.queueTimes = new ArrayDeque<Long>();
-            this.nl = NotificationLite.instance();
         }
 
         @Override
@@ -99,7 +97,7 @@ public final class OperatorTakeLastTimed<T> implements Operator<T, T> {
 
                 evictOld(now);
 
-                queue.offer(nl.next(t));
+                queue.offer(NotificationLite.next(t));
                 queueTimes.offer(now);
             }
         }
@@ -134,7 +132,7 @@ public final class OperatorTakeLastTimed<T> implements Operator<T, T> {
 
         @Override
         public T call(Object t) {
-            return nl.getValue(t);
+            return NotificationLite.getValue(t);
         }
 
         void requestMore(long n) {

--- a/src/main/java/rx/internal/operators/OperatorWindowWithObservable.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithObservable.java
@@ -35,8 +35,6 @@ public final class OperatorWindowWithObservable<T, U> implements Operator<Observ
     final Observable<U> other;
     /** Indicate the current subject should complete and a new subject be emitted. */
     static final Object NEXT_SUBJECT = new Object();
-    /** For error and completion indication. */
-    static final NotificationLite<Object> NL = NotificationLite.instance();
 
     public OperatorWindowWithObservable(final Observable<U> other) {
         this.other = other;
@@ -132,11 +130,11 @@ public final class OperatorWindowWithObservable<T, U> implements Operator<Observ
                 if (o == NEXT_SUBJECT) {
                     replaceSubject();
                 } else
-                if (NL.isError(o)) {
-                    error(NL.getError(o));
+                if (NotificationLite.isError(o)) {
+                    error(NotificationLite.getError(o));
                     break;
                 } else
-                if (NL.isCompleted(o)) {
+                if (NotificationLite.isCompleted(o)) {
                     complete();
                     break;
                 } else {
@@ -170,7 +168,7 @@ public final class OperatorWindowWithObservable<T, U> implements Operator<Observ
         public void onError(Throwable e) {
             synchronized (guard) {
                 if (emitting) {
-                    queue = Collections.singletonList(NL.error(e));
+                    queue = Collections.singletonList(NotificationLite.error(e));
                     return;
                 }
                 queue = null;
@@ -187,7 +185,7 @@ public final class OperatorWindowWithObservable<T, U> implements Operator<Observ
                     if (queue == null) {
                         queue = new ArrayList<Object>();
                     }
-                    queue.add(NL.completed());
+                    queue.add(NotificationLite.completed());
                     return;
                 }
                 localQueue = queue;

--- a/src/main/java/rx/internal/operators/OperatorWindowWithObservableFactory.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithObservableFactory.java
@@ -38,8 +38,6 @@ public final class OperatorWindowWithObservableFactory<T, U> implements Operator
 
     /** Indicate the current subject should complete and a new subject be emitted. */
     static final Object NEXT_SUBJECT = new Object();
-    /** For error and completion indication. */
-    static final NotificationLite<Object> NL = NotificationLite.instance();
 
     public OperatorWindowWithObservableFactory(Func0<? extends Observable<? extends U>> otherFactory) {
         this.otherFactory = otherFactory;
@@ -139,11 +137,11 @@ public final class OperatorWindowWithObservableFactory<T, U> implements Operator
                 if (o == NEXT_SUBJECT) {
                     replaceSubject();
                 } else
-                if (NL.isError(o)) {
-                    error(NL.getError(o));
+                if (NotificationLite.isError(o)) {
+                    error(NotificationLite.getError(o));
                     break;
                 } else
-                if (NL.isCompleted(o)) {
+                if (NotificationLite.isCompleted(o)) {
                     complete();
                     break;
                 } else {
@@ -189,7 +187,7 @@ public final class OperatorWindowWithObservableFactory<T, U> implements Operator
         public void onError(Throwable e) {
             synchronized (guard) {
                 if (emitting) {
-                    queue = Collections.singletonList(NL.error(e));
+                    queue = Collections.singletonList(NotificationLite.error(e));
                     return;
                 }
                 queue = null;
@@ -206,7 +204,7 @@ public final class OperatorWindowWithObservableFactory<T, U> implements Operator
                     if (queue == null) {
                         queue = new ArrayList<Object>();
                     }
-                    queue.add(NL.completed());
+                    queue.add(NotificationLite.completed());
                     return;
                 }
                 localQueue = queue;

--- a/src/main/java/rx/internal/operators/OperatorWindowWithTime.java
+++ b/src/main/java/rx/internal/operators/OperatorWindowWithTime.java
@@ -48,8 +48,6 @@ public final class OperatorWindowWithTime<T> implements Operator<Observable<T>, 
     final int size;
     /** Indicate the current subject should complete and a new subject be emitted. */
     static final Object NEXT_SUBJECT = new Object();
-    /** For error and completion indication. */
-    static final NotificationLite<Object> NL = NotificationLite.instance();
 
 
     public OperatorWindowWithTime(long timespan, long timeshift, TimeUnit unit, int size, Scheduler scheduler) {
@@ -187,11 +185,11 @@ public final class OperatorWindowWithTime<T> implements Operator<Observable<T>, 
                         return false;
                     }
                 } else
-                if (NL.isError(o)) {
-                    error(NL.getError(o));
+                if (NotificationLite.isError(o)) {
+                    error(NotificationLite.getError(o));
                     break;
                 } else
-                if (NL.isCompleted(o)) {
+                if (NotificationLite.isCompleted(o)) {
                     complete();
                     break;
                 } else {
@@ -244,7 +242,7 @@ public final class OperatorWindowWithTime<T> implements Operator<Observable<T>, 
             synchronized (guard) {
                 if (emitting) {
                     // drop any queued action and terminate asap
-                    queue = Collections.<Object>singletonList(NL.error(e));
+                    queue = Collections.<Object>singletonList(NotificationLite.error(e));
                     return;
                 }
                 queue = null;
@@ -278,7 +276,7 @@ public final class OperatorWindowWithTime<T> implements Operator<Observable<T>, 
                     if (queue == null) {
                         queue = new ArrayList<Object>();
                     }
-                    queue.add(NL.completed());
+                    queue.add(NotificationLite.completed());
                     return;
                 }
                 localQueue = queue;

--- a/src/main/java/rx/internal/util/RxRingBuffer.java
+++ b/src/main/java/rx/internal/util/RxRingBuffer.java
@@ -125,8 +125,6 @@ public class RxRingBuffer implements Subscription {
      * } </pre>
      */
 
-    private static final NotificationLite<Object> ON = NotificationLite.instance();
-
     private Queue<Object> queue;
 
     private final int size;
@@ -342,7 +340,7 @@ public class RxRingBuffer implements Subscription {
         synchronized (this) {
             Queue<Object> q = queue;
             if (q != null) {
-                mbe = !q.offer(ON.next(o));
+                mbe = !q.offer(NotificationLite.next(o));
             } else {
                 iae = true;
             }
@@ -359,14 +357,14 @@ public class RxRingBuffer implements Subscription {
     public void onCompleted() {
         // we ignore terminal events if we already have one
         if (terminalState == null) {
-            terminalState = ON.completed();
+            terminalState = NotificationLite.completed();
         }
     }
 
     public void onError(Throwable t) {
         // we ignore terminal events if we already have one
         if (terminalState == null) {
-            terminalState = ON.error(t);
+            terminalState = NotificationLite.error(t);
         }
     }
 
@@ -429,24 +427,24 @@ public class RxRingBuffer implements Subscription {
     }
 
     public boolean isCompleted(Object o) {
-        return ON.isCompleted(o);
+        return NotificationLite.isCompleted(o);
     }
 
     public boolean isError(Object o) {
-        return ON.isError(o);
+        return NotificationLite.isError(o);
     }
 
     public Object getValue(Object o) {
-        return ON.getValue(o);
+        return NotificationLite.getValue(o);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public boolean accept(Object o, Observer child) {
-        return ON.accept(child, o);
+        return NotificationLite.accept(child, o);
     }
 
     public Throwable asError(Object o) {
-        return ON.getError(o);
+        return NotificationLite.getError(o);
     }
 
     @Override

--- a/src/main/java/rx/observables/BlockingObservable.java
+++ b/src/main/java/rx/observables/BlockingObservable.java
@@ -507,22 +507,21 @@ public final class BlockingObservable<T> {
      */
     @Beta
     public void subscribe(Observer<? super T> observer) {
-        final NotificationLite<T> nl = NotificationLite.instance();
         final BlockingQueue<Object> queue = new LinkedBlockingQueue<Object>();
 
         @SuppressWarnings("unchecked")
         Subscription s = ((Observable<T>)o).subscribe(new Subscriber<T>() {
             @Override
             public void onNext(T t) {
-                queue.offer(nl.next(t));
+                queue.offer(NotificationLite.next(t));
             }
             @Override
             public void onError(Throwable e) {
-                queue.offer(nl.error(e));
+                queue.offer(NotificationLite.error(e));
             }
             @Override
             public void onCompleted() {
-                queue.offer(nl.completed());
+                queue.offer(NotificationLite.completed());
             }
         });
 
@@ -532,7 +531,7 @@ public final class BlockingObservable<T> {
                 if (o == null) {
                     o = queue.take();
                 }
-                if (nl.accept(observer, o)) {
+                if (NotificationLite.accept(observer, o)) {
                     return;
                 }
             }
@@ -554,22 +553,21 @@ public final class BlockingObservable<T> {
     @SuppressWarnings("unchecked")
     @Beta
     public void subscribe(Subscriber<? super T> subscriber) {
-        final NotificationLite<T> nl = NotificationLite.instance();
         final BlockingQueue<Object> queue = new LinkedBlockingQueue<Object>();
         final Producer[] theProducer = { null };
 
         Subscriber<T> s = new Subscriber<T>() {
             @Override
             public void onNext(T t) {
-                queue.offer(nl.next(t));
+                queue.offer(NotificationLite.next(t));
             }
             @Override
             public void onError(Throwable e) {
-                queue.offer(nl.error(e));
+                queue.offer(NotificationLite.error(e));
             }
             @Override
             public void onCompleted() {
-                queue.offer(nl.completed());
+                queue.offer(NotificationLite.completed());
             }
 
             @Override
@@ -612,7 +610,7 @@ public final class BlockingObservable<T> {
                 if (o == SET_PRODUCER) {
                     subscriber.setProducer(theProducer[0]);
                 } else
-                if (nl.accept(subscriber, o)) {
+                if (NotificationLite.accept(subscriber, o)) {
                     return;
                 }
             }

--- a/src/main/java/rx/observers/SerializedObserver.java
+++ b/src/main/java/rx/observers/SerializedObserver.java
@@ -41,7 +41,6 @@ public class SerializedObserver<T> implements Observer<T> {
     private volatile boolean terminated;
     /** If not null, it indicates more work. */
     private FastList queue;
-    private final NotificationLite<T> nl = NotificationLite.instance();
 
     static final class FastList {
         Object[] array;
@@ -83,7 +82,7 @@ public class SerializedObserver<T> implements Observer<T> {
                     list = new FastList();
                     queue = list;
                 }
-                list.add(nl.next(t));
+                list.add(NotificationLite.next(t));
                 return;
             }
             emitting = true;
@@ -110,7 +109,7 @@ public class SerializedObserver<T> implements Observer<T> {
                     break;
                 }
                 try {
-                    if (nl.accept(actual, o)) {
+                    if (NotificationLite.accept(actual, o)) {
                         terminated = true;
                         return;
                     }
@@ -145,7 +144,7 @@ public class SerializedObserver<T> implements Observer<T> {
                     list = new FastList();
                     queue = list;
                 }
-                list.add(nl.error(e));
+                list.add(NotificationLite.error(e));
                 return;
             }
             emitting = true;
@@ -169,7 +168,7 @@ public class SerializedObserver<T> implements Observer<T> {
                     list = new FastList();
                     queue = list;
                 }
-                list.add(nl.completed());
+                list.add(NotificationLite.completed());
                 return;
             }
             emitting = true;

--- a/src/main/java/rx/subjects/BehaviorSubject.java
+++ b/src/main/java/rx/subjects/BehaviorSubject.java
@@ -72,7 +72,6 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
     /** An empty array to trigger getValues() to return a new array. */
     private static final Object[] EMPTY_ARRAY = new Object[0];
     private final SubjectSubscriptionManager<T> state;
-    private final NotificationLite<T> nl = NotificationLite.instance();
 
     /**
      * Creates a {@link BehaviorSubject} without a default item.
@@ -101,13 +100,13 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
     private static <T> BehaviorSubject<T> create(T defaultValue, boolean hasDefault) {
         final SubjectSubscriptionManager<T> state = new SubjectSubscriptionManager<T>();
         if (hasDefault) {
-            state.setLatest(NotificationLite.instance().next(defaultValue));
+            state.setLatest(NotificationLite.next(defaultValue));
         }
         state.onAdded = new Action1<SubjectObserver<T>>() {
 
             @Override
             public void call(SubjectObserver<T> o) {
-                o.emitFirst(state.getLatest(), state.nl);
+                o.emitFirst(state.getLatest());
             }
 
         };
@@ -124,9 +123,9 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
     public void onCompleted() {
         Object last = state.getLatest();
         if (last == null || state.active) {
-            Object n = nl.completed();
+            Object n = NotificationLite.completed();
             for (SubjectObserver<T> bo : state.terminate(n)) {
-                bo.emitNext(n, state.nl);
+                bo.emitNext(n);
             }
         }
     }
@@ -135,11 +134,11 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
     public void onError(Throwable e) {
         Object last = state.getLatest();
         if (last == null || state.active) {
-            Object n = nl.error(e);
+            Object n = NotificationLite.error(e);
             List<Throwable> errors = null;
             for (SubjectObserver<T> bo : state.terminate(n)) {
                 try {
-                    bo.emitNext(n, state.nl);
+                    bo.emitNext(n);
                 } catch (Throwable e2) {
                     if (errors == null) {
                         errors = new ArrayList<Throwable>();
@@ -156,9 +155,9 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
     public void onNext(T v) {
         Object last = state.getLatest();
         if (last == null || state.active) {
-            Object n = nl.next(v);
+            Object n = NotificationLite.next(v);
             for (SubjectObserver<T> bo : state.next(n)) {
-                bo.emitNext(n, state.nl);
+                bo.emitNext(n);
             }
         }
     }
@@ -181,7 +180,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      */
     public boolean hasValue() {
         Object o = state.getLatest();
-        return nl.isNext(o);
+        return NotificationLite.isNext(o);
     }
     /**
      * Check if the Subject has terminated with an exception.
@@ -190,7 +189,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      */
     public boolean hasThrowable() {
         Object o = state.getLatest();
-        return nl.isError(o);
+        return NotificationLite.isError(o);
     }
     /**
      * Check if the Subject has terminated normally.
@@ -199,7 +198,7 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      */
     public boolean hasCompleted() {
         Object o = state.getLatest();
-        return nl.isCompleted(o);
+        return NotificationLite.isCompleted(o);
     }
     /**
      * Returns the current value of the Subject if there is such a value and
@@ -213,8 +212,8 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      */
     public T getValue() {
         Object o = state.getLatest();
-        if (nl.isNext(o)) {
-            return nl.getValue(o);
+        if (NotificationLite.isNext(o)) {
+            return NotificationLite.getValue(o);
         }
         return null;
     }
@@ -226,8 +225,8 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
      */
     public Throwable getThrowable() {
         Object o = state.getLatest();
-        if (nl.isError(o)) {
-            return nl.getError(o);
+        if (NotificationLite.isError(o)) {
+            return NotificationLite.getError(o);
         }
         return null;
     }
@@ -241,11 +240,11 @@ public final class BehaviorSubject<T> extends Subject<T, T> {
     @SuppressWarnings("unchecked")
     public T[] getValues(T[] a) {
         Object o = state.getLatest();
-        if (nl.isNext(o)) {
+        if (NotificationLite.isNext(o)) {
             if (a.length == 0) {
                 a = (T[])Array.newInstance(a.getClass().getComponentType(), 1);
             }
-            a[0] = nl.getValue(o);
+            a[0] = NotificationLite.getValue(o);
             if (a.length > 1) {
                 a[1] = null;
             }

--- a/src/main/java/rx/subjects/SubjectSubscriptionManager.java
+++ b/src/main/java/rx/subjects/SubjectSubscriptionManager.java
@@ -46,8 +46,6 @@ import rx.subscriptions.Subscriptions;
     Action1<SubjectObserver<T>> onAdded = Actions.empty();
     /** Action called when the subscriber wants to subscribe to a terminal state. */
     Action1<SubjectObserver<T>> onTerminated = Actions.empty();
-    /** The notification lite. */
-    public final NotificationLite<T> nl = NotificationLite.instance();
 
     public SubjectSubscriptionManager() {
         super(State.EMPTY);
@@ -238,7 +236,7 @@ import rx.subscriptions.Subscriptions;
          * @param n the NotificationLite value
          * @param nl the type-appropriate notification lite object
          */
-        void emitNext(Object n, final NotificationLite<T> nl) {
+        void emitNext(Object n) {
             if (!fastPath) {
                 synchronized (this) {
                     first = false;
@@ -252,15 +250,14 @@ import rx.subscriptions.Subscriptions;
                 }
                 fastPath = true;
             }
-            nl.accept(actual, n);
+            NotificationLite.accept(actual, n);
         }
         /**
          * Tries to emit a NotificationLite value as the first
          * value and drains the queue as long as possible.
-         * @param n the NotificationLite value
          * @param nl the type-appropriate notification lite object
          */
-        void emitFirst(Object n, final NotificationLite<T> nl) {
+        void emitFirst(Object n) {
             synchronized (this) {
                 if (!first || emitting) {
                     return;
@@ -269,7 +266,7 @@ import rx.subscriptions.Subscriptions;
                 emitting = n != null;
             }
             if (n != null) {
-                emitLoop(null, n, nl);
+                emitLoop(null, n);
             }
         }
         /**
@@ -278,19 +275,19 @@ import rx.subscriptions.Subscriptions;
          * @param current the current content to emit
          * @param nl the type-appropriate notification lite object
          */
-        void emitLoop(List<Object> localQueue, Object current, final NotificationLite<T> nl) {
+        void emitLoop(List<Object> localQueue, Object current) {
             boolean once = true;
             boolean skipFinal = false;
             try {
                 do {
                     if (localQueue != null) {
                         for (Object n : localQueue) {
-                            accept(n, nl);
+                            accept(n);
                         }
                     }
                     if (once) {
                         once = false;
-                        accept(current, nl);
+                        accept(current);
                     }
                     synchronized (this) {
                         localQueue = queue;
@@ -315,9 +312,9 @@ import rx.subscriptions.Subscriptions;
          * @param n the value to dispatch
          * @param nl the type-appropriate notification lite object
          */
-        void accept(Object n, final NotificationLite<T> nl) {
+        void accept(Object n) {
             if (n != null) {
-                nl.accept(actual, n);
+                NotificationLite.accept(actual, n);
             }
         }
 

--- a/src/main/java/rx/subjects/TestSubject.java
+++ b/src/main/java/rx/subjects/TestSubject.java
@@ -52,7 +52,7 @@ public final class TestSubject<T> extends Subject<T, T> {
 
             @Override
             public void call(SubjectObserver<T> o) {
-                o.emitFirst(state.getLatest(), state.nl);
+                o.emitFirst(state.getLatest());
             }
 
         };
@@ -77,7 +77,7 @@ public final class TestSubject<T> extends Subject<T, T> {
 
     void internalOnCompleted() {
         if (state.active) {
-            for (SubjectObserver<T> bo : state.terminate(NotificationLite.instance().completed())) {
+            for (SubjectObserver<T> bo : state.terminate(NotificationLite.completed())) {
                 bo.onCompleted();
             }
         }
@@ -110,7 +110,7 @@ public final class TestSubject<T> extends Subject<T, T> {
 
     void internalOnError(final Throwable e) {
         if (state.active) {
-            for (SubjectObserver<T> bo : state.terminate(NotificationLite.instance().error(e))) {
+            for (SubjectObserver<T> bo : state.terminate(NotificationLite.error(e))) {
                 bo.onError(e);
             }
         }

--- a/src/main/java/rx/subjects/UnicastSubject.java
+++ b/src/main/java/rx/subjects/UnicastSubject.java
@@ -119,8 +119,6 @@ public final class UnicastSubject<T> extends Subject<T, T> {
         final AtomicReference<Subscriber<? super T>> subscriber;
         /** The queue holding values until the subscriber arrives and catches up. */
         final Queue<Object> queue;
-        /** JCTools queues don't accept nulls. */
-        final NotificationLite<T> nl;
         /** Atomically set to true on terminal condition. */
         final AtomicReference<Action0> terminateOnce;
         /** In case the source emitted an error. */
@@ -141,7 +139,6 @@ public final class UnicastSubject<T> extends Subject<T, T> {
          * the single subscriber unsubscribes.
          */
         public State(int capacityHint, Action0 onTerminated) {
-            this.nl = NotificationLite.instance();
             this.subscriber = new AtomicReference<Subscriber<? super T>>();
             this.terminateOnce = onTerminated != null ? new AtomicReference<Action0>(onTerminated) : null;
 
@@ -171,7 +168,7 @@ public final class UnicastSubject<T> extends Subject<T, T> {
                      */
                     synchronized (this) {
                         if (!caughtUp) {
-                            queue.offer(nl.next(t));
+                            queue.offer(NotificationLite.next(t));
                             stillReplay = true;
                         }
                     }
@@ -293,7 +290,7 @@ public final class UnicastSubject<T> extends Subject<T, T> {
                         if (empty) {
                             break;
                         }
-                        T value = nl.getValue(v);
+                        T value = NotificationLite.getValue(v);
                         try {
                             s.onNext(value);
                         } catch (Throwable ex) {

--- a/src/test/java/rx/internal/operators/NotificationLiteTest.java
+++ b/src/test/java/rx/internal/operators/NotificationLiteTest.java
@@ -26,30 +26,28 @@ public class NotificationLiteTest {
 
     @Test
     public void testComplete() {
-        NotificationLite<Object> on = NotificationLite.instance();
-        Object n = on.next("Hello");
-        Object c = on.completed();
+        Object n = NotificationLite.next("Hello");
+        Object c = NotificationLite.completed();
 
-        assertTrue(on.isCompleted(c));
-        assertFalse(on.isCompleted(n));
+        assertTrue(NotificationLite.isCompleted(c));
+        assertFalse(NotificationLite.isCompleted(n));
 
-        assertEquals("Hello", on.getValue(n));
+        assertEquals("Hello", NotificationLite.getValue(n));
     }
 
     @Test
     public void testValueKind() {
-        NotificationLite<Object> on = NotificationLite.instance();
 
-        assertTrue(on.isNull(on.next(null)));
-        assertFalse(on.isNull(on.next(1)));
-        assertFalse(on.isNull(on.error(new TestException())));
-        assertFalse(on.isNull(on.completed()));
-        assertFalse(on.isNull(null));
+        assertTrue(NotificationLite.isNull(NotificationLite.next(null)));
+        assertFalse(NotificationLite.isNull(NotificationLite.next(1)));
+        assertFalse(NotificationLite.isNull(NotificationLite.error(new TestException())));
+        assertFalse(NotificationLite.isNull(NotificationLite.completed()));
+        assertFalse(NotificationLite.isNull(null));
 
-        assertTrue(on.isNext(on.next(null)));
-        assertTrue(on.isNext(on.next(1)));
-        assertFalse(on.isNext(on.completed()));
-        assertFalse(on.isNext(null));
-        assertFalse(on.isNext(on.error(new TestException())));
+        assertTrue(NotificationLite.isNext(NotificationLite.next(null)));
+        assertTrue(NotificationLite.isNext(NotificationLite.next(1)));
+        assertFalse(NotificationLite.isNext(NotificationLite.completed()));
+        assertFalse(NotificationLite.isNext(null));
+        assertFalse(NotificationLite.isNext(NotificationLite.error(new TestException())));
     }
 }


### PR DESCRIPTION
A lot of commonly used operators allocated an instance of `NotificationLite` as a field in a subscriber but for no great type-safety benefit. I've cut these fields by converting all instance methods of `NotificationLite` to static methods and removing the `NotificationLite.instance()` method.

The changes are trivial till you get to the `Subjects` that would pass instances of `NotificationLite` in methods of the `SubjectSubscriptionManager`. Still simple changes but reviewing these is a good idea.

RxJava2 goes a bit further in the internals of `NotificationLite`. I'd like to leave changes to the internals beyond making methods static for another PR if appropriate.
