### PR TITLE
2.x: cleanup, fixes, coverage 10/20-1

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -6139,7 +6139,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> cache() {
-        return FlowableCache.from(this);
+        return cacheWithInitialCapacity(16);
     }
 
     /**
@@ -6201,7 +6201,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> cacheWithInitialCapacity(int initialCapacity) {
         ObjectHelper.verifyPositive(initialCapacity, "initialCapacity");
-        return FlowableCache.from(this, initialCapacity);
+        return RxJavaPlugins.onAssembly(new FlowableCache<T>(this, initialCapacity));
     }
 
     /**
@@ -6466,7 +6466,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             return FlowableScalarXMap.scalarXMap(v, mapper);
         }
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMap<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.IMMEDIATE));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMap<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
     }
 
 
@@ -9633,13 +9633,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param capacity number of slots available in the buffer.
      * @param onOverflow action to execute if an item needs to be buffered, but there are no available slots.  Null is allowed.
      * @param overflowStrategy how should the {@code Publisher} react to buffer overflows.  Null is not allowed.
-     * @return the source {@code Publisher} modified to buffer items up to the given capacity
+     * @return the source {@code Flowable} modified to buffer items up to the given capacity
      * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
      * @since 2.0
      */
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Publisher<T> onBackpressureBuffer(long capacity, Action onOverflow, BackpressureOverflowStrategy overflowStrategy) {
+    public final Flowable<T> onBackpressureBuffer(long capacity, Action onOverflow, BackpressureOverflowStrategy overflowStrategy) {
         ObjectHelper.requireNonNull(overflowStrategy, "strategy is null");
         ObjectHelper.verifyPositive(capacity, "capacity");
         return RxJavaPlugins.onAssembly(new FlowableOnBackpressureBufferStrategy<T>(this, capacity, onOverflow, overflowStrategy));

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
@@ -46,7 +46,7 @@ public final class FlowableDoOnLifecycle<T> extends AbstractFlowableWithUpstream
 
         Subscription s;
 
-        public SubscriptionLambdaSubscriber(Subscriber<? super T> actual,
+        SubscriptionLambdaSubscriber(Subscriber<? super T> actual,
                 Consumer<? super Subscription> onSubscribe,
                 LongConsumer onRequest,
                 Action onCancel) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIntervalRange.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIntervalRange.java
@@ -92,11 +92,10 @@ public final class FlowableIntervalRange extends Flowable<Long> {
                     actual.onNext(c);
 
                     if (c == end) {
-                        try {
+                        if (resource.get() != DisposableHelper.DISPOSED) {
                             actual.onComplete();
-                        } finally {
-                            DisposableHelper.dispose(resource);
                         }
+                        DisposableHelper.dispose(resource);
                         return;
                     }
 
@@ -106,11 +105,8 @@ public final class FlowableIntervalRange extends Flowable<Long> {
                         decrementAndGet();
                     }
                 } else {
-                    try {
-                        actual.onError(new MissingBackpressureException("Can't deliver value " + count + " due to lack of requests"));
-                    } finally {
-                        DisposableHelper.dispose(resource);
-                    }
+                    actual.onError(new MissingBackpressureException("Can't deliver value " + count + " due to lack of requests"));
+                    DisposableHelper.dispose(resource);
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableLift.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableLift.java
@@ -37,20 +37,9 @@ public final class FlowableLift<R, T> extends AbstractFlowableWithUpstream<T, R>
         this.operator = operator;
     }
 
-    /**
-     * Returns the operator of this lift publisher.
-     * @return the operator of this lift publisher
-     */
-    public FlowableOperator<? extends R, ? super T> operator() {
-        return operator;
-    }
-
     @Override
     public void subscribeActual(Subscriber<? super R> s) {
         try {
-            if (s == null) {
-                throw new NullPointerException("Operator " + operator + " received a null Subscriber");
-            }
             Subscriber<? super T> st = operator.apply(s);
 
             if (st == null) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
@@ -264,7 +264,7 @@ public final class FlowableOnBackpressureBufferStrategy<T> extends AbstractFlowa
                     }
                 }
 
-                if (e != 0L && r != Long.MAX_VALUE) {
+                if (e != 0L) {
                     BackpressureHelper.produced(requested, e);
                 }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduce.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduce.java
@@ -13,8 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.NoSuchElementException;
-
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.Exceptions;
@@ -108,7 +106,7 @@ public final class FlowableReduce<T> extends AbstractFlowableWithUpstream<T, T> 
             if (v != null) {
                 complete(v);
             } else {
-                actual.onError(new NoSuchElementException());
+                actual.onComplete();
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
@@ -132,7 +132,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
         @Override
         public void onError(Throwable t) {
             if (done) {
-                RxJavaPlugins.onError(error);
+                RxJavaPlugins.onError(t);
                 return;
             }
             error = t;

--- a/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableIterable.java
@@ -39,7 +39,7 @@ public final class BlockingObservableIterable<T> implements Iterable<T> {
         source.subscribe(it);
         return it;
     }
-    
+
     static final class BlockingObservableIterator<T>
     extends AtomicReference<Disposable>
     implements io.reactivex.Observer<T>, Iterator<T>, Disposable {
@@ -56,7 +56,7 @@ public final class BlockingObservableIterable<T> implements Iterable<T> {
         volatile boolean done;
         Throwable error;
 
-        public BlockingObservableIterator(int batchSize) {
+        BlockingObservableIterator(int batchSize) {
             this.queue = new SpscLinkedArrayQueue<T>(batchSize);
             this.lock = new ReentrantLock();
             this.condition = lock.newCondition();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSampleWithObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSampleWithObservable.java
@@ -80,13 +80,7 @@ public final class ObservableSampleWithObservable<T> extends AbstractObservableW
         }
 
         boolean setOther(Disposable o) {
-            if (other.get() == null) {
-                if (other.compareAndSet(null, o)) {
-                    return true;
-                }
-                o.dispose();
-            }
-            return false;
+            return DisposableHelper.setOnce(other, o);
         }
 
         @Override
@@ -101,12 +95,12 @@ public final class ObservableSampleWithObservable<T> extends AbstractObservableW
         }
 
         public void error(Throwable e) {
-            dispose();
+            s.dispose();
             actual.onError(e);
         }
 
         public void complete() {
-            dispose();
+            s.dispose();
             actual.onComplete();
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -96,7 +96,8 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
                 if (boundary.compareAndSet(null, os)) {
                     windows.getAndIncrement();
                     open.subscribe(os);
-                }            }
+                }
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/util/BackpressureHelper.java
+++ b/src/main/java/io/reactivex/internal/util/BackpressureHelper.java
@@ -121,4 +121,31 @@ public final class BackpressureHelper {
             }
         }
     }
+
+    /**
+     * Atomically subtract the given number (positive, not validated) from the target field if
+     * it doesn't contain Long.MIN_VALUE (indicating some cancelled state).
+     * @param requested the target field holding the current requested amount
+     * @param n the produced element count, positive (not validated)
+     * @return the new amount
+     */
+    public static long producedCancel(AtomicLong requested, long n) {
+        for (;;) {
+            long current = requested.get();
+            if (current == Long.MIN_VALUE) {
+                return Long.MIN_VALUE;
+            }
+            if (current == Long.MAX_VALUE) {
+                return Long.MAX_VALUE;
+            }
+            long update = current - n;
+            if (update < 0L) {
+                RxJavaPlugins.onError(new IllegalStateException("More produced than requested: " + update));
+                update = 0L;
+            }
+            if (requested.compareAndSet(current, update)) {
+                return update;
+            }
+        }
+    }
 }

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -611,17 +611,17 @@ public enum TestHelper {
 
                 s.cancel();
             }
-            
+
             @Override
             public void onNext(Object t) {
                 ts.onNext(t);
             }
-            
+
             @Override
             public void onError(Throwable t) {
                 ts.onError(t);
             }
-            
+
             @Override
             public void onComplete() {
                 ts.onComplete();

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -271,10 +271,7 @@ public class FlowableTests {
         verify(w).onNext(10);
     }
 
-    /**
-     * A reduce should fail with an NoSuchElementException if done on an empty Observable.
-     */
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testReduceWithEmptyObservable() {
         Flowable<Integer> observable = Flowable.range(1, 0);
         observable.reduce(new BiFunction<Integer, Integer, Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -1027,4 +1027,37 @@ public class FlowableConcatMapEagerTest {
         .assertFailure(TestException.class);
     }
 
+    @Test
+    public void fuseAndTake() {
+        UnicastProcessor<Integer> us = UnicastProcessor.create();
+
+        us.onNext(1);
+        us.onComplete();
+
+        us.concatMapEager(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) throws Exception {
+                return Flowable.just(1);
+            }
+        })
+        .take(1)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
+            @Override
+            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
+                return o.concatMapEager(new Function<Object, Flowable<Object>>() {
+                    @Override
+                    public Flowable<Object> apply(Object v) throws Exception {
+                        return Flowable.just(v);
+                    }
+                });
+            }
+        });
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
@@ -17,9 +17,9 @@ import java.util.concurrent.atomic.*;
 import org.junit.*;
 import org.reactivestreams.Subscription;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -308,5 +308,15 @@ public class FlowableDelaySubscriptionOtherTest {
     @Test(expected = NullPointerException.class)
     public void otherNull() {
         Flowable.just(1).delaySubscription((Flowable<Integer>)null);
+    }
+
+    @Test
+    public void badSourceOther() {
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> o) throws Exception {
+                return Flowable.just(1).delaySubscription(o);
+            }
+        }, false, 1, 1, 1);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
@@ -173,11 +173,11 @@ public class FlowableDoOnEachTest {
     @Ignore("crashing publisher can't propagate to a subscriber")
     public void testFatalError() {
 //        try {
-//            Observable.just(1, 2, 3)
-//                    .flatMap(new Function<Integer, Observable<?>>() {
+//            Flowable.just(1, 2, 3)
+//                    .flatMap(new Function<Integer, Flowable<?>>() {
 //                        @Override
-//                        public Observable<?> apply(Integer integer) {
-//                            return Observable.create(new Publisher<Object>() {
+//                        public Flowable<?> apply(Integer integer) {
+//                            return Flowable.create(new Publisher<Object>() {
 //                                @Override
 //                                public void subscribe(Subscriber<Object> o) {
 //                                    throw new NullPointerException("Test NPE");
@@ -716,5 +716,20 @@ public class FlowableDoOnEachTest {
 
         assertEquals(5, call[0]);
         assertEquals(1, call[1]);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Flowable.just(1).doOnEach(new TestSubscriber<Integer>()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
+            @Override
+            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
+                return o.doOnEach(new TestSubscriber<Object>());
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
@@ -195,6 +195,20 @@ public class FlowableElementAtTest {
                 return o.elementAt(0).toFlowable();
             }
         });
+
+        TestHelper.checkDoubleOnSubscribeFlowableToMaybe(new Function<Flowable<Object>, Maybe<Object>>() {
+            @Override
+            public Maybe<Object> apply(Flowable<Object> o) throws Exception {
+                return o.elementAt(0);
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, Single<Object>>() {
+            @Override
+            public Single<Object> apply(Flowable<Object> o) throws Exception {
+                return o.elementAt(0, 1);
+            }
+        });
     }
 
     @Test
@@ -213,6 +227,20 @@ public class FlowableElementAtTest {
             .toFlowable()
             .test()
             .assertFailure(TestException.class);
+    }
+
+
+    @Test
+    public void error() {
+        Flowable.error(new TestException())
+            .elementAt(1, 10)
+            .test()
+            .assertFailure(TestException.class);
+
+        Flowable.error(new TestException())
+        .elementAt(1)
+        .test()
+        .assertFailure(TestException.class);
     }
 
     @Test
@@ -239,12 +267,43 @@ public class FlowableElementAtTest {
         } finally {
             RxJavaPlugins.reset();
         }
+
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.elementAt(0);
+            }
+        }, false, null, 1);
+
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.elementAt(0, 1);
+            }
+        }, false, null, 1, 1);
+
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.elementAt(0).toFlowable();
+            }
+        }, false, null, 1);
+
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.elementAt(0, 1).toFlowable();
+            }
+        }, false, null, 1, 1);
     }
 
     @Test
     public void dispose() {
         TestHelper.checkDisposed(PublishProcessor.create().elementAt(0).toFlowable());
         TestHelper.checkDisposed(PublishProcessor.create().elementAt(0, 1).toFlowable());
+
+        TestHelper.checkDisposed(PublishProcessor.create().elementAt(0));
+        TestHelper.checkDisposed(PublishProcessor.create().elementAt(0, 1));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -568,4 +568,19 @@ public class FlowableFlattenIterableTest {
             }
         }));
     }
+
+    @Test
+    public void badSource() {
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> o) throws Exception {
+                return o.flatMapIterable(new Function<Object, Iterable<Integer>>() {
+                    @Override
+                    public Iterable<Integer> apply(Object v) throws Exception {
+                        return Arrays.asList(10, 20);
+                    }
+                });
+            }
+        }, false, 1, 1, 10, 20);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
@@ -18,7 +18,9 @@ package io.reactivex.internal.operators.flowable;
 
 import org.junit.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.fuseable.ScalarCallable;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -66,6 +68,31 @@ public class FlowableFromArrayTest {
     }
 
     @Test
+    public void conditionalBackpressure() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+
+        create(1000)
+        .filter(Functions.alwaysTrue())
+        .subscribe(ts);
+
+        ts.assertNoErrors();
+        ts.assertNoValues();
+        ts.assertNotComplete();
+
+        ts.request(10);
+
+        ts.assertNoErrors();
+        ts.assertValueCount(10);
+        ts.assertNotComplete();
+
+        ts.request(1000);
+
+        ts.assertNoErrors();
+        ts.assertValueCount(1000);
+        ts.assertComplete();
+    }
+
+    @Test
     public void empty() {
         Assert.assertSame(Flowable.empty(), Flowable.fromArray(new Object[0]));
     }
@@ -81,5 +108,87 @@ public class FlowableFromArrayTest {
         Flowable.just(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void badRequest() {
+        TestHelper.assertBadRequestReported(Flowable.just(1, 2, 3));
+    }
+
+    @Test
+    public void conditionalOneIsNull() {
+        Flowable.fromArray(new Integer[] { null, 1 })
+        .filter(Functions.alwaysTrue())
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void conditionalOneIsNullSlowPath() {
+        Flowable.fromArray(new Integer[] { null, 1 })
+        .filter(Functions.alwaysTrue())
+        .test(2L)
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void conditionalOneByOne() {
+        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5 })
+        .filter(Functions.alwaysTrue())
+        .rebatchRequests(1)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void conditionalFiltered() {
+        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5 })
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 2 == 0;
+            }
+        })
+        .test()
+        .assertResult(2, 4);
+    }
+
+    @Test
+    public void conditionalSlowPathCancel() {
+        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5 })
+        .filter(Functions.alwaysTrue())
+        .subscribeWith(new TestSubscriber<Integer>(5L) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    cancel();
+                    onComplete();
+                }
+            }
+        })
+        .assertResult(1);
+    }
+
+    @Test
+    public void conditionalSlowPathSkipCancel() {
+        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5 })
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v < 2;
+            }
+        })
+        .subscribeWith(new TestSubscriber<Integer>(5L) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    cancel();
+                    onComplete();
+                }
+            }
+        })
+        .assertResult(1);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -1723,4 +1723,13 @@ public class FlowableGroupByTest {
         to.assertSubscribed().assertValue(1).assertNoErrors().assertNotComplete();
     }
 
+    @Test
+    public void delayErrorSimpleComplete() {
+        Flowable.just(1)
+        .groupBy(Functions.justFunction(1), true)
+        .flatMap(Functions.<Flowable<Integer>>identity())
+        .test()
+        .assertResult(1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalRangeTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.schedulers.Schedulers;
 
 public class FlowableIntervalRangeTest {
@@ -77,5 +78,35 @@ public class FlowableIntervalRangeTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Flowable.intervalRange(1, 2, 1, 1, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void backpressureBounded() {
+        Flowable.intervalRange(1, 2, 1, 1, TimeUnit.MILLISECONDS)
+        .test(2L)
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1L, 2L);
+    }
+
+    @Test
+    public void backpressureOverflow() {
+        Flowable.intervalRange(1, 3, 1, 1, TimeUnit.MILLISECONDS)
+        .test(2L)
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(MissingBackpressureException.class, 1L, 2L);
+    }
+
+    @Test
+    public void badRequest() {
+        TestHelper.assertBadRequestReported(Flowable.intervalRange(1, 3, 1, 1, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void take() {
+        Flowable.intervalRange(1, 2, 1, 1, TimeUnit.MILLISECONDS)
+        .take(1)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1L);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapNotificationTest.java
@@ -16,9 +16,13 @@ package io.reactivex.internal.operators.flowable;
 import java.util.concurrent.Callable;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.operators.flowable.FlowableMapNotification.MapNotificationSubscriber;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -141,5 +145,36 @@ public class FlowableMapNotificationTest {
         ts.assertNoErrors();
         ts.assertComplete();
 
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(new Flowable<Integer>() {
+            @SuppressWarnings({ "rawtypes", "unchecked" })
+            @Override
+            protected void subscribeActual(Subscriber<? super Integer> observer) {
+                MapNotificationSubscriber mn = new MapNotificationSubscriber(
+                        observer,
+                        Functions.justFunction(Flowable.just(1)),
+                        Functions.justFunction(Flowable.just(2)),
+                        Functions.justCallable(Flowable.just(3))
+                );
+                mn.onSubscribe(new BooleanSubscription());
+            }
+        });
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Object> o) throws Exception {
+                return o.flatMap(
+                        Functions.justFunction(Flowable.just(1)),
+                        Functions.justFunction(Flowable.just(2)),
+                        Functions.justCallable(Flowable.just(3))
+                );
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
@@ -729,4 +729,14 @@ public class FlowableMapTest {
         .assertResult(1, 2, 3, 4, 5);
     }
 
+    @Test
+    public void badSource() {
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
+            @Override
+            public Object apply(Flowable<Object> o) throws Exception {
+                return o.map(Functions.identity());
+            }
+        }, false, 1, 1, 1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
@@ -27,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 
-public class FlowableOnErrorResumeNextViaObservableTest {
+public class FlowableOnErrorResumeNextViaFlowableTest {
 
     @Test
     public void testResumeNext() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaFlowableTest.java
@@ -28,7 +28,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
-public class FlowableOnExceptionResumeNextViaObservableTest {
+public class FlowableOnExceptionResumeNextViaFlowableTest {
 
     @Test
     public void testResumeNextWithException() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScalarXMapTest.java
@@ -238,11 +238,11 @@ public class FlowableScalarXMapTest {
     @Test
     public void cancelled() {
         ScalarSubscription<Integer> scalar = new ScalarSubscription<Integer>(new TestSubscriber<Integer>(), 1);
-        
+
         assertFalse(scalar.isCancelled());
-        
+
         scalar.cancel();
-        
+
         assertTrue(scalar.isCancelled());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
@@ -25,6 +25,7 @@ import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.Flowable;
 import io.reactivex.functions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.DefaultSubscriber;
@@ -724,5 +725,39 @@ public class FlowableSingleTest {
         } finally {
             RxJavaPlugins.reset();
         }
+    }
+
+    @Test
+    public void badSource() {
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
+            @Override
+            public Object apply(Flowable<Object> o) throws Exception {
+                return o.singleOrError();
+            }
+        }, false, 1, 1, 1);
+
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
+            @Override
+            public Object apply(Flowable<Object> o) throws Exception {
+                return o.singleElement();
+            }
+        }, false, 1, 1, 1);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, SingleSource<Object>>() {
+            @Override
+            public SingleSource<Object> apply(Flowable<Object> o) throws Exception {
+                return o.singleOrError();
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeFlowableToMaybe(new Function<Flowable<Object>, MaybeSource<Object>>() {
+            @Override
+            public MaybeSource<Object> apply(Flowable<Object> o) throws Exception {
+                return o.singleElement();
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
@@ -227,4 +227,14 @@ public class FlowableSkipLastTimedTest {
         .assertFailure(TestException.class);
     }
 
+    @Test
+    public void take() {
+        Flowable.just(1)
+        .skipLast(0, TimeUnit.SECONDS)
+        .take(1)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -22,7 +22,6 @@ import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.FlowableOperator;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.*;
@@ -51,7 +50,7 @@ public class FlowableSubscribeOnTest {
                         latch.await();
                     } catch (InterruptedException e) {
                         // this means we were unsubscribed (Scheduler shut down and interrupts)
-                        // ... but we'll pretend we are like many Observables that ignore interrupts
+                        // ... but we'll pretend we are like many Flowables that ignore interrupts
                     }
 
                     subscriber.onComplete();
@@ -279,6 +278,11 @@ public class FlowableSubscribeOnTest {
         .assertSubscribed()
         .assertNoValues()
         .assertNotTerminated();
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Flowable.just(1).subscribeOn(Schedulers.single()));
     }
 
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOneTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
 
+import io.reactivex.*;
 import io.reactivex.Flowable;
 import io.reactivex.functions.*;
 import io.reactivex.subscribers.*;
@@ -135,6 +136,21 @@ public class FlowableTakeLastOneTest {
             list.add(t);
         }
 
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Flowable.just(1).takeLast(1));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
+            @Override
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.takeLast(1);
+            }
+        });
     }
 
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -950,4 +950,37 @@ public class ObservableConcatMapEagerTest {
         to
         .assertFailure(TestException.class, 1);
     }
+
+    @Test
+    public void fuseAndTake() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+
+        us.onNext(1);
+        us.onComplete();
+
+        us.concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v) throws Exception {
+                return Observable.just(1);
+            }
+        })
+        .take(1)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.concatMapEager(new Function<Object, ObservableSource<Object>>() {
+                    @Override
+                    public ObservableSource<Object> apply(Object v) throws Exception {
+                        return Observable.just(v);
+                    }
+                });
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
@@ -17,10 +17,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.*;
 
-import io.reactivex.Observable;
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.PublishSubject;
 
@@ -189,5 +189,15 @@ public class ObservableDelaySubscriptionOtherTest {
         ts.assertNoValues();
         ts.assertNotComplete();
         ts.assertError(TestException.class);
+    }
+
+    @Test
+    public void badSourceOther() {
+        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
+            @Override
+            public Object apply(Observable<Integer> o) throws Exception {
+                return Observable.just(1).delaySubscription(o);
+            }
+        }, false, 1, 1, 1);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
@@ -691,4 +691,19 @@ public class ObservableDoOnEachTest {
         assertEquals(5, call[0]);
         assertEquals(1, call[1]);
     }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).doOnEach(new TestObserver<Integer>()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.doOnEach(new TestObserver<Object>());
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -295,13 +295,13 @@ public class ObservableFlatMapMaybeTest {
     @Test
     public void innerSuccessCompletesAfterMain() {
         PublishSubject<Integer> ps = PublishSubject.create();
-        
+
         TestObserver<Integer> to = Observable.just(1).flatMapMaybe(Functions.justFunction(ps.singleElement()))
         .test();
-        
+
         ps.onNext(2);
         ps.onComplete();
-        
+
         to
         .assertResult(2);
     }
@@ -331,7 +331,7 @@ public class ObservableFlatMapMaybeTest {
             .flatMapMaybe(Functions.justFunction(Maybe.just(2)))
             .test()
             .assertFailureAndMessage(TestException.class, "First");
-            
+
             TestHelper.assertError(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
@@ -353,7 +353,7 @@ public class ObservableFlatMapMaybeTest {
             }))
             .test()
             .assertFailureAndMessage(TestException.class, "First");
-            
+
             TestHelper.assertError(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
@@ -364,7 +364,7 @@ public class ObservableFlatMapMaybeTest {
     public void emissionQueueTrigger() {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
-        
+
         TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
@@ -375,7 +375,7 @@ public class ObservableFlatMapMaybeTest {
                 }
             }
         };
-        
+
         Observable.just(ps1, ps2)
                 .flatMapMaybe(new Function<PublishSubject<Integer>, MaybeSource<Integer>>() {
                     @Override
@@ -396,7 +396,7 @@ public class ObservableFlatMapMaybeTest {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
         final PublishSubject<Integer> ps3 = PublishSubject.create();
-        
+
         TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
@@ -407,7 +407,7 @@ public class ObservableFlatMapMaybeTest {
                 }
             }
         };
-        
+
         Observable.just(ps1, ps2, ps3)
                 .flatMapMaybe(new Function<PublishSubject<Integer>, MaybeSource<Integer>>() {
                     @Override
@@ -419,7 +419,7 @@ public class ObservableFlatMapMaybeTest {
 
         ps1.onNext(1);
         ps1.onComplete();
-        
+
         ps3.onComplete();
 
         to.assertResult(1, 2);
@@ -447,7 +447,7 @@ public class ObservableFlatMapMaybeTest {
             }
         })
         .subscribe(to);
-        
+
         to
         .assertEmpty();
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -245,13 +245,13 @@ public class ObservableFlatMapSingleTest {
     @Test
     public void innerSuccessCompletesAfterMain() {
         PublishSubject<Integer> ps = PublishSubject.create();
-        
+
         TestObserver<Integer> to = Observable.just(1).flatMapSingle(Functions.justFunction(ps.singleOrError()))
         .test();
-        
+
         ps.onNext(2);
         ps.onComplete();
-        
+
         to
         .assertResult(2);
     }
@@ -281,7 +281,7 @@ public class ObservableFlatMapSingleTest {
             .flatMapSingle(Functions.justFunction(Single.just(2)))
             .test()
             .assertFailureAndMessage(TestException.class, "First");
-            
+
             TestHelper.assertError(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
@@ -303,7 +303,7 @@ public class ObservableFlatMapSingleTest {
             }))
             .test()
             .assertFailureAndMessage(TestException.class, "First");
-            
+
             TestHelper.assertError(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
@@ -314,7 +314,7 @@ public class ObservableFlatMapSingleTest {
     public void emissionQueueTrigger() {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
-        
+
         TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
@@ -325,7 +325,7 @@ public class ObservableFlatMapSingleTest {
                 }
             }
         };
-        
+
         Observable.just(ps1, ps2)
                 .flatMapSingle(new Function<PublishSubject<Integer>, SingleSource<Integer>>() {
                     @Override
@@ -363,7 +363,7 @@ public class ObservableFlatMapSingleTest {
             }
         })
         .subscribe(to);
-        
+
         to
         .assertEmpty();
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
@@ -21,7 +21,8 @@ import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
 
 public class ObservableFromTest {
@@ -72,5 +73,16 @@ public class ObservableFromTest {
                 return f.toObservable();
             }
         });
+    }
+
+    @Test
+    public void fusionRejected() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ASYNC);
+
+        Observable.fromArray(1, 2, 3)
+        .subscribe(to);
+
+        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+        .assertResult(1, 2, 3);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
@@ -1532,4 +1532,13 @@ public class ObservableGroupByTest {
 
         to.assertSubscribed().assertValue(1).assertNoErrors().assertNotComplete();
     }
+
+    @Test
+    public void delayErrorSimpleComplete() {
+        Observable.just(1)
+        .groupBy(Functions.justFunction(1), true)
+        .flatMap(Functions.<Observable<Integer>>identity())
+        .test()
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMapTest.java
@@ -386,4 +386,14 @@ public class ObservableMapTest {
         ObserverFusion.assertFusion(to, QueueDisposable.NONE)
         .assertResult(1, 2, 3, 4, 5);
     }
+
+    @Test
+    public void badSource() {
+        TestHelper.checkBadSourceObservable(new Function<Observable<Object>, Object>() {
+            @Override
+            public Object apply(Observable<Object> o) throws Exception {
+                return o.map(Functions.identity());
+            }
+        }, false, 1, 1, 1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRedoTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRedoTest.java
@@ -25,7 +25,7 @@ public class ObservableRedoTest {
     @Test
     public void redoCancel() {
         final TestObserver<Integer> to = new TestObserver<Integer>();
-        
+
         Observable.just(1)
         .repeatWhen(new Function<Observable<Object>, ObservableSource<Object>>() {
             @Override

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
@@ -530,5 +530,29 @@ public class ObservableSingleTest {
                 return o.singleOrError();
             }
         }, false, 1, 1, 1);
+
+        TestHelper.checkBadSourceObservable(new Function<Observable<Object>, Object>() {
+            @Override
+            public Object apply(Observable<Object> o) throws Exception {
+                return o.singleElement();
+            }
+        }, false, 1, 1, 1);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservableToSingle(new Function<Observable<Object>, SingleSource<Object>>() {
+            @Override
+            public SingleSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.singleOrError();
+            }
+        });
+
+        TestHelper.checkDoubleOnSubscribeObservableToMaybe(new Function<Observable<Object>, MaybeSource<Object>>() {
+            @Override
+            public MaybeSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.singleElement();
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTimedTest.java
@@ -225,4 +225,14 @@ public class ObservableSkipLastTimedTest {
         .test()
         .assertFailure(TestException.class);
     }
+
+    @Test
+    public void take() {
+        Observable.just(1)
+        .skipLast(0, TimeUnit.SECONDS)
+        .take(1)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/queue/SimpleQueueTest.java
+++ b/src/test/java/io/reactivex/internal/queue/SimpleQueueTest.java
@@ -81,7 +81,7 @@ public class SimpleQueueTest {
         assertTrue(q.offer(3, 4));
         assertTrue(q.offer(5, 6));
         assertTrue(q.offer(7));
-        
+
         assertFalse(q.offer(8, 9));
         assertFalse(q.offer(9, 10));
     }
@@ -93,12 +93,12 @@ public class SimpleQueueTest {
         assertTrue(q.offer(3, 4));
         assertTrue(q.offer(5, 6));
         assertTrue(q.offer(7, 8)); // this should trigger a new buffer
-        
+
         for (int i = 0; i < 8; i++) {
             assertEquals(i + 1, q.peek().intValue());
             assertEquals(i + 1, q.poll().intValue());
         }
-        
+
         assertNull(q.peek());
         assertNull(q.poll());
     }
@@ -106,11 +106,11 @@ public class SimpleQueueTest {
     @Test
     public void mpscOfferPollRace() throws Exception {
         final MpscLinkedQueue<Integer> q = new MpscLinkedQueue<Integer>();
-        
+
         final AtomicInteger c = new AtomicInteger(3);
-        
+
         Thread t1 = new Thread(new Runnable() {
-            int i = 0;
+            int i;
             @Override
             public void run() {
                 c.decrementAndGet();
@@ -126,7 +126,7 @@ public class SimpleQueueTest {
         Thread t2 = new Thread(new Runnable() {
             int i = 10000;
             @Override
-            public void run() { 
+            public void run() {
                 c.decrementAndGet();
                 while (c.get() != 0) { }
 
@@ -140,7 +140,7 @@ public class SimpleQueueTest {
         Runnable r3 = new Runnable() {
             int i = 20000;
             @Override
-            public void run() { 
+            public void run() {
                 c.decrementAndGet();
                 while (c.get() != 0) { }
 
@@ -151,7 +151,7 @@ public class SimpleQueueTest {
         };
 
         r3.run();
-        
+
         t1.join();
         t2.join();
     }

--- a/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
@@ -332,24 +332,24 @@ public class UnicastSubjectTest {
             @Override
             public void run() { calls[0]++; }
         });
-        
+
         TestHelper.checkDisposed(us);
 
         assertEquals(1, calls[0]);
-        
+
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             us.onError(new TestException());
-            
+
             TestHelper.assertError(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
-        
+
         Disposable d = Disposables.empty();
-        
+
         us.onSubscribe(d);
-        
+
         assertTrue(d.isDisposed());
     }
 }


### PR DESCRIPTION
- Finished covering `Observable` operators to a reasonable level (the remaining are either impossible or only reachable by probabilistic race)
- Synced operator coverage between `Observable` and `Flowable`
- Started covering `Flowable` operators
- Cleaning up a few `Flowable` operators (cache, concatMap)
- fix `onBackpressureBuffer(long, Action, BufferOverflowStrategy)` return type
- fix `concatMapDelayError` wrong barrier mode selected
