### PR TITLE
2.x: cleanup, fixes and coverage 10/25

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -11329,6 +11329,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *     Publisher.defer(() -> o.scan(new ArrayList&lt;>(), (list, item) -> list.add(item)))
      * );
      * </code></pre>
+     * <p>
+     * Unlike 1.x, this operator doesn't emit the seed value unless the upstream signals an event.
      * <dl>
      *  <dt><b>Backpressure:</b><dt>
      *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.

--- a/src/main/java/io/reactivex/internal/observers/ForEachWhileObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/ForEachWhileObserver.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.Exceptions;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -82,7 +82,7 @@ implements Observer<T>, Disposable {
             onError.accept(t);
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
-            RxJavaPlugins.onError(ex);
+            RxJavaPlugins.onError(new CompositeException(t, ex));
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCreate.java
@@ -22,7 +22,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.internal.disposables.*;
-import io.reactivex.internal.fuseable.SimpleQueue;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
@@ -91,7 +91,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
         final AtomicThrowable error;
 
-        final SimpleQueue<T> queue;
+        final SimplePlainQueue<T> queue;
 
         volatile boolean done;
 
@@ -116,7 +116,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
                     return;
                 }
             } else {
-                SimpleQueue<T> q = queue;
+                SimplePlainQueue<T> q = queue;
                 synchronized (q) {
                     q.offer(t);
                 }
@@ -161,7 +161,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
         void drainLoop() {
             BaseEmitter<T> e = emitter;
-            SimpleQueue<T> q = queue;
+            SimplePlainQueue<T> q = queue;
             AtomicThrowable error = this.error;
             int missed = 1;
             for (;;) {
@@ -179,15 +179,8 @@ public final class FlowableCreate<T> extends Flowable<T> {
                     }
 
                     boolean d = done;
-                    T v;
 
-                    try {
-                        v = q.poll();
-                    } catch (Throwable ex) {
-                        Exceptions.throwIfFatal(ex);
-                        // should never happen
-                        v = null;
-                    }
+                    T v = q.poll();
 
                     boolean empty = v == null;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
@@ -142,9 +142,7 @@ public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T
                 long r = get();
                 if (r != 0L) {
                     actual.onNext(value);
-                    if (r != Long.MAX_VALUE) {
-                        decrementAndGet();
-                    }
+                    BackpressureHelper.produced(this, 1);
                 } else {
                     cancel();
                     actual.onError(new MissingBackpressureException("Could not deliver value due to lack of requests"));

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
@@ -24,7 +24,6 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.FuseToFlowable;
-import io.reactivex.internal.observers.BasicIntQueueDisposable;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.AtomicThrowable;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -62,8 +61,8 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
         return RxJavaPlugins.onAssembly(new FlowableFlatMapCompletable<T>(source, mapper, delayErrors, maxConcurrency));
     }
 
-    static final class FlatMapCompletableMainSubscriber<T> extends BasicIntQueueDisposable<T>
-    implements Subscriber<T> {
+    static final class FlatMapCompletableMainSubscriber<T> extends AtomicInteger
+    implements Subscriber<T>, Disposable {
         private static final long serialVersionUID = 8443155186132538303L;
 
         final CompletableObserver actual;
@@ -181,26 +180,6 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
         @Override
         public boolean isDisposed() {
             return set.isDisposed();
-        }
-
-        @Override
-        public T poll() throws Exception {
-            return null; // always empty
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return true; // always empty
-        }
-
-        @Override
-        public void clear() {
-            // nothing to clear
-        }
-
-        @Override
-        public int requestFusion(int mode) {
-            return mode & ASYNC;
         }
 
         void innerComplete(InnerObserver inner) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -131,13 +131,10 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
                             done = true;
                             s.cancel();
                             DisposableHelper.dispose(timer);
-                            worker.dispose();
 
-                            if (other == null) {
-                                actual.onError(new TimeoutException());
-                            } else {
-                                subscribeNext();
-                            }
+                            subscribeNext();
+
+                            worker.dispose();
                         }
                     }
                 }, timeout, unit);

--- a/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
@@ -74,8 +74,7 @@ public final class IoScheduler extends Scheduler {
             Future<?> task = null;
             if (unit != null) {
                 evictor = Executors.newScheduledThreadPool(1, EVICTOR_THREAD_FACTORY);
-                task = evictor.scheduleWithFixedDelay(this, this.keepAliveTime, this.keepAliveTime, TimeUnit.NANOSECONDS
-                );
+                task = evictor.scheduleWithFixedDelay(this, this.keepAliveTime, this.keepAliveTime, TimeUnit.NANOSECONDS);
             }
             evictorService = evictor;
             evictorTask = task;

--- a/src/main/java/io/reactivex/internal/subscribers/BasicFuseableConditionalSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/BasicFuseableConditionalSubscriber.java
@@ -90,29 +90,6 @@ public abstract class BasicFuseableConditionalSubscriber<T, R> implements Condit
     // Convenience and state-aware methods
     // -----------------------------------
 
-    /**
-     * Emits the value to the actual subscriber if {@link #done} is false.
-     * @param value the value to signal
-     */
-    protected final void next(R value) {
-        if (done) {
-            return;
-        }
-        actual.onNext(value);
-    }
-
-    /**
-     * Tries to emit the value to the actual subscriber if {@link #done} is false
-     * and returns the response from the {@link ConditionalSubscriber#tryOnNext(Object)}
-     * call.
-     * @param value the value to signal
-     * @return the response from the actual subscriber: true indicates accepted value,
-     * false indicates dropped value
-     */
-    protected final boolean tryNext(R value) {
-        return !done && actual.tryOnNext(value);
-    }
-
     @Override
     public void onError(Throwable t) {
         if (done) {
@@ -140,27 +117,6 @@ public abstract class BasicFuseableConditionalSubscriber<T, R> implements Condit
         }
         done = true;
         actual.onComplete();
-    }
-
-    /**
-     * Calls the upstream's QueueSubscription.requestFusion with the mode and
-     * saves the established mode in {@link #sourceMode}.
-     * <p>
-     * If the upstream doesn't support fusion ({@link #qs} is null), the method
-     * returns {@link QueueSubscription#NONE}.
-     * @param mode the fusion mode requested
-     * @return the established fusion mode
-     */
-    protected final int transitiveFusion(int mode) {
-        QueueSubscription<T> qs = this.qs;
-        if (qs != null) {
-            int m = qs.requestFusion(mode);
-            if (m != NONE) {
-                sourceMode = m;
-            }
-            return m;
-        }
-        return NONE;
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/subscribers/InnerQueuedSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/InnerQueuedSubscriber.java
@@ -143,8 +143,4 @@ implements Subscriber<T>, Subscription {
     public SimpleQueue<T> queue() {
         return queue;
     }
-
-    public int fusionMode() {
-        return fusionMode;
-    }
 }

--- a/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
@@ -1,0 +1,283 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.observers;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class LambdaObserverTest {
+
+    @Test
+    public void onSubscribeThrows() {
+        final List<Object> received = new ArrayList<Object>();
+
+        LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                received.add(v);
+            }
+        },
+        new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                received.add(e);
+            }
+        }, new Action() {
+            @Override
+            public void run() throws Exception {
+                received.add(100);
+            }
+        }, new Consumer<Disposable>() {
+            @Override
+            public void accept(Disposable s) throws Exception {
+                throw new TestException();
+            }
+        });
+
+        assertFalse(o.isDisposed());
+
+        Observable.just(1).subscribe(o);
+
+        assertTrue(received.toString(), received.get(0) instanceof TestException);
+        assertEquals(received.toString(), 1, received.size());
+
+        assertTrue(o.isDisposed());
+    }
+
+    @Test
+    public void onNextThrows() {
+        final List<Object> received = new ArrayList<Object>();
+
+        LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                throw new TestException();
+            }
+        },
+        new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                received.add(e);
+            }
+        }, new Action() {
+            @Override
+            public void run() throws Exception {
+                received.add(100);
+            }
+        }, new Consumer<Disposable>() {
+            @Override
+            public void accept(Disposable s) throws Exception {
+            }
+        });
+
+        assertFalse(o.isDisposed());
+
+        Observable.just(1).subscribe(o);
+
+        assertTrue(received.toString(), received.get(0) instanceof TestException);
+        assertEquals(received.toString(), 1, received.size());
+
+        assertTrue(o.isDisposed());
+    }
+
+    @Test
+    public void onErrorThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            final List<Object> received = new ArrayList<Object>();
+
+            LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+                @Override
+                public void accept(Object v) throws Exception {
+                    received.add(v);
+                }
+            },
+            new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable e) throws Exception {
+                    throw new TestException("Inner");
+                }
+            }, new Action() {
+                @Override
+                public void run() throws Exception {
+                    received.add(100);
+                }
+            }, new Consumer<Disposable>() {
+                @Override
+                public void accept(Disposable s) throws Exception {
+                }
+            });
+
+            assertFalse(o.isDisposed());
+
+            Observable.<Integer>error(new TestException("Outer")).subscribe(o);
+
+            assertTrue(received.toString(), received.isEmpty());
+
+            assertTrue(o.isDisposed());
+
+            TestHelper.assertError(errors, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(errors.get(0));
+            TestHelper.assertError(ce, 0, TestException.class, "Outer");
+            TestHelper.assertError(ce, 1, TestException.class, "Inner");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            final List<Object> received = new ArrayList<Object>();
+
+            LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+                @Override
+                public void accept(Object v) throws Exception {
+                    received.add(v);
+                }
+            },
+            new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable e) throws Exception {
+                    received.add(e);
+                }
+            }, new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            }, new Consumer<Disposable>() {
+                @Override
+                public void accept(Disposable s) throws Exception {
+                }
+            });
+
+            assertFalse(o.isDisposed());
+
+            Observable.<Integer>empty().subscribe(o);
+
+            assertTrue(received.toString(), received.isEmpty());
+
+            assertTrue(o.isDisposed());
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void badSourceOnSubscribe() {
+        Observable<Integer> source = new Observable<Integer>() {
+            @Override
+            public void subscribeActual(Observer<? super Integer> s) {
+                Disposable s1 = Disposables.empty();
+                s.onSubscribe(s1);
+                Disposable s2 = Disposables.empty();
+                s.onSubscribe(s2);
+
+                assertFalse(s1.isDisposed());
+                assertTrue(s2.isDisposed());
+
+                s.onNext(1);
+                s.onComplete();
+            }
+        };
+
+        final List<Object> received = new ArrayList<Object>();
+
+        LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                received.add(v);
+            }
+        },
+        new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                received.add(e);
+            }
+        }, new Action() {
+            @Override
+            public void run() throws Exception {
+                received.add(100);
+            }
+        }, new Consumer<Disposable>() {
+            @Override
+            public void accept(Disposable s) throws Exception {
+            }
+        });
+
+        source.subscribe(o);
+
+        assertEquals(Arrays.asList(1, 100), received);
+    }
+    @Test
+    public void badSourceEmitAfterDone() {
+        Observable<Integer> source = new Observable<Integer>() {
+            @Override
+            public void subscribeActual(Observer<? super Integer> s) {
+                s.onSubscribe(Disposables.empty());
+
+                s.onNext(1);
+                s.onComplete();
+                s.onNext(2);
+                s.onError(new TestException());
+                s.onComplete();
+            }
+        };
+
+        final List<Object> received = new ArrayList<Object>();
+
+        LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                received.add(v);
+            }
+        },
+        new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                received.add(e);
+            }
+        }, new Action() {
+            @Override
+            public void run() throws Exception {
+                received.add(100);
+            }
+        }, new Consumer<Disposable>() {
+            @Override
+            public void accept(Disposable s) throws Exception {
+            }
+        });
+
+        source.subscribe(o);
+
+        assertEquals(Arrays.asList(1, 100), received);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
@@ -25,7 +25,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
-import io.reactivex.exceptions.TestException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
@@ -388,5 +388,23 @@ public class FlowableDebounceTest {
         Flowable.just(1).debounce(Functions.justFunction(Flowable.empty()))
         .test()
         .assertResult(1);
+    }
+
+    @Test
+    public void backpressureNoRequest() {
+        Flowable.just(1)
+        .debounce(Functions.justFunction(Flowable.timer(1, TimeUnit.MILLISECONDS)))
+        .test(0L)
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(MissingBackpressureException.class);
+    }
+
+    @Test
+    public void backpressureNoRequestTimed() {
+        Flowable.just(1)
+        .debounce(1, TimeUnit.MILLISECONDS)
+        .test(0L)
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(MissingBackpressureException.class);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -291,4 +291,22 @@ public class FlowableOnBackpressureBufferTest {
         .assertNoErrors()
         .assertComplete();
     }
+
+    @Test
+    public void emptyDelayError() {
+        Flowable.empty()
+        .onBackpressureBuffer(true)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void fusionRejected() {
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.SYNC);
+
+        Flowable.<Integer>never().onBackpressureBuffer().subscribe(ts);
+
+        SubscriberFusion.assertFusion(ts, QueueSubscription.NONE)
+        .assertEmpty();
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -21,8 +21,8 @@ import java.util.concurrent.atomic.*;
 import org.junit.Test;
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
-import io.reactivex.functions.Consumer;
+import io.reactivex.*;
+import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
@@ -178,5 +178,30 @@ public class FlowableOnBackpressureDropTest {
           .subscribe(ts);
 
         assertFalse(errorOccurred.get());
+    }
+
+    @Test
+    public void badSource() {
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.onBackpressureDrop();
+            }
+        }, false, 1, 1, 1);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
+            @Override
+            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
+                return f.onBackpressureDrop();
+            }
+        });
+    }
+
+    @Test
+    public void badRequest() {
+        TestHelper.assertBadRequestReported(Flowable.just(1).onBackpressureDrop());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
@@ -362,10 +362,11 @@ public class FlowableScanTest {
         });
 
         verify(producer.get(), never()).request(0);
-        verify(producer.get(), times(3)).request(1); // FIXME this was 2 in 1.x
+        verify(producer.get(), times(2)).request(1);
     }
 
     @Test
+    @Ignore("scanSeed no longer emits without upstream signal")
     public void testInitialValueEmittedNoProducer() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -384,6 +385,7 @@ public class FlowableScanTest {
     }
 
     @Test
+    @Ignore("scanSeed no longer emits without upstream signal")
     public void testInitialValueEmittedWithProducer() {
         Flowable<Integer> source = Flowable.never();
 
@@ -456,20 +458,5 @@ public class FlowableScanTest {
         })
         .test()
         .assertFailure(TestException.class);
-    }
-
-    @Test
-    public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
-            @Override
-            public Object apply(Flowable<Object> o) throws Exception {
-                return o.scan(0, new BiFunction<Object, Object, Object>() {
-                    @Override
-                    public Object apply(Object a, Object b) throws Exception {
-                        return a;
-                    }
-                });
-            }
-        }, false, 1, 1, 0, 0);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
@@ -742,6 +742,13 @@ public class FlowableSingleTest {
                 return o.singleElement();
             }
         }, false, 1, 1, 1);
+
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
+            @Override
+            public Object apply(Flowable<Object> o) throws Exception {
+                return o.singleOrError().toFlowable();
+            }
+        }, false, 1, 1, 1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.TestHelper;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.internal.subscriptions.ScalarSubscription;
+
+public class BasicFuseableConditionalSubscriberTest {
+
+    @Test
+    public void offerThrows() {
+        ConditionalSubscriber<Integer> cs = new ConditionalSubscriber<Integer>() {
+
+            @Override
+            public void onSubscribe(Subscription s) {
+            }
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            public boolean tryOnNext(Integer t) {
+                return false;
+            }
+        };
+
+        BasicFuseableConditionalSubscriber<Integer, Integer> fcs = new BasicFuseableConditionalSubscriber<Integer, Integer>(cs) {
+
+            @Override
+            public boolean tryOnNext(Integer t) {
+                return false;
+            }
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public int requestFusion(int mode) {
+                return 0;
+            }
+
+            @Override
+            public Integer poll() throws Exception {
+                return null;
+            }
+        };
+
+        fcs.onSubscribe(new ScalarSubscription<Integer>(fcs, 1));
+
+        TestHelper.assertNoOffer(fcs);
+
+        assertFalse(fcs.isEmpty());
+        fcs.clear();
+        assertTrue(fcs.isEmpty());
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscribers/BasicFuseableSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/BasicFuseableSubscriberTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.internal.subscriptions.ScalarSubscription;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class BasicFuseableSubscriberTest {
+
+    @Test
+    public void offerThrows() {
+        BasicFuseableSubscriber<Integer, Integer> fcs = new BasicFuseableSubscriber<Integer, Integer>(new TestSubscriber<Integer>(0L)) {
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public int requestFusion(int mode) {
+                return 0;
+            }
+
+            @Override
+            public Integer poll() throws Exception {
+                return null;
+            }
+        };
+
+        fcs.onSubscribe(new ScalarSubscription<Integer>(fcs, 1));
+
+        TestHelper.assertNoOffer(fcs);
+
+        assertFalse(fcs.isEmpty());
+        fcs.clear();
+        assertTrue(fcs.isEmpty());
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscribers/InnerQueuedSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/InnerQueuedSubscriberTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+public class InnerQueuedSubscriberTest {
+
+    @Test
+    public void requestInBatches() {
+        InnerQueuedSubscriberSupport<Integer> support = new InnerQueuedSubscriberSupport<Integer>() {
+            @Override
+            public void innerNext(InnerQueuedSubscriber<Integer> inner, Integer value) {
+            }
+            @Override
+            public void innerError(InnerQueuedSubscriber<Integer> inner, Throwable e) {
+            }
+            @Override
+            public void innerComplete(InnerQueuedSubscriber<Integer> inner) {
+            }
+            @Override
+            public void drain() {
+            }
+        };
+
+        InnerQueuedSubscriber<Integer> inner = new InnerQueuedSubscriber<Integer>(support, 4);
+
+        final List<Long> requests = new ArrayList<Long>();
+
+        inner.onSubscribe(new Subscription() {
+            @Override
+            public void request(long n) {
+                requests.add(n);
+            }
+            @Override
+            public void cancel() {
+                // ignore
+            }
+        });
+
+        inner.request(1);
+        inner.request(1);
+        inner.request(1);
+        inner.request(1);
+        inner.request(1);
+
+        assertEquals(Arrays.asList(4L, 3L), requests);
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscribers/SinglePostCompleteSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/SinglePostCompleteSubscriberTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class SinglePostCompleteSubscriberTest {
+
+    @Test
+    public void requestCompleteRace() {
+        for (int i = 0; i < 500; i++) {
+            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+
+            final SinglePostCompleteSubscriber<Integer, Integer> spc = new SinglePostCompleteSubscriber<Integer, Integer>(ts) {
+                private static final long serialVersionUID = -2848918821531562637L;
+
+                @Override
+                public void onNext(Integer t) {
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                }
+
+                @Override
+                public void onComplete() {
+                    complete(1);
+                }
+            };
+
+            spc.onSubscribe(new BooleanSubscription());
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    spc.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.request(1);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/observable/ObservableGroupByTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableGroupByTests.java
@@ -23,7 +23,7 @@ import io.reactivex.observables.GroupedObservable;
 public class ObservableGroupByTests {
 
     @Test
-    public void testTakeUnsubscribesOnGroupBy() {
+    public void testTakeUnsubscribesOnGroupBy() throws Exception {
         Observable.merge(
             ObservableEventStream.getEventStream("HTTP-ClusterA", 50),
             ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
@@ -45,10 +45,12 @@ public class ObservableGroupByTests {
         });
 
         System.out.println("**** finished");
+
+        Thread.sleep(200); // make sure the event streams receive their interrupt
     }
 
     @Test
-    public void testTakeUnsubscribesOnFlatMapOfGroupBy() {
+    public void testTakeUnsubscribesOnFlatMapOfGroupBy() throws Exception {
         Observable.merge(
             ObservableEventStream.getEventStream("HTTP-ClusterA", 50),
             ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
@@ -80,5 +82,7 @@ public class ObservableGroupByTests {
         });
 
         System.out.println("**** finished");
+
+        Thread.sleep(200); // make sure the event streams receive their interrupt
     }
 }

--- a/src/test/java/io/reactivex/observable/ObservableScanTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableScanTests.java
@@ -23,7 +23,7 @@ import io.reactivex.observable.ObservableEventStream.Event;
 public class ObservableScanTests {
 
     @Test
-    public void testUnsubscribeScan() {
+    public void testUnsubscribeScan() throws Exception {
 
         ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
         .scan(new HashMap<String, String>(), new BiFunction<HashMap<String, String>, Event, HashMap<String, String>>() {
@@ -40,5 +40,7 @@ public class ObservableScanTests {
                 System.out.println(pv);
             }
         });
+
+        Thread.sleep(200); // make sure the event streams receive their interrupt
     }
 }

--- a/src/test/java/io/reactivex/observable/ObservableZipTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableZipTests.java
@@ -28,7 +28,7 @@ import io.reactivex.observables.GroupedObservable;
 public class ObservableZipTests {
 
     @Test
-    public void testZipObservableOfObservables() {
+    public void testZipObservableOfObservables() throws Exception {
         ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
                 .groupBy(new Function<Event, String>() {
                     @Override
@@ -63,6 +63,8 @@ public class ObservableZipTests {
                 });
 
         System.out.println("**** finished");
+
+        Thread.sleep(200); // make sure the event streams receive their interrupt
     }
 
     /**


### PR DESCRIPTION
This is the last part of my dedicated coverage improvement run.
- Update code paths and remove unnecessary and unused parts.
- Fix `skipUntil` lifecycle and concurrency properties.
- Fix `concatMapEager` error management.
- `Flowable.scan(T, BiFunction)` now emits the initial value only when the upstream signals an event. This has the effect that even if there is a downstream request, the initial value won't get emitted. This change reduces the overhead of the operator greatly.
