### PR TITLE
2.x: Replace 'resource' observers with plain 'disposable' observers in tests.

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -221,7 +221,7 @@ public class FlowableIgnoreElementsTest {
                 //
                 .ignoreElements()
                 //
-                .subscribe(new ResourceCompletableObserver() {
+                .subscribe(new DisposableCompletableObserver() {
                     @Override
                     public void onComplete() {
                     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -763,7 +763,7 @@ public class ObservableBufferTest {
         final Observer<Object> o = TestHelper.mockObserver();
 
         final CountDownLatch cdl = new CountDownLatch(1);
-        ResourceObserver<Object> s = new ResourceObserver<Object>() {
+        DisposableObserver<Object> s = new DisposableObserver<Object>() {
             @Override
             public void onNext(Object t) {
                 o.onNext(t);

--- a/src/test/java/io/reactivex/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SerializedObserverTest.java
@@ -375,7 +375,7 @@ public class SerializedObserverTest {
         AtomicInteger p2 = new AtomicInteger();
 
         o.onSubscribe(Disposables.empty());
-        ResourceObserver<String> as1 = new ResourceObserver<String>() {
+        DisposableObserver<String> as1 = new DisposableObserver<String>() {
             @Override
             public void onNext(String t) {
                 o.onNext(t);
@@ -392,7 +392,7 @@ public class SerializedObserverTest {
             }
         };
 
-        ResourceObserver<String> as2 = new ResourceObserver<String>() {
+        DisposableObserver<String> as2 = new DisposableObserver<String>() {
             @Override
             public void onNext(String t) {
                 o.onNext(t);


### PR DESCRIPTION
This makes the resource observers unused internally and I'm curious as to whether they deserve to stick around in the public API. Any thoughts?
