### PR TITLE
2.x: fix window-timed test leaking an MBE that affects unrelated tests

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -18,11 +18,10 @@ import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
 
-import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.internal.subscribers.BasicFuseableSubscriber;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.plugins.RxJavaPlugins;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
@@ -17,12 +17,10 @@ import java.util.Collection;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
-import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.observers.BasicFuseableObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
@@ -14,7 +14,6 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.observers.BasicFuseableObserver;
 


### PR DESCRIPTION
The `FlowableWindowWithTimeTest.restartTimerMany` did not wait for its source to receive the cancellation and subsequent tests could delay this cancel.

Related: #4750
