### PR TITLE
2.x: Clean up null usages by using ObjectHelper.requireNonNull

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatIterable.java
@@ -109,15 +109,10 @@ public final class CompletableConcatIterable extends Completable {
                 CompletableSource c;
 
                 try {
-                    c = a.next();
+                    c = ObjectHelper.requireNonNull(a.next(), "The CompletableSource returned is null");
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     actual.onError(ex);
-                    return;
-                }
-
-                if (c == null) {
-                    actual.onError(new NullPointerException("The completable returned is null"));
                     return;
                 }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableErrorSupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableErrorSupplier.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.completable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -32,15 +33,12 @@ public final class CompletableErrorSupplier extends Completable {
         Throwable error;
 
         try {
-            error = errorSupplier.call();
+            error = ObjectHelper.requireNonNull(errorSupplier.call(), "The error returned is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             error = e;
         }
 
-        if (error == null) {
-            error = new NullPointerException("The error supplied is null");
-        }
         EmptyDisposable.error(error, s);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorIterable.java
@@ -40,15 +40,10 @@ public final class CompletableMergeDelayErrorIterable extends Completable {
         Iterator<? extends CompletableSource> iterator;
 
         try {
-            iterator = sources.iterator();
+            iterator = ObjectHelper.requireNonNull(sources.iterator(), "The source iterator returned is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             s.onError(e);
-            return;
-        }
-
-        if (iterator == null) {
-            s.onError(new NullPointerException("The source iterator returned is null"));
             return;
         }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeIterable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.completable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Iterator;
 import java.util.concurrent.atomic.*;
 
@@ -38,15 +39,10 @@ public final class CompletableMergeIterable extends Completable {
         Iterator<? extends CompletableSource> iterator;
 
         try {
-            iterator = sources.iterator();
+            iterator = ObjectHelper.requireNonNull(sources.iterator(), "The source iterator returned is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             s.onError(e);
-            return;
-        }
-
-        if (iterator == null) {
-            s.onError(new NullPointerException("The source iterator returned is null"));
             return;
         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
@@ -104,7 +105,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
             if (b == null) {
 
                 try {
-                    b = bufferSupplier.call();
+                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null buffer");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     cancel();
@@ -112,12 +113,6 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
                     return;
                 }
 
-                if (b == null) {
-                    cancel();
-
-                    onError(new NullPointerException("The bufferSupplier returned a null buffer"));
-                    return;
-                }
                 buffer = b;
             }
 
@@ -231,19 +226,12 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
             if (i % skip == 0L) { // FIXME no need for modulo
                 try {
-                    b = bufferSupplier.call();
+                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null buffer");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     cancel();
 
                     onError(e);
-                    return;
-                }
-
-                if (b == null) {
-                    cancel();
-
-                    onError(new NullPointerException("The bufferSupplier returned a null buffer"));
                     return;
                 }
 
@@ -390,18 +378,11 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
                 C b;
 
                 try {
-                    b = bufferSupplier.call();
+                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null buffer");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     cancel();
                     onError(e);
-                    return;
-                }
-
-                if (b == null) {
-                    cancel();
-
-                    onError(new NullPointerException("The bufferSupplier returned a null buffer"));
                     return;
                 }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -173,30 +174,20 @@ extends AbstractFlowableWithUpstream<T, U> {
             U b;
 
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 onError(e);
-                return;
-            }
-
-            if (b == null) {
-                onError(new NullPointerException("The buffer supplied is null"));
                 return;
             }
 
             Publisher<? extends Close> p;
 
             try {
-                p = bufferClose.apply(window);
+                p = ObjectHelper.requireNonNull(bufferClose.apply(window), "The buffer closing publisher is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 onError(e);
-                return;
-            }
-
-            if (p == null) {
-                onError(new NullPointerException("The buffer closing publisher is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
@@ -76,7 +77,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             U b;
 
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancelled = true;
@@ -85,30 +86,17 @@ extends AbstractFlowableWithUpstream<T, U> {
                 return;
             }
 
-            if (b == null) {
-                cancelled = true;
-                s.cancel();
-                EmptySubscription.error(new NullPointerException("The buffer supplied is null"), actual);
-                return;
-            }
             buffer = b;
 
             Publisher<B> boundary;
 
             try {
-                boundary = boundarySupplier.call();
+                boundary = ObjectHelper.requireNonNull(boundarySupplier.call(), "The boundary publisher supplied is null");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 cancelled = true;
                 s.cancel();
                 EmptySubscription.error(ex, actual);
-                return;
-            }
-
-            if (boundary == null) {
-                cancelled = true;
-                s.cancel();
-                EmptySubscription.error(new NullPointerException("The boundary publisher supplied is null"), actual);
                 return;
             }
 
@@ -185,7 +173,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             U next;
 
             try {
-                next = bufferSupplier.call();
+                next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancel();
@@ -193,28 +181,15 @@ extends AbstractFlowableWithUpstream<T, U> {
                 return;
             }
 
-            if (next == null) {
-                cancel();
-                actual.onError(new NullPointerException("The buffer supplied is null"));
-                return;
-            }
-
             Publisher<B> boundary;
 
             try {
-                boundary = boundarySupplier.call();
+                boundary = ObjectHelper.requireNonNull(boundarySupplier.call(), "The boundary publisher supplied is null");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 cancelled = true;
                 s.cancel();
                 actual.onError(ex);
-                return;
-            }
-
-            if (boundary == null) {
-                cancelled = true;
-                s.cancel();
-                actual.onError(new NullPointerException("The boundary publisher supplied is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
@@ -71,7 +72,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             U b;
 
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancelled = true;
@@ -80,12 +81,6 @@ extends AbstractFlowableWithUpstream<T, U> {
                 return;
             }
 
-            if (b == null) {
-                cancelled = true;
-                s.cancel();
-                EmptySubscription.error(new NullPointerException("The buffer supplied is null"), actual);
-                return;
-            }
             buffer = b;
 
             BufferBoundarySubscriber<T, U, B> bs = new BufferBoundarySubscriber<T, U, B>(this);
@@ -157,17 +152,11 @@ extends AbstractFlowableWithUpstream<T, U> {
             U next;
 
             try {
-                next = bufferSupplier.call();
+                next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
-                return;
-            }
-
-            if (next == null) {
-                cancel();
-                actual.onError(new NullPointerException("The buffer supplied is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -113,17 +114,11 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             U b;
 
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The supplied buffer is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancel();
                 EmptySubscription.error(e, actual);
-                return;
-            }
-
-            if (b == null) {
-                cancel();
-                EmptySubscription.error(new NullPointerException("buffer supplied is null"), actual);
                 return;
             }
 
@@ -206,19 +201,12 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             U next;
 
             try {
-                next = bufferSupplier.call();
+                next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The supplied buffer is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 selfCancel = true;
                 cancel();
                 actual.onError(e);
-                return;
-            }
-
-            if (next == null) {
-                selfCancel = true;
-                cancel();
-                actual.onError(new NullPointerException("buffer supplied is null"));
                 return;
             }
 
@@ -292,19 +280,12 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             final U b; // NOPMD
 
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The supplied buffer is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 w.dispose();
                 s.cancel();
                 EmptySubscription.error(e, actual);
-                return;
-            }
-
-            if (b == null) {
-                w.dispose();
-                s.cancel();
-                EmptySubscription.error(new NullPointerException("The supplied buffer is null"), actual);
                 return;
             }
 
@@ -388,7 +369,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             final U b; // NOPMD
 
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The supplied buffer is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancel();
@@ -396,11 +377,6 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
                 return;
             }
 
-            if (b == null) {
-                cancel();
-                actual.onError(new NullPointerException("The supplied buffer is null"));
-                return;
-            }
             synchronized (this) {
                 if (cancelled) {
                     return;
@@ -470,19 +446,12 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             U b;
 
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The supplied buffer is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 w.dispose();
                 s.cancel();
                 EmptySubscription.error(e, actual);
-                return;
-            }
-
-            if (b == null) {
-                w.dispose();
-                s.cancel();
-                EmptySubscription.error(new NullPointerException("The supplied buffer is null"), actual);
                 return;
             }
 
@@ -521,21 +490,13 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             fastPathOrderedEmitMax(b, false, this);
 
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The supplied buffer is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
                 return;
             }
-
-            if (b == null) {
-                cancel();
-                actual.onError(new NullPointerException("The buffer supplied is null"));
-                return;
-            }
-
-
 
             if (restartTimerOnMaxSize) {
                 synchronized (this) {
@@ -616,17 +577,11 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             U next;
 
             try {
-                next = bufferSupplier.call();
+                next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The supplied buffer is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
-                return;
-            }
-
-            if (next == null) {
-                cancel();
-                actual.onError(new NullPointerException("The buffer supplied is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollect.java
@@ -12,6 +12,7 @@
  */
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
@@ -36,13 +37,9 @@ public final class FlowableCollect<T, U> extends AbstractFlowableWithUpstream<T,
     protected void subscribeActual(Subscriber<? super U> s) {
         U u;
         try {
-            u = initialSupplier.call();
+            u = ObjectHelper.requireNonNull(initialSupplier.call(), "The initial value supplied is null");
         } catch (Throwable e) {
             EmptySubscription.error(e, s);
-            return;
-        }
-        if (u == null) {
-            EmptySubscription.error(new NullPointerException("The initial value supplied is null"), s);
             return;
         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -78,15 +78,10 @@ extends Flowable<R> {
             Iterator<? extends Publisher<? extends T>> it;
 
             try {
-                it = iterable.iterator();
+                it = ObjectHelper.requireNonNull(iterable.iterator(), "The iterator returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 EmptySubscription.error(e, s);
-                return;
-            }
-
-            if (it == null) {
-                EmptySubscription.error(new NullPointerException("The iterator returned is null"), s);
                 return;
             }
 
@@ -109,16 +104,10 @@ extends Flowable<R> {
                 Publisher<? extends T> p;
 
                 try {
-                    p = it.next();
+                    p = ObjectHelper.requireNonNull(it.next(), "The publisher returned by the iterator is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     EmptySubscription.error(e, s);
-                    return;
-                }
-
-                if (p == null) {
-                    EmptySubscription.error(new NullPointerException("The Publisher returned by the iterator is " +
-                      "null"), s);
                     return;
                 }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
@@ -12,6 +12,7 @@
  */
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
@@ -289,18 +290,12 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                             Publisher<? extends R> p;
 
                             try {
-                                p = mapper.apply(v);
+                                p = ObjectHelper.requireNonNull(mapper.apply(v), "The mapper returned a null Publisher");
                             } catch (Throwable e) {
                                 Exceptions.throwIfFatal(e);
 
                                 s.cancel();
                                 actual.onError(e);
-                                return;
-                            }
-
-                            if (p == null) {
-                                s.cancel();
-                                actual.onError(new NullPointerException("The mapper returned a null Publisher"));
                                 return;
                             }
 
@@ -511,18 +506,12 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                             Publisher<? extends R> p;
 
                             try {
-                                p = mapper.apply(v);
+                                p = ObjectHelper.requireNonNull(mapper.apply(v), "The mapper returned a null Publisher");
                             } catch (Throwable e) {
                                 Exceptions.throwIfFatal(e);
 
                                 s.cancel();
                                 actual.onError(e);
-                                return;
-                            }
-
-                            if (p == null) {
-                                s.cancel();
-                                actual.onError(new NullPointerException("The mapper returned a null Publisher"));
                                 return;
                             }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
@@ -86,17 +87,11 @@ public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T
             Publisher<U> p;
 
             try {
-                p = debounceSelector.apply(t);
+                p = ObjectHelper.requireNonNull(debounceSelector.apply(t), "The publisher supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                cancel();
-                actual.onError(new NullPointerException("The publisher supplied is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDefer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
@@ -30,17 +31,13 @@ public final class FlowableDefer<T> extends Flowable<T> {
     public void subscribeActual(Subscriber<? super T> s) {
         Publisher<? extends T> pub;
         try {
-            pub = supplier.call();
+            pub = ObjectHelper.requireNonNull(supplier.call(), "The publisher supplied is null");
         } catch (Throwable t) {
             Exceptions.throwIfFatal(t);
             EmptySubscription.error(t, s);
             return;
         }
 
-        if (pub == null) {
-            EmptySubscription.error(new NullPointerException("null publisher supplied"), s);
-            return;
-        }
         pub.subscribe(s);
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -107,15 +107,10 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
     protected void subscribeActual(Subscriber<? super T> s) {
         Predicate<? super K> coll;
         try {
-            coll = predicateSupplier.call();
+            coll = ObjectHelper.requireNonNull(predicateSupplier.call(), "predicateSupplier returned null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);
-            return;
-        }
-
-        if (coll == null) {
-            EmptySubscription.error(new NullPointerException("predicateSupplier returned null"), s);
             return;
         }
 
@@ -148,20 +143,13 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
             K key;
 
             try {
-                key = keySelector.apply(t);
+                key = ObjectHelper.requireNonNull(keySelector.apply(t), "Null key supplied");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 s.cancel();
                 actual.onError(e);
                 return;
             }
-
-            if (key == null) {
-                s.cancel();
-                actual.onError(new NullPointerException("Null key supplied"));
-                return;
-            }
-
 
             boolean b;
             try {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableError.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableError.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import org.reactivestreams.Subscriber;
@@ -30,13 +31,10 @@ public final class FlowableError<T> extends Flowable<T> {
     public void subscribeActual(Subscriber<? super T> s) {
         Throwable error;
         try {
-            error = errorSupplier.call();
+            error = ObjectHelper.requireNonNull(errorSupplier.call(), "Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable t) {
             Exceptions.throwIfFatal(t);
             error = t;
-        }
-        if (error == null) {
-            error = new NullPointerException("Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         }
         EmptySubscription.error(error, s);
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
@@ -93,15 +94,10 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
             R p;
 
             try {
-                p = onNextMapper.apply(t);
+                p = ObjectHelper.requireNonNull(onNextMapper.apply(t), "The onNext publisher returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                actual.onError(new NullPointerException("The onNext publisher returned is null"));
                 return;
             }
 
@@ -118,15 +114,10 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
             R p;
 
             try {
-                p = onErrorMapper.apply(t);
+                p = ObjectHelper.requireNonNull(onErrorMapper.apply(t), "The onError publisher returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                actual.onError(new NullPointerException("The onError publisher returned is null"));
                 return;
             }
 
@@ -138,15 +129,10 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
             R p;
 
             try {
-                p = onCompleteSupplier.call();
+                p = ObjectHelper.requireNonNull(onCompleteSupplier.call(), "The onComplete publisher returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                actual.onError(new NullPointerException("The onComplete publisher returned is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -66,27 +67,19 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
             public void subscribe(Subscriber<? super R> child) {
                 ConnectableFlowable<U> co;
                 try {
-                    co = connectableFactory.call();
+                    co = ObjectHelper.requireNonNull(connectableFactory.call(), "The connectableFactory returned null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     EmptySubscription.error(e, child);
-                    return;
-                }
-                if (co == null) {
-                    EmptySubscription.error(new NullPointerException("The connectableFactory returned null"), child);
                     return;
                 }
 
                 Publisher<R> observable;
                 try {
-                    observable = selector.apply(co);
+                    observable = ObjectHelper.requireNonNull(selector.apply(co), "The selector returned a null Publisher");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     EmptySubscription.error(e, child);
-                    return;
-                }
-                if (observable == null) {
-                    EmptySubscription.error(new NullPointerException("The selector returned a null Publisher"), child);
                     return;
                 }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.Exceptions;
@@ -63,17 +64,11 @@ public final class FlowableScan<T> extends AbstractFlowableWithUpstream<T, T> {
                 T u;
 
                 try {
-                    u = accumulator.apply(v, t);
+                    u = ObjectHelper.requireNonNull(accumulator.apply(v, t), "The value returned by the accumulator is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     s.cancel();
                     a.onError(e);
-                    return;
-                }
-
-                if (u == null) {
-                    s.cancel();
-                    a.onError(new NullPointerException("The value returned by the accumulator is null"));
                     return;
                 }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
@@ -12,6 +12,7 @@
  */
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
@@ -38,15 +39,10 @@ public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T
         R r;
 
         try {
-            r = seedSupplier.call();
+            r = ObjectHelper.requireNonNull(seedSupplier.call(), "The seed supplied is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);
-            return;
-        }
-
-        if (r == null) {
-            EmptySubscription.error(new NullPointerException("The seed supplied is null"), s);
             return;
         }
 
@@ -83,17 +79,11 @@ public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T
             R u;
 
             try {
-                u = accumulator.apply(v, t);
+                u = ObjectHelper.requireNonNull(accumulator.apply(v, t), "The accumulator returned a null value");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 s.cancel();
                 onError(e);
-                return;
-            }
-
-            if (u == null) {
-                s.cancel();
-                onError(new NullPointerException("The accumulator returned a null value"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
@@ -104,17 +105,11 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
 
             Publisher<? extends R> p;
             try {
-                p = mapper.apply(t);
+                p = ObjectHelper.requireNonNull(mapper.apply(t), "The publisher returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 s.cancel();
                 onError(e);
-                return;
-            }
-
-            if (p == null) {
-                s.cancel();
-                onError(new NullPointerException("The publisher returned is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -118,17 +119,11 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
             Publisher<V> p;
 
             try {
-                p = itemTimeoutIndicator.apply(t);
+                p = ObjectHelper.requireNonNull(itemTimeoutIndicator.apply(t), "The publisher returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancel();
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                cancel();
-                actual.onError(new NullPointerException("The publisher returned is null"));
                 return;
             }
 
@@ -287,15 +282,10 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
             Publisher<V> p;
 
             try {
-                p = itemTimeoutIndicator.apply(t);
+                p = ObjectHelper.requireNonNull(itemTimeoutIndicator.apply(t), "The publisher returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                actual.onError(new NullPointerException("The publisher returned is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -281,16 +282,10 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                         Publisher<V> p;
 
                         try {
-                            p = close.apply(wo.open);
+                            p = ObjectHelper.requireNonNull(close.apply(wo.open), "The publisher supplied is null");
                         } catch (Throwable e) {
                             cancelled = true;
                             a.onError(e);
-                            continue;
-                        }
-
-                        if (p == null) {
-                            cancelled = true;
-                            a.onError(new NullPointerException("The publisher supplied is null"));
                             continue;
                         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
@@ -90,17 +91,11 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
             Publisher<B> p;
 
             try {
-                p = other.call();
+                p = ObjectHelper.requireNonNull(other.call(), "The first window publisher supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 s.cancel();
                 a.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                s.cancel();
-                a.onError(new NullPointerException("The first window publisher supplied is null"));
                 return;
             }
 
@@ -248,17 +243,11 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
                         Publisher<B> p;
 
                         try {
-                            p = other.call();
+                            p = ObjectHelper.requireNonNull(other.call(), "The publisher supplied is null");
                         } catch (Throwable e) {
                             Exceptions.throwIfFatal(e);
                             DisposableHelper.dispose(boundary);
                             a.onError(e);
-                            return;
-                        }
-
-                        if (p == null) {
-                            DisposableHelper.dispose(boundary);
-                            a.onError(new NullPointerException("The publisher supplied is null"));
                             return;
                         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableZipIterable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Iterator;
 
 import org.reactivestreams.*;
@@ -41,15 +42,10 @@ public final class FlowableZipIterable<T, U, V> extends Flowable<V> {
         Iterator<U> it;
 
         try {
-            it = other.iterator();
+            it = ObjectHelper.requireNonNull(other.iterator(), "The iterator returned by other is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, t);
-            return;
-        }
-
-        if (it == null) {
-            EmptySubscription.error(new NullPointerException("The iterator returned by other is null"), t);
             return;
         }
 
@@ -104,27 +100,17 @@ public final class FlowableZipIterable<T, U, V> extends Flowable<V> {
             U u;
 
             try {
-                u = iterator.next();
+                u = ObjectHelper.requireNonNull(iterator.next(), "The iterator returned a null value");
             } catch (Throwable e) {
                 error(e);
                 return;
             }
 
-            if (u == null) {
-                error(new NullPointerException("The iterator returned a null value"));
-                return;
-            }
-
             V v;
             try {
-                v = zipper.apply(t, u);
+                v = ObjectHelper.requireNonNull(zipper.apply(t, u), "The zipper function returned a null value");
             } catch (Throwable e) {
-                error(new NullPointerException("The iterator returned a null value"));
-                return;
-            }
-
-            if (v == null) {
-                error(new NullPointerException("The zipper function returned a null value"));
+                error(e);
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeErrorCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeErrorCallable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.maybe;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -38,14 +39,10 @@ public final class MaybeErrorCallable<T> extends Maybe<T> {
         Throwable ex;
 
         try {
-            ex = errorSupplier.call();
+            ex = ObjectHelper.requireNonNull(errorSupplier.call(), "Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable ex1) {
             Exceptions.throwIfFatal(ex1);
             ex = ex1;
-        }
-
-        if (ex == null) {
-            ex = new NullPointerException("Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         }
 
         observer.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -66,7 +67,7 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
         boolean createBuffer() {
             U b;
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "Empty buffer supplied");
             } catch (Throwable t) {
                 Exceptions.throwIfFatal(t);
                 buffer = null;
@@ -80,16 +81,6 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
             }
 
             buffer = b;
-            if (b == null) {
-                Throwable t = new NullPointerException("Empty buffer supplied");
-                if (s == null) {
-                    EmptyDisposable.error(t, actual);
-                } else {
-                    s.dispose();
-                    actual.onError(t);
-                }
-                return false;
-            }
 
             return true;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -159,30 +160,20 @@ extends AbstractObservableWithUpstream<T, U> {
             U b;
 
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 onError(e);
-                return;
-            }
-
-            if (b == null) {
-                onError(new NullPointerException("The buffer supplied is null"));
                 return;
             }
 
             ObservableSource<? extends Close> p;
 
             try {
-                p = bufferClose.apply(window);
+                p = ObjectHelper.requireNonNull(bufferClose.apply(window), "The buffer closing Observable is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 onError(e);
-                return;
-            }
-
-            if (p == null) {
-                onError(new NullPointerException("The buffer closing Observable is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundarySupplier.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
@@ -72,7 +73,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 U b;
 
                 try {
-                    b = bufferSupplier.call();
+                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     cancelled = true;
@@ -81,30 +82,17 @@ extends AbstractObservableWithUpstream<T, U> {
                     return;
                 }
 
-                if (b == null) {
-                    cancelled = true;
-                    s.dispose();
-                    EmptyDisposable.error(new NullPointerException("The buffer supplied is null"), actual);
-                    return;
-                }
                 buffer = b;
 
                 ObservableSource<B> boundary;
 
                 try {
-                    boundary = boundarySupplier.call();
+                    boundary = ObjectHelper.requireNonNull(boundarySupplier.call(), "The boundary publisher supplied is null");
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     cancelled = true;
                     s.dispose();
                     EmptyDisposable.error(ex, actual);
-                    return;
-                }
-
-                if (boundary == null) {
-                    cancelled = true;
-                    s.dispose();
-                    EmptyDisposable.error(new NullPointerException("The boundary publisher supplied is null"), actual);
                     return;
                 }
 
@@ -180,7 +168,7 @@ extends AbstractObservableWithUpstream<T, U> {
             U next;
 
             try {
-                next = bufferSupplier.call();
+                next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 dispose();
@@ -188,28 +176,15 @@ extends AbstractObservableWithUpstream<T, U> {
                 return;
             }
 
-            if (next == null) {
-                dispose();
-                actual.onError(new NullPointerException("The buffer supplied is null"));
-                return;
-            }
-
             ObservableSource<B> boundary;
 
             try {
-                boundary = boundarySupplier.call();
+                boundary = ObjectHelper.requireNonNull(boundarySupplier.call(), "The boundary publisher supplied is null");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 cancelled = true;
                 s.dispose();
                 actual.onError(ex);
-                return;
-            }
-
-            if (boundary == null) {
-                cancelled = true;
-                s.dispose();
-                actual.onError(new NullPointerException("The boundary publisher supplied is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferExactBoundary.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
@@ -68,7 +69,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 U b;
 
                 try {
-                    b = bufferSupplier.call();
+                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     cancelled = true;
@@ -77,12 +78,6 @@ extends AbstractObservableWithUpstream<T, U> {
                     return;
                 }
 
-                if (b == null) {
-                    cancelled = true;
-                    s.dispose();
-                    EmptyDisposable.error(new NullPointerException("The buffer supplied is null"), actual);
-                    return;
-                }
                 buffer = b;
 
                 BufferBoundaryObserver<T, U, B> bs = new BufferBoundaryObserver<T, U, B>(this);
@@ -153,17 +148,11 @@ extends AbstractObservableWithUpstream<T, U> {
             U next;
 
             try {
-                next = bufferSupplier.call();
+                next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
-                return;
-            }
-
-            if (next == null) {
-                dispose();
-                actual.onError(new NullPointerException("The buffer supplied is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -111,17 +111,11 @@ extends AbstractObservableWithUpstream<T, U> {
                 U b;
 
                 try {
-                    b = bufferSupplier.call();
+                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     dispose();
                     EmptyDisposable.error(e, actual);
-                    return;
-                }
-
-                if (b == null) {
-                    dispose();
-                    EmptyDisposable.error(new NullPointerException("buffer supplied is null"), actual);
                     return;
                 }
 
@@ -267,19 +261,12 @@ extends AbstractObservableWithUpstream<T, U> {
                 final U b; // NOPMD
 
                 try {
-                    b = bufferSupplier.call();
+                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     w.dispose();
                     s.dispose();
                     EmptyDisposable.error(e, actual);
-                    return;
-                }
-
-                if (b == null) {
-                    w.dispose();
-                    s.dispose();
-                    EmptyDisposable.error(new NullPointerException("The supplied buffer is null"), actual);
                     return;
                 }
 
@@ -439,19 +426,12 @@ extends AbstractObservableWithUpstream<T, U> {
                 U b;
 
                 try {
-                    b = bufferSupplier.call();
+                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     w.dispose();
                     s.dispose();
                     EmptyDisposable.error(e, actual);
-                    return;
-                }
-
-                if (b == null) {
-                    w.dispose();
-                    s.dispose();
-                    EmptyDisposable.error(new NullPointerException("The supplied buffer is null"), actual);
                     return;
                 }
 
@@ -489,21 +469,13 @@ extends AbstractObservableWithUpstream<T, U> {
             fastPathOrderedEmit(b, false, this);
 
             try {
-                b = bufferSupplier.call();
+                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
                 return;
             }
-
-            if (b == null) {
-                dispose();
-                actual.onError(new NullPointerException("The buffer supplied is null"));
-                return;
-            }
-
-
 
             if (restartTimerOnMaxSize) {
                 synchronized (this) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCollect.java
@@ -12,6 +12,7 @@
  */
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -35,14 +36,9 @@ public final class ObservableCollect<T, U> extends AbstractObservableWithUpstrea
     protected void subscribeActual(Observer<? super U> t) {
         U u;
         try {
-            u = initialSupplier.call();
+            u = ObjectHelper.requireNonNull(initialSupplier.call(), "The initialSupplier returned a null value");
         } catch (Throwable e) {
             EmptyDisposable.error(e, t);
-            return;
-        }
-
-        if (u == null) {
-            EmptyDisposable.error(new NullPointerException("The initialSupplier returned a null value"), t);
             return;
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Arrays;
 import java.util.concurrent.atomic.*;
 
@@ -235,19 +236,12 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
 
                     R v;
                     try {
-                        v = combiner.apply(array);
+                        v = ObjectHelper.requireNonNull(combiner.apply(array), "The combiner returned a null");
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
                         cancelled = true;
                         cancel(q);
                         a.onError(ex);
-                        return;
-                    }
-
-                    if (v == null) {
-                        cancelled = true;
-                        cancel(q);
-                        a.onError(new NullPointerException("The combiner returned a null"));
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounce.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
@@ -80,17 +81,11 @@ public final class ObservableDebounce<T, U> extends AbstractObservableWithUpstre
             ObservableSource<U> p;
 
             try {
-                p = debounceSelector.apply(t);
+                p = ObjectHelper.requireNonNull(debounceSelector.apply(t), "The publisher supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                dispose();
-                actual.onError(new NullPointerException("The publisher supplied is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDefer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -28,17 +29,13 @@ public final class ObservableDefer<T> extends Observable<T> {
     public void subscribeActual(Observer<? super T> s) {
         ObservableSource<? extends T> pub;
         try {
-            pub = supplier.call();
+            pub = ObjectHelper.requireNonNull(supplier.call(), "null publisher supplied");
         } catch (Throwable t) {
             Exceptions.throwIfFatal(t);
             EmptyDisposable.error(t, s);
             return;
         }
 
-        if (pub == null) {
-            EmptyDisposable.error(new NullPointerException("null publisher supplied"), s);
-            return;
-        }
         pub.subscribe(s);
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
@@ -106,15 +106,10 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
     public void subscribeActual(Observer<? super T> t) {
         Predicate<? super K> coll;
         try {
-            coll = predicateSupplier.call();
+            coll = ObjectHelper.requireNonNull(predicateSupplier.call(), "predicateSupplier returned null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);
-            return;
-        }
-
-        if (coll == null) {
-            EmptyDisposable.error(new NullPointerException("predicateSupplier returned null"), t);
             return;
         }
 
@@ -158,20 +153,13 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
             K key;
 
             try {
-                key = keySelector.apply(t);
+                key = ObjectHelper.requireNonNull(keySelector.apply(t), "Null key supplied");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 s.dispose();
                 actual.onError(e);
                 return;
             }
-
-            if (key == null) {
-                s.dispose();
-                actual.onError(new NullPointerException("Null key supplied"));
-                return;
-            }
-
 
             boolean b;
             try {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableError.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableError.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -28,13 +29,10 @@ public final class ObservableError<T> extends Observable<T> {
     public void subscribeActual(Observer<? super T> s) {
         Throwable error;
         try {
-            error = errorSupplier.call();
+            error = ObjectHelper.requireNonNull(errorSupplier.call(), "Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable t) {
             Exceptions.throwIfFatal(t);
             error = t;
-        }
-        if (error == null) {
-            error = new NullPointerException("Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         }
         EmptyDisposable.error(error, s);
     }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromCallable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -33,7 +34,7 @@ public final class ObservableFromCallable<T> extends Observable<T> {
         }
         T value;
         try {
-            value = callable.call();
+            value = ObjectHelper.requireNonNull(callable.call(), "Callable returned null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
@@ -44,11 +45,7 @@ public final class ObservableFromCallable<T> extends Observable<T> {
         if (d.isDisposed()) {
             return;
         }
-        if (value != null) {
-            s.onNext(value);
-            s.onComplete();
-        } else {
-            s.onError(new NullPointerException("Callable returned null"));
-        }
+        s.onNext(value);
+        s.onComplete();
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromFuture.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromFuture.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.*;
 
 import io.reactivex.*;
@@ -37,7 +38,7 @@ public final class ObservableFromFuture<T> extends Observable<T> {
         if (!d.isDisposed()) {
             T v;
             try {
-                v = unit != null ? future.get(timeout, unit) : future.get();
+                v = ObjectHelper.requireNonNull(unit != null ? future.get(timeout, unit) : future.get(), "Future returned null");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 if (!d.isDisposed()) {
@@ -48,12 +49,8 @@ public final class ObservableFromFuture<T> extends Observable<T> {
                 future.cancel(true); // TODO ?? not sure about this
             }
             if (!d.isDisposed()) {
-                if (v != null) {
-                    s.onNext(v);
-                    s.onComplete();
-                } else {
-                    s.onError(new NullPointerException("Future returned null"));
-                }
+                s.onNext(v);
+                s.onComplete();
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -142,11 +143,8 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
 
         @Override
         public void onError(Throwable t) {
-            if (t == null) {
-                t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
-            }
             terminate = true;
-            actual.onError(t);
+            actual.onError(ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources."));
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupBy.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.*;
@@ -113,17 +114,11 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
 
             V v;
             try {
-                v = valueSelector.apply(t);
+                v = ObjectHelper.requireNonNull(valueSelector.apply(t), "The value supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 s.dispose();
                 onError(e);
-                return;
-            }
-
-            if (v == null) {
-                s.dispose();
-                onError(new NullPointerException("The value supplied is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMapNotification.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -87,15 +88,10 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
             ObservableSource<? extends R> p;
 
             try {
-                p = onNextMapper.apply(t);
+                p = ObjectHelper.requireNonNull(onNextMapper.apply(t), "The onNext publisher returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                actual.onError(new NullPointerException("The onNext publisher returned is null"));
                 return;
             }
 
@@ -107,15 +103,10 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
             ObservableSource<? extends R> p;
 
             try {
-                p = onErrorMapper.apply(t);
+                p = ObjectHelper.requireNonNull(onErrorMapper.apply(t), "The onError publisher returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                actual.onError(new NullPointerException("The onError publisher returned is null"));
                 return;
             }
 
@@ -128,15 +119,10 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
             ObservableSource<? extends R> p;
 
             try {
-                p = onCompleteSupplier.call();
+                p = ObjectHelper.requireNonNull(onCompleteSupplier.call(), "The onComplete publisher returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                actual.onError(new NullPointerException("The onComplete publisher returned is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScan.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScan.java
@@ -18,6 +18,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
 
 public final class ObservableScan<T> extends AbstractObservableWithUpstream<T, T> {
     final BiFunction<T, T, T> accumulator;
@@ -75,17 +76,11 @@ public final class ObservableScan<T> extends AbstractObservableWithUpstream<T, T
                 T u;
 
                 try {
-                    u = accumulator.apply(v, t);
+                    u = ObjectHelper.requireNonNull(accumulator.apply(v, t), "The value returned by the accumulator is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     s.dispose();
                     a.onError(e);
-                    return;
-                }
-
-                if (u == null) {
-                    s.dispose();
-                    a.onError(new NullPointerException("The value returned by the accumulator is null"));
                     return;
                 }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
@@ -12,6 +12,7 @@
  */
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -36,15 +37,10 @@ public final class ObservableScanSeed<T, R> extends AbstractObservableWithUpstre
         R r;
 
         try {
-            r = seedSupplier.call();
+            r = ObjectHelper.requireNonNull(seedSupplier.call(), "The seed supplied is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);
-            return;
-        }
-
-        if (r == null) {
-            EmptyDisposable.error(new NullPointerException("The seed supplied is null"), t);
             return;
         }
 
@@ -96,17 +92,11 @@ public final class ObservableScanSeed<T, R> extends AbstractObservableWithUpstre
             R u;
 
             try {
-                u = accumulator.apply(v, t);
+                u = ObjectHelper.requireNonNull(accumulator.apply(v, t), "The accumulator returned a null value");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 s.dispose();
                 onError(e);
-                return;
-            }
-
-            if (u == null) {
-                s.dispose();
-                onError(new NullPointerException("The accumulator returned a null value"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
@@ -106,17 +107,11 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
 
             ObservableSource<? extends R> p;
             try {
-                p = mapper.apply(t);
+                p = ObjectHelper.requireNonNull(mapper.apply(t), "The ObservableSource returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 s.dispose();
                 onError(e);
-                return;
-            }
-
-            if (p == null) {
-                s.dispose();
-                onError(new NullPointerException("The publisher returned is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -111,17 +112,11 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
             ObservableSource<V> p;
 
             try {
-                p = itemTimeoutIndicator.apply(t);
+                p = ObjectHelper.requireNonNull(itemTimeoutIndicator.apply(t), "The ObservableSource returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 dispose();
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                dispose();
-                actual.onError(new NullPointerException("The ObservableSource returned is null"));
                 return;
             }
 
@@ -279,15 +274,10 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
             ObservableSource<V> p;
 
             try {
-                p = itemTimeoutIndicator.apply(t);
+                p = ObjectHelper.requireNonNull(itemTimeoutIndicator.apply(t), "The ObservableSource returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 actual.onError(e);
-                return;
-            }
-
-            if (p == null) {
-                actual.onError(new NullPointerException("The ObservableSource returned is null"));
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -252,17 +253,11 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
                         ObservableSource<V> p;
 
                         try {
-                            p = close.apply(wo.open);
+                            p = ObjectHelper.requireNonNull(close.apply(wo.open), "The ObservableSource supplied is null");
                         } catch (Throwable e) {
                             Exceptions.throwIfFatal(e);
                             cancelled = true;
                             a.onError(e);
-                            continue;
-                        }
-
-                        if (p == null) {
-                            cancelled = true;
-                            a.onError(new NullPointerException("The ObservableSource supplied is null"));
                             continue;
                         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
@@ -85,17 +86,11 @@ public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObserv
                 ObservableSource<B> p;
 
                 try {
-                    p = other.call();
+                    p = ObjectHelper.requireNonNull(other.call(), "The first window ObservableSource supplied is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     s.dispose();
                     a.onError(e);
-                    return;
-                }
-
-                if (p == null) {
-                    s.dispose();
-                    a.onError(new NullPointerException("The first window ObservableSource supplied is null"));
                     return;
                 }
 
@@ -232,17 +227,11 @@ public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObserv
                         ObservableSource<B> p;
 
                         try {
-                            p = other.call();
+                            p = ObjectHelper.requireNonNull(other.call(), "The ObservableSource supplied is null");
                         } catch (Throwable e) {
                             Exceptions.throwIfFatal(e);
                             DisposableHelper.dispose(boundary);
                             a.onError(e);
-                            return;
-                        }
-
-                        if (p == null) {
-                            DisposableHelper.dispose(boundary);
-                            a.onError(new NullPointerException("The ObservableSource supplied is null"));
                             return;
                         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableZip.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableZip.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Arrays;
 import java.util.concurrent.atomic.*;
 
@@ -182,17 +183,11 @@ public final class ObservableZip<T, R> extends Observable<R> {
 
                     R v;
                     try {
-                        v = zipper.apply(os.clone());
+                        v = ObjectHelper.requireNonNull(zipper.apply(os.clone()), "The zipper returned a null value");
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
                         clear();
                         a.onError(ex);
-                        return;
-                    }
-
-                    if (v == null) {
-                        clear();
-                        a.onError(new NullPointerException("The zipper returned a null value"));
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableZipIterable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Iterator;
 
 import io.reactivex.*;
@@ -40,15 +41,10 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
         Iterator<U> it;
 
         try {
-            it = other.iterator();
+            it = ObjectHelper.requireNonNull(other.iterator(), "The iterator returned by other is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);
-            return;
-        }
-
-        if (it == null) {
-            EmptyDisposable.error(new NullPointerException("The iterator returned by other is null"), t);
             return;
         }
 
@@ -115,29 +111,19 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
             U u;
 
             try {
-                u = iterator.next();
+                u = ObjectHelper.requireNonNull(iterator.next(), "The iterator returned a null value");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 error(e);
                 return;
             }
 
-            if (u == null) {
-                error(new NullPointerException("The iterator returned a null value"));
-                return;
-            }
-
             V v;
             try {
-                v = zipper.apply(t, u);
+                v = ObjectHelper.requireNonNull(zipper.apply(t, u), "The zipper function returned a null value");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                error(new NullPointerException("The iterator returned a null value"));
-                return;
-            }
-
-            if (v == null) {
-                error(new NullPointerException("The zipper function returned a null value"));
+                error(e);
                 return;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleError.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleError.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.single;
 
+import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -32,14 +33,10 @@ public final class SingleError<T> extends Single<T> {
         Throwable error;
 
         try {
-            error = errorSupplier.call();
+            error = ObjectHelper.requireNonNull(errorSupplier.call(), "Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             error = e;
-        }
-
-        if (error == null) {
-            error = new NullPointerException("Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         }
 
         EmptyDisposable.error(error, s);


### PR DESCRIPTION
Instead of using an if statement to check for `null`, `ObjectHelper.requireNonNull` will be used now. This reduces a lot of duplicated code. Also I found a few places (mostly zip operators) where the wrong Throwable was being onError'd.

In addition for one of the Completable operators the CompositeException call has been fixed. In addition I found another one that was wrong.
