### PR TITLE
2.x: coverage and cleanup 10/04-1

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2670,13 +2670,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code ignoreElement} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an empty Maybe that only calls {@code onComplete} or {@code onError}, based on which one is
+     * @return an empty Completable that only calls {@code onComplete} or {@code onError}, based on which one is
      *         called by the source Maybe
      * @see <a href="http://reactivex.io/documentation/operators/ignoreelements.html">ReactiveX operators documentation: IgnoreElements</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> ignoreElement() {
-        return RxJavaPlugins.onAssembly(new MaybeIgnoreElement<T>(this));
+    public final Completable ignoreElement() {
+        return RxJavaPlugins.onAssembly(new MaybeIgnoreElementCompletable<T>(this));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
+++ b/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
@@ -97,6 +97,11 @@ public enum DisposableHelper implements Disposable {
         }
     }
 
+    /**
+     * Atomically disposes the Disposable in the field if not already disposed.
+     * @param field the target field
+     * @return true if the curren thread managed to dispose the Disposable
+     */
     public static boolean dispose(AtomicReference<Disposable> field) {
         Disposable current = field.get();
         Disposable d = DISPOSED;

--- a/src/main/java/io/reactivex/internal/observers/ToNotificationObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/ToNotificationObserver.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.observers;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.Exceptions;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -58,7 +58,7 @@ public final class ToNotificationObserver<T> implements Observer<T> {
             consumer.accept(Notification.<Object>createOnError(t));
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
-            RxJavaPlugins.onError(ex);
+            RxJavaPlugins.onError(new CompositeException(t, ex));
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
@@ -261,28 +261,6 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
 
                 r = get();
                 if (e == r) {
-
-                    if (cancelled) {
-                        return;
-                    }
-
-                    boolean b;
-
-                    try {
-                        b = it.hasNext();
-                    } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        a.onError(ex);
-                        return;
-                    }
-
-                    if (!b) {
-                        if (!cancelled) {
-                            a.onComplete();
-                        }
-                        return;
-                    }
-
                     r = addAndGet(-e);
                     if (r == 0L) {
                         return;
@@ -423,28 +401,6 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
 
                 r = get();
                 if (e == r) {
-
-                    if (cancelled) {
-                        return;
-                    }
-
-                    boolean hasNext;
-
-                    try {
-                        hasNext = it.hasNext();
-                    } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        a.onError(ex);
-                        return;
-                    }
-
-                    if (!hasNext) {
-                        if (!cancelled) {
-                            a.onComplete();
-                        }
-                        return;
-                    }
-
                     r = addAndGet(-e);
                     if (r == 0L) {
                         return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -23,7 +23,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.Exceptions;
+import io.reactivex.exceptions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.MpscLinkedQueue;
@@ -126,7 +126,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             } else {
                 cancelled = true;
                 s.cancel();
-                a.onError(new IllegalStateException("Could not deliver first window due to lack of requests."));
+                a.onError(new MissingBackpressureException("Could not deliver first window due to lack of requests."));
                 return;
             }
 
@@ -281,7 +281,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                                 queue.clear();
                                 s.cancel();
                                 dispose();
-                                a.onError(new IllegalStateException("Could not deliver first window due to lack of requests."));
+                                a.onError(new MissingBackpressureException("Could not deliver first window due to lack of requests."));
                                 return;
                             }
                         } else {
@@ -374,7 +374,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             } else {
                 cancelled = true;
                 s.cancel();
-                a.onError(new IllegalStateException("Could not deliver initial window due to lack of requests."));
+                a.onError(new MissingBackpressureException("Could not deliver initial window due to lack of requests."));
                 return;
             }
 
@@ -436,7 +436,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                         window = null;
                         s.cancel();
                         dispose();
-                        actual.onError(new IllegalStateException("Could not deliver window due to lack of requests"));
+                        actual.onError(new MissingBackpressureException("Could not deliver window due to lack of requests"));
                         return;
                     }
                 } else {
@@ -572,7 +572,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                                 queue.clear();
                                 s.cancel();
                                 dispose();
-                                a.onError(new IllegalStateException("Could not deliver first window due to lack of requests."));
+                                a.onError(new MissingBackpressureException("Could not deliver first window due to lack of requests."));
                                 return;
                             }
                         }
@@ -613,7 +613,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                             window = null;
                             s.cancel();
                             dispose();
-                            actual.onError(new IllegalStateException("Could not deliver window due to lack of requests"));
+                            actual.onError(new MissingBackpressureException("Could not deliver window due to lack of requests"));
                             return;
                         }
                     } else {
@@ -719,7 +719,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
             } else {
                 s.cancel();
-                actual.onError(new IllegalStateException("Could not emit the first window due to lack of requests"));
+                actual.onError(new MissingBackpressureException("Could not emit the first window due to lack of requests"));
             }
         }
 
@@ -878,7 +878,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                                     }
                                 }, timespan, unit);
                             } else {
-                                a.onError(new IllegalStateException("Can't emit window due to lack of requests"));
+                                a.onError(new MissingBackpressureException("Can't emit window due to lack of requests"));
                                 continue;
                             }
                         } else {

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeIgnoreElementCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeIgnoreElementCompletable.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.FuseToMaybe;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Turns an onSuccess into an onComplete, onError and onComplete is relayed as is.
+ *
+ * @param <T> the value type
+ */
+public final class MaybeIgnoreElementCompletable<T> extends Completable implements FuseToMaybe<T> {
+
+    final MaybeSource<T> source;
+
+    public MaybeIgnoreElementCompletable(MaybeSource<T> source) {
+        this.source = source;
+    }
+
+    @Override
+    protected void subscribeActual(CompletableObserver observer) {
+        source.subscribe(new IgnoreMaybeObserver<T>(observer));
+    }
+
+    @Override
+    public Maybe<T> fuseToMaybe() {
+        return RxJavaPlugins.onAssembly(new MaybeIgnoreElement<T>(source));
+    }
+
+    static final class IgnoreMaybeObserver<T> implements MaybeObserver<T>, Disposable {
+
+        final CompletableObserver actual;
+
+        Disposable d;
+
+        IgnoreMaybeObserver(CompletableObserver actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            d = DisposableHelper.DISPOSED;
+            actual.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            d = DisposableHelper.DISPOSED;
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            d = DisposableHelper.DISPOSED;
+            actual.onComplete();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            d = DisposableHelper.DISPOSED;
+        }
+
+    }
+
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -23,6 +23,7 @@ import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.observers.QueueDrainObserver;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.util.QueueDrainHelper;
@@ -201,19 +202,12 @@ extends AbstractObservableWithUpstream<T, U> {
             U next;
 
             try {
-                next = bufferSupplier.call();
+                next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null buffer");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 selfCancel = true;
                 dispose();
                 actual.onError(e);
-                return;
-            }
-
-            if (next == null) {
-                selfCancel = true;
-                dispose();
-                actual.onError(new NullPointerException("buffer supplied is null"));
                 return;
             }
 
@@ -371,7 +365,7 @@ extends AbstractObservableWithUpstream<T, U> {
             final U b; // NOPMD
 
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null buffer");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 dispose();
@@ -379,11 +373,6 @@ extends AbstractObservableWithUpstream<T, U> {
                 return;
             }
 
-            if (b == null) {
-                dispose();
-                actual.onError(new NullPointerException("The supplied buffer is null"));
-                return;
-            }
             synchronized (this) {
                 if (cancelled) {
                     return;
@@ -584,17 +573,11 @@ extends AbstractObservableWithUpstream<T, U> {
             U next;
 
             try {
-                next = bufferSupplier.call();
+                next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null buffer");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
-                return;
-            }
-
-            if (next == null) {
-                dispose();
-                actual.onError(new NullPointerException("The buffer supplied is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/schedulers/DisposeOnCancel.java
+++ b/src/main/java/io/reactivex/internal/schedulers/DisposeOnCancel.java
@@ -24,7 +24,7 @@ import io.reactivex.disposables.Disposable;
 final class DisposeOnCancel implements Future<Object> {
     final Disposable d;
 
-    public DisposeOnCancel(Disposable d) {
+    DisposeOnCancel(Disposable d) {
         this.d = d;
     }
 

--- a/src/test/java/io/reactivex/internal/observers/ToNotificationObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/ToNotificationObserverTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.observers;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class ToNotificationObserverTest {
+
+    @Test
+    public void doubleOnSubscribe() {
+        ToNotificationObserver<Integer> o = new ToNotificationObserver<Integer>(Functions.emptyConsumer());
+
+        Disposable d1 = Disposables.empty();
+
+        o.onSubscribe(d1);
+
+        Disposable d2 = Disposables.empty();
+
+        o.onSubscribe(d2);
+
+        assertFalse(d1.isDisposed());
+
+        assertTrue(d2.isDisposed());
+    }
+
+    @Test
+    public void nullOnNext() {
+        final List<Notification<Object>> list = new ArrayList<Notification<Object>>();
+
+        ToNotificationObserver<Integer> o = new ToNotificationObserver<Integer>(new Consumer<Notification<Object>>() {
+            @Override
+            public void accept(Notification<Object> e) throws Exception {
+                list.add(e);
+            }
+        });
+
+        Disposable d1 = Disposables.empty();
+
+        o.onSubscribe(d1);
+
+        o.onNext(null);
+
+        assertTrue(d1.isDisposed());
+
+        assertTrue(list.toString(), list.get(0).getError() instanceof NullPointerException);
+    }
+
+    @Test
+    public void onNextCrash() {
+        final List<Notification<Object>> list = new ArrayList<Notification<Object>>();
+
+        ToNotificationObserver<Integer> o = new ToNotificationObserver<Integer>(new Consumer<Notification<Object>>() {
+            @Override
+            public void accept(Notification<Object> e) throws Exception {
+                if (e.isOnNext()) {
+                    throw new TestException();
+                } else {
+                    list.add(e);
+                }
+            }
+        });
+
+        Disposable d1 = Disposables.empty();
+
+        o.onSubscribe(d1);
+
+        o.onNext(1);
+
+        assertTrue(d1.isDisposed());
+
+        assertTrue(list.toString(), list.get(0).getError() instanceof TestException);
+    }
+
+    @Test
+    public void onErrorCrash() {
+        final List<Throwable> list = TestHelper.trackPluginErrors();
+
+        try {
+            ToNotificationObserver<Integer> o = new ToNotificationObserver<Integer>(new Consumer<Notification<Object>>() {
+                @Override
+                public void accept(Notification<Object> e) throws Exception {
+                    throw new TestException("Inner");
+                }
+            });
+
+            Disposable d1 = Disposables.empty();
+
+            o.onSubscribe(d1);
+
+            o.onError(new TestException("Outer"));
+
+            TestHelper.assertError(list, 0, CompositeException.class);
+
+            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+
+            TestHelper.assertError(ce, 0, TestException.class, "Outer");
+            TestHelper.assertError(ce, 1, TestException.class, "Inner");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteCrash() {
+        final List<Throwable> list = TestHelper.trackPluginErrors();
+
+        try {
+            ToNotificationObserver<Integer> o = new ToNotificationObserver<Integer>(new Consumer<Notification<Object>>() {
+                @Override
+                public void accept(Notification<Object> e) throws Exception {
+                    throw new TestException("Inner");
+                }
+            });
+
+            Disposable d1 = Disposables.empty();
+
+            o.onSubscribe(d1);
+
+            o.onComplete();
+
+            TestHelper.assertError(list, 0, TestException.class, "Inner");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/AbstractMaybeWithUpstreamTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/AbstractMaybeWithUpstreamTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import io.reactivex.Maybe;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
+
+public class AbstractMaybeWithUpstreamTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void upstream() {
+        Maybe<Integer> source = Maybe.just(1);
+
+        assertSame(source, ((HasUpstreamMaybeSource<Integer>)source.map(Functions.<Integer>identity())).source());
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserverTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserverTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class MaybeCallbackObserverTest {
+
+    @Test
+    public void dispose() {
+        MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<Object>(Functions.emptyConsumer(), Functions.emptyConsumer(), Functions.EMPTY_ACTION);
+
+        Disposable d = Disposables.empty();
+
+        mo.onSubscribe(d);
+
+        assertFalse(mo.isDisposed());
+
+        mo.dispose();
+
+        assertTrue(mo.isDisposed());
+
+        assertTrue(d.isDisposed());
+    }
+
+    @Test
+    public void onSuccessCrashes() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<Object>(
+                    new Consumer<Object>() {
+                        @Override
+                        public void accept(Object v) throws Exception {
+                            throw new TestException();
+                        }
+                    },
+                    Functions.emptyConsumer(),
+                    Functions.EMPTY_ACTION);
+
+            mo.onSubscribe(Disposables.empty());
+
+            mo.onSuccess(1);
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorCrashes() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<Object>(
+                    Functions.emptyConsumer(),
+                    new Consumer<Object>() {
+                        @Override
+                        public void accept(Object v) throws Exception {
+                            throw new TestException("Inner");
+                        }
+                    },
+                    Functions.EMPTY_ACTION);
+
+            mo.onSubscribe(Disposables.empty());
+
+            mo.onError(new TestException("Outer"));
+
+            TestHelper.assertError(errors, 0, CompositeException.class);
+
+            List<Throwable> ce = TestHelper.compositeList(errors.get(0));
+
+            TestHelper.assertError(ce, 0, TestException.class, "Outer");
+            TestHelper.assertError(ce, 1, TestException.class, "Inner");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteCrashes() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<Object>(
+                    Functions.emptyConsumer(),
+                    Functions.emptyConsumer(),
+                    new Action() {
+                        @Override
+                        public void run() throws Exception {
+                            throw new TestException();
+                        }
+                    });
+
+            mo.onSubscribe(Disposables.empty());
+
+            mo.onComplete();
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCreateTest.java
@@ -1,0 +1,313 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+
+public class MaybeCreateTest {
+
+    @Test
+    public void callbackThrows() {
+        Maybe.create(new MaybeOnSubscribe<Object>() {
+            @Override
+            public void subscribe(MaybeEmitter<Object> e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void onSuccessNull() {
+        Maybe.create(new MaybeOnSubscribe<Object>() {
+            @Override
+            public void subscribe(MaybeEmitter<Object> e) throws Exception {
+                e.onSuccess(null);
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void onErrorNull() {
+        Maybe.create(new MaybeOnSubscribe<Object>() {
+            @Override
+            public void subscribe(MaybeEmitter<Object> e) throws Exception {
+                e.onError(null);
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Maybe.create(new MaybeOnSubscribe<Object>() {
+            @Override
+            public void subscribe(MaybeEmitter<Object> e) throws Exception {
+                e.onSuccess(1);
+            }
+        }));
+    }
+
+    @Test
+    public void onSuccessThrows() {
+        Maybe.create(new MaybeOnSubscribe<Object>() {
+            @Override
+            public void subscribe(MaybeEmitter<Object> e) throws Exception {
+                Disposable d = Disposables.empty();
+                e.setDisposable(d);
+
+                try {
+                    e.onSuccess(1);
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+
+                assertTrue(d.isDisposed());
+                assertTrue(e.isDisposed());
+            }
+        }).subscribe(new MaybeObserver<Object>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onSuccess(Object value) {
+                throw new TestException();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+        });
+    }
+
+    @Test
+    public void onErrorThrows() {
+        Maybe.create(new MaybeOnSubscribe<Object>() {
+            @Override
+            public void subscribe(MaybeEmitter<Object> e) throws Exception {
+                Disposable d = Disposables.empty();
+                e.setDisposable(d);
+
+                try {
+                    e.onError(new IOException());
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+
+                assertTrue(d.isDisposed());
+                assertTrue(e.isDisposed());
+            }
+        }).subscribe(new MaybeObserver<Object>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onSuccess(Object value) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new TestException();
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+        });
+    }
+
+    @Test
+    public void onCompleteThrows() {
+        Maybe.create(new MaybeOnSubscribe<Object>() {
+            @Override
+            public void subscribe(MaybeEmitter<Object> e) throws Exception {
+                Disposable d = Disposables.empty();
+                e.setDisposable(d);
+
+                try {
+                    e.onComplete();
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+
+                assertTrue(d.isDisposed());
+                assertTrue(e.isDisposed());
+            }
+        }).subscribe(new MaybeObserver<Object>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onSuccess(Object value) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onComplete() {
+                throw new TestException();
+            }
+        });
+    }
+
+    @Test
+    public void onSuccessThrows2() {
+        Maybe.create(new MaybeOnSubscribe<Object>() {
+            @Override
+            public void subscribe(MaybeEmitter<Object> e) throws Exception {
+                try {
+                    e.onSuccess(1);
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+
+                assertTrue(e.isDisposed());
+            }
+        }).subscribe(new MaybeObserver<Object>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onSuccess(Object value) {
+                throw new TestException();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+        });
+    }
+
+    @Test
+    public void onErrorThrows2() {
+        Maybe.create(new MaybeOnSubscribe<Object>() {
+            @Override
+            public void subscribe(MaybeEmitter<Object> e) throws Exception {
+                try {
+                    e.onError(new IOException());
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+
+                assertTrue(e.isDisposed());
+            }
+        }).subscribe(new MaybeObserver<Object>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onSuccess(Object value) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new TestException();
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+        });
+    }
+
+    @Test
+    public void onCompleteThrows2() {
+        Maybe.create(new MaybeOnSubscribe<Object>() {
+            @Override
+            public void subscribe(MaybeEmitter<Object> e) throws Exception {
+                try {
+                    e.onComplete();
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+
+                assertTrue(e.isDisposed());
+            }
+        }).subscribe(new MaybeObserver<Object>() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onSuccess(Object value) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onComplete() {
+                throw new TestException();
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDetachTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.processors.PublishProcessor;
+
+public class MaybeDetachTest {
+
+    @Test
+    public void doubleSubscribe() {
+
+        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
+            @Override
+            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
+                return m.onTerminateDetach();
+            }
+        });
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishProcessor.create().singleElement().onTerminateDetach());
+    }
+
+    @Test
+    public void onError() {
+        Maybe.error(new TestException())
+        .onTerminateDetach()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void onComplete() {
+        Maybe.empty()
+        .onTerminateDetach()
+        .test()
+        .assertResult();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapNotificationTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapNotificationTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.TestObserver;
+
+public class MaybeFlatMapNotificationTest {
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Maybe.just(1)
+                .flatMap(Functions.justFunction(Maybe.just(1)),
+                        Functions.justFunction(Maybe.just(1)), Functions.justCallable(Maybe.just(1))));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(Maybe<Integer> m) throws Exception {
+                return m
+                        .flatMap(Functions.justFunction(Maybe.just(1)),
+                                Functions.justFunction(Maybe.just(1)), Functions.justCallable(Maybe.just(1)));
+            }
+        });
+    }
+
+    @Test
+    public void onSuccessNull() {
+        Maybe.just(1)
+        .flatMap(Functions.justFunction((Maybe<Integer>)null),
+                Functions.justFunction(Maybe.just(1)),
+                Functions.justCallable(Maybe.just(1)))
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void onErrorNull() {
+        TestObserver<Integer> to = Maybe.<Integer>error(new TestException())
+        .flatMap(Functions.justFunction(Maybe.just(1)),
+                Functions.justFunction((Maybe<Integer>)null),
+                Functions.justCallable(Maybe.just(1)))
+        .test()
+        .assertFailure(CompositeException.class);
+
+        List<Throwable> ce = TestHelper.compositeList(to.errors().get(0));
+
+        TestHelper.assertError(ce, 0, TestException.class);
+        TestHelper.assertError(ce, 1, NullPointerException.class);
+    }
+
+    @Test
+    public void onCompleteNull() {
+        Maybe.<Integer>empty()
+        .flatMap(Functions.justFunction(Maybe.just(1)),
+                Functions.justFunction(Maybe.just(1)),
+                Functions.justCallable((Maybe<Integer>)null))
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void onSuccessEmpty() {
+        Maybe.just(1)
+        .flatMap(Functions.justFunction(Maybe.<Integer>empty()),
+                Functions.justFunction(Maybe.just(1)),
+                Functions.justCallable(Maybe.just(1)))
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void onSuccessError() {
+        Maybe.just(1)
+        .flatMap(Functions.justFunction(Maybe.<Integer>error(new TestException())),
+                Functions.justFunction((Maybe<Integer>)null),
+                Functions.justCallable(Maybe.just(1)))
+        .test()
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromFutureTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import io.reactivex.Maybe;
+import io.reactivex.internal.functions.Functions;
+
+public class MaybeFromFutureTest {
+
+    @Test
+    public void cancelImmediately() {
+        FutureTask<Integer> ft = new FutureTask<Integer>(Functions.justCallable(1));
+
+        Maybe.fromFuture(ft).test(true)
+        .assertEmpty();
+    }
+
+    @Test
+    public void timeout() {
+        FutureTask<Integer> ft = new FutureTask<Integer>(Functions.justCallable(1));
+
+        Maybe.fromFuture(ft, 1, TimeUnit.MILLISECONDS).test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TimeoutException.class);
+    }
+
+    @Test
+    public void timedWait() {
+        FutureTask<Integer> ft = new FutureTask<Integer>(Functions.justCallable(1));
+        ft.run();
+
+        Maybe.fromFuture(ft, 1, TimeUnit.MILLISECONDS).test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void interrupt() {
+        FutureTask<Integer> ft = new FutureTask<Integer>(Functions.justCallable(1));
+
+        Thread.currentThread().interrupt();
+
+        Maybe.fromFuture(ft, 1, TimeUnit.MILLISECONDS).test()
+        .assertFailure(InterruptedException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
@@ -27,39 +27,11 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 
-public class MaybeTakeUntilTest {
-
-    @Test
-    public void normalPublisher() {
-        Maybe.just(1).takeUntil(Flowable.never())
-        .test()
-        .assertResult(1);
-    }
-
-    @Test
-    public void normalMaybe() {
-        Maybe.just(1).takeUntil(Maybe.never())
-        .test()
-        .assertResult(1);
-    }
-
-    @Test
-    public void untilFirstPublisher() {
-        Maybe.just(1).takeUntil(Flowable.just("one"))
-        .test()
-        .assertResult();
-    }
-
-    @Test
-    public void untilFirstMaybe() {
-        Maybe.just(1).takeUntil(Maybe.just("one"))
-        .test()
-        .assertResult();
-    }
+public class MaybeTakeUntilPublisherTest {
 
     @Test
     public void disposed() {
-        TestHelper.checkDisposed(PublishProcessor.create().singleElement().takeUntil(Maybe.never()));
+        TestHelper.checkDisposed(PublishProcessor.create().singleElement().takeUntil(Flowable.never()));
     }
 
     @Test
@@ -67,7 +39,7 @@ public class MaybeTakeUntilTest {
         TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
             @Override
             public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
-                return m.takeUntil(Maybe.never());
+                return m.takeUntil(Flowable.never());
             }
         });
     }
@@ -77,7 +49,7 @@ public class MaybeTakeUntilTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2.singleElement()).test();
+        TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -95,7 +67,7 @@ public class MaybeTakeUntilTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2.singleElement()).test();
+        TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -113,7 +85,7 @@ public class MaybeTakeUntilTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2.singleElement()).test();
+        TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -131,7 +103,7 @@ public class MaybeTakeUntilTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2.singleElement()).test();
+        TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -150,7 +122,7 @@ public class MaybeTakeUntilTest {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-            TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2.singleElement()).test();
+            TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2).test();
 
             final TestException ex1 = new TestException();
             final TestException ex2 = new TestException();
@@ -192,7 +164,7 @@ public class MaybeTakeUntilTest {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-            TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2.singleElement()).test();
+            TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2).test();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeToCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeToCompletableTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
+
+public class MaybeToCompletableTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void source() {
+        Maybe<Integer> source = Maybe.just(1);
+
+        assertSame(source, ((HasUpstreamMaybeSource<Integer>)source.toCompletable()).source());
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Maybe.never().toCompletable());
+    }
+
+    @Test
+    public void successToComplete() {
+        Maybe.just(1)
+        .toCompletable()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void doubleSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybeToCompletable(new Function<Maybe<Object>, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Maybe<Object> m) throws Exception {
+                return m.toCompletable();
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBlockingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBlockingTest.java
@@ -215,4 +215,8 @@ public class ObservableBlockingTest {
         assertEquals(2, Observable.just(1, 2).blockingLast(3).intValue());
     }
 
+    @Test(expected = NoSuchElementException.class)
+    public void blockingSingleEmpty() {
+        Observable.empty().blockingSingle();
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
@@ -19,10 +19,11 @@ import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
 
-import io.reactivex.Observable;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
+import io.reactivex.subjects.PublishSubject;
 
 public class ObservableIgnoreElementsTest {
 
@@ -151,5 +152,21 @@ public class ObservableIgnoreElementsTest {
             }})
             .subscribe();
         assertTrue(unsub.get());
+    }
+
+    @Test
+    public void cancel() {
+
+        PublishSubject<Integer> pp = PublishSubject.create();
+
+        TestObserver<Integer> ts = pp.ignoreElements().<Integer>toObservable().test();
+
+        assertTrue(pp.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasObservers());
+
+        TestHelper.checkDisposed(pp.ignoreElements().<Integer>toObservable());
     }
 }

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -478,6 +478,16 @@ public class MaybeTest {
         }).test().assertResult();
     }
 
+    @Test
+    public void filterEmpty() {
+        Maybe.<Integer>empty().filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v == 1;
+            }
+        }).test().assertResult();
+    }
+
     @Test(expected = NullPointerException.class)
     public void singleFilterNull() {
         Single.just(1).filter(null);
@@ -565,6 +575,21 @@ public class MaybeTest {
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult()
         ;
+    }
+
+    @Test
+    public void observeOnDispose2() {
+        TestHelper.checkDisposed(Maybe.empty().observeOn(Schedulers.single()));
+    }
+
+    @Test
+    public void observeOnDoubleSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
+            @Override
+            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
+                return m.observeOn(Schedulers.single());
+            }
+        });
     }
 
     @Test
@@ -1135,6 +1160,32 @@ public class MaybeTest {
     public void ignoreElementComplete() {
         Maybe.empty()
         .ignoreElement()
+        .test()
+        .assertResult();
+    }
+    @Test
+    public void ignoreElementSuccessMaybe() {
+        Maybe.just(1)
+        .ignoreElement()
+        .toMaybe()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void ignoreElementErrorMaybe() {
+        Maybe.error(new TestException())
+        .ignoreElement()
+        .toMaybe()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void ignoreElementCompleteMaybe() {
+        Maybe.empty()
+        .ignoreElement()
+        .toMaybe()
         .test()
         .assertResult();
     }


### PR DESCRIPTION
- Improve coverage
- remove unused, unnecessary or impossible code paths
- fix order of inner exceptions in the reported `CompositeException` in various operators
- `Maybe.ignoreElement()` now returns `Completable`
