### PR TITLE
2.x: coverage, fixes, cleanup 10/21-1

### DIFF
--- a/src/main/java/io/reactivex/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/internal/functions/Functions.java
@@ -15,6 +15,8 @@ package io.reactivex.internal.functions;
 import java.util.*;
 import java.util.concurrent.*;
 
+import org.reactivestreams.Subscription;
+
 import io.reactivex.*;
 import io.reactivex.functions.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -662,4 +664,11 @@ public final class Functions {
     public static <T, K> BiPredicate<T, T> equalsPredicate(Function<? super T, K> keySelector) {
         return new KeyedEqualsPredicate<T, K>(keySelector);
     }
+
+    public static final Consumer<Subscription> REQUEST_MAX = new Consumer<Subscription>() {
+        @Override
+        public void accept(Subscription t) throws Exception {
+            t.request(Long.MAX_VALUE);
+        }
+    };
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -170,10 +170,10 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
         void innerSuccess(InnerObserver inner, R value) {
             set.delete(inner);
             if (get() == 0 && compareAndSet(0, 1)) {
+                boolean d = active.decrementAndGet() == 0;
                 if (requested.get() != 0) {
                     actual.onNext(value);
 
-                    boolean d = active.decrementAndGet() == 0;
                     SpscLinkedArrayQueue<R> q = queue.get();
 
                     if (d && (q == null || q.isEmpty())) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -170,10 +170,10 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
         void innerSuccess(InnerObserver inner, R value) {
             set.delete(inner);
             if (get() == 0 && compareAndSet(0, 1)) {
+                boolean d = active.decrementAndGet() == 0;
                 if (requested.get() != 0) {
                     actual.onNext(value);
 
-                    boolean d = active.decrementAndGet() == 0;
                     SpscLinkedArrayQueue<R> q = queue.get();
 
                     if (d && (q == null || q.isEmpty())) {

--- a/src/main/java/io/reactivex/internal/util/BlockingIgnoringReceiver.java
+++ b/src/main/java/io/reactivex/internal/util/BlockingIgnoringReceiver.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.util;
+
+import java.util.concurrent.CountDownLatch;
+
+import io.reactivex.functions.*;
+
+/**
+ * Stores an incoming Throwable (if any) and counts itself down.
+ */
+public final class BlockingIgnoringReceiver
+extends CountDownLatch
+implements Consumer<Throwable>, Action {
+    public Throwable error;
+
+    public BlockingIgnoringReceiver() {
+        super(1);
+    }
+
+    @Override
+    public void accept(Throwable e) {
+        error = e;
+        countDown();
+    }
+
+    @Override
+    public void run() {
+        countDown();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
@@ -24,9 +24,10 @@ import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -378,9 +379,10 @@ public class FlowableAllTest {
     }
 
     @Test
-    @Ignore("RS Subscription can't be checked for isCancelled")
     public void dispose() {
-        // TestHelper.checkDisposed(Flowable.just(1).all(Functions.alwaysTrue()).toFlowable());
+        TestHelper.checkDisposed(Flowable.just(1).all(Functions.alwaysTrue()).toFlowable());
+
+        TestHelper.checkDisposed(Flowable.just(1).all(Functions.alwaysTrue()));
     }
 
     @Test
@@ -443,5 +445,38 @@ public class FlowableAllTest {
         } finally {
             RxJavaPlugins.reset();
         }
+    }
+
+    @Test
+    public void badSource() {
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> o) throws Exception {
+                return o.all(Functions.alwaysTrue());
+            }
+        }, false, 1, 1, true);
+
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> o) throws Exception {
+                return o.all(Functions.alwaysTrue()).toFlowable();
+            }
+        }, false, 1, 1, true);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Boolean>>() {
+            @Override
+            public Publisher<Boolean> apply(Flowable<Object> o) throws Exception {
+                return o.all(Functions.alwaysTrue()).toFlowable();
+            }
+        });
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, Single<Boolean>>() {
+            @Override
+            public Single<Boolean> apply(Flowable<Object> o) throws Exception {
+                return o.all(Functions.alwaysTrue());
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -26,6 +26,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
@@ -889,4 +890,11 @@ public class FlowableFlatMapTest {
         TestHelper.assertError(errors, 1, TestException.class);
     }
 
+    @Test
+    public void scalarXMap() {
+        Flowable.fromCallable(Functions.justCallable(1))
+        .flatMap(Functions.justFunction(Flowable.fromCallable(Functions.justCallable(2))))
+        .test()
+        .assertResult(2);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
@@ -297,4 +297,19 @@ public class FlowableMaterializeTest {
             }
         });
     }
+
+    @Test
+    public void badSource() {
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
+            @Override
+            public Object apply(Flowable<Object> f) throws Exception {
+                return f.materialize();
+            }
+        }, false, null, null, Notification.createOnComplete());
+    }
+
+    @Test
+    public void badRequest() {
+        TestHelper.assertBadRequestReported(Flowable.just(1).materialize());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
@@ -48,8 +48,7 @@ public class FlowableOnErrorReturnTest {
 
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
+        Subscriber<String> observer = TestHelper.mockSubscriber();
         observable.subscribe(observer);
 
         try {
@@ -59,9 +58,9 @@ public class FlowableOnErrorReturnTest {
         }
 
         verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
         verify(observer, times(1)).onNext("one");
         verify(observer, times(1)).onNext("failure");
+        verify(observer, times(1)).onComplete();
         assertNotNull(capturedException.get());
     }
 
@@ -267,6 +266,21 @@ public class FlowableOnErrorReturnTest {
                 return f.onErrorReturnItem(1);
             }
         });
+    }
+
+    @Test
+    public void doubleOnError() {
+        new Flowable<Integer>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super Integer> s) {
+                s.onSubscribe(new BooleanSubscription());
+                s.onError(new TestException());
+                s.onError(new TestException());
+            }
+        }
+        .onErrorReturnItem(1)
+        .test()
+        .assertResult(1);
     }
 
 }


### PR DESCRIPTION
- fix `Flowable.materialize()` terminal signal emission in face of backpressure
- fix `Flowable.onErrorReturn()` terminal signal emission in face of backpressure
- cleanup `Flowable.publish()` and enable operator fusion on its input
- fix `Flowable.flatMapSingle()` and `Flowable.flatMapMaybe()` termination detection
- compact `Flowable.blockingSubscribe()` and `Observable.blockingSubscribe()`
- compact `Flowable.subscribeOn()`
