### PR TITLE
2.x: coverage, fixes, cleanup 10/20-2

### DIFF
--- a/src/main/java/io/reactivex/internal/fuseable/SimplePlainQueue.java
+++ b/src/main/java/io/reactivex/internal/fuseable/SimplePlainQueue.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.fuseable;
+
+/**
+ * Override of the SimpleQueue interface with no throws Exception on poll.
+ *
+ * @param <T> the value type to enqueue and dequeue, not null
+ */
+public interface SimplePlainQueue<T> extends SimpleQueue<T> {
+
+    @Override
+    T poll();
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerate.java
@@ -93,14 +93,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
             final BiFunction<S, ? super Emitter<T>, S> f = generator;
 
             for (;;) {
-                if (cancelled) {
-                    dispose(s);
-                    return;
-                }
-
-                boolean unbounded = n == Long.MAX_VALUE; // NOPMD
-
-                while (n != 0L) {
+                while (e != n) {
 
                     if (cancelled) {
                         dispose(s);
@@ -122,30 +115,16 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
                         return;
                     }
 
-                    n--;
-                    e--;
+                    e++;
                 }
 
-                if (!unbounded) {
-                    n = get();
-                    if (n == Long.MAX_VALUE) {
-                        continue;
+                n = get();
+                if (e == n) {
+                    n = addAndGet(-e);
+                    if (n == 0L) {
+                        break;
                     }
-                    n += e;
-                    if (n != 0L) {
-                        continue; // keep draining and delay the addAndGet as much as possible
-                    }
-                }
-                if (e != 0L) {
-                    if (!unbounded) {
-                        state = s; // save state in case we run out of requests
-                        n = addAndGet(e);
-                        e = 0L;
-                    }
-                }
-
-                if (n == 0L) {
-                    break;
+                    e = 0L;
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerate.java
@@ -120,6 +120,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
 
                 n = get();
                 if (e == n) {
+                    state = s;
                     n = addAndGet(-e);
                     if (n == 0L) {
                         break;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
@@ -143,8 +142,11 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
 
         @Override
         public void onError(Throwable t) {
+            if (t == null) {
+                t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+            }
             terminate = true;
-            actual.onError(ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources."));
+            actual.onError(t);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/MpscLinkedQueue.java
@@ -20,13 +20,13 @@ package io.reactivex.internal.queue;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.internal.fuseable.SimpleQueue;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
 
 /**
  * A multi-producer single consumer unbounded queue.
  * @param <T> the contained value type
  */
-public final class MpscLinkedQueue<T> implements SimpleQueue<T> {
+public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
     private final AtomicReference<LinkedQueueNode<T>> producerNode;
     private final AtomicReference<LinkedQueueNode<T>> consumerNode;
 

--- a/src/main/java/io/reactivex/internal/queue/SpscArrayQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/SpscArrayQueue.java
@@ -20,7 +20,7 @@ package io.reactivex.internal.queue;
 
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.internal.fuseable.SimpleQueue;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
 import io.reactivex.internal.util.Pow2;
 
 /**
@@ -37,7 +37,7 @@ import io.reactivex.internal.util.Pow2;
  *
  * @param <E>
  */
-public final class SpscArrayQueue<E> extends AtomicReferenceArray<E> implements SimpleQueue<E> {
+public final class SpscArrayQueue<E> extends AtomicReferenceArray<E> implements SimplePlainQueue<E> {
     private static final long serialVersionUID = -1296597691183856449L;
     private static final Integer MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);
     final int mask;

--- a/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
@@ -20,7 +20,7 @@ package io.reactivex.internal.queue;
 
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.internal.fuseable.SimpleQueue;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
 import io.reactivex.internal.util.Pow2;
 
 /**
@@ -28,7 +28,7 @@ import io.reactivex.internal.util.Pow2;
  * than the producer.
  * @param <T> the contained value type
  */
-public final class SpscLinkedArrayQueue<T> implements SimpleQueue<T> {
+public final class SpscLinkedArrayQueue<T> implements SimplePlainQueue<T> {
     static final int MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);
     final AtomicLong producerIndex = new AtomicLong();
 

--- a/src/main/java/io/reactivex/internal/subscribers/QueueDrainSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/QueueDrainSubscriber.java
@@ -19,7 +19,7 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.MissingBackpressureException;
-import io.reactivex.internal.fuseable.SimpleQueue;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 
@@ -33,14 +33,14 @@ import io.reactivex.internal.util.*;
  */
 public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriberPad4 implements Subscriber<T>, QueueDrain<U, V> {
     protected final Subscriber<? super V> actual;
-    protected final SimpleQueue<U> queue;
+    protected final SimplePlainQueue<U> queue;
 
     protected volatile boolean cancelled;
 
     protected volatile boolean done;
     protected Throwable error;
 
-    public QueueDrainSubscriber(Subscriber<? super V> actual, SimpleQueue<U> queue) {
+    public QueueDrainSubscriber(Subscriber<? super V> actual, SimplePlainQueue<U> queue) {
         this.actual = actual;
         this.queue = queue;
     }
@@ -66,7 +66,7 @@ public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriber
 
     protected final void fastPathEmitMax(U value, boolean delayError, Disposable dispose) {
         final Subscriber<? super V> s = actual;
-        final SimpleQueue<U> q = queue;
+        final SimplePlainQueue<U> q = queue;
 
         if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
             long r = requested.get();

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -281,12 +281,8 @@ public class FlowableTests {
             }
         })
         .toFlowable()
-        .blockingForEach(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t1) {
-                // do nothing ... we expect an exception instead
-            }
-        });
+        .test()
+        .assertResult();
     }
 
     /**

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class FlowableDoOnLifecycleTest {
+
+    @Test
+    public void onSubscribeCrashed() {
+        Flowable.just(1)
+        .doOnLifecycle(new Consumer<Subscription>() {
+            @Override
+            public void accept(Subscription s) throws Exception {
+                throw new TestException();
+            }
+        }, Functions.EMPTY_LONG_CONSUMER, Functions.EMPTY_ACTION)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        final int[] calls = { 0, 0 };
+
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
+            @Override
+            public Publisher<Object> apply(Flowable<Object> o) throws Exception {
+                return o
+                .doOnLifecycle(new Consumer<Subscription>() {
+                    @Override
+                    public void accept(Subscription s) throws Exception {
+                        calls[0]++;
+                    }
+                }, Functions.EMPTY_LONG_CONSUMER, new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        calls[1]++;
+                    }
+                });
+            }
+        });
+
+        assertEquals(2, calls[0]);
+        assertEquals(0, calls[1]);
+    }
+
+    @Test
+    public void dispose() {
+        final int[] calls = { 0, 0 };
+
+        TestHelper.checkDisposed(Flowable.just(1)
+                .doOnLifecycle(new Consumer<Subscription>() {
+                    @Override
+                    public void accept(Subscription s) throws Exception {
+                        calls[0]++;
+                    }
+                }, Functions.EMPTY_LONG_CONSUMER, new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        calls[1]++;
+                    }
+                })
+            );
+
+        assertEquals(1, calls[0]);
+        assertEquals(2, calls[1]);
+    }
+
+    @Test
+    public void requestCrashed() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.just(1)
+            .doOnLifecycle(Functions.emptyConsumer(),
+                    new LongConsumer() {
+                        @Override
+                        public void accept(long v) throws Exception {
+                            throw new TestException();
+                        }
+                    },
+                    Functions.EMPTY_ACTION)
+            .test()
+            .assertResult(1);
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void cancelCrashed() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.just(1)
+            .doOnLifecycle(Functions.emptyConsumer(),
+                    Functions.EMPTY_LONG_CONSUMER,
+                    new Action() {
+                        @Override
+                        public void run() throws Exception {
+                            throw new TestException();
+                        }
+                    })
+            .take(1)
+            .test()
+            .assertResult(1);
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromObservableTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+
+public class FlowableFromObservableTest {
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).toFlowable(BackpressureStrategy.NONE));
+    }
+
+    @Test
+    public void error() {
+        Observable.error(new TestException())
+        .toFlowable(BackpressureStrategy.NONE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
@@ -378,7 +378,6 @@ public class FlowableRangeLongTest {
     @Test
     public void slowPathRebatch() {
         Flowable.rangeLong(1L, 5L)
-        .filter(Functions.alwaysTrue())
         .rebatchRequests(1)
         .test()
         .assertResult(1L, 2L, 3L, 4L, 5L);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -389,4 +389,13 @@ public class FlowableWindowWithStartEndFlowableTest {
         assertFalse("Start has observers!", start.hasSubscribers());
         assertFalse("End has observers!", end.hasSubscribers());
     }
+
+    @Test
+    public void mainError() {
+        Flowable.<Integer>error(new TestException())
+        .window(Flowable.never(), Functions.justFunction(Flowable.just(1)))
+        .flatMap(Functions.<Flowable<Integer>>identity())
+        .test()
+        .assertFailure(TestException.class);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.observable;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.*;
@@ -125,5 +126,25 @@ public class ObservableGenerateTest {
                     e.onComplete();
                 }
             }, Functions.emptyConsumer()));
+    }
+
+    @Test
+    public void nullError() {
+        final int[] call = { 0 };
+        Observable.generate(Functions.justCallable(1),
+        new BiConsumer<Integer, Emitter<Object>>() {
+            @Override
+            public void accept(Integer s, Emitter<Object> e) throws Exception {
+                try {
+                    e.onError(null);
+                } catch (NullPointerException ex) {
+                    call[0]++;
+                }
+            }
+        }, Functions.emptyConsumer())
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertEquals(0, call[0]);
     }
 }

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -282,12 +282,9 @@ public class ObservableTest {
                 return t1 + t2;
             }
         })
-        .subscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t1) {
-                // do nothing ... we expect an exception instead
-            }
-        });
+        .toObservable()
+        .test()
+        .assertResult();
     }
 
     /**


### PR DESCRIPTION
I cut this short so there is time for the **2.0.0-RC release preparations**.
- Introduce `SimplePlainQueue` where `poll` doesn't throw, avoiding the need for try-catches where the queue is one of the standard lock-free queues.
- Fix `FlatMap` error, cancellation and resource management.
- Coverage of some `Flowable` operators
- Removal of impossible and unused code paths.
