### PR TITLE
2.x: fix flatMapX calling SpscLinkedArrayQueue.offer concurrently

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -191,14 +191,18 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
                     }
                 } else {
                     SpscLinkedArrayQueue<R> q = getOrCreateQueue();
-                    q.offer(value);
+                    synchronized (q) {
+                        q.offer(value);
+                    }
                 }
                 if (decrementAndGet() == 0) {
                     return;
                 }
             } else {
                 SpscLinkedArrayQueue<R> q = getOrCreateQueue();
-                q.offer(value);
+                synchronized (q) {
+                    q.offer(value);
+                }
                 active.decrementAndGet();
                 if (getAndIncrement() != 0) {
                     return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -191,14 +191,18 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
                     }
                 } else {
                     SpscLinkedArrayQueue<R> q = getOrCreateQueue();
-                    q.offer(value);
+                    synchronized (q) {
+                        q.offer(value);
+                    }
                 }
                 if (decrementAndGet() == 0) {
                     return;
                 }
             } else {
                 SpscLinkedArrayQueue<R> q = getOrCreateQueue();
-                q.offer(value);
+                synchronized (q) {
+                    q.offer(value);
+                }
                 active.decrementAndGet();
                 if (getAndIncrement() != 0) {
                     return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
@@ -167,7 +167,9 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
                 }
             } else {
                 SpscLinkedArrayQueue<R> q = getOrCreateQueue();
-                q.offer(value);
+                synchronized (q) {
+                    q.offer(value);
+                }
                 active.decrementAndGet();
                 if (getAndIncrement() != 0) {
                     return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
@@ -167,7 +167,9 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
                 }
             } else {
                 SpscLinkedArrayQueue<R> q = getOrCreateQueue();
-                q.offer(value);
+                synchronized (q) {
+                    q.offer(value);
+                }
                 active.decrementAndGet();
                 if (getAndIncrement() != 0) {
                     return;


### PR DESCRIPTION
I forgot to synchronize the offer part of the new flatMapX operators (since of course, Spsc is for single producer only but here there could be concurrent non fast-path queueing of values). 

(There is an MpscLinkedArrayQueue in JCTools but I'm not confident in it and don't want to use MpscLinkedQueue due to the node allocation.)
