### PR TITLE
2.x: cleanup, coverage, fixes 10/14-2

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -5683,7 +5683,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Flowable<List<T>> buffer(long timespan, TimeUnit unit) {
-        return buffer(timespan, unit, Integer.MAX_VALUE, Schedulers.computation());
+        return buffer(timespan, unit, Schedulers.computation(), Integer.MAX_VALUE);
     }
 
     /**
@@ -5717,7 +5717,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Flowable<List<T>> buffer(long timespan, TimeUnit unit, int count) {
-        return buffer(timespan, unit, count, Schedulers.computation());
+        return buffer(timespan, unit, Schedulers.computation(), count);
     }
 
     /**
@@ -5742,10 +5742,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            buffer
      * @param unit
      *            the unit of time which applies to the {@code timespan} argument
-     * @param count
-     *            the maximum size of each buffer before it is emitted
      * @param scheduler
      *            the {@link Scheduler} to use when determining the end and start of a buffer
+     * @param count
+     *            the maximum size of each buffer before it is emitted
      * @return a Flowable that emits connected, non-overlapping buffers of items emitted by the source
      *         Publisher after a fixed duration or when the buffer reaches maximum capacity (whichever occurs
      *         first)
@@ -5753,8 +5753,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<List<T>> buffer(long timespan, TimeUnit unit, int count, Scheduler scheduler) {
-        return buffer(timespan, unit, count, scheduler, ArrayListSupplier.<T>asCallable(), false);
+    public final Flowable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler, int count) {
+        return buffer(timespan, unit, scheduler, count, ArrayListSupplier.<T>asCallable(), false);
     }
 
     /**
@@ -5780,10 +5780,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            buffer
      * @param unit
      *            the unit of time which applies to the {@code timespan} argument
-     * @param count
-     *            the maximum size of each buffer before it is emitted
      * @param scheduler
      *            the {@link Scheduler} to use when determining the end and start of a buffer
+     * @param count
+     *            the maximum size of each buffer before it is emitted
      * @param bufferSupplier
      *            a factory function that returns an instance of the collection subclass to be used and returned
      *            as the buffer
@@ -5798,7 +5798,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final <U extends Collection<? super T>> Flowable<U> buffer(
             long timespan, TimeUnit unit,
-            int count, Scheduler scheduler,
+            Scheduler scheduler, int count,
             Callable<U> bufferSupplier,
             boolean restartTimerOnMaxSize) {
         ObjectHelper.requireNonNull(unit, "unit is null");
@@ -5838,7 +5838,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler) {
-        return buffer(timespan, unit, Integer.MAX_VALUE, scheduler, ArrayListSupplier.<T>asCallable(), false);
+        return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.<T>asCallable(), false);
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -4964,7 +4964,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Observable<List<T>> buffer(long timespan, TimeUnit unit) {
-        return buffer(timespan, unit, Integer.MAX_VALUE, Schedulers.computation());
+        return buffer(timespan, unit, Schedulers.computation(), Integer.MAX_VALUE);
     }
 
     /**
@@ -4994,7 +4994,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Observable<List<T>> buffer(long timespan, TimeUnit unit, int count) {
-        return buffer(timespan, unit, count, Schedulers.computation());
+        return buffer(timespan, unit, Schedulers.computation(), count);
     }
 
     /**
@@ -5016,18 +5016,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            buffer
      * @param unit
      *            the unit of time which applies to the {@code timespan} argument
-     * @param count
-     *            the maximum size of each buffer before it is emitted
      * @param scheduler
      *            the {@link Scheduler} to use when determining the end and start of a buffer
+     * @param count
+     *            the maximum size of each buffer before it is emitted
      * @return an Observable that emits connected, non-overlapping buffers of items emitted by the source
      *         ObservableSource after a fixed duration or when the buffer reaches maximum capacity (whichever occurs
      *         first)
      * @see <a href="http://reactivex.io/documentation/operators/buffer.html">ReactiveX operators documentation: Buffer</a>
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<List<T>> buffer(long timespan, TimeUnit unit, int count, Scheduler scheduler) {
-        return buffer(timespan, unit, count, scheduler, ArrayListSupplier.<T>asCallable(), false);
+    public final Observable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler, int count) {
+        return buffer(timespan, unit, scheduler, count, ArrayListSupplier.<T>asCallable(), false);
     }
 
     /**
@@ -5050,10 +5050,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            buffer
      * @param unit
      *            the unit of time which applies to the {@code timespan} argument
-     * @param count
-     *            the maximum size of each buffer before it is emitted
      * @param scheduler
      *            the {@link Scheduler} to use when determining the end and start of a buffer
+     * @param count
+     *            the maximum size of each buffer before it is emitted
      * @param bufferSupplier
      *            a factory function that returns an instance of the collection subclass to be used and returned
      *            as the buffer
@@ -5067,7 +5067,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final <U extends Collection<? super T>> Observable<U> buffer(
             long timespan, TimeUnit unit,
-            int count, Scheduler scheduler,
+            Scheduler scheduler, int count,
             Callable<U> bufferSupplier,
             boolean restartTimerOnMaxSize) {
         ObjectHelper.requireNonNull(unit, "unit is null");
@@ -5103,7 +5103,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler) {
-        return buffer(timespan, unit, Integer.MAX_VALUE, scheduler, ArrayListSupplier.<T>asCallable(), false);
+        return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.<T>asCallable(), false);
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/observers/BasicFuseableObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/BasicFuseableObserver.java
@@ -121,27 +121,6 @@ public abstract class BasicFuseableObserver<T, R> implements Observer<T>, QueueD
 
     /**
      * Calls the upstream's QueueDisposable.requestFusion with the mode and
-     * saves the established mode in {@link #sourceMode}.
-     * <p>
-     * If the upstream doesn't support fusion ({@link #qs} is null), the method
-     * returns {@link QueueDisposable#NONE}.
-     * @param mode the fusion mode requested
-     * @return the established fusion mode
-     */
-    protected final int transitiveFusion(int mode) {
-        QueueDisposable<T> qs = this.qs;
-        if (qs != null) {
-            int m = qs.requestFusion(mode);
-            if (m != NONE) {
-                sourceMode = m;
-            }
-            return m;
-        }
-        return NONE;
-    }
-
-    /**
-     * Calls the upstream's QueueDisposable.requestFusion with the mode and
      * saves the established mode in {@link #sourceMode} if that mode doesn't
      * have the {@link QueueDisposable#BOUNDARY} flag set.
      * <p>

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAt.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAt.java
@@ -96,7 +96,7 @@ public final class ObservableElementAt<T> extends AbstractObservableWithUpstream
 
         @Override
         public void onComplete() {
-            if (index <= count && !done) {
+            if (!done) {
                 done = true;
                 T v = defaultValue;
                 if (v != null) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtSingle.java
@@ -16,10 +16,12 @@ package io.reactivex.internal.operators.observable;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.FuseToObservable;
+
 import java.util.NoSuchElementException;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class ObservableElementAtSingle<T> extends Single<T> {
+public final class ObservableElementAtSingle<T> extends Single<T> implements FuseToObservable<T> {
     final ObservableSource<T> source;
     final long index;
     final T defaultValue;
@@ -33,6 +35,11 @@ public final class ObservableElementAtSingle<T> extends Single<T> {
     @Override
     public void subscribeActual(SingleObserver<? super T> t) {
         source.subscribe(new ElementAtObserver<T>(t, index, defaultValue));
+    }
+
+    @Override
+    public Observable<T> fuseToObservable() {
+        return RxJavaPlugins.onAssembly(new ObservableElementAt<T>(source, index, defaultValue));
     }
 
     static final class ElementAtObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
@@ -469,7 +469,7 @@ public final class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> ex
 
         @Override
         public void onError(Throwable t) {
-            parent.innerError(t);
+            parent.innerCloseError(t);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
@@ -334,6 +334,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                 ConsumerIndexHolder consumerIndexHolder = new ConsumerIndexHolder(producerIndex, this);
                 if (restartTimerOnMaxSize) {
                     Scheduler.Worker sw = scheduler.createWorker();
+                    worker = sw;
                     sw.schedulePeriodically(consumerIndexHolder, timespan, timespan, unit);
                     d = sw;
                 } else {

--- a/src/main/java/io/reactivex/internal/subscribers/BasicFuseableSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/BasicFuseableSubscriber.java
@@ -121,27 +121,6 @@ public abstract class BasicFuseableSubscriber<T, R> implements Subscriber<T>, Qu
 
     /**
      * Calls the upstream's QueueSubscription.requestFusion with the mode and
-     * saves the established mode in {@link #sourceMode}.
-     * <p>
-     * If the upstream doesn't support fusion ({@link #qs} is null), the method
-     * returns {@link QueueSubscription#NONE}.
-     * @param mode the fusion mode requested
-     * @return the established fusion mode
-     */
-    protected final int transitiveFusion(int mode) {
-        QueueSubscription<T> qs = this.qs;
-        if (qs != null) {
-            int m = qs.requestFusion(mode);
-            if (m != NONE) {
-                sourceMode = m;
-            }
-            return m;
-        }
-        return NONE;
-    }
-
-    /**
-     * Calls the upstream's QueueSubscription.requestFusion with the mode and
      * saves the established mode in {@link #sourceMode} if that mode doesn't
      * have the {@link QueueSubscription#BOUNDARY} flag set.
      * <p>

--- a/src/test/java/io/reactivex/internal/observers/BasicFuseableObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/BasicFuseableObserverTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.observers;
+
+import org.junit.Test;
+
+import io.reactivex.disposables.Disposables;
+import io.reactivex.observers.TestObserver;
+
+public class BasicFuseableObserverTest {
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void offer() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        BasicFuseableObserver<Integer, Integer> o = new BasicFuseableObserver<Integer, Integer>(to) {
+            @Override
+            public Integer poll() throws Exception {
+                return null;
+            }
+            @Override
+            public int requestFusion(int mode) {
+                return 0;
+            }
+            @Override
+            public void onNext(Integer value) {
+            }
+            @Override
+            protected boolean beforeDownstream() {
+                return false;
+            }
+        };
+
+        o.onSubscribe(Disposables.disposed());
+
+        to.assertNotSubscribed();
+
+        o.offer(1);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void offer2() {
+        BasicFuseableObserver<Integer, Integer> o = new BasicFuseableObserver<Integer, Integer>(new TestObserver<Integer>()) {
+            @Override
+            public Integer poll() throws Exception {
+                return null;
+            }
+            @Override
+            public int requestFusion(int mode) {
+                return 0;
+            }
+            @Override
+            public void onNext(Integer value) {
+            }
+        };
+
+        o.offer(1, 2);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -131,7 +131,7 @@ public class FlowableBufferTest {
             }
         });
 
-        Flowable<List<String>> buffered = source.buffer(100, TimeUnit.MILLISECONDS, 2, scheduler);
+        Flowable<List<String>> buffered = source.buffer(100, TimeUnit.MILLISECONDS, scheduler, 2);
         buffered.subscribe(observer);
 
         InOrder inOrder = Mockito.inOrder(observer);
@@ -663,7 +663,7 @@ public class FlowableBufferTest {
     public void bufferWithTimeAndSize() {
         Flowable<Long> source = Flowable.interval(30, 30, TimeUnit.MILLISECONDS, scheduler);
 
-        Flowable<List<Long>> result = source.buffer(100, TimeUnit.MILLISECONDS, 2, scheduler).take(3);
+        Flowable<List<Long>> result = source.buffer(100, TimeUnit.MILLISECONDS, scheduler, 2).take(3);
 
         Subscriber<Object> o = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(o);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapTest.java
@@ -1,0 +1,370 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposables;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.*;
+
+public class ObservableConcatMapTest {
+
+    @Test
+    public void asyncFused() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+
+        TestObserver<Integer> to = us.concatMap(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.range(v, 2);
+            }
+        })
+        .test();
+
+        us.onNext(1);
+        us.onComplete();
+
+        to.assertResult(1, 2);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.<Integer>just(1).hide()
+        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.error(new TestException());
+            }
+        }));
+    }
+
+    @Test
+    public void dispose2() {
+        TestHelper.checkDisposed(Observable.<Integer>just(1).hide()
+        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.error(new TestException());
+            }
+        }));
+    }
+
+    @Test
+    public void mainError() {
+        Observable.<Integer>error(new TestException())
+        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.range(v, 2);
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerError() {
+        Observable.<Integer>just(1).hide()
+        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.error(new TestException());
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mainErrorDelayed() {
+        Observable.<Integer>error(new TestException())
+        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.range(v, 2);
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerErrorDelayError() {
+        Observable.<Integer>just(1).hide()
+        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.error(new TestException());
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerErrorDelayError2() {
+        Observable.<Integer>just(1).hide()
+        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.fromCallable(new Callable<Integer>() {
+                    @Override
+                    public Integer call() throws Exception {
+                        throw new TestException();
+                    }
+                });
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void badSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+
+                    observer.onNext(1);
+                    observer.onComplete();
+                    observer.onNext(2);
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .concatMap(new Function<Integer, ObservableSource<Integer>>() {
+                @Override
+                public ObservableSource<Integer> apply(Integer v) throws Exception {
+                    return Observable.range(v, 2);
+                }
+            })
+            .test()
+            .assertResult(1, 2);
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void badSourceDelayError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+
+                    observer.onNext(1);
+                    observer.onComplete();
+                    observer.onNext(2);
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+                @Override
+                public ObservableSource<Integer> apply(Integer v) throws Exception {
+                    return Observable.range(v, 2);
+                }
+            })
+            .test()
+            .assertResult(1, 2);
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void normalDelayErrors() {
+        Observable.just(1).hide()
+        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.range(v, 2);
+            }
+        })
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void normalDelayErrorsTillTheEnd() {
+        Observable.just(1).hide()
+        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.range(v, 2);
+            }
+        }, 16, true)
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void onErrorRace() {
+        for (int i = 0; i < 500; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final PublishSubject<Integer> ps1 = PublishSubject.create();
+                final PublishSubject<Integer> ps2 = PublishSubject.create();
+
+                TestObserver<Integer> to = ps1.concatMap(new Function<Integer, ObservableSource<Integer>>() {
+                    @Override
+                    public ObservableSource<Integer> apply(Integer v) throws Exception {
+                        return ps2;
+                    }
+                }).test();
+
+                final TestException ex1 = new TestException();
+                final TestException ex2 = new TestException();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps1.onError(ex1);
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps2.onError(ex2);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                to.assertFailure(TestException.class);
+
+                if (!errors.isEmpty()) {
+                    TestHelper.assertError(errors, 0, TestException.class);
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void mapperThrows() {
+        Observable.just(1).hide()
+        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void fusedPollThrows() {
+        Observable.just(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.range(v, 2);
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void fusedPollThrowsDelayError() {
+        Observable.just(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.range(v, 2);
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapperThrowsDelayError() {
+        Observable.just(1).hide()
+        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void badInnerDelayError() {
+        @SuppressWarnings("rawtypes")
+        final Observer[] o = { null };
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Observable.just(1).hide()
+            .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+                @Override
+                public ObservableSource<Integer> apply(Integer v) throws Exception {
+                    return new Observable<Integer>() {
+                        @Override
+                        protected void subscribeActual(Observer<? super Integer> observer) {
+                            o[0] = observer;
+                            observer.onSubscribe(Disposables.empty());
+                            observer.onComplete();
+                        }
+                    };
+                }
+            })
+            .test()
+            .assertResult();
+
+            o[0].onError(new TestException());
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableElementAtTest.java
@@ -15,11 +15,18 @@ package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.*;
 
+import java.util.*;
+
 import org.junit.Test;
 
-import java.util.NoSuchElementException;
-
+import io.reactivex.*;
 import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.PublishSubject;
 
 public class ObservableElementAtTest {
 
@@ -165,5 +172,65 @@ public class ObservableElementAtTest {
             .elementAtOrError(1)
             .test()
             .assertFailure(NoSuchElementException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishSubject.create().elementAt(0).toObservable());
+        TestHelper.checkDisposed(PublishSubject.create().elementAt(0, 1).toObservable());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.elementAt(0).toObservable();
+            }
+        });
+    }
+
+    @Test
+    public void elementAtIndex1WithDefaultOnEmptySourceObservable() {
+        Observable.empty()
+            .elementAt(1, 10)
+            .toObservable()
+            .test()
+            .assertResult(10);
+    }
+
+    @Test
+    public void errorObservable() {
+        Observable.error(new TestException())
+            .elementAt(1, 10)
+            .toObservable()
+            .test()
+            .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void badSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+
+                    observer.onNext(1);
+                    observer.onNext(2);
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .elementAt(0)
+            .toObservable()
+            .test()
+            .assertResult(1);
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFilterTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFilterTest.java
@@ -13,13 +13,19 @@
 
 package io.reactivex.internal.operators.observable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import io.reactivex.*;
-import io.reactivex.functions.Predicate;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.observers.*;
+import io.reactivex.subjects.UnicastSubject;
 
 public class ObservableFilterTest {
 
@@ -70,4 +76,87 @@ public class ObservableFilterTest {
 //            }
 //        }
 //    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.range(1, 5).filter(Functions.alwaysTrue()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.filter(Functions.alwaysTrue());
+            }
+        });
+    }
+
+    @Test
+    public void fusedSync() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+
+        Observable.range(1, 5)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 2 == 0;
+            }
+        })
+        .subscribe(to);
+
+        ObserverFusion.assertFusion(to, QueueDisposable.SYNC)
+        .assertResult(2, 4);
+    }
+
+    @Test
+    public void fusedAsync() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+
+        UnicastSubject<Integer> us = UnicastSubject.create();
+
+        us
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 2 == 0;
+            }
+        })
+        .subscribe(to);
+
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        ObserverFusion.assertFusion(to, QueueDisposable.ASYNC)
+        .assertResult(2, 4);
+    }
+
+    @Test
+    public void fusedReject() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY | QueueDisposable.BOUNDARY);
+
+        Observable.range(1, 5)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 2 == 0;
+            }
+        })
+        .subscribe(to);
+
+        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+        .assertResult(2, 4);
+    }
+
+    @Test
+    public void filterThrows() {
+        Observable.range(1, 5)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromCompletableTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class ObservableFromCompletableTest {
+
+    @Test
+    public void disposedOnArrival() {
+        final int[] count = { 0 };
+        Observable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                count[0]++;
+                return 1;
+            }
+        })
+        .test(true)
+        .assertEmpty();
+
+        assertEquals(0, count[0]);
+    }
+
+    @Test
+    public void disposedOnCall() {
+        final TestObserver<Integer> to = new TestObserver<Integer>();
+
+        Observable.fromCallable(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                to.cancel();
+                return 1;
+            }
+        })
+        .subscribe(to);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void disposedOnCallThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final TestObserver<Integer> to = new TestObserver<Integer>();
+
+            Observable.fromCallable(new Callable<Integer>() {
+                @Override
+                public Integer call() throws Exception {
+                    to.cancel();
+                    throw new TestException();
+                }
+            })
+            .subscribe(to);
+
+            to.assertEmpty();
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void take() {
+        Observable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return 1;
+            }
+        })
+        .take(1)
+        .test()
+        .assertResult(1);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupJoinTest.java
@@ -15,16 +15,24 @@
  */
 package io.reactivex.internal.operators.observable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import java.util.Arrays;
+import java.util.*;
 
 import org.junit.*;
 import org.mockito.MockitoAnnotations;
 
 import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
 public class ObservableGroupJoinTest {
@@ -354,5 +362,331 @@ public class ObservableGroupJoinTest {
         verify(observer, times(1)).onError(any(Throwable.class));
         verify(observer, never()).onComplete();
         verify(observer, never()).onNext(any());
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).groupJoin(
+            Observable.just(2),
+            new Function<Integer, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Integer left) throws Exception {
+                    return Observable.never();
+                }
+            },
+            new Function<Integer, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Integer right) throws Exception {
+                    return Observable.never();
+                }
+            },
+            new BiFunction<Integer, Observable<Integer>, Object>() {
+                @Override
+                public Object apply(Integer r, Observable<Integer> l) throws Exception {
+                    return l;
+                }
+            }
+        ));
+    }
+
+    @Test
+    public void innerCompleteLeft() {
+        Observable.just(1)
+        .groupJoin(
+            Observable.just(2),
+            new Function<Integer, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Integer left) throws Exception {
+                    return Observable.empty();
+                }
+            },
+            new Function<Integer, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Integer right) throws Exception {
+                    return Observable.never();
+                }
+            },
+            new BiFunction<Integer, Observable<Integer>, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> apply(Integer r, Observable<Integer> l) throws Exception {
+                    return l;
+                }
+            }
+        )
+        .flatMap(Functions.<Observable<Integer>>identity())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void innerErrorLeft() {
+        Observable.just(1)
+        .groupJoin(
+            Observable.just(2),
+            new Function<Integer, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Integer left) throws Exception {
+                    return Observable.error(new TestException());
+                }
+            },
+            new Function<Integer, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Integer right) throws Exception {
+                    return Observable.never();
+                }
+            },
+            new BiFunction<Integer, Observable<Integer>, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> apply(Integer r, Observable<Integer> l) throws Exception {
+                    return l;
+                }
+            }
+        )
+        .flatMap(Functions.<Observable<Integer>>identity())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerCompleteRight() {
+        Observable.just(1)
+        .groupJoin(
+            Observable.just(2),
+            new Function<Integer, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Integer left) throws Exception {
+                    return Observable.never();
+                }
+            },
+            new Function<Integer, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Integer right) throws Exception {
+                    return Observable.empty();
+                }
+            },
+            new BiFunction<Integer, Observable<Integer>, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> apply(Integer r, Observable<Integer> l) throws Exception {
+                    return l;
+                }
+            }
+        )
+        .flatMap(Functions.<Observable<Integer>>identity())
+        .test()
+        .assertResult(2);
+    }
+
+    @Test
+    public void innerErrorRight() {
+        Observable.just(1)
+        .groupJoin(
+            Observable.just(2),
+            new Function<Integer, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Integer left) throws Exception {
+                    return Observable.never();
+                }
+            },
+            new Function<Integer, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Integer right) throws Exception {
+                    return Observable.error(new TestException());
+                }
+            },
+            new BiFunction<Integer, Observable<Integer>, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> apply(Integer r, Observable<Integer> l) throws Exception {
+                    return l;
+                }
+            }
+        )
+        .flatMap(Functions.<Observable<Integer>>identity())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerErrorRace() {
+        for (int i = 0; i < 500; i++) {
+            final PublishSubject<Object> ps1 = PublishSubject.create();
+            final PublishSubject<Object> ps2 = PublishSubject.create();
+
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+
+            try {
+                TestObserver<Observable<Integer>> to = Observable.just(1)
+                .groupJoin(
+                    Observable.just(2).concatWith(Observable.<Integer>never()),
+                    new Function<Integer, ObservableSource<Object>>() {
+                        @Override
+                        public ObservableSource<Object> apply(Integer left) throws Exception {
+                            return ps1;
+                        }
+                    },
+                    new Function<Integer, ObservableSource<Object>>() {
+                        @Override
+                        public ObservableSource<Object> apply(Integer right) throws Exception {
+                            return ps2;
+                        }
+                    },
+                    new BiFunction<Integer, Observable<Integer>, Observable<Integer>>() {
+                        @Override
+                        public Observable<Integer> apply(Integer r, Observable<Integer> l) throws Exception {
+                            return l;
+                        }
+                    }
+                )
+                .test();
+
+                final TestException ex1 = new TestException();
+                final TestException ex2 = new TestException();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps1.onError(ex1);
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps2.onError(ex2);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                to.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertValueCount(1);
+
+                Throwable exc = to.errors().get(0);
+
+                if (exc instanceof CompositeException) {
+                    List<Throwable> es = TestHelper.compositeList(exc);
+                    TestHelper.assertError(es, 0, TestException.class);
+                    TestHelper.assertError(es, 1, TestException.class);
+                } else {
+                    to.assertError(TestException.class);
+                }
+
+                if (!errors.isEmpty()) {
+                    TestHelper.assertError(errors, 0, TestException.class);
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void outerErrorRace() {
+        for (int i = 0; i < 500; i++) {
+            final PublishSubject<Object> ps1 = PublishSubject.create();
+            final PublishSubject<Object> ps2 = PublishSubject.create();
+
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+
+            try {
+                TestObserver<Object> to = ps1
+                .groupJoin(
+                    ps2,
+                    new Function<Object, ObservableSource<Object>>() {
+                        @Override
+                        public ObservableSource<Object> apply(Object left) throws Exception {
+                            return Observable.never();
+                        }
+                    },
+                    new Function<Object, ObservableSource<Object>>() {
+                        @Override
+                        public ObservableSource<Object> apply(Object right) throws Exception {
+                            return Observable.never();
+                        }
+                    },
+                    new BiFunction<Object, Observable<Object>, Observable<Object>>() {
+                        @Override
+                        public Observable<Object> apply(Object r, Observable<Object> l) throws Exception {
+                            return l;
+                        }
+                    }
+                )
+                .flatMap(Functions.<Observable<Object>>identity())
+                .test();
+
+                final TestException ex1 = new TestException();
+                final TestException ex2 = new TestException();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps1.onError(ex1);
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps2.onError(ex2);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                to.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertNoValues();
+
+                Throwable exc = to.errors().get(0);
+
+                if (exc instanceof CompositeException) {
+                    List<Throwable> es = TestHelper.compositeList(exc);
+                    TestHelper.assertError(es, 0, TestException.class);
+                    TestHelper.assertError(es, 1, TestException.class);
+                } else {
+                    to.assertError(TestException.class);
+                }
+
+                if (!errors.isEmpty()) {
+                    TestHelper.assertError(errors, 0, TestException.class);
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void rightEmission() {
+        final PublishSubject<Object> ps1 = PublishSubject.create();
+        final PublishSubject<Object> ps2 = PublishSubject.create();
+
+        TestObserver<Object> to = ps1
+        .groupJoin(
+            ps2,
+            new Function<Object, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Object left) throws Exception {
+                    return Observable.never();
+                }
+            },
+            new Function<Object, ObservableSource<Object>>() {
+                @Override
+                public ObservableSource<Object> apply(Object right) throws Exception {
+                    return Observable.never();
+                }
+            },
+            new BiFunction<Object, Observable<Object>, Observable<Object>>() {
+                @Override
+                public Observable<Object> apply(Object r, Observable<Object> l) throws Exception {
+                    return l;
+                }
+            }
+        )
+        .flatMap(Functions.<Observable<Object>>identity())
+        .test();
+
+        ps2.onNext(2);
+
+        ps1.onNext(1);
+        ps1.onComplete();
+
+        ps2.onComplete();
+
+        to.assertResult(2);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -408,4 +408,25 @@ public class ObservableWindowWithTimeTest {
 
         ts.assertFailure(TestException.class);
     }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.range(1, 5).window(1, TimeUnit.DAYS, Schedulers.single()));
+
+        TestHelper.checkDisposed(Observable.range(1, 5).window(2, 1, TimeUnit.DAYS, Schedulers.single()));
+
+        TestHelper.checkDisposed(Observable.range(1, 5).window(1, 2, TimeUnit.DAYS, Schedulers.single()));
+
+        TestHelper.checkDisposed(Observable.range(1, 5)
+                .window(1, TimeUnit.DAYS, Schedulers.single(), 2, true));
+    }
+
+    @Test
+    public void restartTimer() {
+        Observable.range(1, 5)
+        .window(1, TimeUnit.DAYS, Schedulers.single(), 2, true)
+        .flatMap(Functions.<Observable<Integer>>identity())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -417,7 +417,7 @@ public class ObservableWindowWithTimeTest {
 
         TestHelper.checkDisposed(Observable.range(1, 5).window(1, 2, TimeUnit.DAYS, Schedulers.single()));
 
-        TestHelper.checkDisposed(Observable.range(1, 5)
+        TestHelper.checkDisposed(Observable.never()
                 .window(1, TimeUnit.DAYS, Schedulers.single(), 2, true));
     }
 


### PR DESCRIPTION
- more `Observable` operator coverage
- enable fusion with `filter` and `fromCallable`
- change order of size parameter in timed `buffer` and `window` operators
- fix minor mistakes in operators
