### PR TITLE
2.x: cleanup & coverage 10/24-2

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
@@ -484,7 +484,7 @@ public final class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> exte
 
         @Override
         public void onError(Throwable t) {
-            parent.innerError(t);
+            parent.innerCloseError(t);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableInterval.java
@@ -82,15 +82,10 @@ public final class FlowableInterval extends Flowable<Long> {
 
                 if (r != 0L) {
                     actual.onNext(count++);
-                    if (r != Long.MAX_VALUE) {
-                        decrementAndGet();
-                    }
+                    BackpressureHelper.produced(this, 1);
                 } else {
-                    try {
-                        actual.onError(new MissingBackpressureException("Can't deliver value " + count + " due to lack of requests"));
-                    } finally {
-                        DisposableHelper.dispose(resource);
-                    }
+                    actual.onError(new MissingBackpressureException("Can't deliver value " + count + " due to lack of requests"));
+                    DisposableHelper.dispose(resource);
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
@@ -55,8 +55,8 @@ public final class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends A
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
 
-        GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> parent =
-                new GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>(s, leftEnd, rightEnd, resultSelector);
+        JoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> parent =
+                new JoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>(s, leftEnd, rightEnd, resultSelector);
 
         s.onSubscribe(parent);
 
@@ -69,7 +69,7 @@ public final class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends A
         other.subscribe(right);
     }
 
-    static final class GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>
+    static final class JoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>
     extends AtomicInteger implements Subscription, JoinSupport {
 
 
@@ -111,7 +111,7 @@ public final class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends A
 
         static final Integer RIGHT_CLOSE = 4;
 
-        GroupJoinSubscription(Subscriber<? super R> actual, Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd,
+        JoinSubscription(Subscriber<? super R> actual, Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd,
                 Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
                         BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector) {
             this.actual = actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDrop.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDrop.java
@@ -81,9 +81,7 @@ public final class FlowableOnBackpressureDrop<T> extends AbstractFlowableWithUps
             long r = get();
             if (r != 0L) {
                 actual.onNext(t);
-                if (r != Long.MAX_VALUE) {
-                    decrementAndGet();
-                }
+                BackpressureHelper.produced(this, 1);
             } else {
                 try {
                     onDrop.accept(t);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureError.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureError.java
@@ -65,9 +65,7 @@ public final class FlowableOnBackpressureError<T> extends AbstractFlowableWithUp
             long r = get();
             if (r != 0L) {
                 actual.onNext(t);
-                if (r != Long.MAX_VALUE) {
-                    decrementAndGet();
-                }
+                BackpressureHelper.produced(this, 1);
             } else {
                 onError(new MissingBackpressureException("could not emit value due to lack of requests"));
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
@@ -56,8 +56,8 @@ public final class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
     @Override
     protected void subscribeActual(Observer<? super R> s) {
 
-        GroupJoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R> parent =
-                new GroupJoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R>(
+        JoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R> parent =
+                new JoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R>(
                         s, leftEnd, rightEnd, resultSelector);
 
         s.onSubscribe(parent);
@@ -71,7 +71,7 @@ public final class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
         other.subscribe(right);
     }
 
-    static final class GroupJoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R>
+    static final class JoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R>
     extends AtomicInteger implements Disposable, JoinSupport {
 
 
@@ -111,7 +111,7 @@ public final class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
 
         static final Integer RIGHT_CLOSE = 4;
 
-        GroupJoinDisposable(Observer<? super R> actual,
+        JoinDisposable(Observer<? super R> actual,
                 Function<? super TLeft, ? extends ObservableSource<TLeftEnd>> leftEnd,
                 Function<? super TRight, ? extends ObservableSource<TRightEnd>> rightEnd,
                         BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector) {

--- a/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
@@ -47,15 +47,7 @@ public final class ComputationScheduler extends Scheduler {
     private static final String KEY_COMPUTATION_PRIORITY = "rx2.computation-priority";
 
     static {
-        int maxThreads = Integer.getInteger(KEY_MAX_THREADS, 0);
-        int cpuCount = Runtime.getRuntime().availableProcessors();
-        int max;
-        if (maxThreads <= 0 || maxThreads > cpuCount) {
-            max = cpuCount;
-        } else {
-            max = maxThreads;
-        }
-        MAX_THREADS = max;
+        MAX_THREADS = cap(Runtime.getRuntime().availableProcessors(), Integer.getInteger(KEY_MAX_THREADS, 0));
 
         SHUTDOWN_WORKER = new PoolWorker(new RxThreadFactory("RxComputationShutdown"));
         SHUTDOWN_WORKER.dispose();
@@ -64,6 +56,10 @@ public final class ComputationScheduler extends Scheduler {
                 Integer.getInteger(KEY_COMPUTATION_PRIORITY, Thread.NORM_PRIORITY)));
 
         THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX, priority);
+    }
+
+    static int cap(int cpuCount, int paramThreads) {
+        return paramThreads <= 0 || paramThreads > cpuCount ? cpuCount : paramThreads;
     }
 
     static final class FixedSchedulerPool {

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
@@ -123,6 +123,7 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
             }
             sr.setFuture(f);
         } catch (RejectedExecutionException ex) {
+            parent.remove(sr);
             RxJavaPlugins.onError(ex);
         }
 

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerPoolFactory.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerPoolFactory.java
@@ -25,8 +25,11 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Manages the creating of ScheduledExecutorServices and sets up purging.
  */
-public enum SchedulerPoolFactory {
-    ;
+public final class SchedulerPoolFactory {
+    /** Utility class. */
+    private SchedulerPoolFactory() {
+        throw new IllegalStateException("No instances!");
+    }
 
     static final String PURGE_ENABLED_KEY = "rx2.purge-enabled";
 

--- a/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
@@ -168,27 +168,25 @@ public final class TrampolineScheduler extends Scheduler {
 
         @Override
         public void run() {
-            if (worker.disposed) {
-                return;
-            }
-            long t = worker.now(TimeUnit.MILLISECONDS);
-            if (execTime > t) {
-                long delay = execTime - t;
-                if (delay > 0) {
-                    try {
-                        Thread.sleep(delay);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        RxJavaPlugins.onError(e);
-                        return;
+            if (!worker.disposed) {
+                long t = worker.now(TimeUnit.MILLISECONDS);
+                if (execTime > t) {
+                    long delay = execTime - t;
+                    if (delay > 0) {
+                        try {
+                            Thread.sleep(delay);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            RxJavaPlugins.onError(e);
+                            return;
+                        }
                     }
                 }
-            }
 
-            if (worker.disposed) {
-                return;
+                if (!worker.disposed) {
+                    run.run();
+                }
             }
-            run.run();
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureErrorTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+public class FlowableOnBackpressureErrorTest {
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.just(1).toFlowable(BackpressureStrategy.ERROR));
+    }
+
+    @Test
+    public void badRequest() {
+        TestHelper.assertBadRequestReported(Observable.just(1).toFlowable(BackpressureStrategy.ERROR));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
+            @Override
+            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
+                return new FlowableOnBackpressureError<Object>(f);
+            }
+        });
+    }
+
+    @Test
+    public void badSource() {
+        TestHelper.<Integer>checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return new FlowableOnBackpressureError<Integer>(f);
+            }
+        }, false, 1, 1, 1);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -544,7 +544,7 @@ public class FlowableReplayTest {
         verifyObserverMock(spiedSubscriberBeforeConnect, 2, 4);
         verifyObserverMock(spiedSubscriberAfterConnect, 2, 4);
 
-        verify(sourceUnsubscribed, times(1)).run();
+        verify(sourceUnsubscribed, never()).run();
 
         verifyNoMoreInteractions(sourceNext);
         verifyNoMoreInteractions(sourceCompleted);
@@ -603,8 +603,8 @@ public class FlowableReplayTest {
         // FIXME not supported
 //        verify(spiedWorker, times(1)).isUnsubscribed();
         // FIXME publish calls cancel too
-        verify(spiedWorker, times(2)).dispose();
-        verify(sourceUnsubscribed, times(1)).run();
+        verify(spiedWorker, times(1)).dispose();
+        verify(sourceUnsubscribed, never()).run();
 
         verifyNoMoreInteractions(sourceNext);
         verifyNoMoreInteractions(sourceCompleted);
@@ -669,8 +669,8 @@ public class FlowableReplayTest {
         // FIXME no longer supported
 //        verify(spiedWorker, times(1)).isUnsubscribed();
         // FIXME publish also calls cancel
-        verify(spiedWorker, times(2)).dispose();
-        verify(sourceUnsubscribed, times(1)).run();
+        verify(spiedWorker, times(1)).dispose();
+        verify(sourceUnsubscribed, never()).run();
 
         verifyNoMoreInteractions(sourceNext);
         verifyNoMoreInteractions(sourceCompleted);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
@@ -68,7 +68,7 @@ public class FlowableTakeUntilTest {
 
         verify(result, times(1)).onNext("one");
         verify(result, times(1)).onNext("two");
-        verify(sSource, times(1)).cancel();
+        verify(sSource, never()).cancel();
         verify(sOther, times(1)).cancel();
 
     }
@@ -93,7 +93,7 @@ public class FlowableTakeUntilTest {
         verify(result, times(1)).onNext("two");
         verify(result, times(0)).onNext("three");
         verify(result, times(1)).onError(error);
-        verify(sSource, times(1)).cancel();
+        verify(sSource, never()).cancel();
         verify(sOther, times(1)).cancel();
 
     }
@@ -120,7 +120,7 @@ public class FlowableTakeUntilTest {
         verify(result, times(1)).onError(error);
         verify(result, times(0)).onComplete();
         verify(sSource, times(1)).cancel();
-        verify(sOther, times(1)).cancel();
+        verify(sOther, never()).cancel();
 
     }
 
@@ -147,7 +147,7 @@ public class FlowableTakeUntilTest {
         verify(result, times(0)).onNext("three");
         verify(result, times(1)).onComplete();
         verify(sSource, times(1)).cancel();
-        verify(sOther, times(1)).cancel(); // unsubscribed since SafeSubscriber unsubscribes after onComplete
+        verify(sOther, never()).cancel(); // unsubscribed since SafeSubscriber unsubscribes after onComplete
 
     }
 

--- a/src/test/java/io/reactivex/internal/schedulers/ComputationSchedulerInternalTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/ComputationSchedulerInternalTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.internal.schedulers;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class ComputationSchedulerInternalTest {
+
+    @Test
+    public void capPoolSize() {
+        assertEquals(8, ComputationScheduler.cap(8, -1));
+        assertEquals(8, ComputationScheduler.cap(8, 0));
+        assertEquals(4, ComputationScheduler.cap(8, 4));
+        assertEquals(8, ComputationScheduler.cap(8, 8));
+        assertEquals(8, ComputationScheduler.cap(8, 9));
+        assertEquals(8, ComputationScheduler.cap(8, 16));
+    }
+}

--- a/src/test/java/io/reactivex/internal/schedulers/DisposeOnCancelTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/DisposeOnCancelTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.schedulers;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.disposables.*;
+
+public class DisposeOnCancelTest {
+
+    @Test
+    public void basicCoverage() throws Exception {
+        Disposable d = Disposables.empty();
+
+        DisposeOnCancel doc = new DisposeOnCancel(d);
+
+        assertFalse(doc.cancel(true));
+
+        assertFalse(doc.isCancelled());
+
+        assertFalse(doc.isDone());
+
+        assertNull(doc.get());
+
+        assertNull(doc.get(1, TimeUnit.SECONDS));
+    }
+}

--- a/src/test/java/io/reactivex/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/ScheduledRunnableTest.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.schedulers;
+
+import static org.junit.Assert.*;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.List;
+import java.util.concurrent.FutureTask;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class ScheduledRunnableTest {
+
+    @Test
+    public void dispose() {
+        CompositeDisposable set = new CompositeDisposable();
+        ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
+        set.add(run);
+
+        assertFalse(run.isDisposed());
+
+        set.dispose();
+
+        assertTrue(run.isDisposed());
+    }
+
+    @Test
+    public void disposeRun() {
+        CompositeDisposable set = new CompositeDisposable();
+        ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
+        set.add(run);
+
+        assertFalse(run.isDisposed());
+
+        run.dispose();
+        run.dispose();
+
+        assertTrue(run.isDisposed());
+    }
+
+    @Test
+    public void setFutureCancelRace() {
+        for (int i = 0; i < 500; i++) {
+            CompositeDisposable set = new CompositeDisposable();
+            final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
+            set.add(run);
+
+            final FutureTask<Object> ft = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, 0);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    run.setFuture(ft);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    run.dispose();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            assertEquals(0, set.size());
+        }
+    }
+
+    @Test
+    public void setFutureRunRace() {
+        for (int i = 0; i < 500; i++) {
+            CompositeDisposable set = new CompositeDisposable();
+            final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
+            set.add(run);
+
+            final FutureTask<Object> ft = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, 0);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    run.setFuture(ft);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    run.run();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            assertEquals(0, set.size());
+        }
+    }
+
+    @Test
+    public void disposeRace() {
+        for (int i = 0; i < 500; i++) {
+            CompositeDisposable set = new CompositeDisposable();
+            final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
+            set.add(run);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    run.dispose();
+                }
+            };
+
+            TestHelper.race(r1, r1);
+
+            assertEquals(0, set.size());
+        }
+    }
+
+    @Test
+    public void runDispose() {
+        for (int i = 0; i < 500; i++) {
+            CompositeDisposable set = new CompositeDisposable();
+            final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
+            set.add(run);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    run.call();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    run.dispose();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            assertEquals(0, set.size());
+        }
+    }
+
+    @Test
+    public void pluginCrash() {
+        Thread.currentThread().setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread t, Throwable e) {
+                throw new TestException("Second");
+            }
+        });
+
+        CompositeDisposable set = new CompositeDisposable();
+        final ScheduledRunnable run = new ScheduledRunnable(new Runnable() {
+            @Override
+            public void run() {
+                throw new TestException("First");
+            }
+        }, set);
+        set.add(run);
+
+        try {
+            run.run();
+
+            fail("Should have thrown!");
+        } catch (TestException ex) {
+            assertEquals("Second", ex.getMessage());
+        } finally {
+            Thread.currentThread().setUncaughtExceptionHandler(null);
+        }
+        assertTrue(run.isDisposed());
+
+        assertEquals(0, set.size());
+    }
+
+    @Test
+    public void crashReported() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            CompositeDisposable set = new CompositeDisposable();
+            final ScheduledRunnable run = new ScheduledRunnable(new Runnable() {
+                @Override
+                public void run() {
+                    throw new TestException("First");
+                }
+            }, set);
+            set.add(run);
+
+            run.run();
+
+            assertTrue(run.isDisposed());
+
+            assertEquals(0, set.size());
+
+            TestHelper.assertError(errors, 0, TestException.class, "First");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/schedulers/SchedulerPoolFactoryTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/SchedulerPoolFactoryTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.internal.schedulers;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+
+public class SchedulerPoolFactoryTest {
+
+    @Test
+    public void utilityClass() {
+        TestHelper.checkUtilityClass(SchedulerPoolFactory.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/schedulers/SingleSchedulerTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/SingleSchedulerTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.schedulers;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.Scheduler.Worker;
+import io.reactivex.disposables.Disposables;
+import io.reactivex.internal.schedulers.SingleScheduler.ScheduledWorker;
+
+public class SingleSchedulerTest {
+
+    @Test
+    public void shutdownRejects() {
+        final int[] calls = { 0 };
+
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                calls[0]++;
+            }
+        };
+
+        Scheduler s = new SingleScheduler();
+        s.shutdown();
+
+        assertEquals(Disposables.disposed(), s.scheduleDirect(r));
+
+        assertEquals(Disposables.disposed(), s.scheduleDirect(r, 1, TimeUnit.SECONDS));
+
+        assertEquals(Disposables.disposed(), s.schedulePeriodicallyDirect(r, 1, 1, TimeUnit.SECONDS));
+
+        Worker w = s.createWorker();
+        ((ScheduledWorker)w).executor.shutdownNow();
+
+        assertEquals(Disposables.disposed(), w.schedule(r));
+
+        assertEquals(Disposables.disposed(), w.schedule(r, 1, TimeUnit.SECONDS));
+
+        assertEquals(Disposables.disposed(), w.schedulePeriodically(r, 1, 1, TimeUnit.SECONDS));
+
+        assertEquals(0, calls[0]);
+
+        w.dispose();
+
+        assertTrue(w.isDisposed());
+    }
+
+    @Test
+    public void startRace() {
+        final Scheduler s = new SingleScheduler();
+        for (int i = 0; i < 500; i++) {
+            s.shutdown();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    s.start();
+                }
+            };
+
+            TestHelper.race(r1, r1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/schedulers/TrampolineSchedulerInternalTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/TrampolineSchedulerInternalTest.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.internal.schedulers;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.Scheduler.Worker;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.schedulers.Schedulers;
+
+public class TrampolineSchedulerInternalTest {
+
+    @Test
+    public void scheduleDirectInterrupt() {
+        Thread.currentThread().interrupt();
+
+        final int[] calls = { 0 };
+
+        assertSame(EmptyDisposable.INSTANCE, Schedulers.trampoline().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                calls[0]++;
+            }
+        }, 1, TimeUnit.SECONDS));
+
+        assertTrue(Thread.interrupted());
+
+        assertEquals(0, calls[0]);
+    }
+
+    @Test
+    public void dispose() {
+        Worker w = Schedulers.trampoline().createWorker();
+
+        assertFalse(w.isDisposed());
+
+        w.dispose();
+
+        assertTrue(w.isDisposed());
+
+        assertEquals(EmptyDisposable.INSTANCE, w.schedule(Functions.EMPTY_RUNNABLE));
+    }
+
+    @Test
+    public void reentrantScheduleDispose() {
+        final Worker w = Schedulers.trampoline().createWorker();
+        try {
+            final int[] calls = { 0, 0 };
+            w.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    calls[0]++;
+                    w.schedule(new Runnable() {
+                        @Override
+                        public void run() {
+                            calls[1]++;
+                        }
+                    })
+                    .dispose();
+                }
+            });
+
+            assertEquals(1, calls[0]);
+            assertEquals(0, calls[1]);
+        } finally {
+            w.dispose();
+        }
+    }
+
+    @Test
+    public void reentrantScheduleShutdown() {
+        final Worker w = Schedulers.trampoline().createWorker();
+        try {
+            final int[] calls = { 0, 0 };
+            w.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    calls[0]++;
+                    w.schedule(new Runnable() {
+                        @Override
+                        public void run() {
+                            calls[1]++;
+                        }
+                    }, 1, TimeUnit.MILLISECONDS);
+
+                    w.dispose();
+                }
+            });
+
+            assertEquals(1, calls[0]);
+            assertEquals(0, calls[1]);
+        } finally {
+            w.dispose();
+        }
+    }
+
+    @Test
+    public void reentrantScheduleShutdown2() {
+        final Worker w = Schedulers.trampoline().createWorker();
+        try {
+            final int[] calls = { 0, 0 };
+            w.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    calls[0]++;
+                    w.dispose();
+
+                    assertSame(EmptyDisposable.INSTANCE, w.schedule(new Runnable() {
+                        @Override
+                        public void run() {
+                            calls[1]++;
+                        }
+                    }, 1, TimeUnit.MILLISECONDS));
+                }
+            });
+
+            assertEquals(1, calls[0]);
+            assertEquals(0, calls[1]);
+        } finally {
+            w.dispose();
+        }
+    }
+
+    @Test(timeout = 5000)
+    public void reentrantScheduleInterrupt() {
+        final Worker w = Schedulers.trampoline().createWorker();
+        try {
+            final int[] calls = { 0 };
+            Thread.currentThread().interrupt();
+            w.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    calls[0]++;
+                }
+            }, 1, TimeUnit.DAYS);
+
+            assertTrue(Thread.interrupted());
+
+            assertEquals(0, calls[0]);
+        } finally {
+            w.dispose();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscribers/EmptyComponentTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/EmptyComponentTest.java
@@ -63,6 +63,8 @@ public class EmptyComponentTest {
 
             c.onError(new TestException());
 
+            c.onSuccess(2);
+
             c.cancel();
 
             TestHelper.assertError(errors, 0, TestException.class);

--- a/src/test/java/io/reactivex/internal/util/BackpressureHelperTest.java
+++ b/src/test/java/io/reactivex/internal/util/BackpressureHelperTest.java
@@ -67,6 +67,21 @@ public class BackpressureHelperTest {
     }
 
     @Test
+    public void producedMoreCancel() {
+        List<Throwable> list = TestHelper.trackPluginErrors();
+
+        try {
+            AtomicLong requested = new AtomicLong(1);
+
+            assertEquals(0, BackpressureHelper.producedCancel(requested, 2));
+
+            TestHelper.assertError(list, 0, IllegalStateException.class, "More produced than requested: -1");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
     public void requestProduceRace() {
         final AtomicLong requested = new AtomicLong(1);
 


### PR DESCRIPTION
- better coverage of `Flowable` operators
- cleanup of operator internals
- better coverage of standard Schedulers.
- rewrite of `takeUntil` to avoid `onSubscribe()` races.
