### PR TITLE
2.x: remove variance from the input source of retryWhen

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -1415,7 +1415,7 @@ public abstract class Completable implements CompletableSource {
      * @throws NullPointerException if handler is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable retryWhen(Function<? super Flowable<? extends Throwable>, ? extends Publisher<Object>> handler) {
+    public final Completable retryWhen(Function<? super Flowable<Throwable>, ? extends Publisher<Object>> handler) {
         return fromPublisher(toFlowable().retryWhen(handler));
     }
 

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -11105,7 +11105,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> retryWhen(
-            final Function<? super Flowable<? extends Throwable>, ? extends Publisher<?>> handler) {
+            final Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
         ObjectHelper.requireNonNull(handler, "handler is null");
 
         return RxJavaPlugins.onAssembly(new FlowableRetryWhen<T>(this, handler));

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3390,7 +3390,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> retryWhen(
-            final Function<? super Flowable<? extends Throwable>, ? extends Publisher<?>> handler) {
+            final Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
         return toFlowable().retryWhen(handler).singleElement();
     }
 

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -9196,7 +9196,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> retryWhen(
-            final Function<? super Observable<? extends Throwable>, ? extends ObservableSource<?>> handler) {
+            final Function<? super Observable<Throwable>, ? extends ObservableSource<?>> handler) {
         ObjectHelper.requireNonNull(handler, "handler is null");
         return RxJavaPlugins.onAssembly(new ObservableRedo<T>(this, ObservableInternalHelper.retryWhenHandler(handler)));
     }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2396,7 +2396,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the new Single instance
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> retryWhen(Function<? super Flowable<? extends Throwable>, ? extends Publisher<Object>> handler) {
+    public final Single<T> retryWhen(Function<? super Flowable<Throwable>, ? extends Publisher<Object>> handler) {
         return toSingle(toFlowable().retryWhen(handler));
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
@@ -277,10 +277,10 @@ public final class ObservableInternalHelper {
 
     static final class RetryWhenInner
     implements Function<Observable<Notification<Object>>, ObservableSource<?>> {
-        private final Function<? super Observable<? extends Throwable>, ? extends ObservableSource<?>> handler;
+        private final Function<? super Observable<Throwable>, ? extends ObservableSource<?>> handler;
 
         RetryWhenInner(
-                Function<? super Observable<? extends Throwable>, ? extends ObservableSource<?>> handler) {
+                Function<? super Observable<Throwable>, ? extends ObservableSource<?>> handler) {
             this.handler = handler;
         }
 
@@ -293,7 +293,7 @@ public final class ObservableInternalHelper {
         }
     }
 
-    public static <T> Function<Observable<Notification<Object>>, ObservableSource<?>> retryWhenHandler(final Function<? super Observable<? extends Throwable>, ? extends ObservableSource<?>> handler) {
+    public static <T> Function<Observable<Notification<Object>>, ObservableSource<?>> retryWhenHandler(final Function<? super Observable<Throwable>, ? extends ObservableSource<?>> handler) {
         return new RetryWhenInner(handler);
     }
 


### PR DESCRIPTION
The variance of the `retryWhen` operator doesn't infere properly with java 8. This PR removes the `? extends` from the function's input `Observable`.

Reported in: https://twitter.com/HansWurst315/status/788108336285753344
