### PR TITLE
2.x: coverage and cleanup 10/12-1

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableAmb.java
@@ -104,9 +104,6 @@ public final class CompletableAmb extends Completable {
                 }
                 return;
             }
-            if (once.get() || set.isDisposed()) {
-                return;
-            }
 
             // no need to have separate subscribers because inner is stateless
             c.subscribe(inner);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcat.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcat.java
@@ -19,9 +19,10 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.MissingBackpressureException;
-import io.reactivex.internal.disposables.SequentialDisposable;
-import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.exceptions.*;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.queue.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -36,133 +37,218 @@ public final class CompletableConcat extends Completable {
 
     @Override
     public void subscribeActual(CompletableObserver s) {
-        CompletableConcatSubscriber parent = new CompletableConcatSubscriber(s, prefetch);
-        sources.subscribe(parent);
+        sources.subscribe(new CompletableConcatSubscriber(s, prefetch));
     }
 
     static final class CompletableConcatSubscriber
     extends AtomicInteger
     implements Subscriber<CompletableSource>, Disposable {
-        private static final long serialVersionUID = 7412667182931235013L;
-        final CompletableObserver actual;
-        final int prefetch;
-        final SequentialDisposable sd;
+        private static final long serialVersionUID = 9032184911934499404L;
 
-        final SpscArrayQueue<CompletableSource> queue;
+        final CompletableObserver actual;
+
+        final int prefetch;
+
+        final int limit;
+
+        final ConcatInnerObserver inner;
+
+        final AtomicBoolean once;
+
+        int sourceFused;
+
+        int consumed;
+
+        SimpleQueue<CompletableSource> queue;
 
         Subscription s;
 
         volatile boolean done;
 
-        final AtomicBoolean once = new AtomicBoolean();
-
-        final ConcatInnerObserver inner;
+        volatile boolean active;
 
         CompletableConcatSubscriber(CompletableObserver actual, int prefetch) {
             this.actual = actual;
             this.prefetch = prefetch;
-            this.queue = new SpscArrayQueue<CompletableSource>(prefetch);
-            this.sd = new SequentialDisposable();
-            this.inner = new ConcatInnerObserver();
+            this.inner = new ConcatInnerObserver(this);
+            this.once = new AtomicBoolean();
+            this.limit = prefetch - (prefetch >> 2);
         }
 
         @Override
         public void onSubscribe(Subscription s) {
             if (SubscriptionHelper.validate(this.s, s)) {
                 this.s = s;
+
+                long r = prefetch == Integer.MAX_VALUE ? Long.MAX_VALUE : prefetch;
+
+                if (s instanceof QueueSubscription) {
+                    @SuppressWarnings("unchecked")
+                    QueueSubscription<CompletableSource> qs = (QueueSubscription<CompletableSource>) s;
+
+                    int m = qs.requestFusion(QueueSubscription.ANY);
+
+                    if (m == QueueSubscription.SYNC) {
+                        sourceFused = m;
+                        queue = qs;
+                        done = true;
+                        actual.onSubscribe(this);
+                        drain();
+                        return;
+                    }
+                    if (m == QueueSubscription.ASYNC) {
+                        sourceFused = m;
+                        queue = qs;
+                        actual.onSubscribe(this);
+                        s.request(r);
+                        return;
+                    }
+                }
+
+                if (prefetch == Integer.MAX_VALUE) {
+                    queue = new SpscLinkedArrayQueue<CompletableSource>(Flowable.bufferSize());
+                } else {
+                    queue = new SpscArrayQueue<CompletableSource>(prefetch);
+                }
+
                 actual.onSubscribe(this);
-                s.request(prefetch);
+
+                s.request(r);
             }
         }
 
         @Override
         public void onNext(CompletableSource t) {
-            if (!queue.offer(t)) {
-                onError(new MissingBackpressureException());
-                return;
+            if (sourceFused == QueueSubscription.NONE) {
+                if (!queue.offer(t)) {
+                    onError(new MissingBackpressureException());
+                    return;
+                }
             }
-            if (getAndIncrement() == 0) {
-                next();
-            }
+            drain();
         }
 
         @Override
         public void onError(Throwable t) {
             if (once.compareAndSet(false, true)) {
+                DisposableHelper.dispose(inner);
                 actual.onError(t);
-                return;
+            } else {
+                RxJavaPlugins.onError(t);
             }
-            done = true;
-            RxJavaPlugins.onError(t);
         }
 
         @Override
         public void onComplete() {
-            if (done) {
-                return;
-            }
             done = true;
-            if (getAndIncrement() == 0) {
-                next();
-            }
-        }
-
-        void innerError(Throwable e) {
-            s.cancel();
-            onError(e);
-        }
-
-        void innerComplete() {
-            if (decrementAndGet() != 0) {
-                next();
-            }
-            if (!done) {
-                s.request(1);
-            }
+            drain();
         }
 
         @Override
         public void dispose() {
             s.cancel();
-            sd.dispose();
+            DisposableHelper.dispose(inner);
         }
 
         @Override
         public boolean isDisposed() {
-            return sd.isDisposed();
+            return DisposableHelper.isDisposed(inner.get());
         }
 
-        void next() {
-            boolean d = done;
-            CompletableSource c = queue.poll();
-            if (c == null) {
-                if (d) {
-                    if (once.compareAndSet(false, true)) {
-                        actual.onComplete();
-                    }
-                    return;
-                }
-                RxJavaPlugins.onError(new IllegalStateException("Queue is empty?!"));
+        void drain() {
+            if (getAndIncrement() != 0) {
                 return;
             }
 
-            c.subscribe(inner);
+            for (;;) {
+                if (isDisposed()) {
+                    return;
+                }
+
+                if (!active) {
+
+                    boolean d = done;
+
+                    CompletableSource cs;
+
+                    try {
+                        cs = queue.poll();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        innerError(ex);
+                        return;
+                    }
+
+                    boolean empty = cs == null;
+
+                    if (d && empty) {
+                        if (once.compareAndSet(false, true)) {
+                            actual.onComplete();
+                        }
+                        return;
+                    }
+
+                    if (!empty) {
+                        active = true;
+                        cs.subscribe(inner);
+                        request();
+                    }
+                }
+
+                if (decrementAndGet() == 0) {
+                    break;
+                }
+            }
         }
 
-        final class ConcatInnerObserver implements CompletableObserver {
+        void request() {
+            if (sourceFused != QueueSubscription.SYNC) {
+                int p = consumed + 1;
+                if (p == limit) {
+                    consumed = 0;
+                    s.request(p);
+                } else {
+                    consumed = p;
+                }
+            }
+        }
+
+        void innerError(Throwable e) {
+            if (once.compareAndSet(false, true)) {
+                s.cancel();
+                actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        void innerComplete() {
+            active = false;
+            drain();
+        }
+
+        static final class ConcatInnerObserver extends AtomicReference<Disposable> implements CompletableObserver {
+            private static final long serialVersionUID = -5454794857847146511L;
+
+            final CompletableConcatSubscriber parent;
+
+            ConcatInnerObserver(CompletableConcatSubscriber parent) {
+                this.parent = parent;
+            }
+
             @Override
             public void onSubscribe(Disposable d) {
-                sd.update(d);
+                DisposableHelper.replace(this, d);
             }
 
             @Override
             public void onError(Throwable e) {
-                innerError(e);
+                parent.innerError(e);
             }
 
             @Override
             public void onComplete() {
-                innerComplete();
+                parent.innerComplete();
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
@@ -63,12 +63,7 @@ public final class CompletablePeek extends Completable {
 
                 s.onComplete();
 
-                try {
-                    onAfterTerminate.run();
-                } catch (Throwable e) {
-                    Exceptions.throwIfFatal(e);
-                    RxJavaPlugins.onError(e);
-                }
+                doAfter();
             }
 
             @Override
@@ -78,17 +73,12 @@ public final class CompletablePeek extends Completable {
                     onTerminate.run();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
-                    e = new CompositeException(ex, e);
+                    e = new CompositeException(e, ex);
                 }
 
                 s.onError(e);
 
-                try {
-                    onAfterTerminate.run();
-                } catch (Throwable ex) {
-                    Exceptions.throwIfFatal(ex);
-                    RxJavaPlugins.onError(ex);
-                }
+                doAfter();
             }
 
             @Override
@@ -117,6 +107,16 @@ public final class CompletablePeek extends Completable {
                 }));
             }
 
+            void doAfter() {
+
+                try {
+                    onAfterTerminate.run();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    RxJavaPlugins.onError(ex);
+                }
+
+            }
         });
     }
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleResumeNext.java
@@ -47,7 +47,7 @@ public final class SingleResumeNext<T> extends Single<T> {
 
         final Function<? super Throwable, ? extends SingleSource<? extends T>> nextFunction;
 
-        public ResumeMainSingleObserver(SingleObserver<? super T> actual,
+        ResumeMainSingleObserver(SingleObserver<? super T> actual,
                 Function<? super Throwable, ? extends SingleSource<? extends T>> nextFunction) {
             this.actual = actual;
             this.nextFunction = nextFunction;

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -324,6 +324,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     /**
      * Asserts that this TestObserver/TestSubscriber received an onNext value at the given index
      * for the provided predicate returns true.
+     * @param index the position to assert on
      * @param valuePredicate
      *            the predicate that receives the onNext value
      *            and should return true for the expected value.

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -366,8 +366,7 @@ public class CompletableTest {
 
         c.blockingAwait();
 
-        // FIXME this request pattern looks odd because all 10 completions trigger 1 requests
-        Assert.assertEquals(Arrays.asList(5L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L), requested);
+        Assert.assertEquals(Arrays.asList(5L, 4L, 4L), requested);
     }
 
     @Test(expected = NullPointerException.class)
@@ -1876,8 +1875,8 @@ public class CompletableTest {
         } catch (CompositeException ex) {
             List<Throwable> a = ex.getExceptions();
             Assert.assertEquals(2, a.size());
-            Assert.assertTrue(a.get(0) instanceof IllegalStateException);
-            Assert.assertTrue(a.get(1) instanceof TestException);
+            Assert.assertTrue(a.get(0) instanceof TestException);
+            Assert.assertTrue(a.get(1) instanceof IllegalStateException);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableAmbTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.*;
+
+public class CompletableAmbTest {
+
+    @Test
+    public void ambLots() {
+        List<Completable> ms = new ArrayList<Completable>();
+
+        for (int i = 0; i < 32; i++) {
+            ms.add(Completable.never());
+        }
+
+        ms.add(Completable.complete());
+
+        Completable.amb(ms)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void ambFirstDone() {
+        Completable.amb(Arrays.asList(Completable.complete(), Completable.complete()))
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void dispose() {
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestObserver<Void> to = Completable.amb(Arrays.asList(pp1.ignoreElements(), pp2.ignoreElements()))
+        .test();
+
+        assertTrue(pp1.hasSubscribers());
+        assertTrue(pp2.hasSubscribers());
+
+        to.dispose();
+
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+    }
+
+    @Test
+    public void innerErrorRace() {
+        for (int i = 0; i < 500; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final PublishProcessor<Integer> pp0 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+
+                final TestObserver<Void> to = Completable.amb(Arrays.asList(pp0.ignoreElements(), pp1.ignoreElements()))
+                .test();
+
+                final TestException ex = new TestException();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        pp0.onError(ex);
+                    }
+                };
+
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        pp1.onError(ex);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                to.assertFailure(TestException.class);
+
+                if (!errors.isEmpty()) {
+                    TestHelper.assertError(errors, 0, TestException.class);
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void nullSourceSuccessRace() {
+        for (int i = 0; i < 1000; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+
+            try {
+
+                final Subject<Integer> ps = ReplaySubject.create();
+                ps.onNext(1);
+
+                final Completable source = Completable.ambArray(ps.ignoreElements(), Completable.never(), Completable.never(), null);
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        source.test();
+                    }
+                };
+
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps.onComplete();
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                if (!errors.isEmpty()) {
+                    TestHelper.assertError(errors, 0, NullPointerException.class);
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
@@ -14,12 +14,21 @@
 package io.reactivex.internal.operators.completable;
 
 import static org.junit.Assert.*;
+
+import java.util.*;
+
 import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.disposables.Disposables;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.observers.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.*;
+import io.reactivex.schedulers.Schedulers;
 
 public class CompletableConcatTest {
 
@@ -49,6 +58,200 @@ public class CompletableConcatTest {
             fail("Should have thrown IllegalArgumentExceptio");
         } catch (IllegalArgumentException ex) {
             assertEquals("prefetch > 0 required but it was -99", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Completable.concat(Flowable.just(Completable.complete())));
+    }
+
+    @Test
+    public void errorRace() {
+        for (int i = 0; i < 500; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+
+            try {
+                final PublishProcessor<Integer> ps1 = PublishProcessor.create();
+                final PublishProcessor<Integer> ps2 = PublishProcessor.create();
+
+                TestObserver<Void> to = Completable.concat(ps1.map(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Exception {
+                        return ps2.ignoreElements();
+                    }
+                })).test();
+
+                ps1.onNext(1);
+
+                final TestException ex = new TestException();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps1.onError(ex);
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps2.onError(ex);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                to.assertFailure(TestException.class);
+
+                if (!errors.isEmpty()) {
+                    TestHelper.assertError(errors, 0, TestException.class);
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void synchronousFusedCrash() {
+        Completable.concat(Flowable.range(1, 2).map(new Function<Integer, Completable>() {
+            @Override
+            public Completable apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        }))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void unboundedIn() {
+        Completable.concat(Flowable.just(Completable.complete()).hide(), Integer.MAX_VALUE)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void syncFusedUnboundedIn() {
+        Completable.concat(Flowable.just(Completable.complete()), Integer.MAX_VALUE)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void asyncFusedUnboundedIn() {
+        UnicastProcessor<Completable> up = UnicastProcessor.create();
+        up.onNext(Completable.complete());
+        up.onComplete();
+
+        Completable.concat(up, Integer.MAX_VALUE)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void arrayCancelled() {
+        Completable.concatArray(Completable.complete(), Completable.complete())
+        .test(true)
+        .assertEmpty();
+    }
+
+    @Test
+    public void arrayFirstCancels() {
+        final TestObserver<Void> to = new TestObserver<Void>();
+
+        Completable.concatArray(new Completable() {
+            @Override
+            protected void subscribeActual(CompletableObserver s) {
+                s.onSubscribe(Disposables.empty());
+                to.cancel();
+                s.onComplete();
+            }
+        }, Completable.complete())
+        .subscribe(to);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void iterableCancelled() {
+        Completable.concat(Arrays.asList(Completable.complete(), Completable.complete()))
+        .test(true)
+        .assertEmpty();
+    }
+
+    @Test
+    public void iterableFirstCancels() {
+        final TestObserver<Void> to = new TestObserver<Void>();
+
+        Completable.concat(Arrays.asList(new Completable() {
+            @Override
+            protected void subscribeActual(CompletableObserver s) {
+                s.onSubscribe(Disposables.empty());
+                to.cancel();
+                s.onComplete();
+            }
+        }, Completable.complete()))
+        .subscribe(to);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void arrayCancelRace() {
+        Completable[] a = new Completable[1024];
+        Arrays.fill(a, Completable.complete());
+
+        for (int i = 0; i < 500; i++) {
+
+            final Completable c = Completable.concatArray(a);
+
+            final TestObserver<Void> to = new TestObserver<Void>();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    c.subscribe(to);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    to.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+
+    @Test
+    public void iterableCancelRace() {
+        Completable[] a = new Completable[1024];
+        Arrays.fill(a, Completable.complete());
+
+        for (int i = 0; i < 500; i++) {
+
+            final Completable c = Completable.concat(Arrays.asList(a));
+
+            final TestObserver<Void> to = new TestObserver<Void>();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    c.subscribe(to);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    to.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeIterableTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
+
+public class CompletableMergeIterableTest {
+
+    @Test
+    public void errorRace() {
+        for (int i = 0; i < 500; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final PublishSubject<Integer> ps1 = PublishSubject.create();
+                final PublishSubject<Integer> ps2 = PublishSubject.create();
+
+                TestObserver<Void> to = Completable.merge(
+                        Arrays.asList(ps1.ignoreElements(), ps2.ignoreElements())).test();
+
+                final TestException ex = new TestException();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps1.onError(ex);
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps2.onError(ex);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                to.assertFailure(TestException.class);
+
+                if (!errors.isEmpty()) {
+                    TestHelper.assertError(errors, 0, TestException.class);
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void cancelAfterHasNext() {
+        final TestObserver<Void> to = new TestObserver<Void>();
+
+        Completable.merge(new Iterable<Completable>() {
+            @Override
+            public Iterator<Completable> iterator() {
+                return new Iterator<Completable>() {
+                    @Override
+                    public boolean hasNext() {
+                        to.cancel();
+                        return true;
+                    }
+
+                    @Override
+                    public Completable next() {
+                        return Completable.complete();
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        }).subscribe(to);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void cancelAfterNext() {
+        final TestObserver<Void> to = new TestObserver<Void>();
+
+        Completable.merge(new Iterable<Completable>() {
+            @Override
+            public Iterator<Completable> iterator() {
+                return new Iterator<Completable>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+
+                    @Override
+                    public Completable next() {
+                        to.cancel();
+                        return Completable.complete();
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        }).subscribe(to);
+
+        to.assertEmpty();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
@@ -15,16 +15,20 @@ package io.reactivex.internal.operators.completable;
 
 import static org.junit.Assert.*;
 
-import java.util.List;
+import java.util.*;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
-import io.reactivex.disposables.Disposables;
-import io.reactivex.exceptions.TestException;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
 
 public class CompletableMergeTest {
     @Test
@@ -130,5 +134,423 @@ public class CompletableMergeTest {
         pp.onError(new TestException());
 
         to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Completable.merge(Flowable.just(Completable.complete())));
+    }
+
+    @Test
+    public void disposePropagates() {
+
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestObserver<Void> to = Completable.merge(Flowable.just(pp.ignoreElements())).test();
+
+        assertTrue(pp.hasSubscribers());
+
+        to.cancel();
+
+        assertFalse(pp.hasSubscribers());
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void innerComplete() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestObserver<Void> to = Completable.merge(Flowable.just(pp.ignoreElements())).test();
+
+        pp.onComplete();
+
+        to.assertResult();
+    }
+
+    @Test
+    public void innerError() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestObserver<Void> to = Completable.merge(Flowable.just(pp.ignoreElements())).test();
+
+        pp.onError(new TestException());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerErrorDelayError() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestObserver<Void> to = Completable.mergeDelayError(Flowable.just(pp.ignoreElements())).test();
+
+        pp.onError(new TestException());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mainErrorInnerErrorRace() {
+        for (int i = 0; i < 500; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+                TestObserver<Void> to = Completable.merge(pp1.map(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Exception {
+                        return pp2.ignoreElements();
+                    }
+                })).test();
+
+                pp1.onNext(1);
+
+                final Throwable ex1 = new TestException();
+                final Throwable ex2 = new TestException();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        pp1.onError(ex1);
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        pp2.onError(ex2);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                Throwable ex = to.errors().get(0);
+                if (ex instanceof CompositeException) {
+                    to.assertSubscribed().assertNoValues().assertNotComplete();
+
+                    errors = TestHelper.compositeList(ex);
+                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertError(errors, 1, TestException.class);
+                } else {
+                    to.assertFailure(TestException.class);
+
+                    if (!errors.isEmpty()) {
+                        TestHelper.assertError(errors, 0, TestException.class);
+                    }
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void mainErrorInnerErrorDelayedRace() {
+        for (int i = 0; i < 500; i++) {
+            final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+            final PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+            TestObserver<Void> to = Completable.mergeDelayError(pp1.map(new Function<Integer, Completable>() {
+                @Override
+                public Completable apply(Integer v) throws Exception {
+                    return pp2.ignoreElements();
+                }
+            })).test();
+
+            pp1.onNext(1);
+
+            final Throwable ex1 = new TestException();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp1.onError(ex1);
+                }
+            };
+
+            final Throwable ex2 = new TestException();
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    pp2.onError(ex2);
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+
+            to.assertFailure(CompositeException.class);
+
+            List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+
+            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertError(errors, 1, TestException.class);
+        }
+    }
+
+    @Test
+    public void maxConcurrencyOne() {
+        final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        final PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestObserver<Void> to = Completable.merge(Flowable.just(pp1.ignoreElements(), pp2.ignoreElements()), 1)
+        .test();
+
+        assertTrue(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+
+        pp1.onComplete();
+
+        assertTrue(pp2.hasSubscribers());
+
+        pp2.onComplete();
+
+        to.assertResult();
+    }
+
+    @Test
+    public void maxConcurrencyOneDelayError() {
+        final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        final PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestObserver<Void> to = Completable.mergeDelayError(Flowable.just(pp1.ignoreElements(), pp2.ignoreElements()), 1)
+        .test();
+
+        assertTrue(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+
+        pp1.onComplete();
+
+        assertTrue(pp2.hasSubscribers());
+
+        pp2.onComplete();
+
+        to.assertResult();
+    }
+
+    @Test
+    public void maxConcurrencyOneDelayErrorFirst() {
+        final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        final PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestObserver<Void> to = Completable.mergeDelayError(Flowable.just(pp1.ignoreElements(), pp2.ignoreElements()), 1)
+        .test();
+
+        assertTrue(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+
+        pp1.onError(new TestException());
+
+        assertTrue(pp2.hasSubscribers());
+
+        pp2.onComplete();
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void maxConcurrencyOneDelayMainErrors() {
+        final PublishProcessor<PublishProcessor<Integer>> pp0 = PublishProcessor.create();
+        final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        final PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestObserver<Void> to = Completable.mergeDelayError(
+        pp0.map(new Function<PublishProcessor<Integer>, Completable>() {
+            @Override
+            public Completable apply(PublishProcessor<Integer> v) throws Exception {
+                return v.ignoreElements();
+            }
+        }), 1)
+        .test();
+
+        pp0.onNext(pp1);
+
+        assertTrue(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+
+        pp1.onComplete();
+
+        pp0.onNext(pp2);
+        pp0.onError(new TestException());
+
+        assertTrue(pp2.hasSubscribers());
+
+        pp2.onComplete();
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mainDoubleOnError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Completable.mergeDelayError(new Flowable<Completable>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Completable> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(Completable.complete());
+                    s.onError(new TestException("First"));
+                    s.onError(new TestException("Second"));
+                }
+            })
+            .test()
+            .assertFailureAndMessage(TestException.class, "First");
+
+            TestHelper.assertError(errors, 0, TestException.class, "Second");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void innerDoubleOnError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final CompletableObserver[] o = { null };
+            Completable.mergeDelayError(Flowable.just(new Completable() {
+                @Override
+                protected void subscribeActual(CompletableObserver s) {
+                    s.onSubscribe(Disposables.empty());
+                    s.onError(new TestException("First"));
+                    o[0] = s;
+                }
+            }))
+            .test()
+            .assertFailureAndMessage(TestException.class, "First");
+
+            o[0].onError(new TestException("Second"));
+
+            TestHelper.assertError(errors, 0, TestException.class, "Second");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void innerIsDisposed() {
+        final TestObserver<Void> to = new TestObserver<Void>();
+
+        Completable.mergeDelayError(Flowable.just(new Completable() {
+            @Override
+            protected void subscribeActual(CompletableObserver s) {
+                s.onSubscribe(Disposables.empty());
+                assertFalse(((Disposable)s).isDisposed());
+
+                to.dispose();
+
+                assertTrue(((Disposable)s).isDisposed());
+            }
+        }))
+        .subscribe(to);
+    }
+
+    @Test
+    public void mergeArrayInnerErrorRace() {
+        for (int i = 0; i < 500; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+                TestObserver<Void> to = Completable.mergeArray(pp1.ignoreElements(), pp2.ignoreElements()).test();
+
+                pp1.onNext(1);
+
+                final Throwable ex1 = new TestException();
+                final Throwable ex2 = new TestException();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        pp1.onError(ex1);
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        pp2.onError(ex2);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                to.assertFailure(TestException.class);
+
+                if (!errors.isEmpty()) {
+                    TestHelper.assertError(errors, 0, TestException.class);
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void delayErrorIterableCancel() {
+        Completable.mergeDelayError(Arrays.asList(Completable.complete()))
+        .test(true)
+        .assertEmpty();
+    }
+
+    @Test
+    public void delayErrorIterableCancelAfterHasNext() {
+        final TestObserver<Void> to = new TestObserver<Void>();
+
+        Completable.mergeDelayError(new Iterable<Completable>() {
+            @Override
+            public Iterator<Completable> iterator() {
+                return new Iterator<Completable>() {
+                    @Override
+                    public boolean hasNext() {
+                        to.cancel();
+                        return true;
+                    }
+
+                    @Override
+                    public Completable next() {
+                        return Completable.complete();
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        })
+        .subscribe(to);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void delayErrorIterableCancelAfterNext() {
+        final TestObserver<Void> to = new TestObserver<Void>();
+
+        Completable.mergeDelayError(new Iterable<Completable>() {
+            @Override
+            public Iterator<Completable> iterator() {
+                return new Iterator<Completable>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+
+                    @Override
+                    public Completable next() {
+                        to.cancel();
+                        return Completable.complete();
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        })
+        .subscribe(to);
+
+        to.assertEmpty();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableObserveOnTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+import io.reactivex.schedulers.Schedulers;
+
+public class CompletableObserveOnTest {
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Completable.complete().observeOn(Schedulers.single()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeCompletable(new Function<Completable, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Completable c) throws Exception {
+                return c.observeOn(Schedulers.single());
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletablePeekTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletablePeekTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class CompletablePeekTest {
+
+    @Test
+    public void onAfterTerminateCrashes() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Completable.complete()
+            .doAfterTerminate(new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            })
+            .test()
+            .assertResult();
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -273,7 +273,7 @@ public class FlowableMergeTest {
         // to make sure after o1.onNextBeingSent and o2.onNextBeingSent are hit that the following
         // onNext is invoked.
 
-        int timeout = 10;
+        int timeout = 20;
 
         while (timeout-- > 0 && concurrentCounter.get() != 1) {
             Thread.sleep(100);


### PR DESCRIPTION
- Add coverage to remaining `Completable` operators
- Fix inner Throwable order for `CompletablePeek`
- Compact/rewrite a few operators
