### PR TITLE
Limit gradle memory to avoid kill 137

### DIFF
--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # This script will build the project.
 
+GRADLE_OPTS=-Xmx832m
+
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
   ./gradlew -Prelease.useLastTag=true build


### PR DESCRIPTION
I read that decreasing the memory amount Gradle itself uses may help avoid such kills, let's try it.
