### PR TITLE
2.x: coverage, fixes, cleanup 10/15-1

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -8305,7 +8305,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final ConnectableObservable<T> publish() {
-        return publish(bufferSize());
+        return ObservablePublish.create(this);
     }
 
     /**
@@ -8329,58 +8329,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends ObservableSource<R>> selector) {
-        return publish(selector, bufferSize());
-    }
-
-    /**
-     * Returns an Observable that emits the results of invoking a specified selector on items emitted by a
-     * {@link ConnectableObservable} that shares a single subscription to the underlying sequence.
-     * <p>
-     * <img width="640" height="510" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/publishConnect.f.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code publish} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <R>
-     *            the type of items emitted by the resulting ObservableSource
-     * @param selector
-     *            a function that can use the multicasted source sequence as many times as needed, without
-     *            causing multiple subscriptions to the source sequence. Observers to the given source will
-     *            receive all notifications of the source from the time of the subscription forward.
-     * @param bufferSize
-     *            the number of elements to prefetch from the current Observable
-     * @return an Observable that emits the results of invoking the selector on the items emitted by a {@link ConnectableObservable} that shares a single subscription to the underlying sequence
-     * @see <a href="http://reactivex.io/documentation/operators/publish.html">ReactiveX operators documentation: Publish</a>
-     */
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, int bufferSize) {
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         ObjectHelper.requireNonNull(selector, "selector is null");
-        return ObservablePublish.create(this, selector, bufferSize);
-    }
-
-    /**
-     * Returns a {@link ConnectableObservable}, which is a variety of ObservableSource that waits until its
-     * {@link ConnectableObservable#connect connect} method is called before it begins emitting items to those
-     * {@link Observer}s that have subscribed to it.
-     * <p>
-     * <img width="640" height="510" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/publishConnect.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code publish} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param bufferSize
-     *            the number of elements to prefetch from the current Observable
-     * @return a {@link ConnectableObservable} that upon connection causes the source ObservableSource to emit items
-     *         to its {@link Observer}s
-     * @see <a href="http://reactivex.io/documentation/operators/publish.html">ReactiveX operators documentation: Publish</a>
-     */
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final ConnectableObservable<T> publish(int bufferSize) {
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return ObservablePublish.create(this, bufferSize);
+        return new ObservablePublishSelector<T, R>(this, selector);
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
@@ -183,7 +183,7 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
                 U b;
 
                 try {
-                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
                 } catch (Throwable e) {
                     buffers.clear();
                     s.dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapEager.java
@@ -183,12 +183,8 @@ public final class ObservableConcatMapEager<T, R> extends AbstractObservableWith
 
             for (;;) {
 
-                try {
-                    inner = observers.poll();
-                } catch (Throwable ex) {
-                    Exceptions.throwIfFatal(ex);
-                    throw ExceptionHelper.wrapOrThrow(ex);
-                }
+                inner = observers.poll();
+
                 if (inner == null) {
                     return;
                 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservablePublishSelector.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservablePublishSelector.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.subjects.PublishSubject;
+
+/**
+ * Shares a source Observable for the duration of a selector function.
+ * @param <T> the input value type
+ * @param <R> the output value type
+ */
+public final class ObservablePublishSelector<T, R> extends AbstractObservableWithUpstream<T, R> {
+
+    final Function<? super Observable<T>, ? extends ObservableSource<R>> selector;
+
+    public ObservablePublishSelector(final ObservableSource<T> source,
+                                              final Function<? super Observable<T>, ? extends ObservableSource<R>> selector) {
+        super(source);
+        this.selector = selector;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super R> observer) {
+        PublishSubject<T> subject = PublishSubject.create();
+
+        ObservableSource<? extends R> target;
+
+        try {
+            target = ObjectHelper.requireNonNull(selector.apply(subject), "The selector returned a null ObservableSource");
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+
+        TargetObserver<T, R> o = new TargetObserver<T, R>(observer);
+
+        target.subscribe(o);
+
+        source.subscribe(new SourceObserver<T, R>(subject, o));
+    }
+
+    static final class SourceObserver<T, R> implements Observer<T> {
+
+        final PublishSubject<T> subject;
+
+        final AtomicReference<Disposable> target;
+
+        SourceObserver(PublishSubject<T> subject, AtomicReference<Disposable> target) {
+            this.subject = subject;
+            this.target = target;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(target, d);
+        }
+
+        @Override
+        public void onNext(T value) {
+            subject.onNext(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            subject.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            subject.onComplete();
+        }
+    }
+
+    static final class TargetObserver<T, R>
+    extends AtomicReference<Disposable> implements Observer<R>, Disposable {
+        private static final long serialVersionUID = 854110278590336484L;
+
+        final Observer<? super R> actual;
+
+        Disposable d;
+
+        TargetObserver(Observer<? super R> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(R value) {
+            actual.onNext(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            DisposableHelper.dispose(this);
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            DisposableHelper.dispose(this);
+            actual.onComplete();
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimed.java
@@ -14,7 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
@@ -45,7 +45,8 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
         source.subscribe(new TakeLastTimedObserver<T>(t, count, time, unit, scheduler, bufferSize, delayError));
     }
 
-    static final class TakeLastTimedObserver<T> extends AtomicInteger implements Observer<T>, Disposable {
+    static final class TakeLastTimedObserver<T>
+    extends AtomicBoolean implements Observer<T>, Disposable {
 
         private static final long serialVersionUID = -5677354903406201275L;
         final Observer<? super T> actual;
@@ -56,7 +57,7 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
         final SpscLinkedArrayQueue<Object> queue;
         final boolean delayError;
 
-        Disposable s;
+        Disposable d;
 
         volatile boolean cancelled;
 
@@ -74,9 +75,9 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
         }
 
         @Override
-        public void onSubscribe(Disposable s) {
-            if (DisposableHelper.validate(this.s, s)) {
-                this.s = s;
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
                 actual.onSubscribe(this);
             }
         }
@@ -118,12 +119,12 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
 
         @Override
         public void dispose() {
-            if (cancelled) {
+            if (!cancelled) {
                 cancelled = true;
+                d.dispose();
 
-                if (getAndIncrement() == 0) {
+                if (compareAndSet(false, true)) {
                     queue.clear();
-                    s.dispose();
                 }
             }
         }
@@ -134,89 +135,51 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
         }
 
         void drain() {
-            if (getAndIncrement() != 0) {
+            if (!compareAndSet(false, true)) {
                 return;
             }
-
-            int missed = 1;
 
             final Observer<? super T> a = actual;
             final SpscLinkedArrayQueue<Object> q = queue;
             final boolean delayError = this.delayError;
 
             for (;;) {
+                if (cancelled) {
+                    q.clear();
+                    return;
+                }
 
-                if (done) {
-                    boolean empty = q.isEmpty();
-
-                    if (checkTerminated(empty, a, delayError)) {
+                if (!delayError) {
+                    Throwable ex = error;
+                    if (ex != null) {
+                        q.clear();
+                        a.onError(ex);
                         return;
                     }
-
-                    for (;;) {
-                        Object ts = q.poll(); // the timestamp long
-                        empty = ts == null;
-
-                        if (checkTerminated(empty, a, delayError)) {
-                            return;
-                        }
-
-                        if (empty) {
-                            break;
-                        }
-
-                        @SuppressWarnings("unchecked")
-                        T o = (T)q.poll();
-                        if (o == null) {
-                            s.dispose();
-                            a.onError(new IllegalStateException("Queue empty?!"));
-                            return;
-                        }
-
-                        if ((Long)ts < scheduler.now(unit) - time) {
-                            continue;
-                        }
-
-                        a.onNext(o);
-                    }
                 }
 
-                missed = addAndGet(-missed);
-                if (missed == 0) {
-                    break;
-                }
-            }
-        }
+                Object ts = q.poll(); // the timestamp long
+                boolean empty = ts == null;
 
-        boolean checkTerminated(boolean empty, Observer<? super T> a, boolean delayError) {
-            if (cancelled) {
-                queue.clear();
-                s.dispose();
-                return true;
-            }
-            if (delayError) {
                 if (empty) {
-                    Throwable e = error;
-                    if (e != null) {
-                        a.onError(e);
+                    Throwable ex = error;
+                    if (ex != null) {
+                        a.onError(ex);
                     } else {
                         a.onComplete();
                     }
-                    return true;
+                    return;
                 }
-            } else {
-                Throwable e = error;
-                if (e != null) {
-                    queue.clear();
-                    a.onError(e);
-                    return true;
-                } else
-                if (empty) {
-                    a.onComplete();
-                    return true;
+
+                @SuppressWarnings("unchecked")
+                T o = (T)q.poll();
+
+                if ((Long)ts < scheduler.now(unit) - time) {
+                    continue;
                 }
+
+                a.onNext(o);
             }
-            return false;
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableToList.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableToList.java
@@ -13,29 +13,24 @@
 
 package io.reactivex.internal.operators.observable;
 
-import java.util.*;
+import java.util.Collection;
 import java.util.concurrent.Callable;
 
-import io.reactivex.ObservableSource;
-import io.reactivex.Observer;
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.*;
 
 public final class ObservableToList<T, U extends Collection<? super T>>
 extends AbstractObservableWithUpstream<T, U> {
 
     final Callable<U> collectionSupplier;
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public ObservableToList(ObservableSource<T> source, final int defaultCapacityHint) {
         super(source);
-        this.collectionSupplier = new Callable<U>() {
-            @Override
-            @SuppressWarnings("unchecked")
-            public U call() throws Exception {
-                return (U)new ArrayList<T>(defaultCapacityHint);
-            }
-        };
+        this.collectionSupplier = (Callable)Functions.createArrayList(defaultCapacityHint);
     }
 
     public ObservableToList(ObservableSource<T> source, Callable<U> collectionSupplier) {
@@ -47,7 +42,7 @@ extends AbstractObservableWithUpstream<T, U> {
     public void subscribeActual(Observer<? super U> t) {
         U coll;
         try {
-            coll = collectionSupplier.call();
+            coll = ObjectHelper.requireNonNull(collectionSupplier.call(), "The collectionSupplier returned a null Collection");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -316,36 +316,22 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
     static final class OperatorWindowBoundaryOpenObserver<T, B> extends DisposableObserver<B> {
         final WindowBoundaryMainObserver<T, B, ?> parent;
 
-        boolean done;
-
         OperatorWindowBoundaryOpenObserver(WindowBoundaryMainObserver<T, B, ?> parent) {
             this.parent = parent;
         }
 
         @Override
         public void onNext(B t) {
-            if (done) {
-                return;
-            }
             parent.open(t);
         }
 
         @Override
         public void onError(Throwable t) {
-            if (done) {
-                RxJavaPlugins.onError(t);
-                return;
-            }
-            done = true;
             parent.error(t);
         }
 
         @Override
         public void onComplete() {
-            if (done) {
-                return;
-            }
-            done = true;
             parent.onComplete();
         }
     }

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -38,6 +38,7 @@ import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.Subject;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -280,7 +281,16 @@ public enum TestHelper {
             RxJavaPlugins.setErrorHandler(null);
         }
     }
-
+    /**
+     * Synchronizes the execution of two runnables (as much as possible)
+     * to test race conditions.
+     * <p>The method blocks until both have run to completion.
+     * @param r1 the first runnable
+     * @param r2 the second runnable
+     */
+    public static void race(final Runnable r1, final Runnable r2) {
+        race(r1, r2, Schedulers.single());
+    }
     /**
      * Synchronizes the execution of two runnables (as much as possible)
      * to test race conditions.
@@ -1997,5 +2007,23 @@ public enum TestHelper {
         } catch (InterruptedException ex) {
             throw new RuntimeException(ex);
         }
+    }
+
+    /**
+     * Returns an expanded error list of the given test consumer.
+     * @param to the test consumer instance
+     * @return the list
+     */
+    public static List<Throwable> errorList(TestObserver<?> to) {
+        return compositeList(to.errors().get(0));
+    }
+
+    /**
+     * Returns an expanded error list of the given test consumer.
+     * @param to the test consumer instance
+     * @return the list
+     */
+    public static List<Throwable> errorList(TestSubscriber<?> to) {
+        return compositeList(to.errors().get(0));
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -794,7 +794,7 @@ public class FlowableCombineLatestTest {
             }
         }).subscribe(ts);
 
-        if (!latch.await(SIZE + 1000, TimeUnit.MILLISECONDS)) {
+        if (!latch.await(SIZE + 2000, TimeUnit.MILLISECONDS)) {
             fail("timed out");
         }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -16,19 +16,21 @@ package io.reactivex.internal.operators.observable;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
 
 import io.reactivex.*;
-import io.reactivex.exceptions.TestException;
+import io.reactivex.Observable;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subjects.*;
 
 public class ObservableConcatMapEagerTest {
 
@@ -738,5 +740,214 @@ public class ObservableConcatMapEagerTest {
         Observable.concatEager(Arrays.asList(Observable.just(1), Observable.just(2)))
         .test()
         .assertResult(1, 2);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.range(1, 2);
+            }
+        }));
+    }
+
+    @Test
+    public void empty() {
+        Observable.<Integer>empty().hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.range(1, 2);
+            }
+        })
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void innerError() {
+        Observable.<Integer>just(1).hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.error(new TestException());
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerErrorMaxConcurrency() {
+        Observable.<Integer>just(1).hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.error(new TestException());
+            }
+        }, 1, 128)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerCallableThrows() {
+        Observable.<Integer>just(1).hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.fromCallable(new Callable<Integer>() {
+                    @Override
+                    public Integer call() throws Exception {
+                        throw new TestException();
+                    }
+                });
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerOuterRace() {
+        for (int i = 0; i < 500; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final PublishSubject<Integer> ps1 = PublishSubject.create();
+                final PublishSubject<Integer> ps2 = PublishSubject.create();
+
+                TestObserver<Integer> to = ps1.concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+                    @Override
+                    public ObservableSource<Integer> apply(Integer v) throws Exception {
+                        return ps2;
+                    }
+                }).test();
+
+                final TestException ex1 = new TestException();
+                final TestException ex2 = new TestException();
+
+                ps1.onNext(1);
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps1.onError(ex1);
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps2.onError(ex2);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                to.assertSubscribed().assertNoValues().assertNotComplete();
+
+                Throwable ex = to.errors().get(0);
+
+                if (ex instanceof CompositeException) {
+                    List<Throwable> es = TestHelper.errorList(to);
+                    TestHelper.assertError(es, 0, TestException.class);
+                    TestHelper.assertError(es, 1, TestException.class);
+                } else {
+                    to.assertError(TestException.class);
+                    if (!errors.isEmpty()) {
+                        TestHelper.assertError(errors, 0, TestException.class);
+                    }
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void nextCancelRace() {
+        for (int i = 0; i < 500; i++) {
+            final PublishSubject<Integer> ps1 = PublishSubject.create();
+
+            final TestObserver<Integer> to = ps1.concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+                @Override
+                public ObservableSource<Integer> apply(Integer v) throws Exception {
+                    return Observable.never();
+                }
+            }).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ps1.onNext(1);
+                }
+            };
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    to.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2, Schedulers.single());
+
+            to.assertEmpty();
+        }
+    }
+
+    @Test
+    public void mapperCancels() {
+        final TestObserver<Integer> to = new TestObserver<Integer>();
+
+        Observable.just(1).hide()
+        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                to.cancel();
+                return Observable.never();
+            }
+        }, 1, 128)
+        .subscribe(to);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void innerErrorFused() {
+        Observable.<Integer>just(1).hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.range(1, 2).map(new Function<Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer v) throws Exception {
+                        throw new TestException();
+                    }
+                });
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerErrorAfterPoll() {
+        final UnicastSubject<Integer> us = UnicastSubject.create();
+        us.onNext(1);
+
+        TestObserver<Integer> to = new TestObserver<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                us.onError(new TestException());
+            }
+        };
+
+        Observable.<Integer>just(1).hide()
+        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return us;
+            }
+        }, 1, 128)
+        .subscribe(to);
+
+        to
+        .assertFailure(TestException.class, 1);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
@@ -218,4 +218,43 @@ public class ObservableRepeatTest {
         }
     }
 
+    @Test
+    public void repeatUntilError() {
+        Observable.error(new TestException())
+        .repeatUntil(new BooleanSupplier() {
+            @Override
+            public boolean getAsBoolean() throws Exception {
+                return true;
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void repeatUntilFalse() {
+        Observable.just(1)
+        .repeatUntil(new BooleanSupplier() {
+            @Override
+            public boolean getAsBoolean() throws Exception {
+                return true;
+            }
+        })
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void repeatUntilSupplierCrash() {
+        Observable.just(1)
+        .repeatUntil(new BooleanSupplier() {
+            @Override
+            public boolean getAsBoolean() throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
@@ -22,6 +23,7 @@ import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 
@@ -106,4 +108,16 @@ public class ObservableSkipLastTest {
         Observable.just("one").skipLast(-1);
     }
 
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).skipLast(1));
+    }
+
+    @Test
+    public void error() {
+        Observable.error(new TestException())
+        .skipLast(1)
+        .test()
+        .assertFailure(TestException.class);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimedTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
@@ -22,6 +23,7 @@ import org.mockito.InOrder;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
 
@@ -231,4 +233,47 @@ public class ObservableTakeLastTimedTest {
         .assertFailure(TestException.class, 1, 2);
     }
 
+    @Test
+    public void disposed() {
+        TestHelper.checkDisposed(PublishSubject.create().takeLast(1, TimeUnit.MINUTES));
+    }
+
+    @Test
+    public void observeOn() {
+        Observable.range(1, 1000)
+        .takeLast(1, TimeUnit.DAYS)
+        .take(500)
+        .observeOn(Schedulers.single(), true, 1)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertSubscribed()
+        .assertValueCount(500)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void cancelCompleteRace() {
+        for (int i = 0; i < 500; i++) {
+            final PublishSubject<Integer> ps = PublishSubject.create();
+
+            final TestObserver<Integer> to = ps.takeLast(1, TimeUnit.DAYS).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ps.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    to.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+        }
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -24,6 +25,7 @@ import org.mockito.Mockito;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.exceptions.TestException;
 
 public class ObservableToListTest {
 
@@ -181,5 +183,35 @@ public class ObservableToListTest {
         .toList(4)
         .test()
         .assertResult(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).toList().toObservable());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void error() {
+        Observable.error(new TestException())
+        .toList()
+        .toObservable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void collectionSupplierThrows() {
+        Observable.just(1)
+        .toList(new Callable<Collection<Integer>>() {
+            @Override
+            public Collection<Integer> call() throws Exception {
+                throw new TestException();
+            }
+        })
+        .toObservable()
+        .test()
+        .assertFailure(TestException.class);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -429,4 +429,28 @@ public class ObservableWindowWithTimeTest {
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
+
+    @Test
+    public void exactBoundaryError() {
+        Observable.error(new TestException())
+        .window(1, TimeUnit.DAYS, Schedulers.single(), 2, true)
+        .test()
+        .assertSubscribed()
+        .assertError(TestException.class)
+        .assertNotComplete();
+    }
+
+    @Test
+    public void restartTimerMany() {
+        Observable.intervalRange(1, 1000, 1, 1, TimeUnit.MILLISECONDS)
+        .window(1, TimeUnit.MILLISECONDS, Schedulers.single(), 2, true)
+        .flatMap(Functions.<Observable<Long>>identity())
+        .take(500)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertSubscribed()
+        .assertValueCount(500)
+        .assertNoErrors()
+        .assertComplete();
+    }
 }


### PR DESCRIPTION
- improve coverage of `Observable` operators
- remove unnecessary code paths
- fix `publish(Function)` latecommer behavior
- remove `bufferSize` overloads of `publish` as there is no need to buffer anything for an `Observable`
- simplify `Observable.publish`
