### PR TITLE
2.x: Distinct Operator - delegate null Collection down to onError

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -44,7 +44,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
         Collection<? super K> collection;
 
         try {
-            collection = collectionSupplier.call();
+            collection = ObjectHelper.requireNonNull(collectionSupplier.call(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptySubscription.error(ex, observer);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
@@ -43,7 +43,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
         Collection<? super K> collection;
 
         try {
-            collection = collectionSupplier.call();
+            collection = ObjectHelper.requireNonNull(collectionSupplier.call(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptyDisposable.error(ex, observer);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
@@ -213,6 +213,20 @@ public class FlowableDistinctTest {
     }
 
     @Test
+    public void collectionSupplierIsNull() {
+        Flowable.just(1)
+        .distinct(Functions.identity(), new Callable<Collection<Object>>() {
+            @Override
+            public Collection<Object> call() throws Exception {
+                return null;
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class)
+        .assertErrorMessage("The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+    }
+
+    @Test
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctTest.java
@@ -214,6 +214,20 @@ public class ObservableDistinctTest {
     }
 
     @Test
+    public void collectionSupplierIsNull() {
+        Observable.just(1)
+        .distinct(Functions.identity(), new Callable<Collection<Object>>() {
+            @Override
+            public Collection<Object> call() throws Exception {
+                return null;
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class)
+        .assertErrorMessage("The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+    }
+
+    @Test
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {


### PR DESCRIPTION
- returning null as a Collection in the callable didn't go to onError
- adopted flowable & observable
