### PR TITLE
2.x: fix Mockito 2.1 changes using deprecated API of its own

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMap.java
@@ -39,7 +39,10 @@ public final class SingleFlatMap<T, R> extends Single<R> {
     static final class SingleFlatMapCallback<T, R>
     extends AtomicReference<Disposable>
     implements SingleObserver<T>, Disposable {
+        private static final long serialVersionUID = 3258103020495908596L;
+
         final SingleObserver<? super R> actual;
+
         final Function<? super T, ? extends SingleSource<? extends R>> mapper;
 
         SingleFlatMapCallback(SingleObserver<? super R> actual,

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -53,7 +53,7 @@ public class FlowableBufferTest {
         Flowable<List<String>> buffered = source.buffer(3, 3);
         buffered.subscribe(observer);
 
-        Mockito.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        Mockito.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         Mockito.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         Mockito.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -79,7 +79,7 @@ public class FlowableBufferTest {
         inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two", "three"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("two", "three", "four"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("three", "four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.never()).onComplete();
     }
@@ -94,7 +94,7 @@ public class FlowableBufferTest {
         InOrder inOrder = Mockito.inOrder(observer);
         inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two", "three"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -109,7 +109,7 @@ public class FlowableBufferTest {
         InOrder inOrder = Mockito.inOrder(observer);
         inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -141,7 +141,7 @@ public class FlowableBufferTest {
 
         scheduler.advanceTimeTo(300, TimeUnit.MILLISECONDS);
         inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -175,7 +175,7 @@ public class FlowableBufferTest {
 
         scheduler.advanceTimeTo(201, TimeUnit.MILLISECONDS);
         inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -226,7 +226,7 @@ public class FlowableBufferTest {
         scheduler.advanceTimeTo(500, TimeUnit.MILLISECONDS);
         inOrder.verify(observer, Mockito.times(1)).onNext(list("two", "three"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -270,7 +270,7 @@ public class FlowableBufferTest {
         inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("three", "four"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -52,7 +52,7 @@ public class ObservableBufferTest {
         Observable<List<String>> buffered = source.buffer(3, 3);
         buffered.subscribe(observer);
 
-        Mockito.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        Mockito.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         Mockito.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         Mockito.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -78,7 +78,7 @@ public class ObservableBufferTest {
         inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two", "three"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("two", "three", "four"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("three", "four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.never()).onComplete();
     }
@@ -93,7 +93,7 @@ public class ObservableBufferTest {
         InOrder inOrder = Mockito.inOrder(observer);
         inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two", "three"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -108,7 +108,7 @@ public class ObservableBufferTest {
         InOrder inOrder = Mockito.inOrder(observer);
         inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -140,7 +140,7 @@ public class ObservableBufferTest {
 
         scheduler.advanceTimeTo(300, TimeUnit.MILLISECONDS);
         inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -174,7 +174,7 @@ public class ObservableBufferTest {
 
         scheduler.advanceTimeTo(201, TimeUnit.MILLISECONDS);
         inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -225,7 +225,7 @@ public class ObservableBufferTest {
         scheduler.advanceTimeTo(500, TimeUnit.MILLISECONDS);
         inOrder.verify(observer, Mockito.times(1)).onNext(list("two", "three"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }
@@ -269,7 +269,7 @@ public class ObservableBufferTest {
         inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("three", "four"));
         inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.anyListOf(String.class));
+        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
         inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
         inOrder.verify(observer, Mockito.times(1)).onComplete();
     }


### PR DESCRIPTION
`anyListOf()` is deprecated in Mockito 2.1.0-RC.2 and the GitHub diff can't show such uses.

(In addition, there was a missing `serialVersionUID` in another PR.)
