### PR TITLE
2.x: distinctUntilChanged to store the selected key instead of the value

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -25,7 +25,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.functions.*;
 import io.reactivex.internal.fuseable.ScalarCallable;
 import io.reactivex.internal.operators.flowable.*;
-import io.reactivex.internal.operators.observable.*;
+import io.reactivex.internal.operators.observable.ObservableFromPublisher;
 import io.reactivex.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.internal.subscribers.*;
 import io.reactivex.internal.util.*;
@@ -7266,7 +7266,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> distinctUntilChanged() {
-        return new FlowableDistinctUntilChanged<T>(this, Functions.equalsPredicate());
+        return distinctUntilChanged(Functions.identity());
     }
 
     /**
@@ -7294,7 +7294,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Flowable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
-        return new FlowableDistinctUntilChanged<T>(this, Functions.equalsPredicate(keySelector));
+        return RxJavaPlugins.onAssembly(new FlowableDistinctUntilChanged<T, K>(this, keySelector, ObjectHelper.equalsPredicate()));
     }
 
     /**
@@ -7321,7 +7321,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> distinctUntilChanged(BiPredicate<? super T, ? super T> comparer) {
         ObjectHelper.requireNonNull(comparer, "comparer is null");
-        return RxJavaPlugins.onAssembly(new FlowableDistinctUntilChanged<T>(this, comparer));
+        return RxJavaPlugins.onAssembly(new FlowableDistinctUntilChanged<T, T>(this, Functions.<T>identity(), comparer));
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -6333,7 +6333,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> distinctUntilChanged() {
-        return new ObservableDistinctUntilChanged<T>(this, Functions.equalsPredicate());
+        return distinctUntilChanged(Functions.identity());
     }
 
     /**
@@ -6357,7 +6357,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Observable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
-        return new ObservableDistinctUntilChanged<T>(this, Functions.equalsPredicate(keySelector));
+        return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<T, K>(this, keySelector, ObjectHelper.equalsPredicate()));
     }
 
     /**
@@ -6380,7 +6380,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> distinctUntilChanged(BiPredicate<? super T, ? super T> comparer) {
         ObjectHelper.requireNonNull(comparer, "comparer is null");
-        return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<T>(this, comparer));
+        return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<T, T>(this, Functions.<T>identity(), comparer));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/internal/functions/Functions.java
@@ -639,32 +639,6 @@ public final class Functions {
         return new ListSorter<T>(comparator);
     }
 
-    static final BiPredicate<Object, Object> DEFAULT_EQUALS_PREDICATE = equalsPredicate(Functions.identity());
-
-    @SuppressWarnings("unchecked")
-    public static <T> BiPredicate<T, T> equalsPredicate() {
-        return (BiPredicate<T, T>)DEFAULT_EQUALS_PREDICATE;
-    }
-
-    static final class KeyedEqualsPredicate<T, K> implements BiPredicate<T, T> {
-        final Function<? super T, K> keySelector;
-
-        KeyedEqualsPredicate(Function<? super T, K> keySelector) {
-            this.keySelector = keySelector;
-        }
-
-        @Override
-        public boolean test(T t1, T t2) throws Exception {
-            K k1 = ObjectHelper.requireNonNull(keySelector.apply(t1), "The keySelector returned a null key");
-            K k2 = ObjectHelper.requireNonNull(keySelector.apply(t2), "The keySelector returned a null key");
-            return ObjectHelper.equals(k1, k2);
-        }
-    }
-
-    public static <T, K> BiPredicate<T, T> equalsPredicate(Function<? super T, K> keySelector) {
-        return new KeyedEqualsPredicate<T, K>(keySelector);
-    }
-
     public static final Consumer<Subscription> REQUEST_MAX = new Consumer<Subscription>() {
         @Override
         public void accept(Subscription t) throws Exception {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
@@ -22,7 +22,7 @@ import io.reactivex.internal.subscribers.*;
 public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWithUpstream<T, T> {
 
     final Function<? super T, K> keySelector;
-    
+
     final BiPredicate<? super K, ? super K> comparer;
 
     public FlowableDistinctUntilChanged(Publisher<T> source, Function<? super T, K> keySelector, BiPredicate<? super K, ? super K> comparer) {
@@ -46,7 +46,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
 
 
         final Function<? super T, K> keySelector;
-        
+
         final BiPredicate<? super K, ? super K> comparer;
 
         K last;
@@ -79,7 +79,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
             }
 
             K key;
-            
+
             try {
                 key = keySelector.apply(t);
                 if (hasValue) {
@@ -96,7 +96,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
                fail(ex);
                return true;
             }
-            
+
             actual.onNext(t);
             return true;
         }
@@ -136,7 +136,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
     static final class DistinctUntilChangedConditionalSubscriber<T, K> extends BasicFuseableConditionalSubscriber<T, T> {
 
         final Function<? super T, K> keySelector;
-        
+
         final BiPredicate<? super K, ? super K> comparer;
 
         K last;
@@ -168,7 +168,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
             }
 
             K key;
-            
+
             try {
                 key = keySelector.apply(t);
                 if (hasValue) {
@@ -185,7 +185,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
                fail(ex);
                return true;
             }
-            
+
             actual.onNext(t);
             return true;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
@@ -20,7 +20,7 @@ import io.reactivex.internal.observers.BasicFuseableObserver;
 public final class ObservableDistinctUntilChanged<T, K> extends AbstractObservableWithUpstream<T, T> {
 
     final Function<? super T, K> keySelector;
-    
+
     final BiPredicate<? super K, ? super K> comparer;
 
     public ObservableDistinctUntilChanged(ObservableSource<T> source, Function<? super T, K> keySelector, BiPredicate<? super K, ? super K> comparer) {
@@ -37,7 +37,7 @@ public final class ObservableDistinctUntilChanged<T, K> extends AbstractObservab
     static final class DistinctUntilChangedObserver<T, K> extends BasicFuseableObserver<T, T> {
 
         final Function<? super T, K> keySelector;
-        
+
         final BiPredicate<? super K, ? super K> comparer;
 
         K last;
@@ -63,7 +63,7 @@ public final class ObservableDistinctUntilChanged<T, K> extends AbstractObservab
             }
 
             K key;
-            
+
             try {
                 key = keySelector.apply(t);
                 if (hasValue) {
@@ -80,7 +80,7 @@ public final class ObservableDistinctUntilChanged<T, K> extends AbstractObservab
                fail(ex);
                return;
             }
-            
+
             actual.onNext(t);
             return;
         }

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -1167,14 +1167,14 @@ public class FlowableNullTests {
         just1.distinctUntilChanged((BiPredicate<Integer, Integer>)null);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void distinctUntilChangedFunctionReturnsNull() {
         Flowable.range(1, 2).distinctUntilChanged(new Function<Integer, Object>() {
             @Override
             public Object apply(Integer v) {
                 return null;
             }
-        }).blockingSubscribe();
+        }).test().assertResult(1);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
@@ -30,7 +30,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.processors.UnicastProcessor;
+import io.reactivex.processors.*;
 import io.reactivex.subscribers.*;
 
 public class FlowableDistinctUntilChangedTest {
@@ -340,5 +340,31 @@ public class FlowableDistinctUntilChangedTest {
         } finally {
             RxJavaPlugins.reset();
         }
-   }
+    }
+
+    class Mutable {
+        int value;
+    }
+
+    @Test
+    public void mutableWithSelector() {
+        Mutable m = new Mutable();
+        
+        PublishProcessor<Mutable> pp = PublishProcessor.create();
+        
+        TestSubscriber<Mutable> ts = pp.distinctUntilChanged(new Function<Mutable, Object>() {
+            @Override
+            public Object apply(Mutable m) throws Exception {
+                return m.value;
+            }
+        })
+        .test();
+
+        pp.onNext(m);
+        m.value = 1;
+        pp.onNext(m);
+        pp.onComplete();
+
+        ts.assertResult(m, m);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
@@ -349,9 +349,9 @@ public class FlowableDistinctUntilChangedTest {
     @Test
     public void mutableWithSelector() {
         Mutable m = new Mutable();
-        
+
         PublishProcessor<Mutable> pp = PublishProcessor.create();
-        
+
         TestSubscriber<Mutable> ts = pp.distinctUntilChanged(new Function<Mutable, Object>() {
             @Override
             public Object apply(Mutable m) throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChangedTest.java
@@ -256,9 +256,9 @@ public class ObservableDistinctUntilChangedTest {
     @Test
     public void mutableWithSelector() {
         Mutable m = new Mutable();
-        
+
         PublishSubject<Mutable> pp = PublishSubject.create();
-        
+
         TestObserver<Mutable> ts = pp.distinctUntilChanged(new Function<Mutable, Object>() {
             @Override
             public Object apply(Mutable m) throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChangedTest.java
@@ -29,7 +29,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.fuseable.QueueDisposable;
 import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.subjects.UnicastSubject;
+import io.reactivex.subjects.*;
 
 public class ObservableDistinctUntilChangedTest {
 
@@ -248,4 +248,30 @@ public class ObservableDistinctUntilChangedTest {
             RxJavaPlugins.reset();
         }
    }
+
+    class Mutable {
+        int value;
+    }
+
+    @Test
+    public void mutableWithSelector() {
+        Mutable m = new Mutable();
+        
+        PublishSubject<Mutable> pp = PublishSubject.create();
+        
+        TestObserver<Mutable> ts = pp.distinctUntilChanged(new Function<Mutable, Object>() {
+            @Override
+            public Object apply(Mutable m) throws Exception {
+                return m.value;
+            }
+        })
+        .test();
+
+        pp.onNext(m);
+        m.value = 1;
+        pp.onNext(m);
+        pp.onComplete();
+
+        ts.assertResult(m, m);
+    }
 }

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1257,14 +1257,14 @@ public class ObservableNullTests {
         just1.distinctUntilChanged((BiPredicate<Object, Object>)null);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void distinctUntilChangedFunctionReturnsNull() {
         Observable.range(1, 2).distinctUntilChanged(new Function<Integer, Object>() {
             @Override
             public Object apply(Integer v) {
                 return null;
             }
-        }).blockingSubscribe();
+        }).test().assertResult(1);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
Fix `distinctUntilChanged` to store the selected key instead of the input value.

Reported in #4743 
