### PR TITLE
2.x: coverage, fixes and cleanup 10/11-2

### DIFF
--- a/src/main/java/io/reactivex/internal/observers/ResumeSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/ResumeSingleObserver.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.observers;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.SingleObserver;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * A SingleObserver implementation used for subscribing to the actual SingleSource
+ * and replace the current Disposable in a parent AtomicReference.
+ *
+ * @param <T> the value type
+ */
+public final class ResumeSingleObserver<T> implements SingleObserver<T> {
+
+    final AtomicReference<Disposable> parent;
+
+    final SingleObserver<? super T> actual;
+
+    public ResumeSingleObserver(AtomicReference<Disposable> parent, SingleObserver<? super T> actual) {
+        this.parent = parent;
+        this.actual = actual;
+    }
+
+    @Override
+    public void onSubscribe(Disposable d) {
+        DisposableHelper.replace(parent, d);
+    }
+
+    @Override
+    public void onSuccess(T value) {
+        actual.onSuccess(value);
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        actual.onError(e);
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDisposeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDisposeOn.java
@@ -14,7 +14,9 @@
 package io.reactivex.internal.operators.completable;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableDisposeOn extends Completable {
 
@@ -29,34 +31,65 @@ public final class CompletableDisposeOn extends Completable {
 
     @Override
     protected void subscribeActual(final CompletableObserver s) {
-        source.subscribe(new CompletableObserver() {
+        source.subscribe(new CompletableObserverImplementation(s, scheduler));
+    }
 
-            @Override
-            public void onComplete() {
-                s.onComplete();
+    static final class CompletableObserverImplementation implements CompletableObserver, Disposable, Runnable {
+        final CompletableObserver s;
+
+        final Scheduler scheduler;
+
+        Disposable d;
+
+        volatile boolean disposed;
+
+        CompletableObserverImplementation(CompletableObserver s, Scheduler scheduler) {
+            this.s = s;
+            this.scheduler = scheduler;
+        }
+
+        @Override
+        public void onComplete() {
+            if (disposed) {
+                return;
             }
+            s.onComplete();
+        }
 
-            @Override
-            public void onError(Throwable e) {
-                s.onError(e);
+        @Override
+        public void onError(Throwable e) {
+            if (disposed) {
+                RxJavaPlugins.onError(e);
+                return;
             }
+            s.onError(e);
+        }
 
-            @Override
-            public void onSubscribe(final Disposable d) {
-                s.onSubscribe(Disposables.fromRunnable(new Runnable() {
-                    @Override
-                    public void run() {
-                        scheduler.scheduleDirect(new Runnable() {
-                            @Override
-                            public void run() {
-                                d.dispose();
-                            }
-                        });
-                    }
-                }));
+        @Override
+        public void onSubscribe(final Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                s.onSubscribe(this);
             }
+        }
 
-        });
+        @Override
+        public void dispose() {
+            disposed = true;
+            scheduler.scheduleDirect(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return disposed;
+        }
+
+        @Override
+        public void run() {
+            d.dispose();
+            d = DisposableHelper.DISPOSED;
+        }
     }
 
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDoOnEvent.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDoOnEvent.java
@@ -52,7 +52,7 @@ public final class CompletableDoOnEvent extends Completable {
                     onEvent.accept(e);
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
-                    e = new CompositeException(ex, e);
+                    e = new CompositeException(e, ex);
                 }
 
                 s.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
@@ -37,6 +37,7 @@ public final class CompletableResumeNext extends Completable {
     protected void subscribeActual(final CompletableObserver s) {
 
         final SequentialDisposable sd = new SequentialDisposable();
+        s.onSubscribe(sd);
         source.subscribe(new CompletableObserver() {
 
             @Override

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromRunnable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromRunnable.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.internal.operators.maybe;
 
+import java.util.concurrent.Callable;
+
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
@@ -23,7 +25,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the value type
  */
-public final class MaybeFromRunnable<T> extends Maybe<T> {
+public final class MaybeFromRunnable<T> extends Maybe<T> implements Callable<T> {
 
     final Runnable runnable;
 
@@ -54,5 +56,11 @@ public final class MaybeFromRunnable<T> extends Maybe<T> {
                 observer.onComplete();
             }
         }
+    }
+
+    @Override
+    public T call() throws Exception {
+        runnable.run();
+        return null;
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithCompletable.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.observers.ResumeSingleObserver;
 
 public final class SingleDelayWithCompletable<T> extends Single<T> {
 
@@ -66,7 +67,7 @@ public final class SingleDelayWithCompletable<T> extends Single<T> {
 
         @Override
         public void onComplete() {
-            source.subscribe(new DelayWithMainObserver<T>(this, actual));
+            source.subscribe(new ResumeSingleObserver<T>(this, actual));
         }
 
         @Override
@@ -77,33 +78,6 @@ public final class SingleDelayWithCompletable<T> extends Single<T> {
         @Override
         public boolean isDisposed() {
             return DisposableHelper.isDisposed(get());
-        }
-    }
-
-    static final class DelayWithMainObserver<T> implements SingleObserver<T> {
-
-        final AtomicReference<Disposable> parent;
-
-        final SingleObserver<? super T> actual;
-
-        DelayWithMainObserver(AtomicReference<Disposable> parent, SingleObserver<? super T> actual) {
-            this.parent = parent;
-            this.actual = actual;
-        }
-
-        @Override
-        public void onSubscribe(Disposable d) {
-            DisposableHelper.replace(parent, d);
-        }
-
-        @Override
-        public void onSuccess(T value) {
-            actual.onSuccess(value);
-        }
-
-        @Override
-        public void onError(Throwable e) {
-            actual.onError(e);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithObservable.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
-import io.reactivex.internal.operators.single.SingleDelayWithCompletable.DelayWithMainObserver;
+import io.reactivex.internal.observers.ResumeSingleObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class SingleDelayWithObservable<T, U> extends Single<T> {
@@ -85,7 +85,7 @@ public final class SingleDelayWithObservable<T, U> extends Single<T> {
                 return;
             }
             done = true;
-            source.subscribe(new DelayWithMainObserver<T>(this, actual));
+            source.subscribe(new ResumeSingleObserver<T>(this, actual));
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithPublisher.java
@@ -20,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
-import io.reactivex.internal.operators.single.SingleDelayWithCompletable.DelayWithMainObserver;
+import io.reactivex.internal.observers.ResumeSingleObserver;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -93,7 +93,7 @@ public final class SingleDelayWithPublisher<T, U> extends Single<T> {
                 return;
             }
             done = true;
-            source.subscribe(new DelayWithMainObserver<T>(this, actual));
+            source.subscribe(new ResumeSingleObserver<T>(this, actual));
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithSingle.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
-import io.reactivex.internal.operators.single.SingleDelayWithCompletable.DelayWithMainObserver;
+import io.reactivex.internal.observers.ResumeSingleObserver;
 
 public final class SingleDelayWithSingle<T, U> extends Single<T> {
 
@@ -62,7 +62,7 @@ public final class SingleDelayWithSingle<T, U> extends Single<T> {
 
         @Override
         public void onSuccess(U value) {
-            source.subscribe(new DelayWithMainObserver<T>(this, actual));
+            source.subscribe(new ResumeSingleObserver<T>(this, actual));
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnError.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnError.java
@@ -49,7 +49,7 @@ public final class SingleDoOnError<T> extends Single<T> {
                     onError.accept(e);
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
-                    e = new CompositeException(ex, e);
+                    e = new CompositeException(e, ex);
                 }
                 s.onError(e);
             }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnEvent.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnEvent.java
@@ -59,7 +59,7 @@ public final class SingleDoOnEvent<T> extends Single<T> {
                     onEvent.accept(null, e);
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
-                    e = new CompositeException(ex, e);
+                    e = new CompositeException(e, ex);
                 }
                 s.onError(e);
             }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleEquals.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleEquals.java
@@ -67,6 +67,7 @@ public final class SingleEquals<T> extends Single<Boolean> {
                         return;
                     }
                     if (count.compareAndSet(state, 2)) {
+                        set.dispose();
                         s.onError(e);
                         return;
                     }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowable.java
@@ -153,43 +153,8 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
                     long e = 0L;
 
                     if (r == Long.MAX_VALUE) {
-                        for (;;) {
-                            if (cancelled) {
-                                return;
-                            }
-
-                            R v;
-
-                            try {
-                                v = iter.next();
-                            } catch (Throwable ex) {
-                                Exceptions.throwIfFatal(ex);
-                                a.onError(ex);
-                                return;
-                            }
-
-                            a.onNext(v);
-
-                            if (cancelled) {
-                                return;
-                            }
-
-
-                            boolean b;
-
-                            try {
-                                b = iter.hasNext();
-                            } catch (Throwable ex) {
-                                Exceptions.throwIfFatal(ex);
-                                a.onError(ex);
-                                return;
-                            }
-
-                            if (!b) {
-                                a.onComplete();
-                                return;
-                            }
-                        }
+                        slowPath(a, iter);
+                        return;
                     }
 
                     while (e != r) {
@@ -243,6 +208,46 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
 
                 if (iter == null) {
                     iter = it;
+                }
+            }
+        }
+
+        void slowPath(Subscriber<? super R> a, Iterator<? extends R> iter) {
+            for (;;) {
+                if (cancelled) {
+                    return;
+                }
+
+                R v;
+
+                try {
+                    v = iter.next();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    a.onError(ex);
+                    return;
+                }
+
+                a.onNext(v);
+
+                if (cancelled) {
+                    return;
+                }
+
+
+                boolean b;
+
+                try {
+                    b = iter.hasNext();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    a.onError(ex);
+                    return;
+                }
+
+                if (!b) {
+                    a.onComplete();
+                    return;
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleObserveOn.java
@@ -13,8 +13,11 @@
 
 package io.reactivex.internal.operators.single;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
 
 public final class SingleObserveOn<T> extends Single<T> {
 
@@ -29,38 +32,64 @@ public final class SingleObserveOn<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(final SingleObserver<? super T> s) {
-
-        final CompositeDisposable mad = new CompositeDisposable();
-        s.onSubscribe(mad);
-
-        source.subscribe(new SingleObserver<T>() {
-
-            @Override
-            public void onError(final Throwable e) {
-                mad.add(scheduler.scheduleDirect(new Runnable() {
-                    @Override
-                    public void run() {
-                        s.onError(e);
-                    }
-                }));
-            }
-
-            @Override
-            public void onSubscribe(Disposable d) {
-                mad.add(d);
-            }
-
-            @Override
-            public void onSuccess(final T value) {
-                mad.add(scheduler.scheduleDirect(new Runnable() {
-                    @Override
-                    public void run() {
-                        s.onSuccess(value);
-                    }
-                }));
-            }
-
-        });
+        source.subscribe(new ObserveOnSingleObserver<T>(s, scheduler));
     }
 
+    static final class ObserveOnSingleObserver<T> extends AtomicReference<Disposable>
+    implements SingleObserver<T>, Disposable, Runnable {
+        private static final long serialVersionUID = 3528003840217436037L;
+
+        final SingleObserver<? super T> actual;
+
+        final Scheduler scheduler;
+
+        T value;
+        Throwable error;
+
+        ObserveOnSingleObserver(SingleObserver<? super T> actual, Scheduler scheduler) {
+            this.actual = actual;
+            this.scheduler = scheduler;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.setOnce(this, d)) {
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            this.value = value;
+            Disposable d = scheduler.scheduleDirect(this);
+            DisposableHelper.replace(this, d);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            this.error = e;
+            Disposable d = scheduler.scheduleDirect(this);
+            DisposableHelper.replace(this, d);
+        }
+
+        @Override
+        public void run() {
+            Throwable ex = error;
+            if (ex != null) {
+                actual.onError(ex);
+            } else {
+                actual.onSuccess(value);
+            }
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleOnErrorReturn.java
@@ -48,7 +48,7 @@ public final class SingleOnErrorReturn<T> extends Single<T> {
                         v = valueSupplier.apply(e);
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
-                        s.onError(new CompositeException(ex, e));
+                        s.onError(new CompositeException(e, ex));
                         return;
                     }
                 } else {

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTakeUntil.java
@@ -127,7 +127,7 @@ public final class SingleTakeUntil<T, U> extends Single<T> {
 
     static final class TakeUntilOtherSubscriber
     extends AtomicReference<Subscription>
-    implements Subscriber<Object>, Disposable {
+    implements Subscriber<Object> {
 
         private static final long serialVersionUID = 5170026210238877381L;
 
@@ -161,14 +161,8 @@ public final class SingleTakeUntil<T, U> extends Single<T> {
             parent.otherError(new CancellationException());
         }
 
-        @Override
         public void dispose() {
             SubscriptionHelper.cancel(this);
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return SubscriptionHelper.isCancelled(get());
         }
     }
 }

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -1067,6 +1067,60 @@ public enum TestHelper {
      * Check if the given transformed reactive type reports multiple onSubscribe calls to
      * RxJavaPlugins.
      * @param <T> the input value type
+     * @param <R> the output value type
+     * @param transform the transform to drive an operator
+     */
+    public static <T, R> void checkDoubleOnSubscribeSingleToObservable(Function<Single<T>, ? extends ObservableSource<R>> transform) {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            final Boolean[] b = { null, null };
+            final CountDownLatch cdl = new CountDownLatch(1);
+
+            Single<T> source = new Single<T>() {
+                @Override
+                protected void subscribeActual(SingleObserver<? super T> observer) {
+                    try {
+                        Disposable d1 = Disposables.empty();
+
+                        observer.onSubscribe(d1);
+
+                        Disposable d2 = Disposables.empty();
+
+                        observer.onSubscribe(d2);
+
+                        b[0] = d1.isDisposed();
+                        b[1] = d2.isDisposed();
+                    } finally {
+                        cdl.countDown();
+                    }
+                }
+            };
+
+            ObservableSource<R> out = transform.apply(source);
+
+            out.subscribe(NoOpConsumer.INSTANCE);
+
+            try {
+                assertTrue("Timed out", cdl.await(5, TimeUnit.SECONDS));
+            } catch (InterruptedException ex) {
+                throw ExceptionHelper.wrapOrThrow(ex);
+            }
+
+            assertEquals("First disposed?", false, b[0]);
+            assertEquals("Second not disposed?", true, b[1]);
+
+            assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
+        } catch (Throwable ex) {
+            throw ExceptionHelper.wrapOrThrow(ex);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    /**
+     * Check if the given transformed reactive type reports multiple onSubscribe calls to
+     * RxJavaPlugins.
+     * @param <T> the input value type
      * @param transform the transform to drive an operator
      */
     public static <T> void checkDoubleOnSubscribeMaybeToCompletable(Function<Maybe<T>, ? extends CompletableSource> transform) {

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableCreateTest.java
@@ -13,7 +13,9 @@
 
 package io.reactivex.internal.operators.completable;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
 
 import org.junit.Test;
 
@@ -95,5 +97,179 @@ public class CompletableCreateTest {
         .assertFailure(TestException.class);
 
         assertTrue(d.isDisposed());
+    }
+
+    @Test
+    public void callbackThrows() {
+        Completable.create(new CompletableOnSubscribe() {
+            @Override
+            public void subscribe(CompletableEmitter e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void onErrorNull() {
+        Completable.create(new CompletableOnSubscribe() {
+            @Override
+            public void subscribe(CompletableEmitter e) throws Exception {
+                e.onError(null);
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Completable.create(new CompletableOnSubscribe() {
+            @Override
+            public void subscribe(CompletableEmitter e) throws Exception {
+                e.onComplete();
+            }
+        }));
+    }
+
+    @Test
+    public void onErrorThrows() {
+        Completable.create(new CompletableOnSubscribe() {
+            @Override
+            public void subscribe(CompletableEmitter e) throws Exception {
+                Disposable d = Disposables.empty();
+                e.setDisposable(d);
+
+                try {
+                    e.onError(new IOException());
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+
+                assertTrue(d.isDisposed());
+                assertTrue(e.isDisposed());
+            }
+        }).subscribe(new CompletableObserver() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new TestException();
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+        });
+    }
+
+    @Test
+    public void onCompleteThrows() {
+        Completable.create(new CompletableOnSubscribe() {
+            @Override
+            public void subscribe(CompletableEmitter e) throws Exception {
+                Disposable d = Disposables.empty();
+                e.setDisposable(d);
+
+                try {
+                    e.onComplete();
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+
+                assertTrue(d.isDisposed());
+                assertTrue(e.isDisposed());
+            }
+        }).subscribe(new CompletableObserver() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onComplete() {
+                throw new TestException();
+            }
+        });
+    }
+
+    @Test
+    public void onErrorThrows2() {
+        Completable.create(new CompletableOnSubscribe() {
+            @Override
+            public void subscribe(CompletableEmitter e) throws Exception {
+                try {
+                    e.onError(new IOException());
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+
+                assertTrue(e.isDisposed());
+            }
+        }).subscribe(new CompletableObserver() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new TestException();
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+        });
+    }
+
+    @Test
+    public void onCompleteThrows2() {
+        Completable.create(new CompletableOnSubscribe() {
+            @Override
+            public void subscribe(CompletableEmitter e) throws Exception {
+                try {
+                    e.onComplete();
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+
+                assertTrue(e.isDisposed());
+            }
+        }).subscribe(new CompletableObserver() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onComplete() {
+                throw new TestException();
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDisposeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDisposeOnTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subjects.PublishSubject;
+
+public class CompletableDisposeOnTest {
+
+    @Test
+    public void cancelDelayed() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        ps.ignoreElements()
+        .unsubscribeOn(scheduler)
+        .test()
+        .cancel();
+
+        assertTrue(ps.hasObservers());
+
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        assertFalse(ps.hasObservers());
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishSubject.create().ignoreElements().unsubscribeOn(new TestScheduler()));
+    }
+
+    @Test
+    public void completeAfterCancel() {
+        TestScheduler scheduler = new TestScheduler();
+
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Void> to = ps.ignoreElements()
+        .unsubscribeOn(scheduler)
+        .test();
+
+        to.dispose();
+
+        ps.onComplete();
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void errorAfterCancel() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestScheduler scheduler = new TestScheduler();
+
+            PublishSubject<Integer> ps = PublishSubject.create();
+
+            TestObserver<Void> to = ps.ignoreElements()
+            .unsubscribeOn(scheduler)
+            .test();
+
+            to.dispose();
+
+            ps.onError(new TestException());
+
+            to.assertEmpty();
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void normal() {
+        TestScheduler scheduler = new TestScheduler();
+
+        final int[] call = { 0 };
+
+        Completable.complete()
+        .doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                call[0]++;
+            }
+        })
+        .unsubscribeOn(scheduler)
+        .test()
+        .assertResult();
+
+        scheduler.triggerActions();
+
+        assertEquals(0, call[0]);
+    }
+
+    @Test
+    public void error() {
+        TestScheduler scheduler = new TestScheduler();
+
+        final int[] call = { 0 };
+
+        Completable.error(new TestException())
+        .doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                call[0]++;
+            }
+        })
+        .unsubscribeOn(scheduler)
+        .test()
+        .assertFailure(TestException.class);
+
+        scheduler.triggerActions();
+
+        assertEquals(0, call[0]);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDoOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDoOnTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Consumer;
+import io.reactivex.observers.TestObserver;
+
+public class CompletableDoOnTest {
+
+    @Test
+    public void successAcceptThrows() {
+        Completable.complete().doOnEvent(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorAcceptThrows() {
+        TestObserver<Void> to = Completable.error(new TestException("Outer")).doOnEvent(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                throw new TestException("Inner");
+            }
+        })
+        .test()
+        .assertFailure(CompositeException.class);
+
+        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+
+        TestHelper.assertError(errors, 0, TestException.class, "Outer");
+        TestHelper.assertError(errors, 1, TestException.class, "Inner");
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableFromPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableFromPublisherTest.java
@@ -13,9 +13,9 @@
 
 package io.reactivex.internal.operators.completable;
 
-import io.reactivex.Completable;
-import io.reactivex.Flowable;
 import org.junit.Test;
+
+import io.reactivex.*;
 
 public class CompletableFromPublisherTest {
     @Test(expected = NullPointerException.class)
@@ -42,5 +42,10 @@ public class CompletableFromPublisherTest {
         Completable.fromPublisher(Flowable.error(new UnsupportedOperationException()))
             .test()
             .assertFailure(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Completable.fromPublisher(Flowable.just(1)));
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableLiftTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableLiftTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+
+public class CompletableLiftTest {
+
+    @Test
+    public void callbackThrows() {
+        try {
+            Completable.complete()
+            .lift(new CompletableOperator() {
+                @Override
+                public CompletableObserver apply(CompletableObserver o) throws Exception {
+                    throw new TestException();
+                }
+            })
+            .test();
+        } catch (NullPointerException ex) {
+            assertTrue(ex.toString(), ex.getCause() instanceof TestException);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableOnErrorXTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableOnErrorXTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+public class CompletableOnErrorXTest {
+
+    @Test
+    public void normalReturn() {
+        Completable.complete()
+        .onErrorComplete()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void normalResumeNext() {
+        final int[] call = { 0 };
+        Completable.complete()
+        .onErrorResumeNext(new Function<Throwable, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Throwable e) throws Exception {
+                call[0]++;
+                return Completable.complete();
+            }
+        })
+        .test()
+        .assertResult();
+
+        assertEquals(0, call[0]);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeOnTest.java
@@ -21,9 +21,11 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import io.reactivex.*;
+import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.schedulers.*;
+import io.reactivex.subjects.PublishSubject;
 
 public class CompletableSubscribeOnTest {
 
@@ -45,5 +47,20 @@ public class CompletableSubscribeOnTest {
         } finally {
             RxJavaPlugins.reset();
         }
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishSubject.create().ignoreElements().subscribeOn(new TestScheduler()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeCompletable(new Function<Completable, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Completable c) throws Exception {
+                return c.subscribeOn(Schedulers.single());
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableTimerTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.schedulers.TestScheduler;
+
+public class CompletableTimerTest {
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Completable.timer(1, TimeUnit.SECONDS, new TestScheduler()));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
@@ -1,0 +1,569 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
+
+public class CompletableUsingTest {
+
+    @Test
+    public void resourceSupplierThrows() {
+
+        Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                throw new TestException();
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                return Completable.complete();
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorEager() {
+
+        Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                return Completable.error(new TestException());
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+
+            }
+        }, true)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void emptyEager() {
+
+        Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                return Completable.complete();
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+
+            }
+        }, true)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void errorNonEager() {
+
+        Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                return Completable.error(new TestException());
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+
+            }
+        }, false)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void emptyNonEager() {
+
+        Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                return Completable.complete();
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+
+            }
+        }, false)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void supplierCrashEager() {
+
+        Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                throw new TestException();
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+
+            }
+        }, true)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void supplierCrashNonEager() {
+
+        Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                throw new TestException();
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+
+            }
+        }, false)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void supplierAndDisposerCrashEager() {
+        TestObserver<Void> to = Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                throw new TestException("Main");
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+                throw new TestException("Disposer");
+            }
+        }, true)
+        .test()
+        .assertFailure(CompositeException.class);
+
+        List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
+
+        TestHelper.assertError(list, 0, TestException.class, "Main");
+        TestHelper.assertError(list, 1, TestException.class, "Disposer");
+    }
+
+    @Test
+    public void supplierAndDisposerCrashNonEager() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Completable.using(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return 1;
+                }
+            }, new Function<Object, CompletableSource>() {
+                @Override
+                public CompletableSource apply(Object v) throws Exception {
+                    throw new TestException("Main");
+                }
+            }, new Consumer<Object>() {
+                @Override
+                public void accept(Object d) throws Exception {
+                    throw new TestException("Disposer");
+                }
+            }, false)
+            .test()
+            .assertFailureAndMessage(TestException.class, "Main");
+
+            TestHelper.assertError(errors, 0, TestException.class, "Disposer");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void dispose() {
+        final int[] call = {0 };
+
+        TestObserver<Void> to = Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                return Completable.never();
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+                call[0]++;
+            }
+        }, false)
+        .test();
+
+        to.cancel();
+
+        assertEquals(1, call[0]);
+    }
+
+    @Test
+    public void disposeCrashes() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Void> to = Completable.using(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return 1;
+                }
+            }, new Function<Object, CompletableSource>() {
+                @Override
+                public CompletableSource apply(Object v) throws Exception {
+                    return Completable.never();
+                }
+            }, new Consumer<Object>() {
+                @Override
+                public void accept(Object d) throws Exception {
+                    throw new TestException();
+                }
+            }, false)
+            .test();
+
+            to.cancel();
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void isDisposed() {
+        TestHelper.checkDisposed(Completable.using(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return 1;
+                }
+            }, new Function<Object, CompletableSource>() {
+                @Override
+                public CompletableSource apply(Object v) throws Exception {
+                    return Completable.never();
+                }
+            }, new Consumer<Object>() {
+                @Override
+                public void accept(Object d) throws Exception {
+
+                }
+            }, false));
+    }
+
+    @Test
+    public void justDisposerCrashes() {
+        Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                return Completable.complete();
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+                throw new TestException("Disposer");
+            }
+        }, true)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+
+    @Test
+    public void emptyDisposerCrashes() {
+        Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                return Completable.complete();
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+                throw new TestException("Disposer");
+            }
+        }, true)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorDisposerCrash() {
+        TestObserver<Void> to = Completable.using(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        }, new Function<Object, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Object v) throws Exception {
+                return Completable.error(new TestException("Main"));
+            }
+        }, new Consumer<Object>() {
+            @Override
+            public void accept(Object d) throws Exception {
+                throw new TestException("Disposer");
+            }
+        }, true)
+        .test()
+        .assertFailure(CompositeException.class);
+
+        List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
+
+        TestHelper.assertError(list, 0, TestException.class, "Main");
+        TestHelper.assertError(list, 1, TestException.class, "Disposer");
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Completable.using(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return 1;
+                }
+            }, new Function<Object, CompletableSource>() {
+                @Override
+                public CompletableSource apply(Object v) throws Exception {
+                    return Completable.wrap(new CompletableSource() {
+                        @Override
+                        public void subscribe(CompletableObserver s) {
+                            Disposable d1 = Disposables.empty();
+
+                            s.onSubscribe(d1);
+
+                            Disposable d2 = Disposables.empty();
+
+                            s.onSubscribe(d2);
+
+                            assertFalse(d1.isDisposed());
+
+                            assertTrue(d2.isDisposed());
+                        }
+                    });
+                }
+            }, new Consumer<Object>() {
+                @Override
+                public void accept(Object d) throws Exception {
+
+                }
+            }, false).test();
+            TestHelper.assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void successDisposeRace() {
+        for (int i = 0; i < 500; i++) {
+
+            final PublishSubject<Integer> ps = PublishSubject.create();
+
+            final TestObserver<Void> to = Completable.using(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return 1;
+                }
+            }, new Function<Object, CompletableSource>() {
+                @Override
+                public CompletableSource apply(Object v) throws Exception {
+                    return ps.ignoreElements();
+                }
+            }, new Consumer<Object>() {
+                @Override
+                public void accept(Object d) throws Exception {
+                }
+            }, true)
+            .test();
+
+            ps.onNext(1);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    to.cancel();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ps.onComplete();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+
+    @Test
+    public void errorDisposeRace() {
+        for (int i = 0; i < 500; i++) {
+
+            final PublishSubject<Integer> ps = PublishSubject.create();
+
+            final TestObserver<Void> to = Completable.using(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return 1;
+                }
+            }, new Function<Object, CompletableSource>() {
+                @Override
+                public CompletableSource apply(Object v) throws Exception {
+                    return ps.ignoreElements();
+                }
+            }, new Consumer<Object>() {
+                @Override
+                public void accept(Object d) throws Exception {
+                }
+            }, true)
+            .test();
+
+            final TestException ex = new TestException();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    to.cancel();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ps.onError(ex);
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+
+    @Test
+    public void emptyDisposeRace() {
+        for (int i = 0; i < 500; i++) {
+
+            final PublishSubject<Integer> ps = PublishSubject.create();
+
+            final TestObserver<Void> to = Completable.using(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return 1;
+                }
+            }, new Function<Object, CompletableSource>() {
+                @Override
+                public CompletableSource apply(Object v) throws Exception {
+                    return ps.ignoreElements();
+                }
+            }, new Consumer<Object>() {
+                @Override
+                public void accept(Object d) throws Exception {
+
+                }
+            }, true)
+            .test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    to.cancel();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ps.onComplete();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
@@ -13,11 +13,18 @@
 
 package io.reactivex.internal.operators.maybe;
 
-import io.reactivex.Maybe;
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import io.reactivex.*;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
 
 public class MaybeFromRunnableTest {
     @Test(expected = NullPointerException.class)
@@ -94,5 +101,63 @@ public class MaybeFromRunnableTest {
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void callable() throws Exception {
+        final int[] counter = { 0 };
+
+        Maybe<Void> m = Maybe.fromRunnable(new Runnable() {
+            @Override
+            public void run() {
+                counter[0]++;
+            }
+        });
+
+        assertTrue(m.getClass().toString(), m instanceof Callable);
+
+        assertNull(((Callable<Void>)m).call());
+
+        assertEquals(1, counter[0]);
+    }
+
+    @Test
+    public void noErrorLoss() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final CountDownLatch cdl1 = new CountDownLatch(1);
+            final CountDownLatch cdl2 = new CountDownLatch(1);
+
+            TestObserver<Object> to = Maybe.fromRunnable(new Runnable() {
+                @Override
+                public void run() {
+                    cdl1.countDown();
+                    try {
+                        cdl2.await();
+                    } catch (InterruptedException ex) {
+                        throw new RuntimeException(ex);
+                    }
+                }
+            }).subscribeOn(Schedulers.single()).test();
+
+            assertTrue(cdl1.await(5, TimeUnit.SECONDS));
+
+            to.cancel();
+
+            cdl2.countDown();
+
+            int timeout = 10;
+
+            while (timeout-- > 0 && errors.isEmpty()) {
+                Thread.sleep(100);
+            }
+
+            TestHelper.assertError(errors, 0, RuntimeException.class);
+
+            assertTrue(errors.get(0).toString(), errors.get(0).getCause() instanceof InterruptedException);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptySingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptySingleTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import io.reactivex.Maybe;
+import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
+
+public class MaybeIsEmptySingleTest {
+
+    @Test
+    public void source() {
+        Maybe<Integer> m = Maybe.just(1);
+
+        assertSame(m, (((HasUpstreamMaybeSource<?>)m.isEmpty()).source()));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSubscribeOnTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.schedulers.Schedulers;
+
+public class MaybeSubscribeOnTest {
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Maybe.just(1).subscribeOn(Schedulers.single()));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeToFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeToFlowableTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
+
+public class MaybeToFlowableTest {
+
+    @Test
+    public void source() {
+        Maybe<Integer> m = Maybe.just(1);
+
+        assertSame(m, (((HasUpstreamMaybeSource<?>)m.toFlowable()).source()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybeToFlowable(new Function<Maybe<Object>, Publisher<Object>>() {
+            @Override
+            public Publisher<Object> apply(Maybe<Object> m) throws Exception {
+                return m.toFlowable();
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeToObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeToObservableTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
+
+public class MaybeToObservableTest {
+
+    @Test
+    public void source() {
+        Maybe<Integer> m = Maybe.just(1);
+
+        assertSame(m, (((HasUpstreamMaybeSource<?>)m.toObservable()).source()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybeToObservable(new Function<Maybe<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Maybe<Object> m) throws Exception {
+                return m.toObservable();
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleContainstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleContainstTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import org.junit.Test;
+
+import io.reactivex.Single;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.BiPredicate;
+
+public class SingleContainstTest {
+
+    @Test
+    public void comparerThrows() {
+        Single.just(1)
+        .contains(2, new BiPredicate<Object, Object>() {
+            @Override
+            public boolean test(Object a, Object b) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void error() {
+        Single.error(new TestException())
+        .contains(2)
+        .test()
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleEqualsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleEqualsTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class SingleEqualsTest {
+
+    @Test
+    public void bothError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Single.equals(Single.error(new TestException("One")), Single.error(new TestException("Two")))
+            .test()
+            .assertFailureAndMessage(TestException.class, "One");
+
+            TestHelper.assertError(errors, 0, TestException.class, "Two");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleErrorTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import io.reactivex.Single;
+import io.reactivex.exceptions.TestException;
+
+public class SingleErrorTest {
+
+    @Test
+    public void errorCallableThrows() {
+        Single.error(new Callable<Throwable>() {
+            @Override
+            public Throwable call() throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapCompletableTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+public class SingleFlatMapCompletableTest {
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Single.just(1).flatMapCompletable(new Function<Integer, Completable>() {
+            @Override
+            public Completable apply(Integer v) throws Exception {
+                return Completable.complete();
+            }
+        }));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowableTest.java
@@ -13,15 +13,21 @@
 
 package io.reactivex.internal.operators.single;
 
+import static org.junit.Assert.*;
+
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
+import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.util.CrashingIterable;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subscribers.*;
 
 public class SingleFlatMapIterableFlowableTest {
@@ -186,5 +192,396 @@ public class SingleFlatMapIterableFlowableTest {
         })
         .test()
         .assertFailureAndMessage(TestException.class, "hasNext()", 0);
+    }
+
+    @Test
+    public void async1() {
+        Single.just(1)
+        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        Integer[] array = new Integer[1000 * 1000];
+                        Arrays.fill(array, 1);
+                        return Arrays.asList(array);
+                    }
+                })
+        .hide()
+        .observeOn(Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertSubscribed()
+        .assertValueCount(1000 * 1000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void async2() {
+        Single.just(1)
+        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        Integer[] array = new Integer[1000 * 1000];
+                        Arrays.fill(array, 1);
+                        return Arrays.asList(array);
+                    }
+                })
+        .observeOn(Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertSubscribed()
+        .assertValueCount(1000 * 1000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void async3() {
+        Single.just(1)
+        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        Integer[] array = new Integer[1000 * 1000];
+                        Arrays.fill(array, 1);
+                        return Arrays.asList(array);
+                    }
+                })
+        .take(500 * 1000)
+        .observeOn(Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertSubscribed()
+        .assertValueCount(500 * 1000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void async4() {
+        Single.just(1)
+        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        Integer[] array = new Integer[1000 * 1000];
+                        Arrays.fill(array, 1);
+                        return Arrays.asList(array);
+                    }
+                })
+        .observeOn(Schedulers.single())
+        .take(500 * 1000)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertSubscribed()
+        .assertValueCount(500 * 1000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void fusedEmptyCheck() {
+        Single.just(1)
+        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        return Arrays.asList(1, 2, 3);
+                    }
+        }).subscribe(new Subscriber<Integer>() {
+            QueueSubscription<Integer> qd;
+            @SuppressWarnings("unchecked")
+            @Override
+            public void onSubscribe(Subscription d) {
+                qd = (QueueSubscription<Integer>)d;
+
+                assertEquals(QueueSubscription.ASYNC, qd.requestFusion(QueueSubscription.ANY));
+            }
+
+            @Override
+            public void onNext(Integer value) {
+                assertFalse(qd.isEmpty());
+
+                qd.clear();
+
+                assertTrue(qd.isEmpty());
+
+                qd.cancel();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+    }
+
+    @Test
+    public void hasNextThrowsUnbounded() {
+        Single.just(1)
+        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        return new CrashingIterable(100, 2, 100);
+                    }
+                })
+        .test()
+        .assertFailureAndMessage(TestException.class, "hasNext()", 0);
+    }
+
+    @Test
+    public void nextThrowsUnbounded() {
+        Single.just(1)
+        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        return new CrashingIterable(100, 100, 1);
+                    }
+                })
+        .test()
+        .assertFailureAndMessage(TestException.class, "next()");
+    }
+
+    @Test
+    public void hasNextThrows() {
+        Single.just(1)
+        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        return new CrashingIterable(100, 2, 100);
+                    }
+                })
+        .test(2L)
+        .assertFailureAndMessage(TestException.class, "hasNext()", 0);
+    }
+
+    @Test
+    public void nextThrows() {
+        Single.just(1)
+        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        return new CrashingIterable(100, 100, 1);
+                    }
+                })
+        .test(2L)
+        .assertFailureAndMessage(TestException.class, "next()");
+    }
+
+    @Test
+    public void requestBefore() {
+        for (int i = 0; i < 500; i++) {
+            final PublishSubject<Integer> ps = PublishSubject.create();
+
+            ps.singleElement().flattenAsFlowable(
+            new Function<Integer, Iterable<Integer>>() {
+                @Override
+                public Iterable<Integer> apply(Integer v) throws Exception {
+                    return Arrays.asList(1, 2, 3);
+                }
+            })
+            .test(5L)
+            .assertEmpty();
+        }
+    }
+
+    @Test
+    public void requestCreateInnerRace() {
+        final Integer[] a = new Integer[1000];
+        Arrays.fill(a, 1);
+
+        for (int i = 0; i < 500; i++) {
+            final PublishSubject<Integer> ps = PublishSubject.create();
+
+            ps.onNext(1);
+
+            final TestSubscriber<Integer> ts = ps.singleElement().flattenAsFlowable(
+            new Function<Integer, Iterable<Integer>>() {
+                @Override
+                public Iterable<Integer> apply(Integer v) throws Exception {
+                    return Arrays.asList(a);
+                }
+            })
+            .test(0L);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ps.onComplete();
+                    for (int i = 0; i < 500; i++) {
+                        ts.request(1);
+                    }
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    for (int i = 0; i < 500; i++) {
+                        ts.request(1);
+                    }
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+
+    @Test
+    public void cancelCreateInnerRace() {
+        for (int i = 0; i < 500; i++) {
+            final PublishSubject<Integer> ps = PublishSubject.create();
+
+            ps.onNext(1);
+
+            final TestSubscriber<Integer> ts = ps.singleElement().flattenAsFlowable(
+            new Function<Integer, Iterable<Integer>>() {
+                @Override
+                public Iterable<Integer> apply(Integer v) throws Exception {
+                    return Arrays.asList(1, 2, 3);
+                }
+            })
+            .test(0L);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ps.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+
+    @Test
+    public void slowPathCancelAfterHasNext() {
+        final Integer[] a = new Integer[1000];
+        Arrays.fill(a, 1);
+
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+
+        Single.just(1)
+        .flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) throws Exception {
+                return new Iterable<Integer>() {
+                    @Override
+                    public Iterator<Integer> iterator() {
+                        return new Iterator<Integer>() {
+                            int count;
+                            @Override
+                            public boolean hasNext() {
+                                if (count++ == 2) {
+                                    ts.cancel();
+                                }
+                                return true;
+                            }
+
+                            @Override
+                            public Integer next() {
+                                return 1;
+                            }
+
+                            @Override
+                            public void remove() {
+                                throw new UnsupportedOperationException();
+                            }
+                        };
+                    }
+                };
+            }
+        })
+        .subscribe(ts);
+
+        ts.request(3);
+        ts.assertValues(1, 1).assertNoErrors().assertNotComplete();
+    }
+
+    @Test
+    public void fastPathCancelAfterHasNext() {
+        final Integer[] a = new Integer[1000];
+        Arrays.fill(a, 1);
+
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+
+        Single.just(1)
+        .flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) throws Exception {
+                return new Iterable<Integer>() {
+                    @Override
+                    public Iterator<Integer> iterator() {
+                        return new Iterator<Integer>() {
+                            int count;
+                            @Override
+                            public boolean hasNext() {
+                                if (count++ == 2) {
+                                    ts.cancel();
+                                }
+                                return true;
+                            }
+
+                            @Override
+                            public Integer next() {
+                                return 1;
+                            }
+
+                            @Override
+                            public void remove() {
+                                throw new UnsupportedOperationException();
+                            }
+                        };
+                    }
+                };
+            }
+        })
+        .subscribe(ts);
+
+        ts.request(Long.MAX_VALUE);
+        ts.assertValues(1, 1).assertNoErrors().assertNotComplete();
+    }
+
+    @Test
+    public void requestIteratorRace() {
+        final Integer[] a = new Integer[1000];
+        Arrays.fill(a, 1);
+
+        for (int i = 0; i < 500; i++) {
+            final PublishSubject<Integer> ps = PublishSubject.create();
+
+            final TestSubscriber<Integer> ts = ps.singleOrError().flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
+                @Override
+                public Iterable<Integer> apply(Integer v) throws Exception {
+                    return Arrays.asList(a);
+                }
+            }).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    for (int i = 0; i < 1000; i++) {
+                        ts.request(1);
+                    }
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ps.onNext(1);
+                    ps.onComplete();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservableTest.java
@@ -13,16 +13,22 @@
 
 package io.reactivex.internal.operators.single;
 
+import static org.junit.Assert.*;
+
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import io.reactivex.Single;
+import io.reactivex.*;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.fuseable.QueueDisposable;
 import io.reactivex.internal.util.CrashingIterable;
 import io.reactivex.observers.*;
+import io.reactivex.schedulers.Schedulers;
 
 public class SingleFlatMapIterableObservableTest {
 
@@ -164,5 +170,152 @@ public class SingleFlatMapIterableObservableTest {
         })
         .test()
         .assertFailureAndMessage(TestException.class, "hasNext()", 0);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeSingleToObservable(new Function<Single<Object>, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Single<Object> o) throws Exception {
+                return o.flattenAsObservable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        return Collections.singleton(1);
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Single.just(1).flattenAsObservable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        return Collections.singleton(1);
+                    }
+                }));
+    }
+
+    @Test
+    public void async1() {
+        Single.just(1)
+        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        Integer[] array = new Integer[1000 * 1000];
+                        Arrays.fill(array, 1);
+                        return Arrays.asList(array);
+                    }
+                })
+        .hide()
+        .observeOn(Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertSubscribed()
+        .assertValueCount(1000 * 1000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void async2() {
+        Single.just(1)
+        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        Integer[] array = new Integer[1000 * 1000];
+                        Arrays.fill(array, 1);
+                        return Arrays.asList(array);
+                    }
+                })
+        .observeOn(Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertSubscribed()
+        .assertValueCount(1000 * 1000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void async3() {
+        Single.just(1)
+        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        Integer[] array = new Integer[1000 * 1000];
+                        Arrays.fill(array, 1);
+                        return Arrays.asList(array);
+                    }
+                })
+        .take(500 * 1000)
+        .observeOn(Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertSubscribed()
+        .assertValueCount(500 * 1000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void async4() {
+        Single.just(1)
+        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        Integer[] array = new Integer[1000 * 1000];
+                        Arrays.fill(array, 1);
+                        return Arrays.asList(array);
+                    }
+                })
+        .observeOn(Schedulers.single())
+        .take(500 * 1000)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertSubscribed()
+        .assertValueCount(500 * 1000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void fusedEmptyCheck() {
+        Single.just(1)
+        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        return Arrays.asList(1, 2, 3);
+                    }
+        }).subscribe(new Observer<Integer>() {
+            QueueDisposable<Integer> qd;
+            @SuppressWarnings("unchecked")
+            @Override
+            public void onSubscribe(Disposable d) {
+                qd = (QueueDisposable<Integer>)d;
+
+                assertEquals(QueueDisposable.ASYNC, qd.requestFusion(QueueDisposable.ANY));
+            }
+
+            @Override
+            public void onNext(Integer value) {
+                assertFalse(qd.isEmpty());
+
+                qd.clear();
+
+                assertTrue(qd.isEmpty());
+
+                qd.dispose();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapTest.java
@@ -201,4 +201,26 @@ public class SingleFlatMapTest {
             .test()
             .assertError(exception);
     }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Single.just(1).flatMap(new Function<Integer, SingleSource<Integer>>() {
+            @Override
+            public SingleSource<Integer> apply(Integer v) throws Exception {
+                return Single.just(2);
+            }
+        }));
+    }
+
+    @Test
+    public void mappedSingleOnError() {
+        Single.just(1).flatMap(new Function<Integer, SingleSource<Integer>>() {
+            @Override
+            public SingleSource<Integer> apply(Integer v) throws Exception {
+                return Single.error(new TestException());
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleHideTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleHideTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.subjects.PublishSubject;
+
+public class SingleHideTest {
+
+    @Test
+    public void error() {
+        Single.error(new TestException())
+        .hide()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishSubject.create().singleOrError().hide());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
+            @Override
+            public SingleSource<Object> apply(Single<Object> s) throws Exception {
+                return s.hide();
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleObserveOnTest.java
@@ -13,51 +13,36 @@
 
 package io.reactivex.internal.operators.single;
 
-import static org.junit.Assert.assertTrue;
-
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.observers.TestObserver;
-import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.*;
-import io.reactivex.subjects.PublishSubject;
+import io.reactivex.functions.Function;
+import io.reactivex.schedulers.Schedulers;
 
-public class SingleSubscribeOnTest {
-
-    @Test
-    public void normal() {
-        List<Throwable> list = TestHelper.trackPluginErrors();
-        try {
-            TestScheduler scheduler = new TestScheduler();
-
-            TestObserver<Integer> ts = Single.just(1)
-            .subscribeOn(scheduler)
-            .test();
-
-            scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-
-            ts.assertResult(1);
-
-            assertTrue(list.toString(), list.isEmpty());
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
+public class SingleObserveOnTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(PublishSubject.create().singleOrError().subscribeOn(new TestScheduler()));
+        TestHelper.checkDisposed(Single.just(1).observeOn(Schedulers.single()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
+            @Override
+            public SingleSource<Object> apply(Single<Object> s) throws Exception {
+                return s.observeOn(Schedulers.single());
+            }
+        });
     }
 
     @Test
     public void error() {
         Single.error(new TestException())
-        .subscribeOn(Schedulers.single())
+        .observeOn(Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/internal/operators/single/SingleOnErrorXTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleOnErrorXTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
+
+public class SingleOnErrorXTest {
+
+    @Test
+    public void returnSuccess() {
+        Single.just(1)
+        .onErrorReturnItem(2)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void resumeThrows() {
+        TestObserver<Integer> to = Single.<Integer>error(new TestException("Outer"))
+        .onErrorReturn(new Function<Throwable, Integer>() {
+            @Override
+            public Integer apply(Throwable e) throws Exception {
+                throw new TestException("Inner");
+            }
+        })
+        .test()
+        .assertFailure(CompositeException.class);
+
+        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+
+        TestHelper.assertError(errors, 0, TestException.class, "Outer");
+        TestHelper.assertError(errors, 1, TestException.class, "Inner");
+    }
+
+    @Test
+    public void resumeErrors() {
+        Single.error(new TestException("Main"))
+        .onErrorResumeNext(Single.error(new TestException("Resume")))
+        .test()
+        .assertFailureAndMessage(TestException.class, "Resume");
+    }
+
+    @Test
+    public void resumeDispose() {
+        TestHelper.checkDisposed(Single.error(new TestException("Main"))
+        .onErrorResumeNext(Single.just(1)));
+    }
+
+    @Test
+    public void resumeDoubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
+            @Override
+            public SingleSource<Object> apply(Single<Object> s) throws Exception {
+                return s.onErrorResumeNext(Single.just(1));
+            }
+        });
+    }
+
+    @Test
+    public void resumeSuccess() {
+        Single.just(1)
+        .onErrorResumeNext(Single.just(2))
+        .test()
+        .assertResult(1);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.Single;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subjects.PublishSubject;
+
+public class SingleTimeoutTest {
+
+    @Test
+    public void shouldUnsubscribeFromUnderlyingSubscriptionOnDispose() {
+        final PublishSubject<String> subject = PublishSubject.create();
+        final TestScheduler scheduler = new TestScheduler();
+
+        final TestObserver<String> observer = subject.single("")
+                .timeout(100, TimeUnit.MILLISECONDS, scheduler)
+                .test();
+
+        assertTrue(subject.hasObservers());
+
+        observer.dispose();
+
+        assertFalse(subject.hasObservers());
+    }
+
+    @Test
+    public void otherErrors() {
+        Single.never()
+        .timeout(1, TimeUnit.MILLISECONDS, Single.error(new TestException()))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mainSuccess() {
+        Single.just(1)
+        .timeout(1, TimeUnit.DAYS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void mainError() {
+        Single.error(new TestException())
+        .timeout(1, TimeUnit.DAYS)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTimerTest.java
@@ -13,32 +13,17 @@
 
 package io.reactivex.internal.operators.single;
 
-import static org.junit.Assert.*;
-
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import io.reactivex.observers.TestObserver;
+import io.reactivex.*;
 import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subjects.PublishSubject;
 
-public class SingleTimeoutTests {
+public class SingleTimerTest {
 
     @Test
-    public void shouldUnsubscribeFromUnderlyingSubscriptionOnDispose() {
-        final PublishSubject<String> subject = PublishSubject.create();
-        final TestScheduler scheduler = new TestScheduler();
-
-        final TestObserver<String> observer = subject.single("")
-                .timeout(100, TimeUnit.MILLISECONDS, scheduler)
-                .test();
-
-        assertTrue(subject.hasObservers());
-
-        observer.dispose();
-
-        assertFalse(subject.hasObservers());
+    public void disposed() {
+        TestHelper.checkDisposed(Single.timer(1, TimeUnit.SECONDS, new TestScheduler()));
     }
-
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleToObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleToObservableTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+import io.reactivex.subjects.PublishSubject;
+
+public class SingleToObservableTest {
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishSubject.create().singleOrError().toObservable());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeSingleToObservable(new Function<Single<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Single<Object> s) throws Exception {
+                return s.toObservable();
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -13,16 +13,18 @@
 
 package io.reactivex.single;
 
+
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.concurrent.*;
 
+import static org.junit.Assert.*;
 import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.SingleOperator;
-import io.reactivex.exceptions.TestException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.schedulers.Schedulers;
@@ -705,14 +707,18 @@ public class SingleNullTests {
         error.onErrorResumeNext((Function<Throwable, Single<Integer>>)null);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void onErrorResumeNextFunctionReturnsNull() {
-        error.onErrorResumeNext(new Function<Throwable, Single<Integer>>() {
-            @Override
-            public Single<Integer> apply(Throwable e) {
-                return null;
-            }
-        }).blockingGet();
+        try {
+            error.onErrorResumeNext(new Function<Throwable, Single<Integer>>() {
+                @Override
+                public Single<Integer> apply(Throwable e) {
+                    return null;
+                }
+            }).blockingGet();
+        } catch (CompositeException ex) {
+            assertTrue(ex.toString(), ex.getExceptions().get(1) instanceof NullPointerException);
+        }
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/single/SingleTest.java
+++ b/src/test/java/io/reactivex/single/SingleTest.java
@@ -531,5 +531,15 @@ public class SingleTest {
             }
         }).test().assertResult(5);
     }
+
+    @Test
+    public void to() {
+        assertEquals(1, Single.just(1).to(new Function<Single<Integer>, Integer>() {
+            @Override
+            public Integer apply(Single<Integer> v) throws Exception {
+                return 1;
+            }
+        }).intValue());
+    }
 }
 


### PR DESCRIPTION
- cover remaining `Maybe` operators
- cover `Single` operators
- cover some of the `Completable` operators
- fix missing `onSubscribe` calls
- compact a few operator implementations
- fix the order of inner Throwables on certain `CompositeException` emissions
