### PR TITLE
1.x: fix subscribe(Action1 [, Action1]) to report isUnsubscribed

### DIFF
--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -1535,19 +1535,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      */
     public final Subscription subscribe() {
-        return subscribe(new SingleSubscriber<T>() {
-
-            @Override
-            public final void onError(Throwable e) {
-                throw new OnErrorNotImplementedException(e);
-            }
-
-            @Override
-            public final void onSuccess(T args) {
-                // do nothing
-            }
-
-        });
+        return subscribe(Actions.empty(), Actions.errorNotImplemented());
     }
 
     /**
@@ -1567,23 +1555,7 @@ public class Single<T> {
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      */
     public final Subscription subscribe(final Action1<? super T> onSuccess) {
-        if (onSuccess == null) {
-            throw new IllegalArgumentException("onSuccess can not be null");
-        }
-
-        return subscribe(new SingleSubscriber<T>() {
-
-            @Override
-            public final void onError(Throwable e) {
-                throw new OnErrorNotImplementedException(e);
-            }
-
-            @Override
-            public final void onSuccess(T args) {
-                onSuccess.call(args);
-            }
-
-        });
+        return subscribe(onSuccess, Actions.errorNotImplemented());
     }
 
     /**
@@ -1617,12 +1589,20 @@ public class Single<T> {
 
             @Override
             public final void onError(Throwable e) {
-                onError.call(e);
+                try {
+                    onError.call(e);
+                } finally {
+                    unsubscribe();
+                }
             }
 
             @Override
             public final void onSuccess(T args) {
-                onSuccess.call(args);
+                try {
+                    onSuccess.call(args);
+                } finally {
+                    unsubscribe();
+                }
             }
 
         });

--- a/src/main/java/rx/functions/Actions.java
+++ b/src/main/java/rx/functions/Actions.java
@@ -15,6 +15,8 @@
  */
 package rx.functions;
 
+import rx.exceptions.OnErrorNotImplementedException;
+
 /**
  * Utility class for the Action interfaces.
  */
@@ -565,5 +567,21 @@ public final class Actions {
         public void call(T t) {
             action.call();
         }
+    }
+
+    enum NotImplemented implements Action1<Throwable> {
+        INSTANCE;
+        @Override
+        public void call(Throwable t) {
+            throw new OnErrorNotImplementedException(t);
+        }
+    }
+
+    /**
+     * Returns an action which throws OnErrorNotImplementedException.
+     * @return the the shared action
+     */
+    public static Action1<Throwable> errorNotImplemented() {
+        return NotImplemented.INSTANCE;
     }
 }

--- a/src/test/java/rx/SingleTest.java
+++ b/src/test/java/rx/SingleTest.java
@@ -2136,4 +2136,51 @@ public class SingleTest {
 
         assertEquals(1, atomicInteger.get());
     }
+
+    @Test
+    public void isUnsubscribedAfterSuccess() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        final int[] calls = { 0 };
+
+        Subscription s = ps.toSingle().subscribe(new Action1<Integer>() {
+            @Override
+            public void call(Integer t) {
+                calls[0]++;
+            }
+        });
+
+        assertFalse(s.isUnsubscribed());
+
+        ps.onNext(1);
+        ps.onCompleted();
+
+        assertTrue(s.isUnsubscribed());
+
+        assertEquals(1, calls[0]);
+    }
+
+    @Test
+    public void isUnsubscribedAfterError() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        final int[] calls = { 0 };
+
+        Action1<Integer> a = Actions.empty();
+
+        Subscription s = ps.toSingle().subscribe(a, new Action1<Throwable>() {
+            @Override
+            public void call(Throwable t) {
+                calls[0]++;
+            }
+        });
+
+        assertFalse(s.isUnsubscribed());
+
+        ps.onError(new TestException());
+
+        assertTrue(s.isUnsubscribed());
+
+        assertEquals(1, calls[0]);
+    }
 }


### PR DESCRIPTION
The lambda version didn't report `isUnsubscribed()` as before because of the removal of the `SafeSubscriber` wrapping. This PR makes sure it reports consistently again.

Repored in: #4715

Note that there is no `unsafeSubscribe(SingleSubscriber)` so a regular `subscribe(SingleSubscriber)` by default won't report `isUnsubscribed() == true` unless the implementation of `onSuccess` and `onError` - controlled by the user - doesn't call `unsubscribe` on itself.
