### PR TITLE
2.x: Fix javadoc for Single.flatMapObservable

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1922,8 +1922,7 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Returns a Single that is based on applying a specified function to the item emitted by the source Single,
->>>>>>> refs/remotes/akarnokd/SoloFlatMapIterable
+     * Returns an Observable that is based on applying a specified function to the item emitted by the source Single,
      * where that function returns a SingleSource.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.flatMap.png" alt="">


### PR DESCRIPTION
- wrong return type was described
- some git merging information was added
