### PR TITLE
2.x: coverage, cleanup, fixes 10/15-2

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -3034,7 +3034,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns an Observable that emits a Boolean value that indicates whether two ObservableSource sequences are the
+     * Returns a Single that emits a Boolean value that indicates whether two ObservableSource sequences are the
      * same by comparing the items emitted by each ObservableSource pairwise.
      * <p>
      * <img width="640" height="385" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sequenceEqual.png" alt="">
@@ -3049,16 +3049,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the second ObservableSource to compare
      * @param <T>
      *            the type of items emitted by each ObservableSource
-     * @return an Observable that emits a Boolean value that indicates whether the two sequences are the same
+     * @return a Single that emits a Boolean value that indicates whether the two sequences are the same
      * @see <a href="http://reactivex.io/documentation/operators/sequenceequal.html">ReactiveX operators documentation: SequenceEqual</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2) {
+    public static <T> Single<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2) {
         return sequenceEqual(source1, source2, ObjectHelper.equalsPredicate(), bufferSize());
     }
 
     /**
-     * Returns an Observable that emits a Boolean value that indicates whether two ObservableSource sequences are the
+     * Returns a Single that emits a Boolean value that indicates whether two ObservableSource sequences are the
      * same by comparing the items emitted by each ObservableSource pairwise based on the results of a specified
      * equality function.
      * <p>
@@ -3076,18 +3076,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            a function used to compare items emitted by each ObservableSource
      * @param <T>
      *            the type of items emitted by each ObservableSource
-     * @return an Observable that emits a Boolean value that indicates whether the two ObservableSource two sequences
+     * @return a Single that emits a Boolean value that indicates whether the two ObservableSource two sequences
      *         are the same according to the specified function
      * @see <a href="http://reactivex.io/documentation/operators/sequenceequal.html">ReactiveX operators documentation: SequenceEqual</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
+    public static <T> Single<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
             BiPredicate<? super T, ? super T> isEqual) {
         return sequenceEqual(source1, source2, isEqual, bufferSize());
     }
 
     /**
-     * Returns an Observable that emits a Boolean value that indicates whether two ObservableSource sequences are the
+     * Returns a Single that emits a Boolean value that indicates whether two ObservableSource sequences are the
      * same by comparing the items emitted by each ObservableSource pairwise based on the results of a specified
      * equality function.
      * <p>
@@ -3112,17 +3112,17 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/sequenceequal.html">ReactiveX operators documentation: SequenceEqual</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
+    public static <T> Single<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
             BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
         ObjectHelper.requireNonNull(source1, "source1 is null");
         ObjectHelper.requireNonNull(source2, "source2 is null");
         ObjectHelper.requireNonNull(isEqual, "isEqual is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableSequenceEqual<T>(source1, source2, isEqual, bufferSize));
+        return RxJavaPlugins.onAssembly(new ObservableSequenceEqualSingle<T>(source1, source2, isEqual, bufferSize));
     }
 
     /**
-     * Returns an Observable that emits a Boolean value that indicates whether two ObservableSource sequences are the
+     * Returns a Single that emits a Boolean value that indicates whether two ObservableSource sequences are the
      * same by comparing the items emitted by each ObservableSource pairwise.
      * <p>
      * <img width="640" height="385" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sequenceEqual.png" alt="">
@@ -3139,11 +3139,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the number of items to prefetch from the first and second source ObservableSource
      * @param <T>
      *            the type of items emitted by each ObservableSource
-     * @return an Observable that emits a Boolean value that indicates whether the two sequences are the same
+     * @return a Single that emits a Boolean value that indicates whether the two sequences are the same
      * @see <a href="http://reactivex.io/documentation/operators/sequenceequal.html">ReactiveX operators documentation: SequenceEqual</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
+    public static <T> Single<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
             int bufferSize) {
         return sequenceEqual(source1, source2, ObjectHelper.equalsPredicate(), bufferSize);
     }
@@ -6319,7 +6319,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <K> Observable<T> distinct(Function<? super T, K> keySelector, Callable<? extends Collection<? super K>> collectionSupplier) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
-        return ObservableDistinct.withCollection(this, keySelector, collectionSupplier);
+        return new ObservableDistinct<T, K>(this, keySelector, collectionSupplier);
     }
 
     /**
@@ -6338,7 +6338,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> distinctUntilChanged() {
-        return ObservableDistinct.<T>untilChanged(this);
+        return new ObservableDistinctUntilChanged<T>(this, Functions.equalsPredicate());
     }
 
     /**
@@ -6362,7 +6362,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Observable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
-        return ObservableDistinct.untilChanged(this, keySelector);
+        return new ObservableDistinctUntilChanged<T>(this, Functions.equalsPredicate(keySelector));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/disposables/ObserverFullArbiter.java
+++ b/src/main/java/io/reactivex/internal/disposables/ObserverFullArbiter.java
@@ -54,7 +54,8 @@ public final class ObserverFullArbiter<T> extends FullArbiterPad1 implements Dis
 
     @Override
     public boolean isDisposed() {
-        return cancelled;
+        Disposable d = resource;
+        return d != null ? d.isDisposed() : cancelled;
     }
 
     void disposeResource() {

--- a/src/main/java/io/reactivex/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/internal/functions/Functions.java
@@ -637,4 +637,29 @@ public final class Functions {
         return new ListSorter<T>(comparator);
     }
 
+    static final BiPredicate<Object, Object> DEFAULT_EQUALS_PREDICATE = equalsPredicate(Functions.identity());
+
+    @SuppressWarnings("unchecked")
+    public static <T> BiPredicate<T, T> equalsPredicate() {
+        return (BiPredicate<T, T>)DEFAULT_EQUALS_PREDICATE;
+    }
+
+    static final class KeyedEqualsPredicate<T, K> implements BiPredicate<T, T> {
+        final Function<? super T, K> keySelector;
+
+        KeyedEqualsPredicate(Function<? super T, K> keySelector) {
+            this.keySelector = keySelector;
+        }
+
+        @Override
+        public boolean test(T t1, T t2) throws Exception {
+            K k1 = ObjectHelper.requireNonNull(keySelector.apply(t1), "The keySelector returned a null key");
+            K k2 = ObjectHelper.requireNonNull(keySelector.apply(t2), "The keySelector returned a null key");
+            return ObjectHelper.equals(k1, k2);
+        }
+    }
+
+    public static <T, K> BiPredicate<T, T> equalsPredicate(Function<? super T, K> keySelector) {
+        return new KeyedEqualsPredicate<T, K>(keySelector);
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
@@ -18,186 +18,122 @@ import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.*;
-import io.reactivex.functions.*;
-import io.reactivex.internal.disposables.*;
-import io.reactivex.internal.functions.*;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.fuseable.SimpleQueue;
+import io.reactivex.internal.observers.BasicFuseableObserver;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstream<T, T> {
+
     final Function<? super T, K> keySelector;
-    final Callable<? extends Predicate<? super K>> predicateSupplier;
 
-    public ObservableDistinct(ObservableSource<T> source, Function<? super T, K> keySelector, Callable<? extends Predicate<? super K>> predicateSupplier) {
+    final Callable<? extends Collection<? super K>> collectionSupplier;
+
+    public ObservableDistinct(ObservableSource<T> source, Function<? super T, K> keySelector, Callable<? extends Collection<? super K>> collectionSupplier) {
         super(source);
-        this.predicateSupplier = predicateSupplier;
         this.keySelector = keySelector;
+        this.collectionSupplier = collectionSupplier;
     }
-
-    public static <T, K> ObservableDistinct<T, K> withCollection(ObservableSource<T> source, final Function<? super T, K> keySelector, final Callable<? extends Collection<? super K>> collectionSupplier) {
-        Callable<? extends Predicate<? super K>> p = new Callable<Predicate<K>>() {
-            @Override
-            public Predicate<K> call() throws Exception {
-                final Collection<? super K> coll = collectionSupplier.call();
-
-                return new Predicate<K>() {
-                    @Override
-                    public boolean test(K t) {
-                        if (t == null) {
-                            coll.clear();
-                            return true;
-                        }
-                        return coll.add(t);
-                    }
-                };
-            }
-        };
-
-        return new ObservableDistinct<T, K>(source, keySelector, p);
-    }
-
-    public static <T> ObservableDistinct<T, T> untilChanged(ObservableSource<T> source) {
-        Callable<? extends Predicate<? super T>> p = new Callable<Predicate<T>>() {
-            @Override
-            public Predicate<T> call() {
-                final Object[] last = { null };
-
-                return new Predicate<T>() {
-                    @Override
-                    public boolean test(T t) {
-                        if (t == null) {
-                            last[0] = null;
-                            return true;
-                        }
-                        Object o = last[0];
-                        last[0] = t;
-                        return !ObjectHelper.equals(o, t);
-                    }
-                };
-            }
-        };
-        return new ObservableDistinct<T, T>(source, Functions.<T>identity(), p);
-    }
-
-    public static <T, K> ObservableDistinct<T, K> untilChanged(ObservableSource<T> source, Function<? super T, K> keySelector) {
-        Callable<? extends Predicate<? super K>> p = new Callable<Predicate<K>>() {
-            @Override
-            public Predicate<K> call() {
-                final Object[] last = { null };
-
-                return new Predicate<K>() {
-                    @Override
-                    public boolean test(K t) {
-                        if (t == null) {
-                            last[0] = null;
-                            return true;
-                        }
-                        Object o = last[0];
-                        last[0] = t;
-                        return !ObjectHelper.equals(o, t);
-                    }
-                };
-            }
-        };
-        return new ObservableDistinct<T, K>(source, keySelector, p);
-    }
-
 
     @Override
-    public void subscribeActual(Observer<? super T> t) {
-        Predicate<? super K> coll;
+    protected void subscribeActual(Observer<? super T> observer) {
+        Collection<? super K> collection;
+
         try {
-            coll = ObjectHelper.requireNonNull(predicateSupplier.call(), "predicateSupplier returned null");
-        } catch (Throwable e) {
-            Exceptions.throwIfFatal(e);
-            EmptyDisposable.error(e, t);
+            collection = collectionSupplier.call();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
             return;
         }
 
-        source.subscribe(new DistinctObserver<T, K>(t, keySelector, coll));
+        source.subscribe(new DistinctObserver<T, K>(observer, keySelector, collection));
     }
 
-    static final class DistinctObserver<T, K> implements Observer<T>, Disposable {
-        final Observer<? super T> actual;
-        final Predicate<? super K> predicate;
+    static final class DistinctObserver<T, K> extends BasicFuseableObserver<T, T> {
+
+        final Collection<? super K> collection;
+
         final Function<? super T, K> keySelector;
 
-        Disposable s;
+        Disposable d;
 
-        DistinctObserver(Observer<? super T> actual, Function<? super T, K> keySelector, Predicate<? super K> predicate) {
-            this.actual = actual;
+        SimpleQueue<T> queue;
+
+        DistinctObserver(Observer<? super T> actual, Function<? super T, K> keySelector, Collection<? super K> collection) {
+            super(actual);
             this.keySelector = keySelector;
-            this.predicate = predicate;
+            this.collection = collection;
         }
 
         @Override
-        public void onSubscribe(Disposable s) {
-            if (DisposableHelper.validate(this.s, s)) {
-                this.s = s;
-                actual.onSubscribe(this);
+        public void onNext(T value) {
+            if (done) {
+                return;
+            }
+            if (sourceMode == NONE) {
+                K key;
+                boolean b;
+
+                try {
+                    key = ObjectHelper.requireNonNull(keySelector.apply(value), "The keySelector returned a null key");
+                    b = collection.add(key);
+                } catch (Throwable ex) {
+                    fail(ex);
+                    return;
+                }
+
+                if (b) {
+                    actual.onNext(value);
+                }
+            } else {
+                actual.onNext(null);
             }
         }
 
-
         @Override
-        public void dispose() {
-            s.dispose();
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return s.isDisposed();
-        }
-
-        @Override
-        public void onNext(T t) {
-            K key;
-
-            try {
-                key = ObjectHelper.requireNonNull(keySelector.apply(t), "Null key supplied");
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                s.dispose();
+        public void onError(Throwable e) {
+            if (done) {
+                RxJavaPlugins.onError(e);
+            } else {
+                done = true;
+                collection.clear();
                 actual.onError(e);
-                return;
             }
-
-            boolean b;
-            try {
-                b = predicate.test(key);
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                s.dispose();
-                actual.onError(e);
-                return;
-            }
-
-            if (b) {
-                actual.onNext(t);
-            }
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            try {
-                predicate.test(null); // special case: poison pill
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                actual.onError(new CompositeException(t, e));
-                return;
-            }
-            actual.onError(t);
         }
 
         @Override
         public void onComplete() {
-            try {
-                predicate.test(null); // special case: poison pill
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                actual.onError(e);
-                return;
+            if (!done) {
+                done = true;
+                collection.clear();
+                actual.onComplete();
             }
-            actual.onComplete();
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            return transitiveBoundaryFusion(mode);
+        }
+
+        @Override
+        public T poll() throws Exception {
+            for (;;) {
+                T v = qs.poll();
+
+                if (v == null || collection.add(ObjectHelper.requireNonNull(keySelector.apply(v), "The keySelector returned a null key"))) {
+                    return v;
+                }
+            }
+        }
+
+        @Override
+        public void clear() {
+            collection.clear();
+            super.clear();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
@@ -23,8 +23,11 @@ import io.reactivex.observables.ConnectableObservable;
 /**
  * Helper utility class to support Observable with inner classes.
  */
-public enum ObservableInternalHelper {
-    ;
+public final class ObservableInternalHelper {
+
+    private ObservableInternalHelper() {
+        throw new IllegalStateException("No instances!");
+    }
 
     static final class SimpleGenerator<T, S> implements BiFunction<S, Emitter<T>, S> {
         final Consumer<Emitter<T>> consumer;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeInterval.java
@@ -53,6 +53,7 @@ public final class ObservableTimeInterval<T> extends AbstractObservableWithUpstr
         @Override
         public void onSubscribe(Disposable s) {
             if (DisposableHelper.validate(this.s, s)) {
+                this.s = s;
                 lastTime = scheduler.now(unit);
                 actual.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableToListSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableToListSingle.java
@@ -22,6 +22,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.fuseable.FuseToObservable;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -32,15 +33,10 @@ extends Single<U> implements FuseToObservable<U> {
 
     final Callable<U> collectionSupplier;
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public ObservableToListSingle(ObservableSource<T> source, final int defaultCapacityHint) {
         this.source = source;
-        this.collectionSupplier = new Callable<U>() {
-            @Override
-            @SuppressWarnings("unchecked")
-            public U call() throws Exception {
-                return (U)new ArrayList<T>(defaultCapacityHint);
-            }
-        };
+        this.collectionSupplier = (Callable)Functions.createArrayList(defaultCapacityHint);
     }
 
     public ObservableToListSingle(ObservableSource<T> source, Callable<U> collectionSupplier) {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayTest.java
@@ -1,9 +1,16 @@
 /**
- * Concatenate values of each MaybeSource provided in an array and delays
- * any errors till the very end.
+ * Copyright 2016 Netflix, Inc.
  *
- * @param <T> the value type
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
  */
+
 package io.reactivex.internal.operators.maybe;
 
 import java.io.IOException;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCountTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+public class ObservableCountTest {
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).count());
+
+        TestHelper.checkDisposed(Observable.just(1).count().toObservable());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Long>>() {
+            @Override
+            public ObservableSource<Long> apply(Observable<Object> o) throws Exception {
+                return o.count().toObservable();
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeObservableToSingle(new Function<Observable<Object>, SingleSource<Long>>() {
+            @Override
+            public SingleSource<Long> apply(Observable<Object> o) throws Exception {
+                return o.count();
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctTest.java
@@ -13,13 +13,27 @@
 
 package io.reactivex.internal.operators.observable;
 
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.concurrent.Callable;
 
 import org.junit.*;
 import org.mockito.InOrder;
 
-import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.observers.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.UnicastSubject;
 
 public class ObservableDistinctTest {
 
@@ -118,5 +132,110 @@ public class ObservableDistinctTest {
         inOrder.verify(w, times(1)).onError(any(NullPointerException.class));
         inOrder.verify(w, never()).onNext(anyString());
         inOrder.verify(w, never()).onComplete();
+    }
+
+    @Test
+    public void error() {
+        Observable.error(new TestException())
+        .distinct()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void fusedSync() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+
+        Observable.just(1, 1, 2, 1, 3, 2, 4, 5, 4)
+        .distinct()
+        .subscribe(to);
+
+        ObserverFusion.assertFusion(to, QueueDisposable.SYNC)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void fusedAsync() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+
+        UnicastSubject<Integer> us = UnicastSubject.create();
+
+        us
+        .distinct()
+        .subscribe(to);
+
+        TestHelper.emit(us, 1, 1, 2, 1, 3, 2, 4, 5, 4);
+
+        ObserverFusion.assertFusion(to, QueueDisposable.ASYNC)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void fusedClear() {
+        Observable.just(1, 1, 2, 1, 3, 2, 4, 5, 4)
+        .distinct()
+        .subscribe(new Observer<Integer>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                QueueDisposable<?> qd = (QueueDisposable<?>)d;
+
+                assertFalse(qd.isEmpty());
+
+                qd.clear();
+
+                assertTrue(qd.isEmpty());
+            }
+
+            @Override
+            public void onNext(Integer value) {
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+    }
+
+    @Test
+    public void collectionSupplierThrows() {
+        Observable.just(1)
+        .distinct(Functions.identity(), new Callable<Collection<Object>>() {
+            @Override
+            public Collection<Object> call() throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void badSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+
+                    observer.onNext(1);
+                    observer.onComplete();
+                    observer.onNext(2);
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .distinct()
+            .test()
+            .assertResult(1);
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromIterableTest.java
@@ -13,7 +13,8 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -25,7 +26,11 @@ import org.mockito.Mockito;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.util.CrashingIterable;
 import io.reactivex.observers.*;
 
 public class ObservableFromIterableTest {
@@ -242,5 +247,106 @@ public class ObservableFromIterableTest {
         to.assertValues(1, 2, 2, 3, 3, 4, 4, 5);
         to.assertNoErrors();
         to.assertComplete();
+    }
+
+    @Test
+    public void iteratorThrows() {
+        Observable.fromIterable(new CrashingIterable(1, 100, 100))
+        .test()
+        .assertFailureAndMessage(TestException.class, "iterator()");
+    }
+
+    @Test
+    public void hasNext2Throws() {
+        Observable.fromIterable(new CrashingIterable(100, 2, 100))
+        .test()
+        .assertFailureAndMessage(TestException.class, "hasNext()", 0);
+    }
+
+    @Test
+    public void hasNextCancels() {
+        final TestObserver<Integer> to = new TestObserver<Integer>();
+
+        Observable.fromIterable(new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    int count;
+
+                    @Override
+                    public boolean hasNext() {
+                        if (++count == 2) {
+                            to.cancel();
+                        }
+                        return true;
+                    }
+
+                    @Override
+                    public Integer next() {
+                        return 1;
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        })
+        .subscribe(to);
+
+        to.assertValue(1)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+
+    @Test
+    public void fusionRejected() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ASYNC);
+
+        Observable.fromIterable(Arrays.asList(1, 2, 3))
+        .subscribe(to);
+
+        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void fusionClear() {
+        Observable.fromIterable(Arrays.asList(1, 2, 3))
+        .subscribe(new Observer<Integer>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                @SuppressWarnings("unchecked")
+                QueueDisposable<Integer> qd = (QueueDisposable<Integer>)d;
+
+                qd.requestFusion(QueueDisposable.ANY);
+
+                try {
+                    assertEquals(1, qd.poll().intValue());
+                } catch (Throwable ex) {
+                    fail(ex.toString());
+                }
+
+                qd.clear();
+                try {
+                    assertNull(qd.poll());
+                } catch (Throwable ex) {
+                    fail(ex.toString());
+                }
+            }
+
+            @Override
+            public void onNext(Integer value) {
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableInternalHelperTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableInternalHelperTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+
+public class ObservableInternalHelperTest {
+
+    @Test
+    public void utilityClass() {
+        TestHelper.checkUtilityClass(ObservableInternalHelper.class);
+    }
+
+    @Test
+    public void enums() {
+        assertNotNull(ObservableInternalHelper.MapToInt.values()[0]);
+        assertNotNull(ObservableInternalHelper.MapToInt.valueOf("INSTANCE"));
+
+        assertNotNull(ObservableInternalHelper.ErrorMapperFilter.values()[0]);
+        assertNotNull(ObservableInternalHelper.ErrorMapperFilter.valueOf("INSTANCE"));
+    }
+
+    @Test
+    public void mapToInt() throws Exception {
+        assertEquals(0, ObservableInternalHelper.MapToInt.INSTANCE.apply(null));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableLastTest.java
@@ -299,7 +299,14 @@ public class ObservableLastTest {
 
     @Test
     public void dispose() {
+        TestHelper.checkDisposed(Observable.never().lastElement().toObservable());
         TestHelper.checkDisposed(Observable.never().lastElement());
+
+        TestHelper.checkDisposed(Observable.just(1).lastOrError().toObservable());
+        TestHelper.checkDisposed(Observable.just(1).lastOrError());
+
+        TestHelper.checkDisposed(Observable.just(1).last(2).toObservable());
+        TestHelper.checkDisposed(Observable.just(1).last(2));
     }
 
     @Test
@@ -308,6 +315,38 @@ public class ObservableLastTest {
             @Override
             public MaybeSource<Object> apply(Observable<Object> o) throws Exception {
                 return o.lastElement();
+            }
+        });
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.lastElement().toObservable();
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeObservableToSingle(new Function<Observable<Object>, SingleSource<Object>>() {
+            @Override
+            public SingleSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.lastOrError();
+            }
+        });
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.lastOrError().toObservable();
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeObservableToSingle(new Function<Observable<Object>, SingleSource<Object>>() {
+            @Override
+            public SingleSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.last(2);
+            }
+        });
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.last(2).toObservable();
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 
 import org.junit.*;
@@ -21,12 +22,159 @@ import org.mockito.InOrder;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.BiPredicate;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.subjects.PublishSubject;
 
 public class ObservableSequenceEqualTest {
 
     @Test
-    public void test1() {
+    public void test1Observable() {
         Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.just("one", "two", "three"),
+                Observable.just("one", "two", "three")).toObservable();
+        verifyResult(o, true);
+    }
+
+    @Test
+    public void test2Observable() {
+        Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.just("one", "two", "three"),
+                Observable.just("one", "two", "three", "four")).toObservable();
+        verifyResult(o, false);
+    }
+
+    @Test
+    public void test3Observable() {
+        Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.just("one", "two", "three", "four"),
+                Observable.just("one", "two", "three")).toObservable();
+        verifyResult(o, false);
+    }
+
+    @Test
+    public void testWithError1Observable() {
+        Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.concat(Observable.just("one"),
+                        Observable.<String> error(new TestException())),
+                Observable.just("one", "two", "three")).toObservable();
+        verifyError(o);
+    }
+
+    @Test
+    public void testWithError2Observable() {
+        Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.just("one", "two", "three"),
+                Observable.concat(Observable.just("one"),
+                        Observable.<String> error(new TestException()))).toObservable();
+        verifyError(o);
+    }
+
+    @Test
+    public void testWithError3Observable() {
+        Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.concat(Observable.just("one"),
+                        Observable.<String> error(new TestException())),
+                Observable.concat(Observable.just("one"),
+                        Observable.<String> error(new TestException()))).toObservable();
+        verifyError(o);
+    }
+
+    @Test
+    public void testWithEmpty1Observable() {
+        Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.<String> empty(),
+                Observable.just("one", "two", "three")).toObservable();
+        verifyResult(o, false);
+    }
+
+    @Test
+    public void testWithEmpty2Observable() {
+        Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.just("one", "two", "three"),
+                Observable.<String> empty()).toObservable();
+        verifyResult(o, false);
+    }
+
+    @Test
+    public void testWithEmpty3Observable() {
+        Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.<String> empty(), Observable.<String> empty()).toObservable();
+        verifyResult(o, true);
+    }
+
+    @Test
+    @Ignore("Null values not allowed")
+    public void testWithNull1Observable() {
+        Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.just((String) null), Observable.just("one")).toObservable();
+        verifyResult(o, false);
+    }
+
+    @Test
+    @Ignore("Null values not allowed")
+    public void testWithNull2Observable() {
+        Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.just((String) null), Observable.just((String) null)).toObservable();
+        verifyResult(o, true);
+    }
+
+    @Test
+    public void testWithEqualityErrorObservable() {
+        Observable<Boolean> o = Observable.sequenceEqual(
+                Observable.just("one"), Observable.just("one"),
+                new BiPredicate<String, String>() {
+                    @Override
+                    public boolean test(String t1, String t2) {
+                        throw new TestException();
+                    }
+                }).toObservable();
+        verifyError(o);
+    }
+
+    private void verifyResult(Single<Boolean> o, boolean result) {
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
+
+        o.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onSuccess(result);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    private void verifyError(Observable<Boolean> observable) {
+        Observer<Boolean> observer = TestHelper.mockObserver();
+        observable.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(isA(TestException.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    private void verifyError(Single<Boolean> observable) {
+        SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
+        observable.subscribe(observer);
+
+        InOrder inOrder = inOrder(observer);
+        inOrder.verify(observer, times(1)).onError(isA(TestException.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void prefetchObservable() {
+        Observable.sequenceEqual(Observable.range(1, 20), Observable.range(1, 20), 2)
+        .toObservable()
+        .test()
+        .assertResult(true);
+    }
+
+    @Test
+    public void disposedObservable() {
+        TestHelper.checkDisposed(Observable.sequenceEqual(Observable.just(1), Observable.just(2)).toObservable());
+    }
+
+    @Test
+    public void test1() {
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.just("one", "two", "three"),
                 Observable.just("one", "two", "three"));
         verifyResult(o, true);
@@ -34,7 +182,7 @@ public class ObservableSequenceEqualTest {
 
     @Test
     public void test2() {
-        Observable<Boolean> o = Observable.sequenceEqual(
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.just("one", "two", "three"),
                 Observable.just("one", "two", "three", "four"));
         verifyResult(o, false);
@@ -42,7 +190,7 @@ public class ObservableSequenceEqualTest {
 
     @Test
     public void test3() {
-        Observable<Boolean> o = Observable.sequenceEqual(
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.just("one", "two", "three", "four"),
                 Observable.just("one", "two", "three"));
         verifyResult(o, false);
@@ -50,7 +198,7 @@ public class ObservableSequenceEqualTest {
 
     @Test
     public void testWithError1() {
-        Observable<Boolean> o = Observable.sequenceEqual(
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.concat(Observable.just("one"),
                         Observable.<String> error(new TestException())),
                 Observable.just("one", "two", "three"));
@@ -59,7 +207,7 @@ public class ObservableSequenceEqualTest {
 
     @Test
     public void testWithError2() {
-        Observable<Boolean> o = Observable.sequenceEqual(
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.just("one", "two", "three"),
                 Observable.concat(Observable.just("one"),
                         Observable.<String> error(new TestException())));
@@ -68,7 +216,7 @@ public class ObservableSequenceEqualTest {
 
     @Test
     public void testWithError3() {
-        Observable<Boolean> o = Observable.sequenceEqual(
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.concat(Observable.just("one"),
                         Observable.<String> error(new TestException())),
                 Observable.concat(Observable.just("one"),
@@ -78,7 +226,7 @@ public class ObservableSequenceEqualTest {
 
     @Test
     public void testWithEmpty1() {
-        Observable<Boolean> o = Observable.sequenceEqual(
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.<String> empty(),
                 Observable.just("one", "two", "three"));
         verifyResult(o, false);
@@ -86,7 +234,7 @@ public class ObservableSequenceEqualTest {
 
     @Test
     public void testWithEmpty2() {
-        Observable<Boolean> o = Observable.sequenceEqual(
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.just("one", "two", "three"),
                 Observable.<String> empty());
         verifyResult(o, false);
@@ -94,7 +242,7 @@ public class ObservableSequenceEqualTest {
 
     @Test
     public void testWithEmpty3() {
-        Observable<Boolean> o = Observable.sequenceEqual(
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.<String> empty(), Observable.<String> empty());
         verifyResult(o, true);
     }
@@ -102,7 +250,7 @@ public class ObservableSequenceEqualTest {
     @Test
     @Ignore("Null values not allowed")
     public void testWithNull1() {
-        Observable<Boolean> o = Observable.sequenceEqual(
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.just((String) null), Observable.just("one"));
         verifyResult(o, false);
     }
@@ -110,14 +258,14 @@ public class ObservableSequenceEqualTest {
     @Test
     @Ignore("Null values not allowed")
     public void testWithNull2() {
-        Observable<Boolean> o = Observable.sequenceEqual(
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.just((String) null), Observable.just((String) null));
         verifyResult(o, true);
     }
 
     @Test
     public void testWithEqualityError() {
-        Observable<Boolean> o = Observable.sequenceEqual(
+        Single<Boolean> o = Observable.sequenceEqual(
                 Observable.just("one"), Observable.just("one"),
                 new BiPredicate<String, String>() {
                     @Override
@@ -139,19 +287,84 @@ public class ObservableSequenceEqualTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    private void verifyError(Observable<Boolean> observable) {
-        Observer<Boolean> observer = TestHelper.mockObserver();
-        observable.subscribe(observer);
-
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(isA(TestException.class));
-        inOrder.verifyNoMoreInteractions();
-    }
-
     @Test
     public void prefetch() {
         Observable.sequenceEqual(Observable.range(1, 20), Observable.range(1, 20), 2)
         .test()
         .assertResult(true);
+    }
+
+    @Test
+    public void disposed() {
+        TestHelper.checkDisposed(Observable.sequenceEqual(Observable.just(1), Observable.just(2)));
+    }
+
+    @Test
+    public void simpleInequal() {
+        Observable.sequenceEqual(Observable.just(1), Observable.just(2))
+        .test()
+        .assertResult(false);
+    }
+
+    @Test
+    public void simpleInequalObservable() {
+        Observable.sequenceEqual(Observable.just(1), Observable.just(2))
+        .toObservable()
+        .test()
+        .assertResult(false);
+    }
+
+    @Test
+    public void onNextCancelRace() {
+        for (int i = 0; i < 500; i++) {
+            final PublishSubject<Integer> ps = PublishSubject.create();
+
+            final TestObserver<Boolean> to = Observable.sequenceEqual(Observable.never(), ps).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    to.cancel();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ps.onNext(1);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            to.assertEmpty();
+        }
+    }
+
+    @Test
+    public void onNextCancelRaceObservable() {
+        for (int i = 0; i < 500; i++) {
+            final PublishSubject<Integer> ps = PublishSubject.create();
+
+            final TestObserver<Boolean> to = Observable.sequenceEqual(Observable.never(), ps).toObservable().test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    to.cancel();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ps.onNext(1);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            to.assertEmpty();
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeIntervalTest.java
@@ -21,6 +21,7 @@ import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.*;
@@ -121,4 +122,17 @@ public class ObservableTimeIntervalTest {
         }
     }
 
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).timeInterval());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void error() {
+        Observable.error(new TestException())
+        .timeInterval()
+        .test()
+        .assertFailure(TestException.class);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
@@ -188,6 +188,8 @@ public class ObservableToListTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Observable.just(1).toList().toObservable());
+
+        TestHelper.checkDisposed(Observable.just(1).toList());
     }
 
     @SuppressWarnings("unchecked")
@@ -196,6 +198,15 @@ public class ObservableToListTest {
         Observable.error(new TestException())
         .toList()
         .toObservable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void errorSingle() {
+        Observable.error(new TestException())
+        .toList()
         .test()
         .assertFailure(TestException.class);
     }
@@ -211,6 +222,20 @@ public class ObservableToListTest {
             }
         })
         .toObservable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void singleCollectionSupplierThrows() {
+        Observable.just(1)
+        .toList(new Callable<Collection<Integer>>() {
+            @Override
+            public Collection<Integer> call() throws Exception {
+                throw new TestException();
+            }
+        })
         .test()
         .assertFailure(TestException.class);
     }

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1259,7 +1259,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void distinctUntilChangedFunctionReturnsNull() {
-        just1.distinctUntilChanged(new Function<Integer, Object>() {
+        Observable.range(1, 2).distinctUntilChanged(new Function<Integer, Object>() {
             @Override
             public Object apply(Integer v) {
                 return null;


### PR DESCRIPTION
- more `Observable` coverage
- make `Observable.sequenceEqual` return `Single<Boolean>`
- reimplement `Observable.distinct()`
- fix `Observable.combineLatest` error management
- remove or compact unused code paths
- fix `Observable.flatMap` maxConcurrency behavior with scalars, use of unbounded queue
- fix `Observable.timeInterval` not saving the `Disposable` 
