### PR TITLE
2.x: Remove checked exceptions from transformer interfaces.

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -942,12 +942,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable compose(CompletableTransformer transformer) {
-        try {
-            return wrap(transformer.apply(this));
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+        return wrap(transformer.apply(this));
     }
 
     /**

--- a/src/main/java/io/reactivex/CompletableTransformer.java
+++ b/src/main/java/io/reactivex/CompletableTransformer.java
@@ -22,8 +22,6 @@ public interface CompletableTransformer {
      * Applies a function to the upstream Completable and returns a CompletableSource.
      * @param upstream the upstream Completable instance
      * @return the transformed CompletableSource instance
-     * @throws Exception in case the transformation throws, checked exceptions will be wrapped
-     * into a RuntimeException
      */
-    CompletableSource apply(Completable upstream) throws Exception;
+    CompletableSource apply(Completable upstream);
 }

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -6322,12 +6322,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> compose(FlowableTransformer<T, R> composer) {
-        try {
-            return fromPublisher(composer.apply(this));
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+        return fromPublisher(composer.apply(this));
     }
 
     /**

--- a/src/main/java/io/reactivex/FlowableTransformer.java
+++ b/src/main/java/io/reactivex/FlowableTransformer.java
@@ -27,8 +27,6 @@ public interface FlowableTransformer<Upstream, Downstream> {
      * optionally different element type.
      * @param upstream the upstream Flowable instance
      * @return the transformed Publisher instance
-     * @throws Exception in case the transformation throws, checked exceptions will be wrapped
-     * into a RuntimeException
      */
-    Publisher<Downstream> apply(Flowable<Upstream> upstream) throws Exception;
+    Publisher<Downstream> apply(Flowable<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2010,12 +2010,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Maybe<R> compose(MaybeTransformer<T, R> transformer) {
-        try {
-            return wrap(transformer.apply(this));
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+        return wrap(transformer.apply(this));
     }
 
     /**

--- a/src/main/java/io/reactivex/MaybeTransformer.java
+++ b/src/main/java/io/reactivex/MaybeTransformer.java
@@ -25,8 +25,6 @@ public interface MaybeTransformer<Upstream, Downstream> {
      * optionally different element type.
      * @param upstream the upstream Maybe instance
      * @return the transformed MaybeSource instance
-     * @throws Exception in case the transformation throws, checked exceptions will be wrapped
-     * into a RuntimeException
      */
-    MaybeSource<Downstream> apply(Maybe<Upstream> upstream) throws Exception;
+    MaybeSource<Downstream> apply(Maybe<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -5530,14 +5530,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> compose(ObservableTransformer<T, R> composer) {
-        try {
-            return wrap(composer.apply(this));
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+        return wrap(composer.apply(this));
     }
-
 
     /**
      * Returns a new Observable that emits items resulting from applying a function that you supply to each item

--- a/src/main/java/io/reactivex/ObservableTransformer.java
+++ b/src/main/java/io/reactivex/ObservableTransformer.java
@@ -25,8 +25,6 @@ public interface ObservableTransformer<Upstream, Downstream> {
      * optionally different element type.
      * @param upstream the upstream Observable instance
      * @return the transformed ObservableSource instance
-     * @throws Exception in case the transformation throws, checked exceptions will be wrapped
-     * into a RuntimeException
      */
-    ObservableSource<Downstream> apply(Observable<Upstream> upstream) throws Exception;
+    ObservableSource<Downstream> apply(Observable<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1473,12 +1473,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Single<R> compose(SingleTransformer<T, R> transformer) {
-        try {
-            return wrap(transformer.apply(this));
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+        return wrap(transformer.apply(this));
     }
 
     /**

--- a/src/main/java/io/reactivex/SingleTransformer.java
+++ b/src/main/java/io/reactivex/SingleTransformer.java
@@ -25,8 +25,6 @@ public interface SingleTransformer<Upstream, Downstream> {
      * optionally different element type.
      * @param upstream the upstream Single instance
      * @return the transformed SingleSource instance
-     * @throws Exception in case the transformation throws, checked exceptions will be wrapped
-     * into a RuntimeException
      */
-    SingleSource<Downstream> apply(Single<Upstream> upstream) throws Exception;
+    SingleSource<Downstream> apply(Single<Upstream> upstream);
 }

--- a/src/test/java/io/reactivex/TransformerTest.java
+++ b/src/test/java/io/reactivex/TransformerTest.java
@@ -29,29 +29,13 @@ public class TransformerTest {
         try {
             Flowable.just(1).compose(new FlowableTransformer<Integer, Integer>() {
                 @Override
-                public Publisher<Integer> apply(Flowable<Integer> v) throws Exception {
+                public Publisher<Integer> apply(Flowable<Integer> v) {
                     throw new TestException("Forced failure");
                 }
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
             assertEquals("Forced failure", ex.getMessage());
-        }
-    }
-
-    @Test
-    public void flowableTransformerThrowsChecked() {
-        try {
-            Flowable.just(1).compose(new FlowableTransformer<Integer, Integer>() {
-                @Override
-                public Publisher<Integer> apply(Flowable<Integer> v) throws Exception {
-                    throw new IOException("Forced failure");
-                }
-            });
-            fail("Should have thrown!");
-        } catch (RuntimeException ex) {
-            assertTrue(ex.toString(), ex.getCause() instanceof IOException);
-            assertEquals("Forced failure", ex.getCause().getMessage());
         }
     }
 
@@ -60,29 +44,13 @@ public class TransformerTest {
         try {
             Observable.just(1).compose(new ObservableTransformer<Integer, Integer>() {
                 @Override
-                public Observable<Integer> apply(Observable<Integer> v) throws Exception {
+                public Observable<Integer> apply(Observable<Integer> v) {
                     throw new TestException("Forced failure");
                 }
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
             assertEquals("Forced failure", ex.getMessage());
-        }
-    }
-
-    @Test
-    public void observableTransformerThrowsChecked() {
-        try {
-            Observable.just(1).compose(new ObservableTransformer<Integer, Integer>() {
-                @Override
-                public Observable<Integer> apply(Observable<Integer> v) throws Exception {
-                    throw new IOException("Forced failure");
-                }
-            });
-            fail("Should have thrown!");
-        } catch (RuntimeException ex) {
-            assertTrue(ex.toString(), ex.getCause() instanceof IOException);
-            assertEquals("Forced failure", ex.getCause().getMessage());
         }
     }
 
@@ -91,29 +59,13 @@ public class TransformerTest {
         try {
             Single.just(1).compose(new SingleTransformer<Integer, Integer>() {
                 @Override
-                public Single<Integer> apply(Single<Integer> v) throws Exception {
+                public Single<Integer> apply(Single<Integer> v) {
                     throw new TestException("Forced failure");
                 }
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
             assertEquals("Forced failure", ex.getMessage());
-        }
-    }
-
-    @Test
-    public void singleTransformerThrowsChecked() {
-        try {
-            Single.just(1).compose(new SingleTransformer<Integer, Integer>() {
-                @Override
-                public Single<Integer> apply(Single<Integer> v) throws Exception {
-                    throw new IOException("Forced failure");
-                }
-            });
-            fail("Should have thrown!");
-        } catch (RuntimeException ex) {
-            assertTrue(ex.toString(), ex.getCause() instanceof IOException);
-            assertEquals("Forced failure", ex.getCause().getMessage());
         }
     }
 
@@ -122,29 +74,13 @@ public class TransformerTest {
         try {
             Maybe.just(1).compose(new MaybeTransformer<Integer, Integer>() {
                 @Override
-                public Maybe<Integer> apply(Maybe<Integer> v) throws Exception {
+                public Maybe<Integer> apply(Maybe<Integer> v) {
                     throw new TestException("Forced failure");
                 }
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
             assertEquals("Forced failure", ex.getMessage());
-        }
-    }
-
-    @Test
-    public void maybeTransformerThrowsChecked() {
-        try {
-            Maybe.just(1).compose(new MaybeTransformer<Integer, Integer>() {
-                @Override
-                public Maybe<Integer> apply(Maybe<Integer> v) throws Exception {
-                    throw new IOException("Forced failure");
-                }
-            });
-            fail("Should have thrown!");
-        } catch (RuntimeException ex) {
-            assertTrue(ex.toString(), ex.getCause() instanceof IOException);
-            assertEquals("Forced failure", ex.getCause().getMessage());
         }
     }
 
@@ -153,29 +89,13 @@ public class TransformerTest {
         try {
             Completable.complete().compose(new CompletableTransformer() {
                 @Override
-                public Completable apply(Completable v) throws Exception {
+                public Completable apply(Completable v) {
                     throw new TestException("Forced failure");
                 }
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
             assertEquals("Forced failure", ex.getMessage());
-        }
-    }
-
-    @Test
-    public void completabeTransformerThrowsChecked() {
-        try {
-            Completable.complete().compose(new CompletableTransformer() {
-                @Override
-                public Completable apply(Completable v) throws Exception {
-                    throw new IOException("Forced failure");
-                }
-            });
-            fail("Should have thrown!");
-        } catch (RuntimeException ex) {
-            assertTrue(ex.toString(), ex.getCause() instanceof IOException);
-            assertEquals("Forced failure", ex.getCause().getMessage());
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
@@ -85,7 +85,7 @@ public class SingleMiscTest {
         Single.just(1)
         .compose(new SingleTransformer<Integer, Object>() {
             @Override
-            public SingleSource<Object> apply(Single<Integer> f) throws Exception {
+            public SingleSource<Object> apply(Single<Integer> f) {
                 return f.map(new Function<Integer, Object>() {
                     @Override
                     public Object apply(Integer v) throws Exception {

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -390,7 +390,7 @@ public class MaybeTest {
     public void compose() {
         Maybe.just(1).compose(new MaybeTransformer<Integer, Integer>() {
             @Override
-            public MaybeSource<Integer> apply(Maybe<Integer> m) throws Exception {
+            public MaybeSource<Integer> apply(Maybe<Integer> m) {
                 return m.map(new Function<Integer, Integer>() {
                     @Override
                     public Integer apply(Integer w) throws Exception {


### PR DESCRIPTION
These functions are for transforming the stream shape, not doing work. Any operation that would throw a checked exception should happen inside the stream, not when shaping it.

Closes #4709.
