### PR TITLE
2.: Fix flatMapX over-cancellation in case of an inner error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,13 @@ jacoco {
     toolVersion = '0.7.7.201606060606' // See http://www.eclemma.org/jacoco/.
 }
 
+task GCandMem(dependsOn: 'check') << {
+    System.gc()
+    Thread.sleep(200)
+    print("Memory usage: ")
+    println(java.lang.management.ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / 1024.0 / 1024.0)
+}
+
 jacocoTestReport {
     reports {
         xml.enabled = true
@@ -128,6 +135,8 @@ jacocoTestReport {
         })
     }
 }
+
+jacocoTestReport.dependsOn GCandMem
 
 build.dependsOn jacocoTestReport
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -228,7 +228,8 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
             set.delete(inner);
             if (errors.addThrowable(e)) {
                 if (!delayErrors) {
-                    cancel();
+                    s.cancel();
+                    set.dispose();
                 }
                 active.decrementAndGet();
                 drain();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -228,7 +228,8 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
             set.delete(inner);
             if (errors.addThrowable(e)) {
                 if (!delayErrors) {
-                    cancel();
+                    s.cancel();
+                    set.dispose();
                 }
                 active.decrementAndGet();
                 drain();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
@@ -195,7 +195,8 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
             set.delete(inner);
             if (errors.addThrowable(e)) {
                 if (!delayErrors) {
-                    dispose();
+                    d.dispose();
+                    set.dispose();
                 }
                 active.decrementAndGet();
                 drain();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
@@ -195,7 +195,8 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
             set.delete(inner);
             if (errors.addThrowable(e)) {
                 if (!delayErrors) {
-                    dispose();
+                    d.dispose();
+                    set.dispose();
                 }
                 active.decrementAndGet();
                 drain();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import static org.junit.Assert.*;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import org.junit.Test;
 
@@ -252,5 +252,23 @@ public class FlowableFlatMapMaybeTest {
         .take(2)
         .test()
         .assertResult(1, 2);
+    }
+
+    @Test
+    public void middleError() {
+        Flowable.fromArray(new String[]{"1","a","2"}).flatMapMaybe(new Function<String, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(final String s) throws NumberFormatException {
+                //return Single.just(Integer.valueOf(s)); //This works
+                return Maybe.fromCallable(new Callable<Integer>() {
+                    @Override
+                    public Integer call() throws NumberFormatException {
+                        return Integer.valueOf(s);
+                    }
+                });
+            }
+        })
+        .test()
+        .assertFailure(NumberFormatException.class, 1);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import static org.junit.Assert.*;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import org.junit.Test;
 
@@ -239,5 +239,23 @@ public class FlowableFlatMapSingleTest {
         .take(2)
         .test()
         .assertResult(1, 2);
+    }
+
+    @Test
+    public void middleError() {
+        Flowable.fromArray(new String[]{"1","a","2"}).flatMapSingle(new Function<String, SingleSource<Integer>>() {
+            @Override
+            public SingleSource<Integer> apply(final String s) throws NumberFormatException {
+                //return Single.just(Integer.valueOf(s)); //This works
+                return Single.fromCallable(new Callable<Integer>() {
+                    @Override
+                    public Integer call() throws NumberFormatException {
+                        return Integer.valueOf(s);
+                    }
+                });
+            }
+        })
+        .test()
+        .assertFailure(NumberFormatException.class, 1);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.observable;
 import static org.junit.Assert.*;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import org.junit.Test;
 
@@ -180,5 +180,23 @@ public class ObservableFlatMapMaybeTest {
         .take(2)
         .test()
         .assertResult(1, 2);
+    }
+
+    @Test
+    public void middleError() {
+        Observable.fromArray(new String[]{"1","a","2"}).flatMapMaybe(new Function<String, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(final String s) throws NumberFormatException {
+                //return Single.just(Integer.valueOf(s)); //This works
+                return Maybe.fromCallable(new Callable<Integer>() {
+                    @Override
+                    public Integer call() throws NumberFormatException {
+                        return Integer.valueOf(s);
+                    }
+                });
+            }
+        })
+        .test()
+        .assertFailure(NumberFormatException.class, 1);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.observable;
 import static org.junit.Assert.*;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import org.junit.Test;
 
@@ -167,5 +167,23 @@ public class ObservableFlatMapSingleTest {
         .take(2)
         .test()
         .assertResult(1, 2);
+    }
+
+    @Test
+    public void middleError() {
+        Observable.fromArray(new String[]{"1","a","2"}).flatMapSingle(new Function<String, SingleSource<Integer>>() {
+            @Override
+            public SingleSource<Integer> apply(final String s) throws NumberFormatException {
+                //return Single.just(Integer.valueOf(s)); //This works
+                return Single.fromCallable(new Callable<Integer>() {
+                    @Override
+                    public Integer call() throws NumberFormatException {
+                        return Integer.valueOf(s);
+                    }
+                });
+            }
+        })
+        .test()
+        .assertFailure(NumberFormatException.class, 1);
     }
 }


### PR DESCRIPTION
A non-delayed error set the cancellation flag and thus any subsequent drain would just quit instead of delivering the error.

(And while I'm at it, I'll try to figure out a way to not get killed by OOMKiller).

Reported in #4684.
