### PR TITLE
2.x Remove Function from transformer interfaces to allow a single obj…

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -942,7 +942,12 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable compose(CompletableTransformer transformer) {
-        return wrap(to(transformer));
+        try {
+            return wrap(transformer.apply(this));
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
     }
 
     /**

--- a/src/main/java/io/reactivex/CompletableTransformer.java
+++ b/src/main/java/io/reactivex/CompletableTransformer.java
@@ -13,12 +13,10 @@
 
 package io.reactivex;
 
-import io.reactivex.functions.Function;
-
 /**
  * Convenience interface and callback used by the compose operator to turn a Completable into another
  * Completable fluently.
  */
-public interface CompletableTransformer extends Function<Completable, CompletableSource> {
-
+public interface CompletableTransformer {
+    CompletableSource apply(Completable completable);
 }

--- a/src/main/java/io/reactivex/CompletableTransformer.java
+++ b/src/main/java/io/reactivex/CompletableTransformer.java
@@ -18,5 +18,5 @@ package io.reactivex;
  * Completable fluently.
  */
 public interface CompletableTransformer {
-    CompletableSource apply(Completable completable);
+    CompletableSource apply(Completable completable) throws Exception;
 }

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -6278,7 +6278,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> compose(FlowableTransformer<T, R> composer) {
-        return fromPublisher(to(composer));
+        try {
+            return fromPublisher(composer.apply(this));
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
     }
 
     /**

--- a/src/main/java/io/reactivex/FlowableTransformer.java
+++ b/src/main/java/io/reactivex/FlowableTransformer.java
@@ -15,14 +15,12 @@ package io.reactivex;
 
 import org.reactivestreams.Publisher;
 
-import io.reactivex.functions.Function;
-
 /**
  * Interface to compose Flowables.
  *
  * @param <Upstream> the upstream value type
  * @param <Downstream> the downstream value type
  */
-public interface FlowableTransformer<Upstream, Downstream> extends Function<Flowable<Upstream>, Publisher<? extends Downstream>> {
-
+public interface FlowableTransformer<Upstream, Downstream> {
+    Publisher<? extends Downstream> apply(Flowable<Upstream> flowable);
 }

--- a/src/main/java/io/reactivex/FlowableTransformer.java
+++ b/src/main/java/io/reactivex/FlowableTransformer.java
@@ -22,5 +22,5 @@ import org.reactivestreams.Publisher;
  * @param <Downstream> the downstream value type
  */
 public interface FlowableTransformer<Upstream, Downstream> {
-    Publisher<? extends Downstream> apply(Flowable<Upstream> flowable);
+    Publisher<? extends Downstream> apply(Flowable<Upstream> flowable) throws Exception;
 }

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -1974,7 +1974,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Maybe<R> compose(MaybeTransformer<T, R> transformer) {
-        return wrap(to(transformer));
+        try {
+            return wrap(transformer.apply(this));
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
     }
 
     /**

--- a/src/main/java/io/reactivex/MaybeTransformer.java
+++ b/src/main/java/io/reactivex/MaybeTransformer.java
@@ -20,5 +20,5 @@ package io.reactivex;
  * @param <Downstream> the downstream value type
  */
 public interface MaybeTransformer<Upstream, Downstream> {
-    MaybeSource<Downstream> apply(Maybe<Upstream> maybe);
+    MaybeSource<Downstream> apply(Maybe<Upstream> maybe) throws Exception;
 }

--- a/src/main/java/io/reactivex/MaybeTransformer.java
+++ b/src/main/java/io/reactivex/MaybeTransformer.java
@@ -13,14 +13,12 @@
 
 package io.reactivex;
 
-import io.reactivex.functions.Function;
-
 /**
  * Interface to compose Maybes.
  *
  * @param <Upstream> the upstream value type
  * @param <Downstream> the downstream value type
  */
-public interface MaybeTransformer<Upstream, Downstream> extends Function<Maybe<Upstream>, MaybeSource<Downstream>> {
-
+public interface MaybeTransformer<Upstream, Downstream> {
+    MaybeSource<Downstream> apply(Maybe<Upstream> maybe);
 }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -5489,7 +5489,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> compose(ObservableTransformer<T, R> composer) {
-        return wrap(to(composer));
+        try {
+            return wrap(composer.apply(this));
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
     }
 
 

--- a/src/main/java/io/reactivex/ObservableTransformer.java
+++ b/src/main/java/io/reactivex/ObservableTransformer.java
@@ -13,14 +13,12 @@
 
 package io.reactivex;
 
-import io.reactivex.functions.Function;
-
 /**
  * Interface to compose Observables.
  *
  * @param <Upstream> the upstream value type
  * @param <Downstream> the downstream value type
  */
-public interface ObservableTransformer<Upstream, Downstream> extends Function<Observable<Upstream>, ObservableSource<Downstream>> {
-
+public interface ObservableTransformer<Upstream, Downstream> {
+    ObservableSource<Downstream> apply(Observable<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/ObservableTransformer.java
+++ b/src/main/java/io/reactivex/ObservableTransformer.java
@@ -20,5 +20,5 @@ package io.reactivex;
  * @param <Downstream> the downstream value type
  */
 public interface ObservableTransformer<Upstream, Downstream> {
-    ObservableSource<Downstream> apply(Observable<Upstream> upstream);
+    ObservableSource<Downstream> apply(Observable<Upstream> upstream) throws Exception;
 }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1473,7 +1473,12 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Single<R> compose(SingleTransformer<T, R> transformer) {
-        return wrap(to(transformer));
+        try {
+            return wrap(transformer.apply(this));
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
     }
 
     /**

--- a/src/main/java/io/reactivex/SingleTransformer.java
+++ b/src/main/java/io/reactivex/SingleTransformer.java
@@ -13,14 +13,12 @@
 
 package io.reactivex;
 
-import io.reactivex.functions.Function;
-
 /**
  * Interface to compose Singles.
  *
  * @param <Upstream> the upstream value type
  * @param <Downstream> the downstream value type
  */
-public interface SingleTransformer<Upstream, Downstream> extends Function<Single<Upstream>, SingleSource<Downstream>> {
-
+public interface SingleTransformer<Upstream, Downstream> {
+    SingleSource<Downstream> apply(Single<Upstream> upstream) throws Exception;
 }


### PR DESCRIPTION
This pull request removes Function from the super type of the various Transformer interfaces. While these are technically functions, the problem is that if they all extend Function then you cannot have a single object instance that can implement multiple Transformer interfaces. The goal is to be able to call a function that returns an object that can be passed to Observable.compose or Single.Compose and so on.

This was an issue with RxLifecycle project. See this for more info: https://github.com/trello/RxLifecycle/issues/39
