### PR TITLE
1.x: rework Single internals to reduce overhead and stack depth

### DIFF
--- a/src/main/java/rx/Completable.java
+++ b/src/main/java/rx/Completable.java
@@ -540,6 +540,7 @@ public class Completable {
      * @return the new Completable instance
      * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
      */
+    @SuppressWarnings("deprecation")
     @Experimental
     public static Completable fromEmitter(Action1<CompletableEmitter> producer) {
         return create(new CompletableFromEmitter(producer));

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -2016,7 +2016,7 @@ public class Observable<T> {
      * @see AsyncEmitter.BackpressureMode
      * @see AsyncEmitter.Cancellable
      * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
-     * @deprecated since 1.2.1 because Async prefix of AsyncEmitter class is potentially misleading. Use 
+     * @deprecated since 1.2.1 because Async prefix of AsyncEmitter class is potentially misleading. Use
      *            {@link #fromEmitter(Action1, Emitter.BackpressureMode)} instead.
      */
     @Experimental
@@ -2024,7 +2024,7 @@ public class Observable<T> {
     public static <T> Observable<T> fromEmitter(Action1<AsyncEmitter<T>> emitter, AsyncEmitter.BackpressureMode backpressure) {
         return create(new OnSubscribeFromAsyncEmitter<T>(emitter, backpressure));
     }
-    
+
     /**
      * Provides an API (via a cold Observable) that bridges the reactive world with the callback-style,
      * generally non-backpressured world.
@@ -2063,7 +2063,7 @@ public class Observable<T> {
      * @return the new Observable instance
      * @see Emitter
      * @see Emitter.BackpressureMode
-     * @see Emitter.Cancellable
+     * @see rx.functions.Cancellable
      * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
      */
     @Experimental

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -75,7 +75,10 @@ public class Single<T> {
      * @param f
      *            {@code f} to be executed when {@code execute(SingleSubscriber)} or
      *            {@code subscribe(Subscriber)} is called
+     * @deprecated 1.2.1: Not recommended, use {@link #Single(OnSubscribe)} to avoid wrapping and
+     * conversion between the Observable and Single protocols.
      */
+    @Deprecated
     protected Single(final Observable.OnSubscribe<T> f) {
         onSubscribe = RxJavaHooks.onCreate(new SingleFromObservable<T>(f));
     }

--- a/src/main/java/rx/internal/operators/CompletableFromEmitter.java
+++ b/src/main/java/rx/internal/operators/CompletableFromEmitter.java
@@ -28,6 +28,7 @@ import rx.plugins.RxJavaHooks;
 /**
  * Allows push-based emission of terminal events to a CompletableSubscriber.
  */
+@SuppressWarnings("deprecation")
 public final class CompletableFromEmitter implements Completable.OnSubscribe {
 
     final Action1<CompletableEmitter> producer;

--- a/src/main/java/rx/internal/operators/NotificationLite.java
+++ b/src/main/java/rx/internal/operators/NotificationLite.java
@@ -75,6 +75,7 @@ public final class NotificationLite<T> {
      * Creates a lite {@code onNext} notification for the value passed in without doing any allocation. Can
      * be unwrapped and sent with the {@link #accept} method.
      *
+     * @param <T> the value type to convert
      * @param t
      *          the item emitted to {@code onNext}
      * @return the item, or a null token representing the item if the item is {@code null}
@@ -113,6 +114,7 @@ public final class NotificationLite<T> {
     /**
      * Unwraps the lite notification and calls the appropriate method on the {@link Observer}.
      *
+     * @param <T> the value type to accept
      * @param o
      *            the {@link Observer} to call {@code onNext}, {@code onCompleted}, or {@code onError}.
      * @param n
@@ -212,6 +214,7 @@ public final class NotificationLite<T> {
      * this an {@code OnComplete} or {@code OnError} notification type. For performance reasons, this method
      * does not check for this, so you are expected to prevent such a mishap.
      *
+     * @param <T> the value type to convert
      * @param n
      *            the lite notification (of type {@code Kind.OnNext})
      * @return the unwrapped value, which can be null

--- a/src/main/java/rx/internal/operators/SingleDelay.java
+++ b/src/main/java/rx/internal/operators/SingleDelay.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import java.util.concurrent.TimeUnit;
+
+import rx.*;
+import rx.Scheduler.Worker;
+import rx.Single.OnSubscribe;
+import rx.functions.Action0;
+
+/**
+ * Signal the success or error value on the Scheduler's thread.
+ *
+ * @param <T> the value type
+ */
+public final class SingleDelay<T> implements Single.OnSubscribe<T> {
+
+    final Single.OnSubscribe<T> source;
+
+    final long delay;
+
+    final TimeUnit unit;
+
+    final Scheduler scheduler;
+
+    public SingleDelay(OnSubscribe<T> source, long delay, TimeUnit unit, Scheduler scheduler) {
+        this.source = source;
+        this.scheduler = scheduler;
+        this.delay = delay;
+        this.unit = unit;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        Worker w = scheduler.createWorker();
+
+        ObserveOnSingleSubscriber<T> parent = new ObserveOnSingleSubscriber<T>(t, w, delay, unit);
+
+        t.add(w);
+        t.add(parent);
+
+        source.call(parent);
+    }
+
+    static final class ObserveOnSingleSubscriber<T> extends SingleSubscriber<T>
+    implements Action0 {
+        final SingleSubscriber<? super T> actual;
+
+        final Worker w;
+
+        final long delay;
+
+        final TimeUnit unit;
+
+        T value;
+        Throwable error;
+
+        public ObserveOnSingleSubscriber(SingleSubscriber<? super T> actual, Worker w, long delay, TimeUnit unit) {
+            this.actual = actual;
+            this.w = w;
+            this.delay = delay;
+            this.unit = unit;
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            this.value = value;
+            w.schedule(this, delay, unit);
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            this.error = error;
+            w.schedule(this, delay, unit);
+        }
+
+        @Override
+        public void call() {
+            try {
+                Throwable ex = error;
+                if (ex != null) {
+                    error = null;
+                    actual.onError(ex);
+                } else {
+                    T v = value;
+                    value = null;
+                    actual.onSuccess(v);
+                }
+            } finally {
+                w.unsubscribe();
+            }
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleDoOnSubscribe.java
+++ b/src/main/java/rx/internal/operators/SingleDoOnSubscribe.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import rx.*;
+import rx.exceptions.Exceptions;
+import rx.functions.Action0;
+
+/**
+ * Call an Action0 when the subscription happens to the source.
+ *
+ * @param <T> the value type
+ */
+public final class SingleDoOnSubscribe<T> implements Single.OnSubscribe<T> {
+
+    final Single.OnSubscribe<T> source;
+
+    final Action0 onSubscribe;
+
+    public SingleDoOnSubscribe(Single.OnSubscribe<T> source, Action0 onSubscribe) {
+        this.source = source;
+        this.onSubscribe = onSubscribe;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+
+        try {
+            onSubscribe.call();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            t.onError(ex);
+            return;
+        }
+
+        source.call(t);
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleDoOnUnsubscribe.java
+++ b/src/main/java/rx/internal/operators/SingleDoOnUnsubscribe.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import rx.*;
+import rx.functions.Action0;
+import rx.subscriptions.Subscriptions;
+
+/**
+ * Call an Action0 when the subscription happens to the source.
+ *
+ * @param <T> the value type
+ */
+public final class SingleDoOnUnsubscribe<T> implements Single.OnSubscribe<T> {
+
+    final Single.OnSubscribe<T> source;
+
+    final Action0 onUnsubscribe;
+
+    public SingleDoOnUnsubscribe(Single.OnSubscribe<T> source, Action0 onUnsubscribe) {
+        this.source = source;
+        this.onUnsubscribe = onUnsubscribe;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        t.add(Subscriptions.create(onUnsubscribe));
+        source.call(t);
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleFromCallable.java
+++ b/src/main/java/rx/internal/operators/SingleFromCallable.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import java.util.concurrent.Callable;
+
+import rx.*;
+import rx.exceptions.Exceptions;
+
+/**
+ * Execute a callable and emit its resulting value.
+ *
+ * @param <T> the value type
+ */
+public final class SingleFromCallable<T> implements Single.OnSubscribe<T> {
+
+    final Callable<? extends T> callable;
+
+    public SingleFromCallable(Callable<? extends T> callable) {
+        this.callable = callable;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        // TODO Auto-generated method stub
+        T v;
+        try {
+            v = callable.call();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            t.onError(ex);
+            return;
+        }
+
+        t.onSuccess(v);
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleFromCallable.java
+++ b/src/main/java/rx/internal/operators/SingleFromCallable.java
@@ -36,7 +36,6 @@ public final class SingleFromCallable<T> implements Single.OnSubscribe<T> {
 
     @Override
     public void call(SingleSubscriber<? super T> t) {
-        // TODO Auto-generated method stub
         T v;
         try {
             v = callable.call();

--- a/src/main/java/rx/internal/operators/SingleFromFuture.java
+++ b/src/main/java/rx/internal/operators/SingleFromFuture.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import java.util.concurrent.*;
+
+import rx.*;
+import rx.exceptions.Exceptions;
+import rx.subscriptions.Subscriptions;
+
+/**
+ * Wait and emit the value of the Future.
+ *
+ * @param <T> the value type
+ */
+public final class SingleFromFuture<T> implements Single.OnSubscribe<T> {
+
+    final Future<? extends T> future;
+
+    final long timeout;
+
+    final TimeUnit unit;
+
+    public SingleFromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
+        this.future = future;
+        this.timeout = timeout;
+        this.unit = unit;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        Future<? extends T> f = future;
+
+        t.add(Subscriptions.from(f));
+
+        T v;
+
+        try {
+            if (timeout == 0L) {
+                v = f.get();
+            } else {
+                v = f.get(timeout, unit);
+            }
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            t.onError(ex);
+            return;
+        }
+
+        t.onSuccess(v);
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleFromObservable.java
+++ b/src/main/java/rx/internal/operators/SingleFromObservable.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.operators;
+
+import java.util.NoSuchElementException;
+
+import rx.*;
+import rx.Observable.OnSubscribe;
+import rx.plugins.RxJavaHooks;
+
+/**
+ * Wrap an Observable.OnSubscribe and expose it as a Single.OnSubscribe.
+ *
+ * @param <T> the value type
+ */
+public final class SingleFromObservable<T> implements Single.OnSubscribe<T> {
+
+    final Observable.OnSubscribe<T> source;
+
+    public SingleFromObservable(OnSubscribe<T> source) {
+        this.source = source;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        WrapSingleIntoSubscriber<T> parent = new WrapSingleIntoSubscriber<T>(t);
+        t.add(parent);
+        source.call(parent);
+    }
+
+    static final class WrapSingleIntoSubscriber<T> extends Subscriber<T> {
+
+        final SingleSubscriber<? super T> actual;
+
+        T value;
+        int state;
+
+        static final int STATE_EMPTY = 0;
+        static final int STATE_HAS_VALUE = 1;
+        static final int STATE_DONE = 2;
+
+        WrapSingleIntoSubscriber(SingleSubscriber<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onNext(T t) {
+            int s = state;
+            if (s == STATE_EMPTY) {
+                state = STATE_HAS_VALUE;
+                value = t;
+            } else if (s == STATE_HAS_VALUE) {
+                state = STATE_DONE;
+                actual.onError(new IndexOutOfBoundsException("The upstream produced more than one value"));
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (state == STATE_DONE) {
+                RxJavaHooks.onError(e);
+            } else {
+                value = null;
+                actual.onError(e);
+            }
+        }
+
+        @Override
+        public void onCompleted() {
+            int s = state;
+            if (s == STATE_EMPTY) {
+                actual.onError(new NoSuchElementException());
+            } else if (s == STATE_HAS_VALUE) {
+                state = STATE_DONE;
+                T v = value;
+                value = null;
+                actual.onSuccess(v);
+            }
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleLiftObservableOperator.java
+++ b/src/main/java/rx/internal/operators/SingleLiftObservableOperator.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import rx.*;
+import rx.Observable.Operator;
+import rx.Single.OnSubscribe;
+import rx.exceptions.Exceptions;
+import rx.internal.operators.SingleFromObservable.WrapSingleIntoSubscriber;
+import rx.internal.producers.SingleProducer;
+import rx.plugins.RxJavaHooks;
+
+/**
+ * Lift an Observable.Operator into the Single sequence.
+ * @param <T> the input value type
+ * @param <R> the output value type
+ */
+public final class SingleLiftObservableOperator<T, R> implements Single.OnSubscribe<R> {
+
+    final Single.OnSubscribe<T> source;
+
+    final Operator<? extends R, ? super T> lift;
+
+    public SingleLiftObservableOperator(OnSubscribe<T> source, Operator<? extends R, ? super T> lift) {
+        this.source = source;
+        this.lift = lift;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super R> t) {
+        Subscriber<R> outputAsSubscriber = new WrapSingleIntoSubscriber<R>(t);
+        t.add(outputAsSubscriber);
+
+        try {
+            Subscriber<? super T> inputAsSubscriber = RxJavaHooks.onSingleLift(lift).call(outputAsSubscriber);
+
+            SingleSubscriber<? super T> input = wrap(inputAsSubscriber);
+
+            inputAsSubscriber.onStart();
+
+            source.call(input);
+        } catch (Throwable ex) {
+            Exceptions.throwOrReport(ex, t);
+        }
+    }
+
+    public static <T> SingleSubscriber<T> wrap(Subscriber<T> subscriber) {
+        WrapSubscriberIntoSingle<T> parent = new WrapSubscriberIntoSingle<T>(subscriber);
+        subscriber.add(parent);
+        return parent;
+    }
+
+    static final class WrapSubscriberIntoSingle<T> extends SingleSubscriber<T> {
+        final Subscriber<? super T> actual;
+
+        WrapSubscriberIntoSingle(Subscriber<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.setProducer(new SingleProducer<T>(actual, value));
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            actual.onError(error);
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleObserveOn.java
+++ b/src/main/java/rx/internal/operators/SingleObserveOn.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import rx.*;
+import rx.Scheduler.Worker;
+import rx.Single.OnSubscribe;
+import rx.functions.Action0;
+
+/**
+ * Signal the success or error value on the Scheduler's thread.
+ *
+ * @param <T> the value type
+ */
+public final class SingleObserveOn<T> implements Single.OnSubscribe<T> {
+
+    final Single.OnSubscribe<T> source;
+
+    final Scheduler scheduler;
+
+    public SingleObserveOn(OnSubscribe<T> source, Scheduler scheduler) {
+        this.source = source;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        Worker w = scheduler.createWorker();
+
+        ObserveOnSingleSubscriber<T> parent = new ObserveOnSingleSubscriber<T>(t, w);
+
+        t.add(w);
+        t.add(parent);
+
+        source.call(parent);
+    }
+
+    static final class ObserveOnSingleSubscriber<T> extends SingleSubscriber<T>
+    implements Action0 {
+        final SingleSubscriber<? super T> actual;
+
+        final Worker w;
+
+        T value;
+        Throwable error;
+
+        public ObserveOnSingleSubscriber(SingleSubscriber<? super T> actual, Worker w) {
+            this.actual = actual;
+            this.w = w;
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            this.value = value;
+            w.schedule(this);
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            this.error = error;
+            w.schedule(this);
+        }
+
+        @Override
+        public void call() {
+            try {
+                Throwable ex = error;
+                if (ex != null) {
+                    error = null;
+                    actual.onError(ex);
+                } else {
+                    T v = value;
+                    value = null;
+                    actual.onSuccess(v);
+                }
+            } finally {
+                w.unsubscribe();
+            }
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleOnErrorReturn.java
+++ b/src/main/java/rx/internal/operators/SingleOnErrorReturn.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import rx.*;
+import rx.Single.OnSubscribe;
+import rx.exceptions.Exceptions;
+import rx.functions.Func1;
+
+/**
+ * Signal a value returned by a resumeFunction when the source signals a Throwable.
+ *
+ * @param <T> the value type
+ */
+public final class SingleOnErrorReturn<T> implements Single.OnSubscribe<T> {
+
+    final Single.OnSubscribe<T> source;
+
+    final Func1<Throwable, ? extends T> resumeFunction;
+
+    public SingleOnErrorReturn(OnSubscribe<T> source, Func1<Throwable, ? extends T> resumeFunction) {
+        this.source = source;
+        this.resumeFunction = resumeFunction;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        OnErrorReturnsSingleSubscriber<T> parent = new OnErrorReturnsSingleSubscriber<T>(t, resumeFunction);
+        t.add(parent);
+        source.call(parent);
+    }
+
+    static final class OnErrorReturnsSingleSubscriber<T> extends SingleSubscriber<T> {
+
+        final SingleSubscriber<? super T> actual;
+
+        final Func1<Throwable, ? extends T> resumeFunction;
+
+        public OnErrorReturnsSingleSubscriber(SingleSubscriber<? super T> actual,
+                Func1<Throwable, ? extends T> resumeFunction) {
+            this.actual = actual;
+            this.resumeFunction = resumeFunction;
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            actual.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            T v;
+
+            try {
+                v = resumeFunction.call(error);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                actual.onError(ex);
+                return;
+            }
+
+            actual.onSuccess(v);
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleTakeUntilCompletable.java
+++ b/src/main/java/rx/internal/operators/SingleTakeUntilCompletable.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import rx.*;
+import rx.Single.OnSubscribe;
+import rx.plugins.RxJavaHooks;
+
+/**
+ * Relay the source signals if the other doesn't terminate before.
+ *
+ * @param <T> the value type
+ */
+public final class SingleTakeUntilCompletable<T> implements Single.OnSubscribe<T> {
+
+    final Single.OnSubscribe<T> source;
+
+    final Completable other;
+
+    public SingleTakeUntilCompletable(OnSubscribe<T> source, Completable other) {
+        this.source = source;
+        this.other = other;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        TakeUntilSourceSubscriber<T> parent = new TakeUntilSourceSubscriber<T>(t);
+        t.add(parent);
+
+        other.subscribe(parent);
+        source.call(parent);
+    }
+
+    static final class TakeUntilSourceSubscriber<T> extends SingleSubscriber<T>
+    implements CompletableSubscriber {
+
+        final SingleSubscriber<? super T> actual;
+
+        final AtomicBoolean once;
+
+        TakeUntilSourceSubscriber(SingleSubscriber<? super T> actual) {
+            this.actual = actual;
+            this.once = new AtomicBoolean();
+        }
+
+        @Override
+        public void onSubscribe(Subscription d) {
+            add(d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            if (once.compareAndSet(false, true)) {
+                unsubscribe();
+
+                actual.onSuccess(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            if (once.compareAndSet(false, true)) {
+                unsubscribe();
+                actual.onError(error);
+            } else {
+                RxJavaHooks.onError(error);
+            }
+        }
+
+        @Override
+        public void onCompleted() {
+            onError(new CancellationException("Stream was canceled before emitting a terminal event."));
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleTakeUntilObservable.java
+++ b/src/main/java/rx/internal/operators/SingleTakeUntilObservable.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import rx.*;
+import rx.Single.OnSubscribe;
+import rx.plugins.RxJavaHooks;
+
+/**
+ * Relay the source signals if the other doesn't terminate before.
+ *
+ * @param <T> the value type
+ * @param <U> the other's value type (not relevant)
+ */
+public final class SingleTakeUntilObservable<T, U> implements Single.OnSubscribe<T> {
+
+    final Single.OnSubscribe<T> source;
+
+    final Observable<? extends U> other;
+
+    public SingleTakeUntilObservable(OnSubscribe<T> source, Observable<? extends U> other) {
+        this.source = source;
+        this.other = other;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        TakeUntilSourceSubscriber<T, U> parent = new TakeUntilSourceSubscriber<T, U>(t);
+        t.add(parent);
+
+        other.subscribe(parent.other);
+        source.call(parent);
+    }
+
+    static final class TakeUntilSourceSubscriber<T, U> extends SingleSubscriber<T> {
+
+        final SingleSubscriber<? super T> actual;
+
+        final AtomicBoolean once;
+
+        final Subscriber<U> other;
+
+        TakeUntilSourceSubscriber(SingleSubscriber<? super T> actual) {
+            this.actual = actual;
+            this.once = new AtomicBoolean();
+            this.other = new OtherSubscriber();
+            add(other);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            if (once.compareAndSet(false, true)) {
+                unsubscribe();
+
+                actual.onSuccess(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            if (once.compareAndSet(false, true)) {
+                unsubscribe();
+                actual.onError(error);
+            } else {
+                RxJavaHooks.onError(error);
+            }
+        }
+
+        final class OtherSubscriber extends Subscriber<U> {
+            @Override
+            public void onNext(U value) {
+                onCompleted();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                TakeUntilSourceSubscriber.this.onError(error);
+            }
+
+            @Override
+            public void onCompleted() {
+                onError(new CancellationException("Stream was canceled before emitting a terminal event."));
+            }
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleTakeUntilSingle.java
+++ b/src/main/java/rx/internal/operators/SingleTakeUntilSingle.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import rx.*;
+import rx.Single.OnSubscribe;
+import rx.plugins.RxJavaHooks;
+
+/**
+ * Relay the source signals if the other doesn't terminate before.
+ *
+ * @param <T> the value type
+ * @param <U> the other's value type (not relevant)
+ */
+public final class SingleTakeUntilSingle<T, U> implements Single.OnSubscribe<T> {
+
+    final Single.OnSubscribe<T> source;
+
+    final Single<? extends U> other;
+
+    public SingleTakeUntilSingle(OnSubscribe<T> source, Single<? extends U> other) {
+        this.source = source;
+        this.other = other;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        TakeUntilSourceSubscriber<T, U> parent = new TakeUntilSourceSubscriber<T, U>(t);
+        t.add(parent);
+
+        other.subscribe(parent.other);
+        source.call(parent);
+    }
+
+    static final class TakeUntilSourceSubscriber<T, U> extends SingleSubscriber<T> {
+
+        final SingleSubscriber<? super T> actual;
+
+        final AtomicBoolean once;
+
+        final SingleSubscriber<U> other;
+
+        TakeUntilSourceSubscriber(SingleSubscriber<? super T> actual) {
+            this.actual = actual;
+            this.once = new AtomicBoolean();
+            this.other = new OtherSubscriber();
+            add(other);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            if (once.compareAndSet(false, true)) {
+                unsubscribe();
+
+                actual.onSuccess(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            if (once.compareAndSet(false, true)) {
+                unsubscribe();
+                actual.onError(error);
+            } else {
+                RxJavaHooks.onError(error);
+            }
+        }
+
+        final class OtherSubscriber extends SingleSubscriber<U> {
+            @Override
+            public void onSuccess(U value) {
+                onError(new CancellationException("Stream was canceled before emitting a terminal event."));
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                TakeUntilSourceSubscriber.this.onError(error);
+            }
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleTimeout.java
+++ b/src/main/java/rx/internal/operators/SingleTimeout.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import rx.*;
+import rx.functions.Action0;
+import rx.plugins.RxJavaHooks;
+
+public final class SingleTimeout<T> implements Single.OnSubscribe<T> {
+
+    final Single.OnSubscribe<T> source;
+
+    final long timeout;
+
+    final TimeUnit unit;
+
+    final Scheduler scheduler;
+
+    final Single.OnSubscribe<? extends T> other;
+
+    public SingleTimeout(Single.OnSubscribe<T> source, long timeout, TimeUnit unit, Scheduler scheduler,
+            Single.OnSubscribe<? extends T> other) {
+        this.source = source;
+        this.timeout = timeout;
+        this.unit = unit;
+        this.scheduler = scheduler;
+        this.other = other;
+    }
+
+    @Override
+    public void call(SingleSubscriber<? super T> t) {
+        TimeoutSingleSubscriber<T> parent = new TimeoutSingleSubscriber<T>(t, other);
+
+        Scheduler.Worker w = scheduler.createWorker();
+        parent.add(w);
+
+        t.add(parent);
+
+        w.schedule(parent, timeout, unit);
+
+        source.call(parent);
+    }
+
+    static final class TimeoutSingleSubscriber<T> extends SingleSubscriber<T> implements Action0 {
+
+        final SingleSubscriber<? super T> actual;
+
+        final AtomicBoolean once;
+
+        final Single.OnSubscribe<? extends T> other;
+
+        TimeoutSingleSubscriber(SingleSubscriber<? super T> actual, Single.OnSubscribe<? extends T> other) {
+            this.actual = actual;
+            this.other = other;
+            this.once = new AtomicBoolean();
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            if (once.compareAndSet(false, true)) {
+                try {
+                    actual.onSuccess(value);
+                } finally {
+                    unsubscribe();
+                }
+            }
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            if (once.compareAndSet(false, true)) {
+                try {
+                    actual.onError(error);
+                } finally {
+                    unsubscribe();
+                }
+            } else {
+                RxJavaHooks.onError(error);
+            }
+        }
+
+        @Override
+        public void call() {
+            if (once.compareAndSet(false, true)) {
+                try {
+                    Single.OnSubscribe<? extends T> o = other;
+
+                    if (o == null) {
+                        actual.onError(new TimeoutException());
+                    } else {
+                        OtherSubscriber<T> p = new OtherSubscriber<T>(actual);
+                        actual.add(p);
+                        o.call(p);
+                    }
+                } finally {
+                    unsubscribe();
+                }
+            }
+        }
+
+        static final class OtherSubscriber<T> extends SingleSubscriber<T> {
+
+            final SingleSubscriber<? super T> actual;
+
+            OtherSubscriber(SingleSubscriber<? super T> actual) {
+                this.actual = actual;
+            }
+
+            @Override
+            public void onSuccess(T value) {
+                actual.onSuccess(value);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                actual.onError(error);
+            }
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/SingleToObservable.java
+++ b/src/main/java/rx/internal/operators/SingleToObservable.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import rx.*;
+import rx.internal.operators.SingleLiftObservableOperator.WrapSubscriberIntoSingle;
+
+/**
+ * Expose a Single.OnSubscribe as an Observable.OnSubscribe.
+ *
+ * @param <T> the value type
+ */
+public final class SingleToObservable<T> implements Observable.OnSubscribe<T> {
+
+    final Single.OnSubscribe<T> source;
+
+    public SingleToObservable(Single.OnSubscribe<T> source) {
+        this.source = source;
+    }
+
+    @Override
+    public void call(Subscriber<? super T> t) {
+        WrapSubscriberIntoSingle<T> parent = new WrapSubscriberIntoSingle<T>(t);
+        t.add(parent);
+        source.call(parent);
+    }
+}

--- a/src/main/java/rx/internal/util/ScalarSynchronousSingle.java
+++ b/src/main/java/rx/internal/util/ScalarSynchronousSingle.java
@@ -15,13 +15,9 @@
  */
 package rx.internal.util;
 
-import rx.Scheduler;
+import rx.*;
 import rx.Scheduler.Worker;
-import rx.Single;
-import rx.SingleSubscriber;
-import rx.Subscriber;
-import rx.functions.Action0;
-import rx.functions.Func1;
+import rx.functions.*;
 import rx.internal.schedulers.EventLoopsScheduler;
 
 public final class ScalarSynchronousSingle<T> extends Single<T> {
@@ -133,24 +129,19 @@ public final class ScalarSynchronousSingle<T> extends Single<T> {
                 if (o instanceof ScalarSynchronousSingle) {
                     child.onSuccess(((ScalarSynchronousSingle<? extends R>) o).value);
                 } else {
-                    Subscriber<R> subscriber = new Subscriber<R>() {
-                        @Override
-                        public void onCompleted() {
-                            // deliberately ignored
-                        }
-
+                    SingleSubscriber<R> subscriber = new SingleSubscriber<R>() {
                         @Override
                         public void onError(Throwable e) {
                             child.onError(e);
                         }
 
                         @Override
-                        public void onNext(R r) {
+                        public void onSuccess(R r) {
                             child.onSuccess(r);
                         }
                     };
                     child.add(subscriber);
-                    o.unsafeSubscribe(subscriber);
+                    o.subscribe(subscriber);
                 }
             }
         });

--- a/src/test/java/rx/ObservableDoOnTest.java
+++ b/src/test/java/rx/ObservableDoOnTest.java
@@ -66,7 +66,7 @@ public class ObservableDoOnTest {
         assertNotNull(t);
         assertEquals(t, r.get());
     }
-    
+
     @Test
     public void testDoOnErrorWithActionOfTypeObject() {
         final AtomicReference<Boolean> r = new AtomicReference<Boolean>();

--- a/src/test/java/rx/SingleTest.java
+++ b/src/test/java/rx/SingleTest.java
@@ -41,7 +41,7 @@ public class SingleTest {
     private Func1<Single.OnSubscribe, Single.OnSubscribe> onCreate;
 
     @SuppressWarnings("rawtypes")
-    private Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe> onStart;
+    private Func2<Single, Single.OnSubscribe, Single.OnSubscribe> onStart;
 
     private Func1<Subscription, Subscription> onReturn;
 
@@ -57,9 +57,9 @@ public class SingleTest {
 
         RxJavaHooks.setOnSingleCreate(onCreate);
 
-        onStart = spy(new Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe>() {
+        onStart = spy(new Func2<Single, Single.OnSubscribe, Single.OnSubscribe>() {
             @Override
-            public Observable.OnSubscribe call(Single t1, Observable.OnSubscribe t2) {
+            public Single.OnSubscribe call(Single t1, Single.OnSubscribe t2) {
                 return t2;
             }
         });
@@ -445,7 +445,7 @@ public class SingleTest {
         });
         single.subscribe(ts);
 
-        verify(onStart, times(1)).call(eq(single), any(Observable.OnSubscribe.class));
+        verify(onStart, times(1)).call(eq(single), any(Single.OnSubscribe.class));
     }
 
     @Test
@@ -458,7 +458,7 @@ public class SingleTest {
         });
         single.unsafeSubscribe(ts);
 
-        verify(onStart, times(1)).call(eq(single), any(Observable.OnSubscribe.class));
+        verify(onStart, times(1)).call(eq(single), any(Single.OnSubscribe.class));
     }
 
     @Test

--- a/src/test/java/rx/internal/operators/CompletableFromEmitterTest.java
+++ b/src/test/java/rx/internal/operators/CompletableFromEmitterTest.java
@@ -29,6 +29,7 @@ import rx.functions.*;
 import rx.observers.TestSubscriber;
 import rx.subscriptions.BooleanSubscription;
 
+@SuppressWarnings("deprecation")
 public class CompletableFromEmitterTest {
 
     @Test

--- a/src/test/java/rx/internal/operators/OperatorDoOnRequestTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDoOnRequestTest.java
@@ -141,7 +141,7 @@ public class OperatorDoOnRequestTest {
             Assert.assertEquals(Arrays.asList(0L, 1L), requested);
         }
     }
-    
+
     @Test
     public void canCallDoOnRequestWithActionOfTypeObject() {
         final AtomicReference<Boolean> r = new AtomicReference<Boolean>();

--- a/src/test/java/rx/internal/operators/SingleOnSubscribeUsingTest.java
+++ b/src/test/java/rx/internal/operators/SingleOnSubscribeUsingTest.java
@@ -289,7 +289,7 @@ public class SingleOnSubscribeUsingTest {
                 .doOnSuccess(completion);
         observable.subscribe(observer);
 
-        assertEquals(Arrays.asList("disposed", "completed", "unsub"), events);
+        assertEquals(Arrays.asList("disposed", "completed"/*, "unsub"*/), events);
 
     }
 
@@ -314,7 +314,7 @@ public class SingleOnSubscribeUsingTest {
                 .doOnSuccess(completion);
         observable.subscribe(observer);
 
-        assertEquals(Arrays.asList("completed", "unsub", "disposed"), events);
+        assertEquals(Arrays.asList("completed", /* "unsub",*/ "disposed"), events);
 
     }
 
@@ -341,7 +341,7 @@ public class SingleOnSubscribeUsingTest {
                 .doOnError(onError);
         observable.subscribe(observer);
 
-        assertEquals(Arrays.asList("disposed", "error", "unsub"), events);
+        assertEquals(Arrays.asList("disposed", "error"/*, "unsub"*/), events);
 
     }
 
@@ -366,7 +366,7 @@ public class SingleOnSubscribeUsingTest {
                 .doOnError(onError);
         observable.subscribe(observer);
 
-        assertEquals(Arrays.asList("error", "unsub", "disposed"), events);
+        assertEquals(Arrays.asList("error", /* "unsub",*/ "disposed"), events);
     }
 
     private static Action0 createUnsubAction(final List<String> events) {

--- a/src/test/java/rx/plugins/RxJavaHooksTest.java
+++ b/src/test/java/rx/plugins/RxJavaHooksTest.java
@@ -31,7 +31,6 @@ import rx.Scheduler.Worker;
 import rx.exceptions.*;
 import rx.functions.*;
 import rx.internal.operators.OnSubscribeRange;
-import rx.internal.producers.SingleProducer;
 import rx.internal.util.UtilityFunctions;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
@@ -429,13 +428,13 @@ public class RxJavaHooksTest {
     @Test
     public void singleStart() {
         try {
-            RxJavaHooks.setOnSingleStart(new Func2<Single, Observable.OnSubscribe, Observable.OnSubscribe>() {
+            RxJavaHooks.setOnSingleStart(new Func2<Single, Single.OnSubscribe, Single.OnSubscribe>() {
                 @Override
-                public Observable.OnSubscribe call(Single o, Observable.OnSubscribe t) {
-                    return new Observable.OnSubscribe<Object>() {
+                public Single.OnSubscribe call(Single o, Single.OnSubscribe t) {
+                    return new Single.OnSubscribe<Object>() {
                         @Override
-                        public void call(Subscriber<? super Object> t) {
-                            t.setProducer(new SingleProducer<Integer>(t, 10));
+                        public void call(SingleSubscriber<? super Object> t) {
+                            t.onSuccess(10);
                         }
                     };
                 }
@@ -792,7 +791,7 @@ public class RxJavaHooksTest {
 
             assertNull(RxJavaHooks.onSingleStart(Single.just(1), null));
 
-            assertSame(oos, RxJavaHooks.onSingleStart(Single.just(1), oos));
+            assertSame(sos, RxJavaHooks.onSingleStart(Single.just(1), sos));
 
             assertNull(RxJavaHooks.onCompletableStart(Completable.never(), null));
 


### PR DESCRIPTION
This PR makes the `Single.OnSubscribe` as the primary means to execute the subscribe action in `Single` and former couple of reused `Observable` operators are now recreated with `Single.OnSubscribe`.

Because `Single` is now marked final, we can't remove the former `Observable.Operator` and `Observable.OnSubscribe` entry points (but may be deprecated in a separate PR).
