### PR TITLE
1.x: SafeSubscriber not to call RxJavaHooks before delivering the original error.

### DIFF
--- a/src/main/java/rx/observers/SafeSubscriber.java
+++ b/src/main/java/rx/observers/SafeSubscriber.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 
 import rx.Subscriber;
 import rx.exceptions.*;
-import rx.plugins.RxJavaHooks;
+import rx.plugins.*;
 
 /**
  * {@code SafeSubscriber} is a wrapper around {@code Subscriber} that ensures that the {@code Subscriber}
@@ -146,8 +146,9 @@ public class SafeSubscriber<T> extends Subscriber<T> {
      *
      * @see <a href="https://github.com/ReactiveX/RxJava/issues/630">the report of this bug</a>
      */
+    @SuppressWarnings("deprecation")
     protected void _onError(Throwable e) { // NOPMD
-        RxJavaHooks.onError(e);
+        RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
         try {
             actual.onError(e);
         } catch (OnErrorNotImplementedException e2) { // NOPMD

--- a/src/test/java/rx/plugins/RxJavaHooksTest.java
+++ b/src/test/java/rx/plugins/RxJavaHooksTest.java
@@ -1084,4 +1084,25 @@ public class RxJavaHooksTest {
         }
     }
 
+    @Test
+    public void noCallToHooksOnPlainError() {
+
+        final boolean[] called = { false };
+        
+        RxJavaHooks.setOnError(new Action1<Throwable>() {
+            @Override
+            public void call(Throwable t) {
+                called[0] = true;
+            }
+        });
+        
+        try {
+            Observable.error(new TestException())
+            .subscribe(new TestSubscriber<Object>());
+            
+            assertFalse(called[0]);
+        } finally {
+            RxJavaHooks.reset();
+        }
+    }
 }


### PR DESCRIPTION
Before the introduction of `RxJavaHooks`, the `SafeSubscriber._onError` called the original error handler with the exception it received which was by default an empty handler. The default `RxJavaHooks.onError` behavior, however is to signal errors to the uncaught exception handler of the caller thread which leads to unnecessary logging or app crashes even though the error itself is to be handled properly.

This PR restores the `SafeSubscriber._onError` to skip the `RxJavaHooks` and call the original handler directy so old tracking code should still get all safe error while newer hooking doesn't get called.

Related: #4332.
