### PR TITLE
2.x: coverage, fixes, cleanup, copy to Flowable 10/19-1

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -7966,7 +7966,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Modifies an ObservableSource to perform its emissions and notifications on a specified {@link Scheduler},
-     * asynchronously with a bounded buffer of {@link Flowable#bufferSize()} slots.
+     * asynchronously with an unbounded buffer with {@link Flowable#bufferSize()} "island size".
      *
      * <p>Note that onError notifications will cut ahead of onNext notifications on the emission thread if Scheduler is truly
      * asynchronous. If strict event ordering is required, consider using the {@link #observeOn(Scheduler, boolean)} overload.
@@ -7976,7 +7976,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
-     *
+     * <p>"Island size" indicates how large chunks the unbounded buffer allocates to store the excess elements waiting to be consumed
+     * on the other side of the asynchronous boundary.
+     * 
      * @param scheduler
      *            the {@link Scheduler} to notify {@link Observer}s on
      * @return the source ObservableSource modified so that its {@link Observer}s are notified on the specified
@@ -7994,13 +7996,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Modifies an ObservableSource to perform its emissions and notifications on a specified {@link Scheduler},
-     * asynchronously with a bounded buffer and optionally delays onError notifications.
+     * asynchronously with an unbounded buffer with {@link Flowable#bufferSize()} "island size" and optionally delays onError notifications.
      * <p>
      * <img width="640" height="308" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/observeOn.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
+     * <p>"Island size" indicates how large chunks the unbounded buffer allocates to store the excess elements waiting to be consumed
+     * on the other side of the asynchronous boundary.
      *
      * @param scheduler
      *            the {@link Scheduler} to notify {@link Observer}s on
@@ -8023,13 +8027,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Modifies an ObservableSource to perform its emissions and notifications on a specified {@link Scheduler},
-     * asynchronously with a bounded buffer of configurable size and optionally delays onError notifications.
+     * asynchronously with an unbounded buffer of configurable "island size" and optionally delays onError notifications.
      * <p>
      * <img width="640" height="308" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/observeOn.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use</dd>
      * </dl>
+     * <p>"Island size" indicates how large chunks the unbounded buffer allocates to store the excess elements waiting to be consumed
+     * on the other side of the asynchronous boundary. Values below 16 are not recommended in performance sensitive scenarios.
      *
      * @param scheduler
      *            the {@link Scheduler} to notify {@link Observer}s on

--- a/src/main/java/io/reactivex/internal/observers/QueueDrainObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/QueueDrainObserver.java
@@ -121,6 +121,11 @@ public abstract class QueueDrainObserver<T, U, V> extends QueueDrainSubscriberPa
             QueueDrainHelper.drainLoop(queue, actual, delayError, dispose, this);
         }
     }
+
+    @Override
+    public void accept(Observer<? super V> a, U v) {
+        // ignored by default
+    }
 }
 
 // -------------------------------------------------------------------

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
@@ -125,7 +125,9 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
             if (!DisposableHelper.isDisposed(d)) {
                 @SuppressWarnings("unchecked")
                 DebounceEmitter<T> de = (DebounceEmitter<T>)d;
-                de.emit();
+                if (de != null) {
+                    de.emit();
+                }
                 DisposableHelper.dispose(timer);
                 worker.dispose();
                 actual.onComplete();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDematerialize.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDematerialize.java
@@ -52,6 +52,9 @@ public final class FlowableDematerialize<T> extends AbstractFlowableWithUpstream
         @Override
         public void onNext(Notification<T> t) {
             if (done) {
+                if (t.isOnError()) {
+                    RxJavaPlugins.onError(t.getError());
+                }
                 return;
             }
             if (t.isOnError()) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
@@ -150,14 +150,12 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
         @Override
         public void onComplete() {
             if (decrementAndGet() == 0) {
-                if (delayErrors) {
-                    Throwable ex = errors.terminate();
-                    if (ex != null) {
-                        actual.onError(ex);
-                        return;
-                    }
+                Throwable ex = errors.terminate();
+                if (ex != null) {
+                    actual.onError(ex);
+                } else {
+                    actual.onComplete();
                 }
-                actual.onComplete();
             } else {
                 if (maxConcurrency != Integer.MAX_VALUE) {
                     s.request(1);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
@@ -159,14 +159,12 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
         @Override
         public void onComplete() {
             if (decrementAndGet() == 0) {
-                if (delayErrors) {
-                    Throwable ex = errors.terminate();
-                    if (ex != null) {
-                        actual.onError(ex);
-                        return;
-                    }
+                Throwable ex = errors.terminate();
+                if (ex != null) {
+                    actual.onError(ex);
+                } else {
+                    actual.onComplete();
                 }
-                actual.onComplete();
             } else {
                 if (maxConcurrency != Integer.MAX_VALUE) {
                     s.request(1);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
@@ -24,6 +24,7 @@ import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableObserveOn<T> extends AbstractFlowableWithUpstream<T, T> {
 final Scheduler scheduler;
@@ -99,6 +100,9 @@ final Scheduler scheduler;
 
         @Override
         public final void onNext(T t) {
+            if (done) {
+                return;
+            }
             if (sourceMode == ASYNC) {
                 trySchedule();
                 return;
@@ -114,6 +118,10 @@ final Scheduler scheduler;
 
         @Override
         public final void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
             error = t;
             done = true;
             trySchedule();
@@ -121,8 +129,10 @@ final Scheduler scheduler;
 
         @Override
         public final void onComplete() {
-            done = true;
-            trySchedule();
+            if (!done) {
+                done = true;
+                trySchedule();
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublish.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublish.java
@@ -97,7 +97,7 @@ public final class FlowablePublish<T> extends ConnectableFlowable<T> implements 
                  * Note: although technically correct, concurrent disconnects can cause
                  * unexpected behavior such as child subscribers never receiving anything
                  * (unless connected again). An alternative approach, similar to
-                 * PublishSubject would be to immediately terminate such child
+                 * PublishProcessor would be to immediately terminate such child
                  * subscribers as well:
                  *
                  * Object term = r.terminalEvent;
@@ -172,7 +172,7 @@ public final class FlowablePublish<T> extends ConnectableFlowable<T> implements 
          * Disposable as subscribe() may never return on its own.
          *
          * Note however, that asynchronously disconnecting a running source might leave
-         * child subscribers without any terminal event; PublishSubject does not have this
+         * child subscribers without any terminal event; PublishProcessor does not have this
          * issue because the cancellation was always triggered by the child subscribers
          * themselves.
          */

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicate.java
@@ -18,6 +18,7 @@ import org.reactivestreams.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableTakeUntilPredicate<T> extends AbstractFlowableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
@@ -75,6 +76,8 @@ public final class FlowableTakeUntilPredicate<T> extends AbstractFlowableWithUps
             if (!done) {
                 done = true;
                 actual.onError(t);
+            } else {
+                RxJavaPlugins.onError(t);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
@@ -196,6 +196,11 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
 
         @Override
         public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
             parent.onError(t);
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -156,15 +156,14 @@ extends AbstractObservableWithUpstream<T, U> {
             U b;
             synchronized (this) {
                 b = buffer;
-                if (b == null) {
-                    return;
-                }
                 buffer = null;
             }
-            queue.offer(b);
-            done = true;
-            if (enter()) {
-                QueueDrainHelper.drainLoop(queue, actual, false, this, this);
+            if (b != null) {
+                queue.offer(b);
+                done = true;
+                if (enter()) {
+                    QueueDrainHelper.drainLoop(queue, actual, false, this, this);
+                }
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
@@ -128,14 +128,12 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
         @Override
         public void onComplete() {
             if (decrementAndGet() == 0) {
-                if (delayErrors) {
-                    Throwable ex = errors.terminate();
-                    if (ex != null) {
-                        actual.onError(ex);
-                        return;
-                    }
+                Throwable ex = errors.terminate();
+                if (ex != null) {
+                    actual.onError(ex);
+                } else {
+                    actual.onComplete();
                 }
-                actual.onComplete();
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupBy.java
@@ -254,12 +254,7 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
         }
 
         public void onNext(T t) {
-            if (t == null) {
-                error = new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
-                done = true;
-            } else {
-                queue.offer(t);
-            }
+            queue.offer(t);
             drain();
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRange.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRange.java
@@ -12,30 +12,30 @@
  */
 package io.reactivex.internal.operators.observable;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import io.reactivex.*;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.observers.BasicIntQueueDisposable;
 
+/**
+ * Emits a range of integer values from start to end.
+ */
 public final class ObservableRange extends Observable<Integer> {
     private final int start;
-    private final int count;
+    private final long end;
 
     public ObservableRange(int start, int count) {
         this.start = start;
-        this.count = count;
+        this.end = (long)start + count;
     }
 
     @Override
     protected void subscribeActual(Observer<? super Integer> o) {
-        RangeDisposable parent = new RangeDisposable(o, start, (long)start + count);
+        RangeDisposable parent = new RangeDisposable(o, start, end);
         o.onSubscribe(parent);
         parent.run();
     }
 
     static final class RangeDisposable
-    extends AtomicInteger
-    implements QueueDisposable<Integer> {
+    extends BasicIntQueueDisposable<Integer> {
 
         private static final long serialVersionUID = 396518478098735504L;
 
@@ -66,16 +66,6 @@ public final class ObservableRange extends Observable<Integer> {
                 lazySet(1);
                 actual.onComplete();
             }
-        }
-
-        @Override
-        public boolean offer(Integer value) {
-            throw new UnsupportedOperationException("Should not be called!");
-        }
-
-        @Override
-        public boolean offer(Integer v1, Integer v2) {
-            throw new UnsupportedOperationException("Should not be called!");
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
@@ -87,6 +87,10 @@ public final class ObservableScanSeed<T, R> extends AbstractObservableWithUpstre
 
         @Override
         public void onNext(T t) {
+            if (done) {
+                return;
+            }
+
             R v = value;
 
             R u;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -24,7 +23,7 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
-import io.reactivex.internal.fuseable.SimpleQueue;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.observers.QueueDrainObserver;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.util.NotificationLite;
@@ -178,7 +177,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
         }
 
         void drainLoop() {
-            final SimpleQueue<Object> q = queue;
+            final MpscLinkedQueue<Object> q = (MpscLinkedQueue<Object>)queue;
             final Observer<? super Observable<T>> a = actual;
             final List<UnicastSubject<T>> ws = this.ws;
             int missed = 1;
@@ -188,18 +187,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
                 for (;;) {
                     boolean d = done;
 
-                    Object o;
-
-                    try {
-                        o = q.poll();
-                    } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        DisposableHelper.dispose(boundary);
-                        for (UnicastSubject<T> w : ws) {
-                            w.onError(ex);
-                        }
-                        return;
-                    }
+                    Object o = q.poll();
 
                     boolean empty = o == null;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -1522,7 +1522,6 @@ public class FlowableBufferTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void dispose() {
         TestHelper.checkDisposed(Flowable.range(1, 5).buffer(1, TimeUnit.DAYS, Schedulers.single()));
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -299,7 +299,6 @@ public class FlowableCacheTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void dispose() {
         TestHelper.checkDisposed(Flowable.range(1, 5).cache());
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1230,7 +1230,6 @@ public class FlowableCombineLatestTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void disposed() {
         TestHelper.checkDisposed(Flowable.combineLatest(Flowable.never(), Flowable.never(), new BiFunction<Object, Object, Object>() {
             @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -831,7 +831,6 @@ public class FlowableConcatMapEagerTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void dispose() {
         TestHelper.checkDisposed(Flowable.just(1).hide().concatMapEager(new Function<Integer, Flowable<Integer>>() {
             @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
@@ -161,7 +161,6 @@ public class FlowableDetachTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void dispose() {
         TestHelper.checkDisposed(Flowable.never().onTerminateDetach());
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.processors.PublishProcessor;
@@ -557,5 +557,15 @@ public class FlowableFlattenIterableTest {
         }, 1)
         .test()
         .assertResult(10, 20);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishProcessor.create().flatMapIterable(new Function<Object, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Object v) throws Exception {
+                return Arrays.asList(10, 20);
+            }
+        }));
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
@@ -113,7 +113,6 @@ public class FlowableGenerateTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void dispose() {
         TestHelper.checkDisposed(Flowable.generate(new Callable<Object>() {
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.*;
 import org.junit.Test;
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.fuseable.QueueSubscription;
@@ -322,5 +322,12 @@ public class FlowableIgnoreElementsTest {
             public void onComplete() {
             }
         });
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Flowable.just(1).ignoreElements());
+
+        TestHelper.checkDisposed(Flowable.just(1).ignoreElements().toFlowable());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalRangeTest.java
@@ -73,4 +73,9 @@ public class FlowableIntervalRangeTest {
             assertEquals("Overflow! start + count is bigger than Long.MAX_VALUE", ex.getMessage());
         }
     }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Flowable.intervalRange(1, 2, 1, 1, TimeUnit.MILLISECONDS));
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
@@ -281,5 +281,20 @@ public class FlowableMaterializeTest {
         ts.assertValueCount(6)
         .assertNoErrors()
         .assertComplete();
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Flowable.just(1).materialize());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Notification<Object>>>() {
+            @Override
+            public Flowable<Notification<Object>> apply(Flowable<Object> o) throws Exception {
+                return o.materialize();
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMulticastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMulticastTest.java
@@ -14,13 +14,11 @@
 package io.reactivex.internal.operators.flowable;
 
 public class FlowableMulticastTest {
-    // FIXME operator multicast not supported
-//
 //    @Test
 //    public void testMulticast() {
-//        Subject<String, String> source = PublishSubject.create();
+//        Processor<String, String> source = PublishProcessor.create();
 //
-//        ConnectableObservable<String> multicasted = new OperatorMulticast<String, String>(source, new PublishSubjectFactory());
+//        ConnectableObservable<String> multicasted = new OperatorMulticast<String, String>(source, new PublishProcessorFactory());
 //
 //        @SuppressWarnings("unchecked")
 //        Observer<String> observer = mock(Observer.class);
@@ -45,9 +43,9 @@ public class FlowableMulticastTest {
 //
 //    @Test
 //    public void testMulticastConnectTwice() {
-//        Subject<String, String> source = PublishSubject.create();
+//        Processor<String, String> source = PublishProcessor.create();
 //
-//        ConnectableObservable<String> multicasted = new OperatorMulticast<String, String>(source, new PublishSubjectFactory());
+//        ConnectableObservable<String> multicasted = new OperatorMulticast<String, String>(source, new PublishProcessorFactory());
 //
 //        @SuppressWarnings("unchecked")
 //        Observer<String> observer = mock(Observer.class);
@@ -71,9 +69,9 @@ public class FlowableMulticastTest {
 //
 //    @Test
 //    public void testMulticastDisconnect() {
-//        Subject<String, String> source = PublishSubject.create();
+//        Processor<String, String> source = PublishProcessor.create();
 //
-//        ConnectableObservable<String> multicasted = new OperatorMulticast<String, String>(source, new PublishSubjectFactory());
+//        ConnectableObservable<String> multicasted = new OperatorMulticast<String, String>(source, new PublishProcessorFactory());
 //
 //        @SuppressWarnings("unchecked")
 //        Observer<String> observer = mock(Observer.class);
@@ -102,11 +100,11 @@ public class FlowableMulticastTest {
 //
 //    }
 //
-//    private static final class PublishSubjectFactory implements Func0<Subject<String, String>> {
+//    private static final class PublishProcessorFactory implements Callable<Processor<String, String>> {
 //
 //        @Override
 //        public Subject<String, String> call() {
-//            return PublishSubject.<String> create();
+//            return PublishProcessor.<String> create();
 //        }
 //
 //    }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -24,6 +25,7 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.functions.Consumer;
+import io.reactivex.internal.fuseable.QueueDisposable;
 import io.reactivex.subscribers.*;
 
 public class FlowableRangeTest {
@@ -276,5 +278,16 @@ public class FlowableRangeTest {
         } catch (IllegalArgumentException ex) {
             assertEquals("count >= 0 required but it was -1", ex.getMessage());
         }
+    }
+
+    @Test
+    public void requestWrongFusion() {
+        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ASYNC);
+
+        Flowable.range(1, 5)
+        .subscribe(to);
+
+        SubscriberFusion.assertFusion(to, QueueDisposable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -595,7 +595,6 @@ public class FlowableRefCountTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void disposed() {
         TestHelper.checkDisposed(Flowable.just(1).publish().refCount());
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
@@ -354,7 +354,7 @@ public class FlowableRetryTest {
         Consumer<Integer> throwException = mock(Consumer.class);
         doThrow(new RuntimeException()).when(throwException).accept(Mockito.anyInt());
 
-        // create a retrying observable based on a PublishSubject
+        // create a retrying observable based on a PublishProcessor
         PublishProcessor<Integer> subject = PublishProcessor.create();
         subject
         // record item

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
@@ -22,6 +23,7 @@ import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
@@ -274,5 +276,20 @@ public class FlowableSampleTest {
         );
         o.throttleLast(1, TimeUnit.MILLISECONDS).subscribe().dispose();
         verify(s).cancel();
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishProcessor.create().sample(1, TimeUnit.SECONDS, new TestScheduler()));
+
+        TestHelper.checkDisposed(PublishProcessor.create().sample(Flowable.never()));
+    }
+
+    @Test
+    public void error() {
+        Flowable.error(new TestException())
+        .sample(1, TimeUnit.SECONDS)
+        .test()
+        .assertFailure(TestException.class);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -359,7 +359,6 @@ public class FlowableSequenceEqualTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void disposedFlowable() {
         TestHelper.checkDisposed(Flowable.sequenceEqual(Flowable.just(1), Flowable.just(2)).toFlowable());
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTest.java
@@ -109,7 +109,6 @@ public class FlowableSkipLastTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void dispose() {
         TestHelper.checkDisposed(Flowable.just(1).skipLast(1));
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
@@ -23,8 +24,10 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.*;
+import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableSkipLastTimedTest {
 
@@ -173,6 +176,55 @@ public class FlowableSkipLastTimedTest {
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishProcessor.create().skipLast(1, TimeUnit.DAYS));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
+            @Override
+            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
+                return o.skipLast(1, TimeUnit.DAYS);
+            }
+        });
+    }
+
+    @Test
+    public void onNextDisposeRace() {
+        TestScheduler scheduler = new TestScheduler();
+        for (int i = 0; i < 500; i++) {
+            final PublishProcessor<Integer> ps = PublishProcessor.create();
+
+            final TestSubscriber<Integer> to = ps.skipLast(1, TimeUnit.DAYS, scheduler).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ps.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    to.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+        }
+    }
+
+    @Test
+    public void errorDelayed() {
+        Flowable.error(new TestException())
+        .skipLast(1, TimeUnit.DAYS, new TestScheduler(), true)
+        .test()
+        .assertFailure(TestException.class);
     }
 
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTest.java
@@ -170,4 +170,9 @@ public class FlowableSkipTest {
         assertEquals(Arrays.asList(6,7,8,9,10), ts.values());
     }
 
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Flowable.just(1).skip(2));
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipUntilTest.java
@@ -19,6 +19,7 @@ import org.junit.*;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
+import io.reactivex.functions.Function;
 import io.reactivex.processors.PublishProcessor;
 
 public class FlowableSkipUntilTest {
@@ -151,5 +152,27 @@ public class FlowableSkipUntilTest {
         verify(observer, never()).onNext(any());
         verify(observer, times(1)).onError(any(Throwable.class));
         verify(observer, never()).onComplete();
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishProcessor.create().skipUntil(PublishProcessor.create()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
+            @Override
+            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
+                return o.skipUntil(Flowable.never());
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
+            @Override
+            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
+                return Flowable.never().skipUntil(o);
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipWhileTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;
@@ -20,7 +21,10 @@ import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
-import io.reactivex.functions.Predicate;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.processors.PublishProcessor;
 
 public class FlowableSkipWhileTest {
 
@@ -128,5 +132,28 @@ public class FlowableSkipWhileTest {
             inOrder.verify(o).onComplete();
             verify(o, never()).onError(any(Throwable.class));
         }
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishProcessor.create().skipWhile(Functions.alwaysFalse()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
+            @Override
+            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
+                return o.skipWhile(Functions.alwaysFalse());
+            }
+        });
+    }
+
+    @Test
+    public void error() {
+        Flowable.error(new TestException())
+        .skipWhile(Functions.alwaysFalse())
+        .test()
+        .assertFailure(TestException.class);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
@@ -24,6 +24,8 @@ import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
@@ -315,5 +317,37 @@ public class FlowableTakeLastTest {
                 request(Long.MAX_VALUE - 1);
             }});
         assertEquals(50, list.size());
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Flowable.range(1, 10).takeLast(5));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
+            @Override
+            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
+                return o.takeLast(5);
+            }
+        });
+    }
+
+    @Test
+    public void error() {
+        Flowable.error(new TestException())
+        .takeLast(5)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void takeLastTake() {
+        Flowable.range(1, 10)
+        .takeLast(5)
+        .take(2)
+        .test()
+        .assertResult(6, 7);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
@@ -277,4 +277,9 @@ public class FlowableTakeUntilTest {
         assertFalse("Until still has observers", until.hasSubscribers());
         assertFalse("TestSubscriber is unsubscribed", ts.isCancelled());
     }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishProcessor.create().takeUntil(Flowable.never()));
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
@@ -163,7 +163,6 @@ public class FlowableThrottleFirstTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void dispose() {
         TestHelper.checkDisposed(Flowable.just(1).throttleFirst(1, TimeUnit.DAYS));
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeIntervalTest.java
@@ -124,7 +124,6 @@ public class FlowableTimeIntervalTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void dispose() {
         TestHelper.checkDisposed(Flowable.just(1).timeInterval());
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -387,7 +387,6 @@ public class FlowableTimeoutTests {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void disposed() {
         TestHelper.checkDisposed(PublishProcessor.create().timeout(1, TimeUnit.DAYS));
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimerTest.java
@@ -284,7 +284,6 @@ public class FlowableTimerTest {
     }
 
     @Test
-    @Ignore("RS Subscription no isCancelled")
     public void disposed() {
         TestHelper.checkDisposed(Flowable.timer(1, TimeUnit.DAYS));
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
@@ -121,7 +121,7 @@ public class FlowableToListTest {
         ts.assertComplete();
     }
     @Test(timeout = 2000)
-    @Ignore("PublishSubject no longer emits without requests so this test fails due to the race of onComplete and request")
+    @Ignore("PublishProcessor no longer emits without requests so this test fails due to the race of onComplete and request")
     public void testAsyncRequestedFlowable() {
         Scheduler.Worker w = Schedulers.newThread().createWorker();
         try {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
@@ -92,7 +92,7 @@ public class FlowableToSortedListTest {
     }
 
     @Test(timeout = 2000)
-    @Ignore("PublishSubject no longer emits without requests so this test fails due to the race of onComplete and request")
+    @Ignore("PublishProcessor no longer emits without requests so this test fails due to the race of onComplete and request")
     public void testAsyncRequestedFlowable() {
         Scheduler.Worker w = Schedulers.newThread().createWorker();
         try {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -24,8 +25,10 @@ import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 
@@ -325,5 +328,122 @@ public class FlowableWindowWithSizeTest {
                 Arrays.asList(3, 4), Arrays.asList(4, 5), Arrays.asList(5));
         ts.assertNoErrors();
         ts.assertComplete();
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishProcessor.create().window(1));
+
+        TestHelper.checkDisposed(PublishProcessor.create().window(2, 1));
+
+        TestHelper.checkDisposed(PublishProcessor.create().window(1, 2));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Flowable<Object>>>() {
+            @Override
+            public Flowable<Flowable<Object>> apply(Flowable<Object> o) throws Exception {
+                return o.window(1);
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Flowable<Object>>>() {
+            @Override
+            public Flowable<Flowable<Object>> apply(Flowable<Object> o) throws Exception {
+                return o.window(2, 1);
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Flowable<Object>>>() {
+            @Override
+            public Flowable<Flowable<Object>> apply(Flowable<Object> o) throws Exception {
+                return o.window(1, 2);
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void errorExact() {
+        Flowable.error(new TestException())
+        .window(1)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void errorSkip() {
+        Flowable.error(new TestException())
+        .window(1, 2)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void errorOverlap() {
+        Flowable.error(new TestException())
+        .window(2, 1)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void errorExactInner() {
+        @SuppressWarnings("rawtypes")
+        final TestSubscriber[] to = { null };
+        Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
+        .window(2)
+        .doOnNext(new Consumer<Flowable<Integer>>() {
+            @Override
+            public void accept(Flowable<Integer> w) throws Exception {
+                to[0] = w.test();
+            }
+        })
+        .test()
+        .assertError(TestException.class);
+
+        to[0].assertFailure(TestException.class, 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void errorSkipInner() {
+        @SuppressWarnings("rawtypes")
+        final TestSubscriber[] to = { null };
+        Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
+        .window(2, 3)
+        .doOnNext(new Consumer<Flowable<Integer>>() {
+            @Override
+            public void accept(Flowable<Integer> w) throws Exception {
+                to[0] = w.test();
+            }
+        })
+        .test()
+        .assertError(TestException.class);
+
+        to[0].assertFailure(TestException.class, 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void errorOverlapInner() {
+        @SuppressWarnings("rawtypes")
+        final TestSubscriber[] to = { null };
+        Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
+        .window(3, 2)
+        .doOnNext(new Consumer<Flowable<Integer>>() {
+            @Override
+            public void accept(Flowable<Integer> w) throws Exception {
+                to[0] = w.test();
+            }
+        })
+        .test()
+        .assertError(TestException.class);
+
+        to[0].assertFailure(TestException.class, 1);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
@@ -26,6 +26,7 @@ import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.Flowable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
@@ -82,12 +83,12 @@ public class FlowableZipTest {
     }
 
     @Test
-    public void testStartpingDifferentLengthObservableSequences1() {
+    public void testStartpingDifferentLengthFlowableSequences1() {
         Subscriber<String> w = TestHelper.mockSubscriber();
 
-        TestObservable w1 = new TestObservable();
-        TestObservable w2 = new TestObservable();
-        TestObservable w3 = new TestObservable();
+        TestFlowable w1 = new TestFlowable();
+        TestFlowable w2 = new TestFlowable();
+        TestFlowable w3 = new TestFlowable();
 
         Flowable<String> zipW = Flowable.zip(
                 Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2),
@@ -117,12 +118,12 @@ public class FlowableZipTest {
     }
 
     @Test
-    public void testStartpingDifferentLengthObservableSequences2() {
+    public void testStartpingDifferentLengthFlowableSequences2() {
         Subscriber<String> w = TestHelper.mockSubscriber();
 
-        TestObservable w1 = new TestObservable();
-        TestObservable w2 = new TestObservable();
-        TestObservable w3 = new TestObservable();
+        TestFlowable w1 = new TestFlowable();
+        TestFlowable w2 = new TestFlowable();
+        TestFlowable w3 = new TestFlowable();
 
         Flowable<String> zipW = Flowable.zip(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2), Flowable.unsafeCreate(w3), getConcat3StringsZipr());
         zipW.subscribe(w);
@@ -179,7 +180,7 @@ public class FlowableZipTest {
 
         Flowable.zip(r1, r2, zipr2).subscribe(observer);
 
-        /* simulate the Observables pushing data into the aggregator */
+        /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext("world");
 
@@ -205,7 +206,7 @@ public class FlowableZipTest {
 
     @Test
     public void testAggregatorDifferentSizedResultsWithOnComplete() {
-        /* create the aggregator which will execute the zip function when all Observables provide values */
+        /* create the aggregator which will execute the zip function when all Flowables provide values */
         /* define a Subscriber to receive aggregated events */
         PublishProcessor<String> r1 = PublishProcessor.create();
         PublishProcessor<String> r2 = PublishProcessor.create();
@@ -213,7 +214,7 @@ public class FlowableZipTest {
         Subscriber<String> observer = TestHelper.mockSubscriber();
         Flowable.zip(r1, r2, zipr2).subscribe(observer);
 
-        /* simulate the Observables pushing data into the aggregator */
+        /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext("world");
         r2.onComplete();
@@ -241,7 +242,7 @@ public class FlowableZipTest {
 
         Flowable.zip(r1, r2, zipr2).subscribe(observer);
 
-        /* simulate the Observables pushing data into the aggregator */
+        /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext(1);
         r2.onComplete();
@@ -270,7 +271,7 @@ public class FlowableZipTest {
 
         Flowable.zip(r1, r2, r3, zipr3).subscribe(observer);
 
-        /* simulate the Observables pushing data into the aggregator */
+        /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext(2);
         r3.onNext(Arrays.asList(5, 6, 7));
@@ -289,7 +290,7 @@ public class FlowableZipTest {
 
         Flowable.zip(r1, r2, zipr2).subscribe(observer);
 
-        /* simulate the Observables pushing data into the aggregator */
+        /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("one");
         r1.onNext("two");
         r1.onNext("three");
@@ -324,7 +325,7 @@ public class FlowableZipTest {
 
         Flowable.zip(r1, r2, zipr2).subscribe(observer);
 
-        /* simulate the Observables pushing data into the aggregator */
+        /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext("world");
 
@@ -352,7 +353,7 @@ public class FlowableZipTest {
 
         Flowable.zip(r1, r2, zipr2).subscribe(ts);
 
-        /* simulate the Observables pushing data into the aggregator */
+        /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext("world");
 
@@ -379,7 +380,7 @@ public class FlowableZipTest {
 
         Flowable.zip(r1, r2, zipr2).subscribe(observer);
 
-        /* simulate the Observables pushing data into the aggregator */
+        /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("one");
         r1.onNext("two");
         r1.onComplete();
@@ -614,7 +615,7 @@ public class FlowableZipTest {
         }
     }
 
-    private static class TestObservable implements Publisher<String> {
+    private static class TestFlowable implements Publisher<String> {
 
         Subscriber<? super String> observer;
 
@@ -808,9 +809,9 @@ public class FlowableZipTest {
     @Test
     public void testStartInfiniteAndFinite() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final CountDownLatch infiniteObservable = new CountDownLatch(1);
+        final CountDownLatch infiniteFlowable = new CountDownLatch(1);
         Flowable<String> os = OBSERVABLE_OF_5_INTEGERS
-                .zipWith(ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(infiniteObservable), new BiFunction<Integer, Integer, String>() {
+                .zipWith(ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(infiniteFlowable), new BiFunction<Integer, Integer, String>() {
 
                     @Override
                     public String apply(Integer a, Integer b) {
@@ -840,7 +841,7 @@ public class FlowableZipTest {
         });
 
         latch.await(1000, TimeUnit.MILLISECONDS);
-        if (!infiniteObservable.await(2000, TimeUnit.MILLISECONDS)) {
+        if (!infiniteFlowable.await(2000, TimeUnit.MILLISECONDS)) {
             throw new RuntimeException("didn't unsubscribe");
         }
 
@@ -930,7 +931,7 @@ public class FlowableZipTest {
     }
 
     @Test
-    public void testStartEmptyObservables() {
+    public void testStartEmptyFlowables() {
 
         Flowable<String> o = Flowable.zip(Flowable.<Integer> empty(), Flowable.<String> empty(), new BiFunction<Integer, String, String>() {
 
@@ -999,8 +1000,8 @@ public class FlowableZipTest {
     public void testBackpressureSync() {
         AtomicInteger generatedA = new AtomicInteger();
         AtomicInteger generatedB = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteObservable(generatedA);
-        Flowable<Integer> o2 = createInfiniteObservable(generatedB);
+        Flowable<Integer> o1 = createInfiniteFlowable(generatedA);
+        Flowable<Integer> o2 = createInfiniteFlowable(generatedB);
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
         Flowable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
@@ -1023,8 +1024,8 @@ public class FlowableZipTest {
     public void testBackpressureAsync() {
         AtomicInteger generatedA = new AtomicInteger();
         AtomicInteger generatedB = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteObservable(generatedA).subscribeOn(Schedulers.computation());
-        Flowable<Integer> o2 = createInfiniteObservable(generatedB).subscribeOn(Schedulers.computation());
+        Flowable<Integer> o1 = createInfiniteFlowable(generatedA).subscribeOn(Schedulers.computation());
+        Flowable<Integer> o2 = createInfiniteFlowable(generatedB).subscribeOn(Schedulers.computation());
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
         Flowable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
@@ -1044,11 +1045,11 @@ public class FlowableZipTest {
     }
 
     @Test
-    public void testDownstreamBackpressureRequestsWithFiniteSyncObservables() {
+    public void testDownstreamBackpressureRequestsWithFiniteSyncFlowables() {
         AtomicInteger generatedA = new AtomicInteger();
         AtomicInteger generatedB = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteObservable(generatedA).take(Flowable.bufferSize() * 2);
-        Flowable<Integer> o2 = createInfiniteObservable(generatedB).take(Flowable.bufferSize() * 2);
+        Flowable<Integer> o1 = createInfiniteFlowable(generatedA).take(Flowable.bufferSize() * 2);
+        Flowable<Integer> o2 = createInfiniteFlowable(generatedB).take(Flowable.bufferSize() * 2);
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
         Flowable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
@@ -1069,11 +1070,11 @@ public class FlowableZipTest {
     }
 
     @Test
-    public void testDownstreamBackpressureRequestsWithInfiniteAsyncObservables() {
+    public void testDownstreamBackpressureRequestsWithInfiniteAsyncFlowables() {
         AtomicInteger generatedA = new AtomicInteger();
         AtomicInteger generatedB = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteObservable(generatedA).subscribeOn(Schedulers.computation());
-        Flowable<Integer> o2 = createInfiniteObservable(generatedB).subscribeOn(Schedulers.computation());
+        Flowable<Integer> o1 = createInfiniteFlowable(generatedA).subscribeOn(Schedulers.computation());
+        Flowable<Integer> o2 = createInfiniteFlowable(generatedB).subscribeOn(Schedulers.computation());
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
         Flowable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
@@ -1094,11 +1095,11 @@ public class FlowableZipTest {
     }
 
     @Test
-    public void testDownstreamBackpressureRequestsWithInfiniteSyncObservables() {
+    public void testDownstreamBackpressureRequestsWithInfiniteSyncFlowables() {
         AtomicInteger generatedA = new AtomicInteger();
         AtomicInteger generatedB = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteObservable(generatedA);
-        Flowable<Integer> o2 = createInfiniteObservable(generatedB);
+        Flowable<Integer> o1 = createInfiniteFlowable(generatedA);
+        Flowable<Integer> o2 = createInfiniteFlowable(generatedB);
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
         Flowable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
@@ -1118,7 +1119,7 @@ public class FlowableZipTest {
         assertTrue(generatedB.get() < (Flowable.bufferSize() * 4));
     }
 
-    private Flowable<Integer> createInfiniteObservable(final AtomicInteger generated) {
+    private Flowable<Integer> createInfiniteFlowable(final AtomicInteger generated) {
         Flowable<Integer> observable = Flowable.fromIterable(new Iterable<Integer>() {
             @Override
             public Iterator<Integer> iterator() {
@@ -1586,5 +1587,32 @@ public class FlowableZipTest {
         .assertResult("123456789");
     }
 
+
+    @Test
+    public void zipArrayMany() {
+        @SuppressWarnings("unchecked")
+        Flowable<Integer>[] arr = new Flowable[10];
+
+        Arrays.fill(arr, Flowable.just(1));
+
+        Flowable.zip(Arrays.asList(arr), new Function<Object[], Object>() {
+            @Override
+            public Object apply(Object[] a) throws Exception {
+                return Arrays.toString(a);
+            }
+        })
+        .test()
+        .assertResult("[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]");
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Flowable.zip(Flowable.just(1), Flowable.just(1), new BiFunction<Integer, Integer, Object>() {
+            @Override
+            public Object apply(Integer a, Integer b) throws Exception {
+                return a + b;
+            }
+        }));
+    }
 
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
@@ -22,9 +22,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 
+import io.reactivex.*;
 import io.reactivex.Observable;
-import io.reactivex.Single;
-import io.reactivex.functions.BiConsumer;
+import io.reactivex.functions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableCollectTest {
@@ -273,5 +273,89 @@ public final class ObservableCollectTest {
         })
         .test()
         .assertResult(new HashSet<Integer>(Arrays.asList(1, 2)));
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.range(1, 3).collect(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                return new ArrayList<Integer>();
+            }
+        }, new BiConsumer<List<Integer>, Integer>() {
+            @Override
+            public void accept(List<Integer> a, Integer b) throws Exception {
+                a.add(b);
+            }
+        }));
+
+        TestHelper.checkDisposed(Observable.range(1, 3).collect(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                return new ArrayList<Integer>();
+            }
+        }, new BiConsumer<List<Integer>, Integer>() {
+            @Override
+            public void accept(List<Integer> a, Integer b) throws Exception {
+                a.add(b);
+            }
+        }).toObservable());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservableToSingle(new Function<Observable<Integer>, SingleSource<List<Integer>>>() {
+            @Override
+            public SingleSource<List<Integer>> apply(Observable<Integer> o) throws Exception {
+                return o.collect(new Callable<List<Integer>>() {
+                    @Override
+                    public List<Integer> call() throws Exception {
+                        return new ArrayList<Integer>();
+                    }
+                }, new BiConsumer<List<Integer>, Integer>() {
+                    @Override
+                    public void accept(List<Integer> a, Integer b) throws Exception {
+                        a.add(b);
+                    }
+                });
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Integer>, ObservableSource<List<Integer>>>() {
+            @Override
+            public ObservableSource<List<Integer>> apply(Observable<Integer> o) throws Exception {
+                return o.collect(new Callable<List<Integer>>() {
+                    @Override
+                    public List<Integer> call() throws Exception {
+                        return new ArrayList<Integer>();
+                    }
+                }, new BiConsumer<List<Integer>, Integer>() {
+                    @Override
+                    public void accept(List<Integer> a, Integer b) throws Exception {
+                        a.add(b);
+                    }
+                }).toObservable();
+            }
+        });
+    }
+
+    @Test
+    public void badSource() {
+        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
+            @Override
+            public Object apply(Observable<Integer> o) throws Exception {
+                return o.collect(new Callable<List<Integer>>() {
+                    @Override
+                    public List<Integer> call() throws Exception {
+                        return new ArrayList<Integer>();
+                    }
+                }, new BiConsumer<List<Integer>, Integer>() {
+                    @Override
+                    public void accept(List<Integer> a, Integer b) throws Exception {
+                        a.add(b);
+                    }
+                }).toObservable();
+            }
+        }, false, 1, 2, Arrays.asList(1));
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
@@ -342,4 +342,38 @@ public class ObservableDebounceTest {
             RxJavaPlugins.reset();
         }
     }
+
+    @Test
+    public void badSourceSelector() {
+        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
+            @Override
+            public Object apply(Observable<Integer> o) throws Exception {
+                return o.debounce(new Function<Integer, ObservableSource<Long>>() {
+                    @Override
+                    public ObservableSource<Long> apply(Integer v) throws Exception {
+                        return Observable.timer(1, TimeUnit.SECONDS);
+                    }
+                });
+            }
+        }, false, 1, 1, 1);
+
+        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
+            @Override
+            public Object apply(final Observable<Integer> o) throws Exception {
+                return Observable.just(1).debounce(new Function<Integer, ObservableSource<Integer>>() {
+                    @Override
+                    public ObservableSource<Integer> apply(Integer v) throws Exception {
+                        return o;
+                    }
+                });
+            }
+        }, false, 1, 1, 1);
+    }
+
+    @Test
+    public void debounceWithEmpty() {
+        Observable.just(1).debounce(Functions.justFunction(Observable.empty()))
+        .test()
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
@@ -169,4 +169,11 @@ public class ObservableIgnoreElementsTest {
 
         TestHelper.checkDisposed(pp.ignoreElements().<Integer>toObservable());
     }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).ignoreElements());
+
+        TestHelper.checkDisposed(Observable.just(1).ignoreElements().toObservable());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableIntervalRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableIntervalRangeTest.java
@@ -71,4 +71,9 @@ public class ObservableIntervalRangeTest {
             assertEquals("Overflow! start + count is bigger than Long.MAX_VALUE", ex.getMessage());
         }
     }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.intervalRange(1, 2, 1, 1, TimeUnit.MILLISECONDS));
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMaterializeTest.java
@@ -24,7 +24,7 @@ import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposables;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.observers.*;
 
 public class ObservableMaterializeTest {
@@ -175,5 +175,20 @@ public class ObservableMaterializeTest {
             });
             t.start();
         }
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).materialize());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Notification<Object>>>() {
+            @Override
+            public ObservableSource<Notification<Object>> apply(Observable<Object> o) throws Exception {
+                return o.materialize();
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRangeTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.functions.Consumer;
+import io.reactivex.internal.fuseable.QueueDisposable;
 import io.reactivex.observers.*;
 
 public class ObservableRangeTest {
@@ -153,4 +154,14 @@ public class ObservableRangeTest {
         }
     }
 
+    @Test
+    public void requestWrongFusion() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ASYNC);
+
+        Observable.range(1, 5)
+        .subscribe(to);
+
+        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableScanTest.java
@@ -237,6 +237,13 @@ public class ObservableScanTest {
                 return a;
             }
         }));
+
+        TestHelper.checkDisposed(PublishSubject.<Integer>create().scan(0, new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer a, Integer b) throws Exception {
+                return a + b;
+            }
+        }));
     }
 
     @Test
@@ -245,6 +252,18 @@ public class ObservableScanTest {
             @Override
             public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
                 return o.scan(new BiFunction<Object, Object, Object>() {
+                    @Override
+                    public Object apply(Object a, Object b) throws Exception {
+                        return a;
+                    }
+                });
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.scan(0, new BiFunction<Object, Object, Object>() {
                     @Override
                     public Object apply(Object a, Object b) throws Exception {
                         return a;
@@ -265,5 +284,20 @@ public class ObservableScanTest {
         })
         .test()
         .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void badSource() {
+        TestHelper.checkBadSourceObservable(new Function<Observable<Object>, Object>() {
+            @Override
+            public Object apply(Observable<Object> o) throws Exception {
+                return o.scan(0, new BiFunction<Object, Object, Object>() {
+                    @Override
+                    public Object apply(Object a, Object b) throws Exception {
+                        return a;
+                    }
+                });
+            }
+        }, false, 1, 1, 0, 0);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipTest.java
@@ -144,4 +144,8 @@ public class ObservableSkipTest {
         assertEquals(Arrays.asList(6,7,8,9,10), ts.values());
     }
 
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).skip(2));
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipUntilTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.*;
 import org.junit.*;
 
 import io.reactivex.*;
+import io.reactivex.functions.Function;
 import io.reactivex.subjects.PublishSubject;
 
 public class ObservableSkipUntilTest {
@@ -150,5 +151,27 @@ public class ObservableSkipUntilTest {
         verify(observer, never()).onNext(any());
         verify(observer, times(1)).onError(any(Throwable.class));
         verify(observer, never()).onComplete();
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishSubject.create().skipUntil(PublishSubject.create()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.skipUntil(Observable.never());
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return Observable.never().skipUntil(o);
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/tck/BaseTck.java
+++ b/src/test/java/io/reactivex/tck/BaseTck.java
@@ -32,7 +32,11 @@ import io.reactivex.exceptions.TestException;
 public abstract class BaseTck<T> extends PublisherVerification<T> {
 
     public BaseTck() {
-        super(new TestEnvironment(25L));
+        this(25L);
+    }
+
+    public BaseTck(long timeout) {
+        super(new TestEnvironment(timeout));
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/ObserveOnTckTest.java
+++ b/src/test/java/io/reactivex/tck/ObserveOnTckTest.java
@@ -22,6 +22,10 @@ import io.reactivex.schedulers.Schedulers;
 @Test
 public class ObserveOnTckTest extends BaseTck<Integer> {
 
+    public ObserveOnTckTest() {
+        super(100L);
+    }
+
     @Override
     public Publisher<Integer> createPublisher(long elements) {
         return FlowableTck.wrap(


### PR DESCRIPTION
- Explain `Observable.observeOn` unboundedness
- improve `Observable` operator coverage
- copy test methods over to `Flowable` operators
- apply fixes to `Flowable` operators
- add missing calls to `RxJavaPlugins.onError()`
- add more time to RS TCK test of `observeOn`
