### PR TITLE
2.x: Fix Flowable + Single elementAt and elementAtOrError operators on empty sources

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtMaybe.java
@@ -97,7 +97,7 @@ public final class FlowableElementAtMaybe<T> extends Maybe<T> implements FuseToF
         @Override
         public void onComplete() {
             s = SubscriptionHelper.CANCELLED;
-            if (index <= count && !done) {
+            if (!done) {
                 done = true;
                 actual.onComplete();
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtSingle.java
@@ -103,7 +103,7 @@ public final class FlowableElementAtSingle<T> extends Single<T> implements FuseT
         @Override
         public void onComplete() {
             s = SubscriptionHelper.CANCELLED;
-            if (index <= count && !done) {
+            if (!done) {
                 done = true;
 
                 T v = defaultValue;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtMaybe.java
@@ -98,7 +98,7 @@ public final class ObservableElementAtMaybe<T> extends Maybe<T> implements FuseT
 
         @Override
         public void onComplete() {
-            if (index <= count && !done) {
+            if (!done) {
                 done = true;
                 actual.onComplete();
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtSingle.java
@@ -99,7 +99,7 @@ public final class ObservableElementAtSingle<T> extends Single<T> {
 
         @Override
         public void onComplete() {
-            if (index <= count && !done) {
+            if (!done) {
                 done = true;
 
                 T v = defaultValue;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
@@ -135,4 +135,44 @@ public class FlowableElementAtTest {
             .assertErrorMessage("error")
             .assertError(RuntimeException.class);
     }
+
+    @Test
+    public void elementAtIndex0OnEmptySource() {
+        Flowable.empty()
+            .elementAt(0)
+            .test()
+            .assertResult();
+    }
+
+    @Test
+    public void elementAtIndex0WithDefaultOnEmptySource() {
+        Flowable.empty()
+            .elementAt(0, 5)
+            .test()
+            .assertResult(5);
+    }
+
+    @Test
+    public void elementAtIndex1OnEmptySource() {
+        Flowable.empty()
+            .elementAt(1)
+            .test()
+            .assertResult();
+    }
+
+    @Test
+    public void elementAtIndex1WithDefaultOnEmptySource() {
+        Flowable.empty()
+            .elementAt(1, 10)
+            .test()
+            .assertResult(10);
+    }
+
+    @Test
+    public void elementAtOrErrorIndex1OnEmptySource() {
+        Flowable.empty()
+            .elementAtOrError(1)
+            .test()
+            .assertFailure(NoSuchElementException.class);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableElementAtTest.java
@@ -126,4 +126,44 @@ public class ObservableElementAtTest {
             .assertErrorMessage("error")
             .assertError(RuntimeException.class);
     }
+
+    @Test
+    public void elementAtIndex0OnEmptySource() {
+        Observable.empty()
+            .elementAt(0)
+            .test()
+            .assertResult();
+    }
+
+    @Test
+    public void elementAtIndex0WithDefaultOnEmptySource() {
+        Observable.empty()
+            .elementAt(0, 5)
+            .test()
+            .assertResult(5);
+    }
+
+    @Test
+    public void elementAtIndex1OnEmptySource() {
+        Observable.empty()
+            .elementAt(1)
+            .test()
+            .assertResult();
+    }
+
+    @Test
+    public void elementAtIndex1WithDefaultOnEmptySource() {
+        Observable.empty()
+            .elementAt(1, 10)
+            .test()
+            .assertResult(10);
+    }
+
+    @Test
+    public void elementAtOrErrorIndex1OnEmptySource() {
+        Observable.empty()
+            .elementAtOrError(1)
+            .test()
+            .assertFailure(NoSuchElementException.class);
+    }
 }


### PR DESCRIPTION
This will fix #4680
- elementAtOrError(1) on an empty source just leaves the new Single hanging without signalling onError()
- elementAt(1) on an empty source just leaves the Maybe hanging without signalling onComplete()
- I also noticed that elementAt() with a default value on an empty source did not work either.
