### PR TITLE
Upgrade Mockito to 2.1.0-RC.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'org.mockito:mockito-core:2.1.0-RC.2'
     testCompile 'com.google.guava:guava:19.0'
     testCompile 'com.pushtorefresh.java-private-constructor-checker:checker:1.2.0'
 

--- a/src/test/java/rx/CompletableTest.java
+++ b/src/test/java/rx/CompletableTest.java
@@ -17,7 +17,6 @@
 package rx;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/NotificationTest.java
+++ b/src/test/java/rx/NotificationTest.java
@@ -16,7 +16,6 @@
 
 package rx;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.junit.Assert.*;
 

--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -16,7 +16,6 @@
 package rx;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -788,8 +787,7 @@ public class ObservableTests {
         verify(observer, times(1)).onNext("abc");
         verify(observer, never()).onNext(false);
         verify(observer, never()).onNext(2L);
-        verify(observer, never()).onError(
-                org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -809,8 +807,7 @@ public class ObservableTests {
         verify(observer, times(1)).onNext(l1);
         verify(observer, times(1)).onNext(l2);
         verify(observer, never()).onNext("123");
-        verify(observer, never()).onError(
-                org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -823,8 +820,7 @@ public class ObservableTests {
         observable.subscribe(observer);
         verify(observer, times(1)).onNext(true);
         verify(observer, never()).onNext(false);
-        verify(observer, never()).onError(
-                org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -837,8 +833,7 @@ public class ObservableTests {
         observable.subscribe(observer);
         verify(observer, times(1)).onNext(false);
         verify(observer, never()).onNext(true);
-        verify(observer, never()).onError(
-                org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -851,8 +846,7 @@ public class ObservableTests {
         observable.subscribe(observer);
         verify(observer, times(1)).onNext(true);
         verify(observer, never()).onNext(false);
-        verify(observer, never()).onError(
-                org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -865,8 +859,7 @@ public class ObservableTests {
         observable.subscribe(observer);
         verify(observer, times(1)).onNext(false);
         verify(observer, never()).onNext(true);
-        verify(observer, never()).onError(
-                org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 

--- a/src/test/java/rx/SingleTest.java
+++ b/src/test/java/rx/SingleTest.java
@@ -13,7 +13,6 @@
 package rx;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;

--- a/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCombineLatestTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -60,7 +59,7 @@ public class OnSubscribeCombineLatestTest {
 
         verify(w, never()).onNext(anyString());
         verify(w, never()).onCompleted();
-        verify(w, times(1)).onError(Matchers.<RuntimeException> any());
+        verify(w, times(1)).onError(Mockito.<RuntimeException> any());
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/OnSubscribeDeferTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeDeferTest.java
@@ -15,13 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 

--- a/src/test/java/rx/internal/operators/OnSubscribeDoOnEachTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeDoOnEachTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;

--- a/src/test/java/rx/internal/operators/OnSubscribeFilterTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFilterTest.java
@@ -15,7 +15,6 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.CountDownLatch;

--- a/src/test/java/rx/internal/operators/OnSubscribeFromCallableTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromCallableTest.java
@@ -79,7 +79,7 @@ public class OnSubscribeFromCallableTest {
 
         fromCallableObservable.subscribe(observer);
 
-        verify(observer, never()).onNext(anyObject());
+        verify(observer, never()).onNext(any());
         verify(observer, never()).onCompleted();
         verify(observer).onError(throwable);
     }

--- a/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OnSubscribeGroupJoinTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeGroupJoinTest.java
@@ -15,10 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 

--- a/src/test/java/rx/internal/operators/OnSubscribeJoinTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeJoinTest.java
@@ -15,10 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/rx/internal/operators/OnSubscribeMapTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeMapTest.java
@@ -15,7 +15,6 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRangeTest.java
@@ -42,7 +42,7 @@ public class OnSubscribeRangeTest {
         verify(observer, times(1)).onNext(3);
         verify(observer, times(1)).onNext(4);
         verify(observer, never()).onNext(5);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -64,7 +64,7 @@ public class OnSubscribeRangeTest {
         verify(observer, times(1)).onNext(2);
         verify(observer, times(1)).onNext(3);
         verify(observer, never()).onNext(4);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
         assertEquals(3, count.get());
     }

--- a/src/test/java/rx/internal/operators/OnSubscribeReduceTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeReduceTest.java
@@ -17,10 +17,7 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OnSubscribeTimerTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeTimerTest.java
@@ -15,13 +15,7 @@
  */
 package rx.internal.operators;
 
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/test/java/rx/internal/operators/OnSubscribeToMapTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeToMapTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/rx/internal/operators/OnSubscribeToMultimapTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeToMultimapTest.java
@@ -16,10 +16,7 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/rx/internal/operators/OnSubscribeToObservableFutureTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeToObservableFutureTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.*;

--- a/src/test/java/rx/internal/operators/OperatorAnyTest.java
+++ b/src/test/java/rx/internal/operators/OperatorAnyTest.java
@@ -45,7 +45,7 @@ public class OperatorAnyTest {
         observable.subscribe(observer);
         verify(observer, never()).onNext(false);
         verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -59,7 +59,7 @@ public class OperatorAnyTest {
         observable.subscribe(observer);
         verify(observer, never()).onNext(true);
         verify(observer, times(1)).onNext(false);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -73,7 +73,7 @@ public class OperatorAnyTest {
         observable.subscribe(observer);
         verify(observer, never()).onNext(false);
         verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -87,7 +87,7 @@ public class OperatorAnyTest {
         observable.subscribe(observer);
         verify(observer, never()).onNext(true);
         verify(observer, times(1)).onNext(false);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -101,7 +101,7 @@ public class OperatorAnyTest {
         observable.subscribe(observer);
         verify(observer, times(1)).onNext(false);
         verify(observer, never()).onNext(true);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -115,7 +115,7 @@ public class OperatorAnyTest {
         observable.subscribe(observer);
         verify(observer, times(1)).onNext(true);
         verify(observer, never()).onNext(false);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -136,7 +136,7 @@ public class OperatorAnyTest {
         observable.subscribe(observer);
         verify(observer, never()).onNext(false);
         verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -157,7 +157,7 @@ public class OperatorAnyTest {
         observable.subscribe(observer);
         verify(observer, never()).onNext(false);
         verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -178,7 +178,7 @@ public class OperatorAnyTest {
         observable.subscribe(observer);
         verify(observer, times(1)).onNext(false);
         verify(observer, never()).onNext(true);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -200,7 +200,7 @@ public class OperatorAnyTest {
         observable.subscribe(observer);
         verify(observer, times(1)).onNext(false);
         verify(observer, never()).onNext(true);
-        verify(observer, never()).onError(org.mockito.Matchers.any(Throwable.class));
+        verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 

--- a/src/test/java/rx/internal/operators/OperatorAsObservableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorAsObservableTest.java
@@ -17,10 +17,7 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 

--- a/src/test/java/rx/internal/operators/OperatorBufferTest.java
+++ b/src/test/java/rx/internal/operators/OperatorBufferTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OperatorCastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorCastTest.java
@@ -36,7 +36,7 @@ public class OperatorCastTest {
         verify(observer, times(1)).onNext(1);
         verify(observer, times(1)).onNext(1);
         verify(observer, never()).onError(
-                org.mockito.Matchers.any(Throwable.class));
+                any(Throwable.class));
         verify(observer, times(1)).onCompleted();
     }
 
@@ -49,7 +49,7 @@ public class OperatorCastTest {
         Observer<Boolean> observer = mock(Observer.class);
         observable.subscribe(observer);
         verify(observer, times(1)).onError(
-                org.mockito.Matchers.any(ClassCastException.class));
+                any(ClassCastException.class));
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;

--- a/src/test/java/rx/internal/operators/OperatorDebounceTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDebounceTest.java
@@ -15,13 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/rx/internal/operators/OperatorDefaultIfEmptyTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDefaultIfEmptyTest.java
@@ -15,10 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 

--- a/src/test/java/rx/internal/operators/OperatorDelayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDelayTest.java
@@ -16,14 +16,7 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.ArrayList;

--- a/src/test/java/rx/internal/operators/OperatorDematerializeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDematerializeTest.java
@@ -15,11 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 

--- a/src/test/java/rx/internal/operators/OperatorDistinctTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDistinctTest.java
@@ -15,12 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 

--- a/src/test/java/rx/internal/operators/OperatorDistinctUntilChangedTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDistinctUntilChangedTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 

--- a/src/test/java/rx/internal/operators/OperatorFirstTest.java
+++ b/src/test/java/rx/internal/operators/OperatorFirstTest.java
@@ -15,14 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.NoSuchElementException;

--- a/src/test/java/rx/internal/operators/OperatorFlatMapTest.java
+++ b/src/test/java/rx/internal/operators/OperatorFlatMapTest.java
@@ -15,7 +15,6 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.junit.Assert.*;
 

--- a/src/test/java/rx/internal/operators/OperatorGroupByTest.java
+++ b/src/test/java/rx/internal/operators/OperatorGroupByTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -1003,8 +1002,8 @@ public class OperatorGroupByTest {
         stream.subscribe(o2);
 
         // check that subscriptions were successful
-        verify(o1, never()).onError(Matchers.<Throwable> any());
-        verify(o2, never()).onError(Matchers.<Throwable> any());
+        verify(o1, never()).onError(Mockito.<Throwable> any());
+        verify(o2, never()).onError(Mockito.<Throwable> any());
     }
 
     private static Func1<Long, Boolean> IS_EVEN = new Func1<Long, Boolean>() {

--- a/src/test/java/rx/internal/operators/OperatorLastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorLastTest.java
@@ -16,10 +16,7 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.*;
 
 import java.util.NoSuchElementException;
 

--- a/src/test/java/rx/internal/operators/OperatorMergeDelayErrorTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeDelayErrorTest.java
@@ -16,8 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;

--- a/src/test/java/rx/internal/operators/OperatorMergeDelayErrorTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeDelayErrorTest.java
@@ -82,7 +82,7 @@ public class OperatorMergeDelayErrorTest {
         Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
         m.subscribe(stringObserver);
 
-        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
+        verify(stringObserver, times(1)).onError(any(CompositeException.class));
         verify(stringObserver, never()).onCompleted();
         verify(stringObserver, times(1)).onNext("one");
         verify(stringObserver, times(1)).onNext("two");

--- a/src/test/java/rx/internal/operators/OperatorMergeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeTest.java
@@ -17,7 +17,6 @@ package rx.internal.operators;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;

--- a/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
@@ -130,7 +130,8 @@ public class OperatorObserveOnTest {
         }
 
         verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(5)).onNext(any(String.class));
+        verify(observer, times(1)).onNext(null);
+        verify(observer, times(4)).onNext(any(String.class));
         verify(observer, times(1)).onCompleted();
     }
 

--- a/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunctionTest.java
@@ -17,10 +17,7 @@ package rx.internal.operators;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;

--- a/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservableTest.java
@@ -16,10 +16,7 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 import org.mockito.Mockito;

--- a/src/test/java/rx/internal/operators/OperatorOnErrorReturnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnErrorReturnTest.java
@@ -17,10 +17,7 @@ package rx.internal.operators;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/src/test/java/rx/internal/operators/OperatorOnExceptionResumeNextViaObservableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnExceptionResumeNextViaObservableTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;

--- a/src/test/java/rx/internal/operators/OperatorRepeatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRepeatTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OperatorReplayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorReplayTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.management.*;

--- a/src/test/java/rx/internal/operators/OperatorRetryTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRetryTest.java
@@ -230,7 +230,7 @@ public class OperatorRetryTest {
         inOrder.verify(observer, never()).onNext("beginningEveryTime");
         inOrder.verify(observer, never()).onNext("onSuccessOnly");
         inOrder.verify(observer, never()).onCompleted();
-        inOrder.verify(observer, times(1)).onError(any(IllegalStateException.class));
+        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/rx/internal/operators/OperatorRetryTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRetryTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OperatorRetryWithPredicateTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRetryWithPredicateTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;

--- a/src/test/java/rx/internal/operators/OperatorSampleTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSampleTest.java
@@ -15,7 +15,6 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/rx/internal/operators/OperatorScanTest.java
+++ b/src/test/java/rx/internal/operators/OperatorScanTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OperatorSequenceEqualTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSequenceEqualTest.java
@@ -15,7 +15,6 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;

--- a/src/test/java/rx/internal/operators/OperatorSerializeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSerializeTest.java
@@ -18,10 +18,7 @@ package rx.internal.operators;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/test/java/rx/internal/operators/OperatorSingleTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSingleTest.java
@@ -16,11 +16,7 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/rx/internal/operators/OperatorSkipLastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSkipLastTest.java
@@ -16,12 +16,7 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/rx/internal/operators/OperatorSkipLastTimedTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSkipLastTimedTest.java
@@ -15,11 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/test/java/rx/internal/operators/OperatorSkipTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSkipTest.java
@@ -17,11 +17,7 @@ package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/rx/internal/operators/OperatorSkipTimedTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSkipTimedTest.java
@@ -16,11 +16,7 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/src/test/java/rx/internal/operators/OperatorSkipUntilTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSkipUntilTest.java
@@ -15,10 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/rx/internal/operators/OperatorSkipWhileTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSkipWhileTest.java
@@ -16,13 +16,7 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/src/test/java/rx/internal/operators/OperatorSwitchTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSwitchTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.ref.WeakReference;

--- a/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeLastTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OperatorTakeLastTimedTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeLastTimedTest.java
@@ -15,12 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/rx/internal/operators/OperatorTakeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;

--- a/src/test/java/rx/internal/operators/OperatorTakeTimedTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeTimedTest.java
@@ -15,11 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeUntilPredicateTest.java
@@ -18,7 +18,6 @@ package rx.internal.operators;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;

--- a/src/test/java/rx/internal/operators/OperatorTakeWhileTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeWhileTest.java
@@ -17,7 +17,6 @@ package rx.internal.operators;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;

--- a/src/test/java/rx/internal/operators/OperatorThrottleFirstTest.java
+++ b/src/test/java/rx/internal/operators/OperatorThrottleFirstTest.java
@@ -15,12 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/test/java/rx/internal/operators/OperatorTimeoutTests.java
+++ b/src/test/java/rx/internal/operators/OperatorTimeoutTests.java
@@ -15,7 +15,6 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;

--- a/src/test/java/rx/internal/operators/OperatorTimeoutWithSelectorTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTimeoutWithSelectorTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;

--- a/src/test/java/rx/internal/operators/OperatorTimestampTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTimestampTest.java
@@ -15,7 +15,6 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/rx/internal/operators/OperatorToObservableListTest.java
+++ b/src/test/java/rx/internal/operators/OperatorToObservableListTest.java
@@ -16,10 +16,7 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.*;
 import java.util.concurrent.*;

--- a/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
+++ b/src/test/java/rx/internal/operators/OperatorToObservableSortedListTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OperatorWindowWithObservableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWindowWithObservableTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OperatorWindowWithSizeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWindowWithSizeTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OperatorWithLatestFromTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWithLatestFromTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/OperatorZipIterableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorZipIterableTest.java
@@ -15,11 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.Iterator;

--- a/src/test/java/rx/internal/operators/OperatorZipTest.java
+++ b/src/test/java/rx/internal/operators/OperatorZipTest.java
@@ -16,7 +16,6 @@
 package rx.internal.operators;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/internal/operators/SafeSubscriberTest.java
+++ b/src/test/java/rx/internal/operators/SafeSubscriberTest.java
@@ -15,10 +15,7 @@
  */
 package rx.internal.operators;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 import org.mockito.Mockito;

--- a/src/test/java/rx/observables/SyncOnSubscribeTest.java
+++ b/src/test/java/rx/observables/SyncOnSubscribeTest.java
@@ -17,7 +17,6 @@
 package rx.observables;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -640,7 +639,7 @@ public class SyncOnSubscribeTest {
         }
 
         assertEquals(count, subscribers.size());
-        verify(onUnSubscribe, times(count)).call(Matchers.<Map<Object, Object>>any());
+        verify(onUnSubscribe, times(count)).call(Mockito.<Map<Object, Object>>any());
     }
 
     @Test(timeout = 3000)

--- a/src/test/java/rx/observables/SyncOnSubscribeTest.java
+++ b/src/test/java/rx/observables/SyncOnSubscribeTest.java
@@ -453,7 +453,7 @@ public class SyncOnSubscribeTest {
         Observable.create(os).take(1).subscribe(ts);
 
         verify(o, never()).onError(any(Throwable.class));
-        verify(onUnSubscribe, times(1)).call(any(Integer.class));
+        verify(onUnSubscribe, times(1)).call(null);
     }
 
     @Test

--- a/src/test/java/rx/observers/SerializedObserverTest.java
+++ b/src/test/java/rx/observers/SerializedObserverTest.java
@@ -16,7 +16,6 @@
 package rx.observers;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;

--- a/src/test/java/rx/schedulers/TestSchedulerTest.java
+++ b/src/test/java/rx/schedulers/TestSchedulerTest.java
@@ -16,11 +16,7 @@
 package rx.schedulers;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/test/java/rx/subjects/AsyncSubjectTest.java
+++ b/src/test/java/rx/subjects/AsyncSubjectTest.java
@@ -16,13 +16,7 @@
 package rx.subjects;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;

--- a/src/test/java/rx/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/rx/subjects/BehaviorSubjectTest.java
@@ -16,13 +16,7 @@
 package rx.subjects;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;

--- a/src/test/java/rx/subjects/PublishSubjectTest.java
+++ b/src/test/java/rx/subjects/PublishSubjectTest.java
@@ -16,13 +16,7 @@
 package rx.subjects;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/test/java/rx/subjects/ReplaySubjectTest.java
+++ b/src/test/java/rx/subjects/ReplaySubjectTest.java
@@ -16,13 +16,7 @@
 package rx.subjects;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;


### PR DESCRIPTION
The second release candidate of Mockito 2 has been released, which is mostly backwards compatible with your code base. I had to remove the deprecated usage of `Matchers` and replace it with the new `Mockito` equivalent matchers. This solved several ambiguity issues where both `Mockito` and `Matchers` were imported in the same file. Other than that all tests were passing locally, so let's see if CI agrees too.

Thanks a lot for using Mockito and if you have any feedback, we are eager to hear from you!
