### PR TITLE
2.x: coverage, cleanup fixes 10/14-1

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -4549,7 +4549,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingLatest() {
-        return BlockingObservableLatest.latest(this);
+        return new BlockingObservableLatest<T>(this);
     }
 
     /**
@@ -4571,7 +4571,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingMostRecent(T initialValue) {
-        return BlockingObservableMostRecent.mostRecent(this, initialValue);
+        return new BlockingObservableMostRecent<T>(this, initialValue);
     }
 
     /**
@@ -4590,7 +4590,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingNext() {
-        return BlockingObservableNext.next(this);
+        return new BlockingObservableNext<T>(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableMostRecent.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableMostRecent.java
@@ -25,36 +25,31 @@ import io.reactivex.observers.DefaultObserver;
  * seed value if no item has yet been emitted.
  * <p>
  * <img width="640" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.mostRecent.png" alt="">
+ * 
+ * @param <T> the value type
  */
-public enum BlockingObservableMostRecent {
-    ;
-    /**
-     * Returns an {@code Iterable} that always returns the item most recently emitted by the {@code Observable}.
-     *
-     * @param <T> the value type
-     * @param source
-     *            the source {@code Observable}
-     * @param initialValue
-     *            a default item to return from the {@code Iterable} if {@code source} has not yet emitted any
-     *            items
-     * @return an {@code Iterable} that always returns the item most recently emitted by {@code source}, or
-     *         {@code initialValue} if {@code source} has not yet emitted any items
-     */
-    public static <T> Iterable<T> mostRecent(final ObservableSource<? extends T> source, final T initialValue) {
-        return new Iterable<T>() {
-            @Override
-            public Iterator<T> iterator() {
-                MostRecentObserver<T> mostRecentObserver = new MostRecentObserver<T>(initialValue);
+public final class BlockingObservableMostRecent<T> implements Iterable<T> {
 
-                /**
-                 * Subscribe instead of unsafeSubscribe since this is the final subscribe in the chain
-                 * since it is for BlockingObservable.
-                 */
-                source.subscribe(mostRecentObserver);
+    final ObservableSource<T> source;
 
-                return mostRecentObserver.getIterable();
-            }
-        };
+    final T initialValue;
+
+    public BlockingObservableMostRecent(ObservableSource<T> source, T initialValue) {
+        this.source = source;
+        this.initialValue = initialValue;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        MostRecentObserver<T> mostRecentObserver = new MostRecentObserver<T>(initialValue);
+
+        /**
+         * Subscribe instead of unsafeSubscribe since this is the final subscribe in the chain
+         * since it is for BlockingObservable.
+         */
+        source.subscribe(mostRecentObserver);
+
+        return mostRecentObserver.getIterable();
     }
 
     static final class MostRecentObserver<T> extends DefaultObserver<T> {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAmb.java
@@ -137,7 +137,7 @@ public final class ObservableAmb<T> extends Observable<T> {
         }
     }
 
-    static final class AmbInnerObserver<T> extends AtomicReference<Disposable> implements Observer<T>, Disposable {
+    static final class AmbInnerObserver<T> extends AtomicReference<Disposable> implements Observer<T> {
 
         private static final long serialVersionUID = -1185974347409665484L;
         final AmbCoordinator<T> parent;
@@ -180,7 +180,6 @@ public final class ObservableAmb<T> extends Observable<T> {
                     won = true;
                     actual.onError(t);
                 } else {
-                    get().dispose();
                     RxJavaPlugins.onError(t);
                 }
             }
@@ -194,20 +193,12 @@ public final class ObservableAmb<T> extends Observable<T> {
                 if (parent.win(index)) {
                     won = true;
                     actual.onComplete();
-                } else {
-                    get().dispose();
                 }
             }
         }
 
-        @Override
         public void dispose() {
             DisposableHelper.dispose(this);
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return get() == DisposableHelper.DISPOSED;
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCreate.java
@@ -136,7 +136,7 @@ public final class ObservableCreate<T> extends Observable<T> {
 
         final AtomicThrowable error;
 
-        final SimpleQueue<T> queue;
+        final SpscLinkedArrayQueue<T> queue;
 
         volatile boolean done;
 
@@ -206,7 +206,7 @@ public final class ObservableCreate<T> extends Observable<T> {
 
         void drainLoop() {
             ObservableEmitter<T> e = emitter;
-            SimpleQueue<T> q = queue;
+            SpscLinkedArrayQueue<T> q = queue;
             AtomicThrowable error = this.error;
             int missed = 1;
             for (;;) {
@@ -224,15 +224,7 @@ public final class ObservableCreate<T> extends Observable<T> {
                     }
 
                     boolean d = done;
-                    T v;
-
-                    try {
-                        v = q.poll();
-                    } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        // should never happen
-                        v = null;
-                    }
+                    T v = q.poll();
 
                     boolean empty = v == null;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDetach.java
@@ -55,8 +55,7 @@ public final class ObservableDetach<T> extends AbstractObservableWithUpstream<T,
 
         @Override
         public boolean isDisposed() {
-            Disposable s = this.s;
-            return s == null || s.isDisposed();
+            return s.isDisposed();
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRangeLong.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRangeLong.java
@@ -12,10 +12,8 @@
  */
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.Observable;
-import io.reactivex.Observer;
-import io.reactivex.internal.fuseable.QueueDisposable;
-import java.util.concurrent.atomic.AtomicLong;
+import io.reactivex.*;
+import io.reactivex.internal.observers.BasicIntQueueDisposable;
 
 public final class ObservableRangeLong extends Observable<Long> {
     private final long start;
@@ -34,8 +32,7 @@ public final class ObservableRangeLong extends Observable<Long> {
     }
 
     static final class RangeDisposable
-    extends AtomicLong
-    implements QueueDisposable<Long> {
+    extends BasicIntQueueDisposable<Long> {
 
         private static final long serialVersionUID = 396518478098735504L;
 
@@ -66,16 +63,6 @@ public final class ObservableRangeLong extends Observable<Long> {
                 lazySet(1);
                 actual.onComplete();
             }
-        }
-
-        @Override
-        public boolean offer(Long value) {
-            throw new UnsupportedOperationException("Should not be called!");
-        }
-
-        @Override
-        public boolean offer(Long v1, Long v2) {
-            throw new UnsupportedOperationException("Should not be called!");
         }
 
         @Override

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -30,7 +30,7 @@ import org.reactivestreams.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.*;
-import io.reactivex.internal.fuseable.SimpleQueue;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.operators.maybe.MaybeToFlowable;
 import io.reactivex.internal.operators.single.SingleToFlowable;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
@@ -1278,7 +1278,6 @@ public enum TestHelper {
         }
     }
 
-
     /**
      * Check if the given transformed reactive type reports multiple onSubscribe calls to
      * RxJavaPlugins.
@@ -1326,6 +1325,221 @@ public enum TestHelper {
             assertEquals("Second not disposed?", true, b[1]);
 
             assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
+        } catch (Throwable ex) {
+            throw ExceptionHelper.wrapOrThrow(ex);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    /**
+     * Check if the given transformed reactive type reports multiple onSubscribe calls to
+     * RxJavaPlugins.
+     * @param <T> the input value type
+     * @param <R> the output value type
+     * @param transform the transform to drive an operator
+     */
+    public static <T, R> void checkDoubleOnSubscribeObservableToSingle(Function<Observable<T>, ? extends SingleSource<R>> transform) {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            final Boolean[] b = { null, null };
+            final CountDownLatch cdl = new CountDownLatch(1);
+
+            Observable<T> source = new Observable<T>() {
+                @Override
+                protected void subscribeActual(Observer<? super T> observer) {
+                    try {
+                        Disposable d1 = Disposables.empty();
+
+                        observer.onSubscribe(d1);
+
+                        Disposable d2 = Disposables.empty();
+
+                        observer.onSubscribe(d2);
+
+                        b[0] = d1.isDisposed();
+                        b[1] = d2.isDisposed();
+                    } finally {
+                        cdl.countDown();
+                    }
+                }
+            };
+
+            SingleSource<R> out = transform.apply(source);
+
+            out.subscribe(NoOpConsumer.INSTANCE);
+
+            try {
+                assertTrue("Timed out", cdl.await(5, TimeUnit.SECONDS));
+            } catch (InterruptedException ex) {
+                throw ExceptionHelper.wrapOrThrow(ex);
+            }
+
+            assertEquals("First disposed?", false, b[0]);
+            assertEquals("Second not disposed?", true, b[1]);
+
+            assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
+        } catch (Throwable ex) {
+            throw ExceptionHelper.wrapOrThrow(ex);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    /**
+     * Check if the given transformed reactive type reports multiple onSubscribe calls to
+     * RxJavaPlugins.
+     * @param <T> the input value type
+     * @param <R> the output value type
+     * @param transform the transform to drive an operator
+     */
+    public static <T, R> void checkDoubleOnSubscribeObservableToMaybe(Function<Observable<T>, ? extends MaybeSource<R>> transform) {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            final Boolean[] b = { null, null };
+            final CountDownLatch cdl = new CountDownLatch(1);
+
+            Observable<T> source = new Observable<T>() {
+                @Override
+                protected void subscribeActual(Observer<? super T> observer) {
+                    try {
+                        Disposable d1 = Disposables.empty();
+
+                        observer.onSubscribe(d1);
+
+                        Disposable d2 = Disposables.empty();
+
+                        observer.onSubscribe(d2);
+
+                        b[0] = d1.isDisposed();
+                        b[1] = d2.isDisposed();
+                    } finally {
+                        cdl.countDown();
+                    }
+                }
+            };
+
+            MaybeSource<R> out = transform.apply(source);
+
+            out.subscribe(NoOpConsumer.INSTANCE);
+
+            try {
+                assertTrue("Timed out", cdl.await(5, TimeUnit.SECONDS));
+            } catch (InterruptedException ex) {
+                throw ExceptionHelper.wrapOrThrow(ex);
+            }
+
+            assertEquals("First disposed?", false, b[0]);
+            assertEquals("Second not disposed?", true, b[1]);
+
+            assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
+        } catch (Throwable ex) {
+            throw ExceptionHelper.wrapOrThrow(ex);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    /**
+     * Check if the given transformed reactive type reports multiple onSubscribe calls to
+     * RxJavaPlugins.
+     * @param <T> the input value type
+     * @param transform the transform to drive an operator
+     */
+    public static <T> void checkDoubleOnSubscribeObservableToCompletable(Function<Observable<T>, ? extends CompletableSource> transform) {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            final Boolean[] b = { null, null };
+            final CountDownLatch cdl = new CountDownLatch(1);
+
+            Observable<T> source = new Observable<T>() {
+                @Override
+                protected void subscribeActual(Observer<? super T> observer) {
+                    try {
+                        Disposable d1 = Disposables.empty();
+
+                        observer.onSubscribe(d1);
+
+                        Disposable d2 = Disposables.empty();
+
+                        observer.onSubscribe(d2);
+
+                        b[0] = d1.isDisposed();
+                        b[1] = d2.isDisposed();
+                    } finally {
+                        cdl.countDown();
+                    }
+                }
+            };
+
+            CompletableSource out = transform.apply(source);
+
+            out.subscribe(NoOpConsumer.INSTANCE);
+
+            try {
+                assertTrue("Timed out", cdl.await(5, TimeUnit.SECONDS));
+            } catch (InterruptedException ex) {
+                throw ExceptionHelper.wrapOrThrow(ex);
+            }
+
+            assertEquals("First disposed?", false, b[0]);
+            assertEquals("Second not disposed?", true, b[1]);
+
+            assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
+        } catch (Throwable ex) {
+            throw ExceptionHelper.wrapOrThrow(ex);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    /**
+     * Check if the given transformed reactive type reports multiple onSubscribe calls to
+     * RxJavaPlugins.
+     * @param <T> the input value type
+     * @param <R> the output value type
+     * @param transform the transform to drive an operator
+     */
+    public static <T, R> void checkDoubleOnSubscribeFlowableToObservable(Function<Flowable<T>, ? extends ObservableSource<R>> transform) {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            final Boolean[] b = { null, null };
+            final CountDownLatch cdl = new CountDownLatch(1);
+
+            Flowable<T> source = new Flowable<T>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super T> observer) {
+                    try {
+                        BooleanSubscription d1 = new BooleanSubscription();
+
+                        observer.onSubscribe(d1);
+
+                        BooleanSubscription d2 = new BooleanSubscription();
+
+                        observer.onSubscribe(d2);
+
+                        b[0] = d1.isCancelled();
+                        b[1] = d2.isCancelled();
+                    } finally {
+                        cdl.countDown();
+                    }
+                }
+            };
+
+            ObservableSource<R> out = transform.apply(source);
+
+            out.subscribe(NoOpConsumer.INSTANCE);
+
+            try {
+                assertTrue("Timed out", cdl.await(5, TimeUnit.SECONDS));
+            } catch (InterruptedException ex) {
+                throw ExceptionHelper.wrapOrThrow(ex);
+            }
+
+            assertEquals("First cancelled?", false, b[0]);
+            assertEquals("Second not cancelled?", true, b[1]);
+
+            assertError(errors, 0, IllegalStateException.class, "Subscription already set!");
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         } finally {
@@ -1651,5 +1865,137 @@ public enum TestHelper {
             p.onNext(v);
         }
         p.onComplete();
+    }
+
+    /**
+     * Checks if the source is fuseable and its isEmpty/clear works properly.
+     * @param <T> the value type
+     * @param source the source sequence
+     */
+    public static <T> void checkFusedIsEmptyClear(Observable<T> source) {
+        final CountDownLatch cdl = new CountDownLatch(1);
+
+        final Boolean[] state = { null, null, null, null };
+
+        source.subscribe(new Observer<T>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                try {
+                    if (d instanceof QueueDisposable) {
+                        @SuppressWarnings("unchecked")
+                        QueueDisposable<Object> qd = (QueueDisposable<Object>) d;
+                        state[0] = true;
+
+                        int m = qd.requestFusion(QueueDisposable.ANY);
+
+                        if (m != QueueDisposable.NONE) {
+                            state[1] = true;
+
+                            state[2] = qd.isEmpty();
+
+                            qd.clear();
+
+                            state[3] = qd.isEmpty();
+                        }
+                    }
+                    cdl.countDown();
+                } finally {
+                    d.dispose();
+                }
+            }
+
+            @Override
+            public void onNext(T value) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+        });
+
+        try {
+            assertTrue(cdl.await(5, TimeUnit.SECONDS));
+
+            assertTrue("Not fuseable", state[0]);
+            assertTrue("Fusion rejected", state[1]);
+
+            assertNotNull(state[2]);
+            assertTrue("Did not empty", state[3]);
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Checks if the source is fuseable and its isEmpty/clear works properly.
+     * @param <T> the value type
+     * @param source the source sequence
+     */
+    public static <T> void checkFusedIsEmptyClear(Flowable<T> source) {
+        final CountDownLatch cdl = new CountDownLatch(1);
+
+        final Boolean[] state = { null, null, null, null };
+
+        source.subscribe(new Subscriber<T>() {
+            @Override
+            public void onSubscribe(Subscription d) {
+                try {
+                    if (d instanceof QueueSubscription) {
+                        @SuppressWarnings("unchecked")
+                        QueueSubscription<Object> qd = (QueueSubscription<Object>) d;
+                        state[0] = true;
+
+                        int m = qd.requestFusion(QueueSubscription.ANY);
+
+                        if (m != QueueSubscription.NONE) {
+                            state[1] = true;
+
+                            state[2] = qd.isEmpty();
+
+                            qd.clear();
+
+                            state[3] = qd.isEmpty();
+                        }
+                    }
+                    cdl.countDown();
+                } finally {
+                    d.cancel();
+                }
+            }
+
+            @Override
+            public void onNext(T value) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+        });
+
+        try {
+            assertTrue(cdl.await(5, TimeUnit.SECONDS));
+
+            assertTrue("Not fuseable", state[0]);
+            assertTrue("Fusion rejected", state[1]);
+
+            assertNotNull(state[2]);
+            assertTrue("Did not empty", state[3]);
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableMostRecentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableMostRecentTest.java
@@ -13,10 +13,9 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static io.reactivex.internal.operators.observable.BlockingObservableMostRecent.mostRecent;
 import static org.junit.Assert.*;
 
-import java.util.Iterator;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.*;
@@ -30,6 +29,10 @@ public class BlockingObservableMostRecentTest {
     @Test
     public void testMostRecentNull() {
         assertEquals(null, Observable.<Void>never().blockingMostRecent(null).iterator().next());
+    }
+
+    static <T> Iterable<T> mostRecent(Observable<T> source, T initialValue) {
+        return source.blockingMostRecent(initialValue);
     }
 
     @Test
@@ -96,5 +99,26 @@ public class BlockingObservableMostRecentTest {
             Assert.assertEquals(false, it.hasNext());
         }
 
+    }
+
+    @Test
+    public void empty() {
+        Iterator<Integer> it = Observable.<Integer>empty()
+        .blockingMostRecent(1)
+        .iterator();
+
+        try {
+            it.next();
+            fail("Should have thrown");
+        } catch (NoSuchElementException ex) {
+            // expected
+        }
+
+        try {
+            it.remove();
+            fail("Should have thrown");
+        } catch (UnsupportedOperationException ex) {
+            // expected
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToIteratorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToIteratorTest.java
@@ -13,13 +13,15 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-import java.util.Iterator;
+import java.util.*;
 
 import org.junit.*;
 
-import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
 
@@ -78,5 +80,42 @@ public class BlockingObservableToIteratorTest {
             // never reaches here
             System.out.println(string);
         }
+    }
+
+    @Test
+    public void dispose() {
+        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<Integer>(128);
+
+        assertFalse(it.isDisposed());
+
+        it.dispose();
+
+        assertTrue(it.isDisposed());
+    }
+
+    @Test
+    public void interruptWait() {
+        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<Integer>(128);
+
+        try {
+            Thread.currentThread().interrupt();
+
+            it.hasNext();
+        } catch (RuntimeException ex) {
+            assertTrue(ex.toString(), ex.getCause() instanceof InterruptedException);
+        }
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void emptyThrowsNoSuch() {
+        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<Integer>(128);
+        it.onComplete();
+        it.next();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void remove() {
+        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<Integer>(128);
+        it.remove();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
@@ -15,12 +15,18 @@ package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Cancellable;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
 
 public class ObservableCreateTest {
 
@@ -250,5 +256,343 @@ public class ObservableCreateTest {
         .assertFailure(NullPointerException.class);
 
         assertNull(error[0]);
+    }
+
+    @Test
+    public void callbackThrows() {
+        Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void nullValue() {
+        Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                e.onNext(null);
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void nullThrowable() {
+        Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                e.onError(null);
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void nullValueSync() {
+        Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                e.serialize().onNext(null);
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void nullThrowableSync() {
+        Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                e.serialize().onError(null);
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void onErrorCrash() {
+        Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                Disposable d = Disposables.empty();
+                e.setDisposable(d);
+                try {
+                    e.onError(new IOException());
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+                assertTrue(d.isDisposed());
+            }
+        })
+        .subscribe(new Observer<Object>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+            }
+
+            @Override
+            public void onNext(Object value) {
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                throw new TestException();
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+    }
+
+    @Test
+    public void onCompleteCrash() {
+        Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                Disposable d = Disposables.empty();
+                e.setDisposable(d);
+                try {
+                    e.onComplete();
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
+                }
+                assertTrue(d.isDisposed());
+            }
+        })
+        .subscribe(new Observer<Object>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+            }
+
+            @Override
+            public void onNext(Object value) {
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onComplete() {
+                throw new TestException();
+            }
+        });
+    }
+
+    @Test
+    public void serialized() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable.create(new ObservableOnSubscribe<Object>() {
+                @Override
+                public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                    ObservableEmitter<Object> f = e.serialize();
+
+                    assertSame(f, f.serialize());
+
+                    assertFalse(f.isDisposed());
+
+                    final int[] calls = { 0 };
+
+                    f.setCancellable(new Cancellable() {
+                        @Override
+                        public void cancel() throws Exception {
+                            calls[0]++;
+                        }
+                    });
+
+                    e.onComplete();
+
+                    assertTrue(f.isDisposed());
+
+                    assertEquals(1, calls[0]);
+                }
+            })
+            .test()
+            .assertResult();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void serializedConcurrentOnNext() {
+        Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                final ObservableEmitter<Object> f = e.serialize();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        for (int i = 0; i < 1000; i++) {
+                            f.onNext(1);
+                        }
+                    }
+                };
+
+                TestHelper.race(r1, r1, Schedulers.single());
+            }
+        })
+        .take(1000)
+        .test()
+        .assertSubscribed().assertValueCount(1000).assertComplete().assertNoErrors();
+    }
+
+    @Test
+    public void serializedConcurrentOnNextOnError() {
+        Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                final ObservableEmitter<Object> f = e.serialize();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        for (int i = 0; i < 1000; i++) {
+                            f.onNext(1);
+                        }
+                    }
+                };
+
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        for (int i = 0; i < 100; i++) {
+                            f.onNext(1);
+                        }
+                        f.onError(new TestException());
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+            }
+        })
+        .test()
+        .assertSubscribed().assertNotComplete()
+        .assertError(TestException.class);
+    }
+
+    @Test
+    public void serializedConcurrentOnNextOnComplete() {
+        TestObserver<Object> to = Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                final ObservableEmitter<Object> f = e.serialize();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        for (int i = 0; i < 1000; i++) {
+                            f.onNext(1);
+                        }
+                    }
+                };
+
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        for (int i = 0; i < 100; i++) {
+                            f.onNext(1);
+                        }
+                        f.onComplete();
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+            }
+        })
+        .test()
+        .assertSubscribed().assertComplete()
+        .assertNoErrors();
+
+        int c = to.valueCount();
+        assertTrue("" + c, c >= 100);
+    }
+
+    @Test
+    public void onErrorRace() {
+        Observable<Object> source = Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                final ObservableEmitter<Object> f = e.serialize();
+
+                final TestException ex = new TestException();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        f.onError(null);
+                    }
+                };
+
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        f.onError(ex);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+            }
+        });
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            for (int i = 0; i < 500; i++) {
+                source
+                .test()
+                .assertFailure(Throwable.class);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+        assertFalse(errors.isEmpty());
+    }
+
+    @Test
+    public void onCompleteRace() {
+        Observable<Object> source = Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> e) throws Exception {
+                final ObservableEmitter<Object> f = e.serialize();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        f.onComplete();
+                    }
+                };
+
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        f.onComplete();
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+            }
+        });
+
+        for (int i = 0; i < 500; i++) {
+            source
+            .test()
+            .assertResult();
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDetachTest.java
@@ -19,8 +19,9 @@ import java.lang.ref.WeakReference;
 
 import org.junit.*;
 
-import io.reactivex.Observable;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 
 
@@ -155,5 +156,20 @@ public class ObservableDetachTest {
 //        ts.assertValues(1, 2, 3);
 //        ts.assertComplete();
 //        ts.assertNoErrors();
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.never().onTerminateDetach());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.onTerminateDetach();
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.*;
 import org.junit.Test;
 
 import io.reactivex.*;
+import io.reactivex.functions.Function;
 import io.reactivex.internal.fuseable.ScalarCallable;
 import io.reactivex.schedulers.Schedulers;
 
@@ -56,5 +57,20 @@ public class ObservableFromTest {
     @Test
     public void fromArraySingle() {
         assertTrue(Observable.fromArray(1) instanceof ScalarCallable);
+    }
+
+    @Test
+    public void fromPublisherDispose() {
+        TestHelper.checkDisposed(Flowable.just(1).toObservable());
+    }
+
+    @Test
+    public void fromPublisherDoubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowableToObservable(new Function<Flowable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Flowable<Object> f) throws Exception {
+                return f.toObservable();
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableLastTest.java
@@ -14,15 +14,17 @@
 package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+
+import java.util.NoSuchElementException;
 
 import org.junit.Test;
 import org.mockito.InOrder;
 
-import java.util.NoSuchElementException;
-
 import io.reactivex.*;
-import io.reactivex.functions.Predicate;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
 
 public class ObservableLastTest {
 
@@ -293,5 +295,28 @@ public class ObservableLastTest {
             .assertNoValues()
             .assertErrorMessage("error")
             .assertError(RuntimeException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.never().lastElement());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservableToMaybe(new Function<Observable<Object>, MaybeSource<Object>>() {
+            @Override
+            public MaybeSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.lastElement();
+            }
+        });
+    }
+
+    @Test
+    public void error() {
+        Observable.error(new TestException())
+        .lastElement()
+        .test()
+        .assertFailure(TestException.class);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableResourceWrapperTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableResourceWrapperTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
+
+public class ObservableResourceWrapperTest {
+
+    @Test
+    public void disposed() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        ObserverResourceWrapper<Object> orw = new ObserverResourceWrapper<Object>(to);
+
+        Disposable d = Disposables.empty();
+
+        orw.onSubscribe(d);
+
+        assertFalse(orw.isDisposed());
+
+        orw.dispose();
+
+        assertTrue(orw.isDisposed());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        ObserverResourceWrapper<Object> orw = new ObserverResourceWrapper<Object>(to);
+
+        TestHelper.doubleOnSubscribe(orw);
+    }
+
+    @Test
+    public void onErrorDisposes() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        ObserverResourceWrapper<Object> orw = new ObserverResourceWrapper<Object>(to);
+
+        Disposable d = Disposables.empty();
+        Disposable d1 = Disposables.empty();
+
+        orw.setResource(d1);
+
+        orw.onSubscribe(d);
+
+        orw.onError(new TestException());
+
+        assertTrue(d1.isDisposed());
+
+        to.assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimerTest.java
@@ -281,4 +281,9 @@ public class ObservableTimerTest {
         inOrder.verifyNoMoreInteractions();
         verify(observer, never()).onComplete();
     }
+
+    @Test
+    public void disposed() {
+        TestHelper.checkDisposed(Observable.timer(1, TimeUnit.DAYS));
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -132,7 +132,7 @@ public class ObservableWindowWithSizeTest {
                         if (count.incrementAndGet() == 500000) {
                             // give it a small break halfway through
                             try {
-                                Thread.sleep(5);
+                                Thread.sleep(10);
                             } catch (InterruptedException ex) {
                                 // ignored
                             }

--- a/src/test/java/io/reactivex/schedulers/SchedulerTestHelper.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerTestHelper.java
@@ -81,7 +81,10 @@ final class SchedulerTestHelper {
                 fail("timed out");
             }
 
-            assertEquals("Handler should not have received anything", 0, handler.count);
+            if (handler.count != 0) {
+                handler.caught.printStackTrace();
+            }
+            assertEquals("Handler should not have received anything: " + handler.caught, 0, handler.count);
             assertEquals("Observer should have received an error", 1, observer.errorCount);
             assertEquals("Observer should not have received a next value", 0, observer.nextCount);
 
@@ -110,7 +113,7 @@ final class SchedulerTestHelper {
         }
     }
 
-    private static final class CapturingObserver<T> extends DefaultSubscriber<T> {
+    static final class CapturingObserver<T> extends DefaultSubscriber<T> {
         CountDownLatch completed = new CountDownLatch(1);
         int errorCount;
         int nextCount;


### PR DESCRIPTION
- improve coverage of `Observable` operators
- remove impossible or unused code paths
- fix `Observable.flatMap`'s dispose behavior and error accumulation
