### PR TITLE
2.x: coverage and cleanup 10/13-1

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
@@ -13,15 +13,15 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.Exceptions;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -147,7 +147,7 @@ public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T
                     }
                 } else {
                     cancel();
-                    actual.onError(new IllegalStateException("Could not deliver value due to lack of requests"));
+                    actual.onError(new MissingBackpressureException("Could not deliver value due to lack of requests"));
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
@@ -21,7 +21,8 @@ import org.reactivestreams.*;
 import io.reactivex.Scheduler;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.*;
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -157,7 +158,7 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
                     emitter.dispose();
                 } else {
                     cancel();
-                    actual.onError(new IllegalStateException("Could not deliver value due to lack of requests"));
+                    actual.onError(new MissingBackpressureException("Could not deliver value due to lack of requests"));
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIntervalRange.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIntervalRange.java
@@ -20,7 +20,8 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.*;
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
@@ -106,7 +107,7 @@ public final class FlowableIntervalRange extends Flowable<Long> {
                     }
                 } else {
                     try {
-                        actual.onError(new IllegalStateException("Can't deliver value " + count + " due to lack of requests"));
+                        actual.onError(new MissingBackpressureException("Can't deliver value " + count + " due to lack of requests"));
                     } finally {
                         DisposableHelper.dispose(resource);
                     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSamplePublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSamplePublisher.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
+import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.subscribers.SerializedSubscriber;
@@ -129,7 +130,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
                     }
                 } else {
                     cancel();
-                    actual.onError(new IllegalStateException("Couldn't emit value due to lack of requests!"));
+                    actual.onError(new MissingBackpressureException("Couldn't emit value due to lack of requests!"));
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSampleTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSampleTimed.java
@@ -18,8 +18,9 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.*;
+import io.reactivex.Scheduler;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -127,7 +128,7 @@ public final class FlowableSampleTimed<T> extends AbstractFlowableWithUpstream<T
                     }
                 } else {
                     cancel();
-                    actual.onError(new IllegalStateException("Couldn't emit value due to lack of requests!"));
+                    actual.onError(new MissingBackpressureException("Couldn't emit value due to lack of requests!"));
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTimed.java
@@ -18,9 +18,10 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.*;
+import io.reactivex.Scheduler;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -106,7 +107,7 @@ public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUps
                 } else {
                     done = true;
                     cancel();
-                    actual.onError(new IllegalStateException("Could not deliver value due to lack of requests"));
+                    actual.onError(new MissingBackpressureException("Could not deliver value due to lack of requests"));
                     return;
                 }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
@@ -19,7 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.Exceptions;
+import io.reactivex.exceptions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.MpscLinkedQueue;
@@ -95,7 +95,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
                     produced(1);
                 }
             } else {
-                a.onError(new IllegalStateException("Could not deliver first window due to lack of requests"));
+                a.onError(new MissingBackpressureException("Could not deliver first window due to lack of requests"));
                 return;
             }
 
@@ -239,7 +239,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
                         } else {
                             // don't emit new windows
                             cancelled = true;
-                            a.onError(new IllegalStateException("Could not deliver new window due to lack of requests"));
+                            a.onError(new MissingBackpressureException("Could not deliver new window due to lack of requests"));
                             continue;
                         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -21,9 +20,10 @@ import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.disposables.*;
-import io.reactivex.exceptions.Exceptions;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.QueueDrainSubscriber;
@@ -275,7 +275,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                             }
                         } else {
                             cancelled = true;
-                            a.onError(new IllegalStateException("Could not deliver new window due to lack of requests"));
+                            a.onError(new MissingBackpressureException("Could not deliver new window due to lack of requests"));
                             continue;
                         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
@@ -21,8 +20,9 @@ import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.Exceptions;
+import io.reactivex.exceptions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.QueueDrainSubscriber;
@@ -109,7 +109,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
                 }
             } else {
                 s.cancel();
-                a.onError(new IllegalStateException("Could not deliver first window due to lack of requests"));
+                a.onError(new MissingBackpressureException("Could not deliver first window due to lack of requests"));
                 return;
             }
 
@@ -264,7 +264,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
                         } else {
                             // don't emit new windows
                             cancelled = true;
-                            a.onError(new IllegalStateException("Could not deliver new window due to lack of requests"));
+                            a.onError(new MissingBackpressureException("Could not deliver new window due to lack of requests"));
                             continue;
                         }
 

--- a/src/main/java/io/reactivex/internal/subscribers/QueueDrainSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/QueueDrainSubscriber.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
@@ -80,7 +81,7 @@ public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriber
                 }
             } else {
                 dispose.dispose();
-                s.onError(new IllegalStateException("Could not emit buffer due to lack of requests"));
+                s.onError(new MissingBackpressureException("Could not emit buffer due to lack of requests"));
                 return;
             }
         } else {
@@ -114,7 +115,7 @@ public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriber
             } else {
                 cancelled = true;
                 dispose.dispose();
-                s.onError(new IllegalStateException("Could not emit buffer due to lack of requests"));
+                s.onError(new MissingBackpressureException("Could not emit buffer due to lack of requests"));
                 return;
             }
         } else {

--- a/src/main/java/io/reactivex/internal/util/QueueDrainHelper.java
+++ b/src/main/java/io/reactivex/internal/util/QueueDrainHelper.java
@@ -13,13 +13,13 @@
 package io.reactivex.internal.util;
 
 import java.util.Queue;
-import java.util.concurrent.atomic.*;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.reactivestreams.*;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.Exceptions;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.BooleanSupplier;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.*;
@@ -136,7 +136,7 @@ public final class QueueDrainHelper {
                     if (dispose != null) {
                         dispose.dispose();
                     }
-                    a.onError(new IllegalStateException("Could not emit value due to lack of requests."));
+                    a.onError(new MissingBackpressureException("Could not emit value due to lack of requests."));
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -279,10 +279,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
             return;
         }
 
-        if (!queue.offer(t)) {
-            onError(new IllegalStateException("The queue is full"));
-            return;
-        }
+        queue.offer(t);
         drain();
     }
 
@@ -404,7 +401,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
 
     @Override
     public boolean hasComplete() {
-        return done;
+        return done && error == null;
     }
 
     @Override

--- a/src/main/java/io/reactivex/subjects/SerializedSubject.java
+++ b/src/main/java/io/reactivex/subjects/SerializedSubject.java
@@ -15,9 +15,8 @@ package io.reactivex.subjects;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Predicate;
 import io.reactivex.internal.util.*;
+import io.reactivex.internal.util.AppendOnlyLinkedArrayList.NonThrowingPredicate;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -26,7 +25,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the item value type
  */
-/* public */ final class SerializedSubject<T> extends Subject<T> {
+/* public */ final class SerializedSubject<T> extends Subject<T> implements NonThrowingPredicate<Object> {
     /** The actual subscriber to serialize Subscriber calls to. */
     final Subject<T> actual;
     /** Indicates an emission is going on, guarded by this. */
@@ -52,7 +51,34 @@ import io.reactivex.plugins.RxJavaPlugins;
 
     @Override
     public void onSubscribe(Disposable s) {
-        // NO-OP
+        boolean cancel;
+        if (!done) {
+            synchronized (this) {
+                if (done) {
+                    cancel = true;
+                } else {
+                    if (emitting) {
+                        AppendOnlyLinkedArrayList<Object> q = queue;
+                        if (q == null) {
+                            q = new AppendOnlyLinkedArrayList<Object>(4);
+                            queue = q;
+                        }
+                        q.add(NotificationLite.disposable(s));
+                        return;
+                    }
+                    emitting = true;
+                    cancel = false;
+                }
+            }
+        } else {
+            cancel = true;
+        }
+        if (cancel) {
+            s.dispose();
+        } else {
+            actual.onSubscribe(s);
+            emitLoop();
+        }
     }
 
     @Override
@@ -147,26 +173,13 @@ import io.reactivex.plugins.RxJavaPlugins;
                 }
                 queue = null;
             }
-            try {
-                q.forEachWhile(consumer);
-            } catch (Throwable ex) {
-                Exceptions.throwIfFatal(ex);
-                actual.onError(ex);
-                return;
-            }
+            q.forEachWhile(this);
         }
     }
 
-    final Predicate<Object> consumer = new Predicate<Object>() {
-        @Override
-        public boolean test(Object v) {
-            return accept(v);
-        }
-    };
-
-    /** Delivers the notification to the actual subscriber. */
-    boolean accept(Object o) {
-        return NotificationLite.accept(o, actual);
+    @Override
+    public boolean test(Object o) {
+        return NotificationLite.acceptFull(o, actual);
     }
 
     @Override

--- a/src/test/java/io/reactivex/internal/util/MiscUtilTest.java
+++ b/src/test/java/io/reactivex/internal/util/MiscUtilTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import io.reactivex.TestHelper;
 import io.reactivex.functions.*;
+import io.reactivex.internal.util.AppendOnlyLinkedArrayList.NonThrowingPredicate;
 
 public class MiscUtilTest {
     @Test
@@ -96,9 +97,9 @@ public class MiscUtilTest {
 
         final List<Integer> out = new ArrayList<Integer>();
 
-        list.forEachWhile(new Predicate<Integer>() {
+        list.forEachWhile(new NonThrowingPredicate<Integer>() {
             @Override
-            public boolean test(Integer t2) throws Exception {
+            public boolean test(Integer t2) {
                 out.add(t2);
                 return t2 == 2;
             }
@@ -117,9 +118,9 @@ public class MiscUtilTest {
 
         final List<Integer> out = new ArrayList<Integer>();
 
-        list.forEachWhile(new Predicate<Integer>() {
+        list.forEachWhile(new NonThrowingPredicate<Integer>() {
             @Override
-            public boolean test(Integer t2) throws Exception {
+            public boolean test(Integer t2) {
                 out.add(t2);
                 return t2 == 2;
             }
@@ -138,9 +139,9 @@ public class MiscUtilTest {
 
         final List<Integer> out = new ArrayList<Integer>();
 
-        list.forEachWhile(new Predicate<Integer>() {
+        list.forEachWhile(new NonThrowingPredicate<Integer>() {
             @Override
-            public boolean test(Integer t2) throws Exception {
+            public boolean test(Integer t2) {
                 out.add(t2);
                 return t2 == 3;
             }
@@ -159,9 +160,9 @@ public class MiscUtilTest {
 
         final List<Integer> out = new ArrayList<Integer>();
 
-        list.forEachWhile(new Predicate<Integer>() {
+        list.forEachWhile(new NonThrowingPredicate<Integer>() {
             @Override
-            public boolean test(Integer t2) throws Exception {
+            public boolean test(Integer t2) {
                 out.add(t2);
                 return false;
             }

--- a/src/test/java/io/reactivex/observers/ObserverFusion.java
+++ b/src/test/java/io/reactivex/observers/ObserverFusion.java
@@ -143,4 +143,18 @@ public enum ObserverFusion {
         TestObserver<T> ts = new TestObserver<T>();
         ts.setInitialFusionMode(mode);
         return ts;
-    }}
+    }
+
+    /**
+     * Assert that the TestSubscriber received a fuseabe QueueSubscription and
+     * is in the given fusion mode.
+     * @param <T> the value type
+     * @param ts the TestSubscriber instance
+     * @param mode the expected mode
+     * @return the TestSubscriber
+     */
+    public static <T> TestObserver<T> assertFusion(TestObserver<T> ts, int mode) {
+        return ts.assertOf(ObserverFusion.<T>assertFuseable())
+                .assertOf(ObserverFusion.<T>assertFusionMode(mode));
+    }
+}

--- a/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
@@ -15,10 +15,17 @@ package io.reactivex.subjects;
 
 import static org.junit.Assert.*;
 
+import java.util.*;
+
 import org.junit.Test;
 
+import io.reactivex.Observable;
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
 
 public class SerializedSubjectTest {
 
@@ -393,5 +400,277 @@ public class SerializedSubjectTest {
         Subject<Object> s1 = s.toSerialized();
         Subject<Object> s2 = s1.toSerialized();
         assertSame(s1, s2);
+    }
+
+    @Test
+    public void normal() {
+        Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
+
+        TestObserver<Integer> ts = s.test();
+
+        Observable.range(1, 10).subscribe(s);
+
+        ts.assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        assertFalse(s.hasObservers());
+
+        s.onNext(11);
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            s.onError(new TestException());
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+        s.onComplete();
+
+        Disposable bs = Disposables.empty();
+        s.onSubscribe(bs);
+        assertTrue(bs.isDisposed());
+    }
+
+    @Test
+    public void onNextOnNextRace() {
+        for (int i = 0; i < 500; i++) {
+            final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
+
+            TestObserver<Integer> ts = s.test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onNext(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onNext(2);
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+
+            ts.assertSubscribed().assertNoErrors().assertNotComplete()
+            .assertValueSet(Arrays.asList(1, 2));
+        }
+    }
+
+    @Test
+    public void onNextOnErrorRace() {
+        for (int i = 0; i < 500; i++) {
+            final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
+
+            TestObserver<Integer> ts = s.test();
+
+            final TestException ex = new TestException();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onNext(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onError(ex);
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+
+            ts.assertError(ex).assertNotComplete();
+
+            if (ts.valueCount() != 0) {
+                ts.assertValue(1);
+            }
+        }
+    }
+
+    @Test
+    public void onNextOnCompleteRace() {
+        for (int i = 0; i < 500; i++) {
+            final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
+
+            TestObserver<Integer> ts = s.test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onNext(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onComplete();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+
+            ts.assertComplete().assertNoErrors();
+
+            if (ts.valueCount() != 0) {
+                ts.assertValue(1);
+            }
+        }
+    }
+
+    @Test
+    public void onNextOnSubscribeRace() {
+        for (int i = 0; i < 500; i++) {
+            final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
+
+            TestObserver<Integer> ts = s.test();
+
+            final Disposable bs = Disposables.empty();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onNext(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onSubscribe(bs);
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+
+            ts.assertValue(1).assertNotComplete().assertNoErrors();
+        }
+    }
+
+    @Test
+    public void onCompleteOnSubscribeRace() {
+        for (int i = 0; i < 500; i++) {
+            final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
+
+            TestObserver<Integer> ts = s.test();
+
+            final Disposable bs = Disposables.empty();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onSubscribe(bs);
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+
+            ts.assertResult();
+        }
+    }
+
+    @Test
+    public void onCompleteOnCompleteRace() {
+        for (int i = 0; i < 500; i++) {
+            final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
+
+            TestObserver<Integer> ts = s.test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onComplete();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+
+            ts.assertResult();
+        }
+    }
+
+    @Test
+    public void onErrorOnErrorRace() {
+        for (int i = 0; i < 500; i++) {
+            final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
+
+            TestObserver<Integer> ts = s.test();
+
+            final TestException ex = new TestException();
+
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        s.onError(ex);
+                    }
+                };
+
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        s.onError(ex);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                ts.assertFailure(TestException.class);
+
+                TestHelper.assertError(errors, 0, TestException.class);
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void onSubscribeOnSubscribeRace() {
+        for (int i = 0; i < 500; i++) {
+            final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
+
+            TestObserver<Integer> ts = s.test();
+
+            final Disposable bs1 = Disposables.empty();
+            final Disposable bs2 = Disposables.empty();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onSubscribe(bs1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    s.onSubscribe(bs2);
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+
+            ts.assertEmpty();
+        }
     }
 }

--- a/src/test/java/io/reactivex/subscribers/SubscriberFusion.java
+++ b/src/test/java/io/reactivex/subscribers/SubscriberFusion.java
@@ -156,4 +156,17 @@ public enum SubscriberFusion {
         ts.setInitialFusionMode(mode);
         return ts;
     }
+
+    /**
+     * Assert that the TestSubscriber received a fuseabe QueueSubscription and
+     * is in the given fusion mode.
+     * @param <T> the value type
+     * @param ts the TestSubscriber instance
+     * @param mode the expected mode
+     * @return the TestSubscriber
+     */
+    public static <T> TestSubscriber<T> assertFusion(TestSubscriber<T> ts, int mode) {
+        return ts.assertOf(SubscriberFusion.<T>assertFuseable())
+                .assertOf(SubscriberFusion.<T>assertFusionMode(mode));
+    }
 }


### PR DESCRIPTION
Improve coverage of `Subject`s and `FlowableProcessor`s, remove impossible paths, cleanup code.
