### PR TITLE
2.x: Use predicates in BaseTestConsumer assertError(Class/Throwable) to remove duplicate code, tests tweaks to remove few IDE warnings

### DIFF
--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -20,6 +20,7 @@ import io.reactivex.Notification;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Predicate;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.ExceptionHelper;
 
@@ -227,18 +228,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      */
     @SuppressWarnings("unchecked")
     public final U assertError(Throwable error) {
-        int s = errors.size();
-        if (s == 0) {
-            throw fail("No errors");
-        }
-        if (errors.contains(error)) {
-            if (s != 1) {
-                throw fail("Error present but other errors as well");
-            }
-        } else {
-            throw fail("Error not present");
-        }
-        return (U)this;
+        return (U)assertError(Functions.equalsWith(error));
     }
 
     /**
@@ -249,28 +239,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      */
     @SuppressWarnings("unchecked")
     public final U assertError(Class<? extends Throwable> errorClass) {
-        int s = errors.size();
-        if (s == 0) {
-            throw fail("No errors");
-        }
-
-        boolean found = false;
-
-        for (Throwable e : errors) {
-            if (errorClass.isInstance(e)) {
-                found = true;
-                break;
-            }
-        }
-
-        if (found) {
-            if (s != 1) {
-                throw fail("Error present but other errors as well");
-            }
-        } else {
-            throw fail("Error not present");
-        }
-        return (U)this;
+        return (U)assertError((Predicate)Functions.isInstanceOf(errorClass));
     }
 
     /**

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -295,10 +295,10 @@ public class TestObserverTest {
             // expected
         }
 
-        ts.assertValueSequence(Arrays.asList(1));
+        ts.assertValueSequence(Collections.singletonList(1));
 
         try {
-            ts.assertValueSequence(Arrays.asList(2));
+            ts.assertValueSequence(Collections.singletonList(2));
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
@@ -344,21 +344,21 @@ public class TestObserverTest {
             ts.assertErrorMessage("");
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
-
+            // expected
         }
 
         try {
             ts.assertSubscribed();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
-
+            // expected
         }
 
         try {
             ts.assertTerminated();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
-
+            // expected
         }
 
         ts.onSubscribe(Disposables.empty());
@@ -390,7 +390,7 @@ public class TestObserverTest {
             ts.assertErrorMessage("");
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
-
+            // expected
         }
 
         try {
@@ -671,11 +671,11 @@ public class TestObserverTest {
 
         assertEquals(0, ts.valueCount());
 
-        assertEquals(Arrays.asList(), ts.values());
+        assertEquals(Collections.emptyList(), ts.values());
 
         ts.onNext(1);
 
-        assertEquals(Arrays.asList(1), ts.values());
+        assertEquals(Collections.singletonList(1), ts.values());
 
         ts.cancel();
 
@@ -684,11 +684,11 @@ public class TestObserverTest {
 
         ts.assertValue(1);
 
-        assertEquals(Arrays.asList(Arrays.asList(1), Collections.emptyList(), Collections.emptyList()), ts.getEvents());
+        assertEquals(Arrays.asList(Collections.singletonList(1), Collections.emptyList(), Collections.emptyList()), ts.getEvents());
 
         ts.onComplete();
 
-        assertEquals(Arrays.asList(Arrays.asList(1), Collections.emptyList(), Collections.singletonList(Notification.createOnComplete())), ts.getEvents());
+        assertEquals(Arrays.asList(Collections.singletonList(1), Collections.emptyList(), Collections.singletonList(Notification.createOnComplete())), ts.getEvents());
     }
 
     @Test
@@ -896,14 +896,14 @@ public class TestObserverTest {
         ts.onNext(2);
 
         try {
-            ts.assertValueSequence(Arrays.<Integer>asList());
+            ts.assertValueSequence(Collections.<Integer>emptyList());
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
         try {
-            ts.assertValueSequence(Arrays.asList(1));
+            ts.assertValueSequence(Collections.singletonList(1));
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -738,10 +738,10 @@ public class TestSubscriberTest {
             // expected
         }
 
-        ts.assertValueSequence(Arrays.asList(1));
+        ts.assertValueSequence(Collections.singletonList(1));
 
         try {
-            ts.assertValueSequence(Arrays.asList(2));
+            ts.assertValueSequence(Collections.singletonList(2));
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
@@ -780,7 +780,7 @@ public class TestSubscriberTest {
             ts.assertErrorMessage("");
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
-
+            // expected
         }
 
         try {
@@ -794,14 +794,14 @@ public class TestSubscriberTest {
             ts.assertSubscribed();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
-
+            // expected
         }
 
         try {
             ts.assertTerminated();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
-
+            // expected
         }
 
         ts.onSubscribe(new BooleanSubscription());
@@ -833,7 +833,7 @@ public class TestSubscriberTest {
             ts.assertErrorMessage("");
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
-
+            // expected
         }
 
         try {
@@ -1113,11 +1113,11 @@ public class TestSubscriberTest {
 
         assertEquals(0, ts.valueCount());
 
-        assertEquals(Arrays.asList(), ts.values());
+        assertEquals(Collections.emptyList(), ts.values());
 
         ts.onNext(1);
 
-        assertEquals(Arrays.asList(1), ts.values());
+        assertEquals(Collections.singletonList(1), ts.values());
 
         ts.cancel();
 
@@ -1126,11 +1126,11 @@ public class TestSubscriberTest {
 
         ts.assertValue(1);
 
-        assertEquals(Arrays.asList(Arrays.asList(1), Collections.emptyList(), Collections.emptyList()), ts.getEvents());
+        assertEquals(Arrays.asList(Collections.singletonList(1), Collections.emptyList(), Collections.emptyList()), ts.getEvents());
 
         ts.onComplete();
 
-        assertEquals(Arrays.asList(Arrays.asList(1), Collections.emptyList(), Collections.singletonList(Notification.createOnComplete())), ts.getEvents());
+        assertEquals(Arrays.asList(Collections.singletonList(1), Collections.emptyList(), Collections.singletonList(Notification.createOnComplete())), ts.getEvents());
     }
 
     @Test
@@ -1338,14 +1338,14 @@ public class TestSubscriberTest {
         ts.onNext(2);
 
         try {
-            ts.assertValueSequence(Arrays.<Integer>asList());
+            ts.assertValueSequence(Collections.<Integer>emptyList());
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
         try {
-            ts.assertValueSequence(Arrays.asList(1));
+            ts.assertValueSequence(Collections.singletonList(1));
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected


### PR DESCRIPTION
Messages and error checking was duplicates between all three assertError overloads.
