### PR TITLE
1.x: zip - check local boolean before volatile in logical and

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorZip.java
+++ b/src/main/java/rx/internal/operators/OperatorZip.java
@@ -246,7 +246,7 @@ public final class OperatorZip<R> implements Operator<R, Observable<?>[]> {
                             }
                         }
                         // we only emit if requested > 0 and have all values available
-                        if (requested.get() > 0 && allHaveValues) {
+                        if (allHaveValues && requested.get() > 0) {
                             try {
                                 // all have something so emit
                                 child.onNext(zipFunction.call(vs));


### PR DESCRIPTION
Minor perf improvement.  Local boolean variable check should be placed before volatile check in `&&` operation.
