### PR TITLE
2.x: fix Flowable.concatMapEager hang due to bad request management

### DIFF
--- a/src/main/java/io/reactivex/internal/subscribers/InnerQueuedSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/InnerQueuedSubscriber.java
@@ -72,14 +72,14 @@ implements Subscriber<T>, Subscription {
                 if (m == QueueSubscription.ASYNC) {
                     fusionMode = m;
                     queue = qs;
-                    QueueDrainHelper.request(get(), prefetch);
+                    QueueDrainHelper.request(s, prefetch);
                     return;
                 }
             }
 
             queue = QueueDrainHelper.createQueue(prefetch);
 
-            QueueDrainHelper.request(get(), prefetch);
+            QueueDrainHelper.request(s, prefetch);
         }
     }
 
@@ -104,22 +104,26 @@ implements Subscriber<T>, Subscription {
 
     @Override
     public void request(long n) {
-        long p = produced + n;
-        if (p >= limit) {
-            produced = 0L;
-            get().request(p);
-        } else {
-            produced = p;
+        if (fusionMode != QueueSubscription.SYNC) {
+            long p = produced + n;
+            if (p >= limit) {
+                produced = 0L;
+                get().request(p);
+            } else {
+                produced = p;
+            }
         }
     }
 
     public void requestOne() {
-        long p = produced + 1;
-        if (p == limit) {
-            produced = 0L;
-            get().request(p);
-        } else {
-            produced = p;
+        if (fusionMode != QueueSubscription.SYNC) {
+            long p = produced + 1;
+            if (p == limit) {
+                produced = 0L;
+                get().request(p);
+            } else {
+                produced = p;
+            }
         }
     }
 

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -160,7 +160,7 @@ public enum TestHelper {
             err.initCause(ex);
             throw err;
         }
-        if (ObjectHelper.equals(message, ex.getMessage())) {
+        if (!ObjectHelper.equals(message, ex.getMessage())) {
             AssertionError err = new AssertionError("Message " + message + " expected but got " + ex.getMessage());
             err.initCause(ex);
             throw err;

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -30,6 +30,7 @@ import org.reactivestreams.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.operators.maybe.MaybeToFlowable;
 import io.reactivex.internal.operators.single.SingleToFlowable;
@@ -144,21 +145,25 @@ public enum TestHelper {
     }
 
     public static void assertError(List<Throwable> list, int index, Class<? extends Throwable> clazz) {
-        try {
-            assertTrue(list.get(index).toString(), clazz.isInstance(list.get(index)));
-        } catch (AssertionError e) {
-            list.get(index).printStackTrace();
-            throw e;
+        Throwable ex = list.get(index);
+        if (!clazz.isInstance(ex)) {
+            AssertionError err = new AssertionError(clazz + " expected but got " + list.get(index));
+            err.initCause(list.get(index));
+            throw err;
         }
     }
 
     public static void assertError(List<Throwable> list, int index, Class<? extends Throwable> clazz, String message) {
-        try {
-            assertTrue(list.get(index).toString(), clazz.isInstance(list.get(index)));
-            assertEquals(message, list.get(index).getMessage());
-        } catch (AssertionError e) {
-            list.get(index).printStackTrace();
-            throw e;
+        Throwable ex = list.get(index);
+        if (!clazz.isInstance(ex)) {
+            AssertionError err = new AssertionError("Type " + clazz + " expected but got " + ex);
+            err.initCause(ex);
+            throw err;
+        }
+        if (ObjectHelper.equals(message, ex.getMessage())) {
+            AssertionError err = new AssertionError("Message " + message + " expected but got " + ex.getMessage());
+            err.initCause(ex);
+            throw err;
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -577,11 +577,12 @@ public class FlowableConcatMapEagerTest {
             public Flowable<Integer> apply(Integer t) {
                 return Flowable.range(1, 1000).subscribeOn(Schedulers.computation());
             }
-        }).observeOn(Schedulers.newThread()).subscribe(ts);
-
-        ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
-        ts.assertNoErrors();
-        ts.assertValueCount(2000);
+        }).observeOn(Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertNoErrors()
+        .assertValueCount(2000)
+        .assertComplete();
     }
 
     @Test


### PR DESCRIPTION
`Flowable.concatMapEager`'s drain loop when encountering a finished inner jumped back to the beginning of the loop but disregarded the potentially changed request amount and just stopped emitting. The fix is to use the typical request management approach of reading the current request at the beginning of the loop and then committing the emission amount before trying to leave the loop.

Related: #4620

In addition `TestHelper.assertError` has been changed to attach the whole unexpected exception to the `AssertionError`. 
