### PR TITLE
2.x: Rename BackpressureStrategy.NONE to MISSING

### DIFF
--- a/src/main/java/io/reactivex/BackpressureStrategy.java
+++ b/src/main/java/io/reactivex/BackpressureStrategy.java
@@ -22,7 +22,7 @@ public enum BackpressureStrategy {
      * Downstream has to deal with any overflow.
      * <p>Useful when one applies one of the custom-parameter onBackpressureXXX operators.
      */
-    NONE,
+    MISSING,
     /**
      * Signals a MissingBackpressureException in case the downstream can't keep up.
      */

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -11758,7 +11758,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
                 return o.onBackpressureDrop();
             case LATEST:
                 return o.onBackpressureLatest();
-            case NONE:
+            case MISSING:
                 return o;
             case ERROR:
                 return RxJavaPlugins.onAssembly(new FlowableOnBackpressureError<T>(o));

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCreate.java
@@ -45,8 +45,8 @@ public final class FlowableCreate<T> extends Flowable<T> {
         BaseEmitter<T> emitter;
 
         switch (backpressure) {
-        case NONE: {
-            emitter = new NoneEmitter<T>(t);
+        case MISSING: {
+            emitter = new MissingEmitter<T>(t);
             break;
         }
         case ERROR: {
@@ -319,12 +319,12 @@ public final class FlowableCreate<T> extends Flowable<T> {
         }
     }
 
-    static final class NoneEmitter<T> extends BaseEmitter<T> {
+    static final class MissingEmitter<T> extends BaseEmitter<T> {
 
 
         private static final long serialVersionUID = 3776720187248809713L;
 
-        NoneEmitter(Subscriber<? super T> actual) {
+        MissingEmitter(Subscriber<? super T> actual) {
             super(actual);
         }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -314,7 +314,7 @@ public class FlowableCreateTest {
     }
 
     @Test
-    public void createNullValueNone() {
+    public void createNullValueMissing() {
         final Throwable[] error = { null };
 
         Flowable.create(new FlowableOnSubscribe<Integer>() {
@@ -329,7 +329,7 @@ public class FlowableCreateTest {
                     error[0] = ex;
                 }
             }
-        }, BackpressureStrategy.NONE)
+        }, BackpressureStrategy.MISSING)
         .test()
         .assertFailure(NullPointerException.class);
 
@@ -433,7 +433,7 @@ public class FlowableCreateTest {
     }
 
     @Test
-    public void createNullValueNoneSerialized() {
+    public void createNullValueMissingSerialized() {
         final Throwable[] error = { null };
 
         Flowable.create(new FlowableOnSubscribe<Integer>() {
@@ -449,7 +449,7 @@ public class FlowableCreateTest {
                     error[0] = ex;
                 }
             }
-        }, BackpressureStrategy.NONE)
+        }, BackpressureStrategy.MISSING)
         .test()
         .assertFailure(NullPointerException.class);
 
@@ -653,7 +653,7 @@ public class FlowableCreateTest {
 
     @Test(expected = NullPointerException.class)
     public void nullArgument() {
-        Flowable.create(null, BackpressureStrategy.NONE);
+        Flowable.create(null, BackpressureStrategy.MISSING);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromObservableTest.java
@@ -21,13 +21,13 @@ import io.reactivex.exceptions.TestException;
 public class FlowableFromObservableTest {
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Observable.just(1).toFlowable(BackpressureStrategy.NONE));
+        TestHelper.checkDisposed(Observable.just(1).toFlowable(BackpressureStrategy.MISSING));
     }
 
     @Test
     public void error() {
         Observable.error(new TestException())
-        .toFlowable(BackpressureStrategy.NONE)
+        .toFlowable(BackpressureStrategy.MISSING)
         .test()
         .assertFailure(TestException.class);
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
@@ -96,8 +96,8 @@ public class FlowableFromSourceTest {
     }
 
     @Test
-    public void normalNone() {
-        Flowable.create(source, BackpressureStrategy.NONE).subscribe(ts);
+    public void normalMissing() {
+        Flowable.create(source, BackpressureStrategy.MISSING).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -109,8 +109,8 @@ public class FlowableFromSourceTest {
     }
 
     @Test
-    public void normalNoneRequested() {
-        Flowable.create(source, BackpressureStrategy.NONE).subscribe(ts);
+    public void normalMissingRequested() {
+        Flowable.create(source, BackpressureStrategy.MISSING).subscribe(ts);
         ts.request(2);
 
         source.onNext(1);
@@ -175,8 +175,8 @@ public class FlowableFromSourceTest {
     }
 
     @Test
-    public void errorNone() {
-        Flowable.create(source, BackpressureStrategy.NONE).subscribe(ts);
+    public void errorMissing() {
+        Flowable.create(source, BackpressureStrategy.MISSING).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -254,8 +254,8 @@ public class FlowableFromSourceTest {
     }
 
     @Test
-    public void unsubscribedNone() {
-        Flowable.create(source, BackpressureStrategy.NONE).subscribe(ts);
+    public void unsubscribedMissing() {
+        Flowable.create(source, BackpressureStrategy.MISSING).subscribe(ts);
         ts.cancel();
 
         source.onNext(1);
@@ -334,8 +334,8 @@ public class FlowableFromSourceTest {
     }
 
     @Test
-    public void unsubscribedNoCancelNone() {
-        Flowable.create(sourceNoCancel, BackpressureStrategy.NONE).subscribe(ts);
+    public void unsubscribedNoCancelMissing() {
+        Flowable.create(sourceNoCancel, BackpressureStrategy.MISSING).subscribe(ts);
         ts.cancel();
 
         sourceNoCancel.onNext(1);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -867,7 +867,7 @@ public class FlowablePublishTest {
                     s.onNext(i);
                 }
             }
-        }, BackpressureStrategy.NONE)
+        }, BackpressureStrategy.MISSING)
         .publish(8)
         .autoConnect()
         .test(0L)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToXTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToXTest.java
@@ -69,7 +69,7 @@ public class ObservableToXTest {
     @Test
     public void toFlowableMissing() {
         TestSubscriber<Integer> ts = Observable.range(1, 5)
-                .toFlowable(BackpressureStrategy.NONE)
+                .toFlowable(BackpressureStrategy.MISSING)
                 .test(0);
 
         ts.request(2);


### PR DESCRIPTION
As discussed in #4643.
