### PR TITLE
2.x: Test static from methods and add Maybe.fromSingle & fromCompletable

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -564,6 +564,42 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
+     * Wraps a CompletableSource into a Maybe.
+     *
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code fromCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the target type
+     * @param completableSource the CompletableSource to convert from
+     * @return the new Maybe instance
+     * @throws NullPointerException if completable is null
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Maybe<T> fromCompletable(CompletableSource completableSource) {
+        ObjectHelper.requireNonNull(completableSource, "completableSource is null");
+        return RxJavaPlugins.onAssembly(new MaybeFromCompletable<T>(completableSource));
+    }
+
+    /**
+     * Wraps a SingleSource into a Maybe.
+     *
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code fromSingle} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the target type
+     * @param singleSource the SingleSource to convert from
+     * @return the new Maybe instance
+     * @throws NullPointerException if single is null
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Maybe<T> fromSingle(SingleSource singleSource) {
+        ObjectHelper.requireNonNull(singleSource, "singleSource is null");
+        return RxJavaPlugins.onAssembly(new MaybeFromSingle<T>(singleSource));
+    }
+
+    /**
      * Returns a {@link Maybe} that invokes passed function and emits its result for each new MaybeObserver that subscribes
      * while considering {@code null} value from the callable as indication for valueless completion.
      * <p>

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromObservable.java
@@ -26,28 +26,34 @@ public final class CompletableFromObservable<T> extends Completable {
 
     @Override
     protected void subscribeActual(final CompletableObserver s) {
-        observable.subscribe(new Observer<T>() {
+        observable.subscribe(new CompletableFromObservableObserver<T>(s));
+    }
 
-            @Override
-            public void onComplete() {
-                s.onComplete();
-            }
+    static final class CompletableFromObservableObserver<T> implements Observer<T> {
+        final CompletableObserver co;
 
-            @Override
-            public void onError(Throwable e) {
-                s.onError(e);
-            }
+        CompletableFromObservableObserver(CompletableObserver co) {
+            this.co = co;
+        }
 
-            @Override
-            public void onNext(T value) {
-                // ignored
-            }
+        @Override
+        public void onSubscribe(Disposable d) {
+            co.onSubscribe(d);
+        }
 
-            @Override
-            public void onSubscribe(Disposable d) {
-                s.onSubscribe(d);
-            }
+        @Override
+        public void onNext(T value) {
+            // Deliberately ignored.
+        }
 
-        });
+        @Override
+        public void onError(Throwable e) {
+            co.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            co.onComplete();
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromSingle.java
@@ -26,24 +26,29 @@ public final class CompletableFromSingle<T> extends Completable {
 
     @Override
     protected void subscribeActual(final CompletableObserver s) {
-        single.subscribe(new SingleObserver<T>() {
-
-            @Override
-            public void onError(Throwable e) {
-                s.onError(e);
-            }
-
-            @Override
-            public void onSubscribe(Disposable d) {
-                s.onSubscribe(d);
-            }
-
-            @Override
-            public void onSuccess(T value) {
-                s.onComplete();
-            }
-
-        });
+        single.subscribe(new CompletableFromSingleObserver<T>(s));
     }
 
+    static final class CompletableFromSingleObserver<T> implements SingleObserver<T> {
+        final CompletableObserver co;
+
+        CompletableFromSingleObserver(CompletableObserver co) {
+            this.co = co;
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            co.onError(e);
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            co.onSubscribe(d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            co.onComplete();
+        }
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableFromActionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableFromActionTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import io.reactivex.Completable;
+import io.reactivex.functions.Action;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CompletableFromActionTest {
+    @Test(expected = NullPointerException.class)
+    public void fromActionNull() {
+        Completable.fromAction(null);
+    }
+
+    @Test
+    public void fromAction() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Completable.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                atomicInteger.incrementAndGet();
+            }
+        })
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromActionTwice() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Action run = new Action() {
+            @Override
+            public void run() throws Exception {
+                atomicInteger.incrementAndGet();
+            }
+        };
+
+        Completable.fromAction(run)
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+
+        Completable.fromAction(run)
+            .test()
+            .assertResult();
+
+        assertEquals(2, atomicInteger.get());
+    }
+
+    @Test
+    public void fromActionInvokesLazy() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Completable completable = Completable.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                atomicInteger.incrementAndGet();
+            }
+        });
+
+        assertEquals(0, atomicInteger.get());
+
+        completable
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromActionThrows() {
+        Completable.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                throw new UnsupportedOperationException();
+            }
+        })
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableFromCallableTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import io.reactivex.Completable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CompletableFromCallableTest {
+    @Test(expected = NullPointerException.class)
+    public void fromCallableNull() {
+        Completable.fromCallable(null);
+    }
+
+    @Test
+    public void fromCallable() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Completable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                atomicInteger.incrementAndGet();
+                return null;
+            }
+        })
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromCallableTwice() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Callable<Object> callable = new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                atomicInteger.incrementAndGet();
+                return null;
+            }
+        };
+
+        Completable.fromCallable(callable)
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+
+        Completable.fromCallable(callable)
+            .test()
+            .assertResult();
+
+        assertEquals(2, atomicInteger.get());
+    }
+
+    @Test
+    public void fromCallableInvokesLazy() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Completable completable = Completable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                atomicInteger.incrementAndGet();
+                return null;
+            }
+        });
+
+        assertEquals(0, atomicInteger.get());
+
+        completable
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromCallableThrows() {
+        Completable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                throw new UnsupportedOperationException();
+            }
+        })
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableFromObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableFromObservableTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import io.reactivex.Completable;
+import io.reactivex.Observable;
+import org.junit.Test;
+
+public class CompletableFromObservableTest {
+    @Test(expected = NullPointerException.class)
+    public void fromObservableNull() {
+        Completable.fromObservable(null);
+    }
+
+    @Test
+    public void fromObservable() {
+        Completable.fromObservable(Observable.just(1))
+            .test()
+            .assertResult();
+    }
+
+    @Test
+    public void fromObservableEmpty() {
+        Completable.fromObservable(Observable.empty())
+            .test()
+            .assertResult();
+    }
+
+    @Test
+    public void fromObservableError() {
+        Completable.fromObservable(Observable.error(new UnsupportedOperationException()))
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableFromPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableFromPublisherTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import org.junit.Test;
+
+public class CompletableFromPublisherTest {
+    @Test(expected = NullPointerException.class)
+    public void fromPublisherNull() {
+        Completable.fromPublisher(null);
+    }
+
+    @Test
+    public void fromPublisher() {
+        Completable.fromPublisher(Flowable.just(1))
+            .test()
+            .assertResult();
+    }
+
+    @Test
+    public void fromPublisherEmpty() {
+        Completable.fromPublisher(Flowable.empty())
+            .test()
+            .assertResult();
+    }
+
+    @Test
+    public void fromPublisherThrows() {
+        Completable.fromPublisher(Flowable.error(new UnsupportedOperationException()))
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableFromRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableFromRunnableTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import io.reactivex.Completable;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CompletableFromRunnableTest {
+    @Test(expected = NullPointerException.class)
+    public void fromRunnableNull() {
+        Completable.fromRunnable(null);
+    }
+
+    @Test
+    public void fromRunnable() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Completable.fromRunnable(new Runnable() {
+            @Override
+            public void run() {
+                atomicInteger.incrementAndGet();
+            }
+        })
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromRunnableTwice() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Runnable run = new Runnable() {
+            @Override
+            public void run() {
+                atomicInteger.incrementAndGet();
+            }
+        };
+
+        Completable.fromRunnable(run)
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+
+        Completable.fromRunnable(run)
+            .test()
+            .assertResult();
+
+        assertEquals(2, atomicInteger.get());
+    }
+
+    @Test
+    public void fromRunnableInvokesLazy() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Completable completable = Completable.fromRunnable(new Runnable() {
+            @Override
+            public void run() {
+                atomicInteger.incrementAndGet();
+            }
+        });
+
+        assertEquals(0, atomicInteger.get());
+
+        completable
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromRunnableThrows() {
+        Completable.fromRunnable(new Runnable() {
+            @Override
+            public void run() {
+                throw new UnsupportedOperationException();
+            }
+        })
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableFromSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableFromSingleTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import io.reactivex.Completable;
+import io.reactivex.Single;
+import org.junit.Test;
+
+public class CompletableFromSingleTest {
+    @Test(expected = NullPointerException.class)
+    public void fromSingleNull() {
+        Completable.fromSingle(null);
+    }
+
+    @Test
+    public void fromSingle() {
+        Completable.fromSingle(Single.just(1))
+            .test()
+            .assertResult();
+    }
+
+    @Test
+    public void fromSingleError() {
+        Completable.fromSingle(Single.error(new UnsupportedOperationException()))
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.Maybe;
+import io.reactivex.functions.Action;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MaybeFromActionTest {
+    @Test(expected = NullPointerException.class)
+    public void fromActionNull() {
+        Maybe.fromAction(null);
+    }
+
+    @Test
+    public void fromAction() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Maybe.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                atomicInteger.incrementAndGet();
+            }
+        })
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromActionTwice() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Action run = new Action() {
+            @Override
+            public void run() throws Exception {
+                atomicInteger.incrementAndGet();
+            }
+        };
+
+        Maybe.fromAction(run)
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+
+        Maybe.fromAction(run)
+            .test()
+            .assertResult();
+
+        assertEquals(2, atomicInteger.get());
+    }
+
+    @Test
+    public void fromActionInvokesLazy() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Maybe<Object> maybe = Maybe.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                atomicInteger.incrementAndGet();
+            }
+        });
+
+        assertEquals(0, atomicInteger.get());
+
+        maybe
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromActionThrows() {
+        Maybe.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                throw new UnsupportedOperationException();
+            }
+        })
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.Maybe;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MaybeFromCallableTest {
+    @Test(expected = NullPointerException.class)
+    public void fromCallableNull() {
+        Maybe.fromCallable(null);
+    }
+
+    @Test
+    public void fromCallable() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Maybe.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                atomicInteger.incrementAndGet();
+                return null;
+            }
+        })
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromCallableTwice() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Callable<Object> callable = new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                atomicInteger.incrementAndGet();
+                return null;
+            }
+        };
+
+        Maybe.fromCallable(callable)
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+
+        Maybe.fromCallable(callable)
+            .test()
+            .assertResult();
+
+        assertEquals(2, atomicInteger.get());
+    }
+
+    @Test
+    public void fromCallableInvokesLazy() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Maybe<Object> completable = Maybe.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                atomicInteger.incrementAndGet();
+                return null;
+            }
+        });
+
+        assertEquals(0, atomicInteger.get());
+
+        completable
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromCallableThrows() {
+        Maybe.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                throw new UnsupportedOperationException();
+            }
+        })
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCompletableTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
+import org.junit.Test;
+
+public class MaybeFromCompletableTest {
+    @Test(expected = NullPointerException.class)
+    public void fromCompletableNull() {
+        Maybe.fromCompletable(null);
+    }
+
+    @Test
+    public void fromCompletable() {
+        Maybe.fromCompletable(Completable.complete())
+            .test()
+            .assertResult();
+    }
+
+    @Test
+    public void fromCompletableError() {
+        Maybe.fromCompletable(Completable.error(new UnsupportedOperationException()))
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.Maybe;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MaybeFromRunnableTest {
+    @Test(expected = NullPointerException.class)
+    public void fromRunnableNull() {
+        Maybe.fromRunnable(null);
+    }
+
+    @Test
+    public void fromRunnable() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Maybe.fromRunnable(new Runnable() {
+            @Override
+            public void run() {
+                atomicInteger.incrementAndGet();
+            }
+        })
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromRunnableTwice() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        Runnable run = new Runnable() {
+            @Override
+            public void run() {
+                atomicInteger.incrementAndGet();
+            }
+        };
+
+        Maybe.fromRunnable(run)
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+
+        Maybe.fromRunnable(run)
+            .test()
+            .assertResult();
+
+        assertEquals(2, atomicInteger.get());
+    }
+
+    @Test
+    public void fromRunnableInvokesLazy() {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+
+        final Maybe<Object> maybe = Maybe.fromRunnable(new Runnable() {
+            @Override public void run() {
+                atomicInteger.incrementAndGet();
+            }
+        });
+
+        assertEquals(0, atomicInteger.get());
+
+        maybe
+            .test()
+            .assertResult();
+
+        assertEquals(1, atomicInteger.get());
+    }
+
+    @Test
+    public void fromRunnableThrows() {
+        Maybe.fromRunnable(new Runnable() {
+            @Override
+            public void run() {
+                throw new UnsupportedOperationException();
+            }
+        })
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromSingleTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+import org.junit.Test;
+
+public class MaybeFromSingleTest {
+    @Test(expected = NullPointerException.class)
+    public void fromSingleNull() {
+        Maybe.fromSingle(null);
+    }
+
+    @Test
+    public void fromSingle() {
+        Maybe.fromSingle(Single.just(1))
+            .test()
+            .assertResult(1);
+    }
+
+    @Test
+    public void fromSingleThrows() {
+        Maybe.fromSingle(Single.error(new UnsupportedOperationException()))
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFromCallableTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import io.reactivex.Single;
+import java.util.concurrent.Callable;
+import org.junit.Test;
+
+public class SingleFromCallableTest {
+    @Test
+    public void fromCallableValue() {
+        Single.fromCallable(new Callable<Integer>() {
+            @Override public Integer call() throws Exception {
+                return 5;
+            }
+        })
+            .test()
+            .assertResult(5);
+    }
+
+    @Test
+    public void fromCallableError() {
+        Single.fromCallable(new Callable<Integer>() {
+            @Override public Integer call() throws Exception {
+                throw new UnsupportedOperationException();
+            }
+        })
+            .test()
+            .assertFailure(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void fromCallableNull() {
+        Single.fromCallable(new Callable<Integer>() {
+            @Override public Integer call() throws Exception {
+                return null;
+            }
+        })
+            .test()
+            .assertFailureAndMessage(NullPointerException.class, "The callable returned a null value");
+    }
+}


### PR DESCRIPTION
- add Maybe.fromSingle by reusing MaybeFromSingle
- add Maybe.fromCompletable by resuing MaybeFromCompletable
- remove anonymous classes in various operators
- add tests for
  - Completable.fromAction()
  - Completable.fromCallable()
  - Completable.fromObservable()
  - Completable.fromPublisher()
  - Completable.fromRunnable()
  - Completable.fromSingle()
  - Maybe.fromAction()
  - Maybe.fromCallable()
  - Maybe.fromCompletable()
  - Maybe.fromRunnable()
  - Maybe.fromSingle()
  - Single.fromCallable()
