### PR TITLE
2.x: allow subscribeOn to work with blocking create

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -12251,7 +12251,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> subscribeOn(Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableSubscribeOn<T>(this, scheduler));
+        return RxJavaPlugins.onAssembly(new FlowableSubscribeOn<T>(this, scheduler, this instanceof FlowableCreate));
     }
 
     /**


### PR DESCRIPTION
When running a blocking emission in `Flowable.create` with `subscribeOn`, the default behavior of `subscribeOn` is to schedule downstream requests onto the same thread. Unfortunately, the blocking emission prevents the backing threadpool the `create` from accumulating that request amount leading to either buffer bloat or dropped emissions till the very end of the sequence.

This PR introduces a `nonScheduledRequests` parameter to `subscribeOn` that simply calls the upstream's `request()` from the caller's thread without scheduling it. The parameter is not exposed to the surface API but the `subscribeOn` operator does an `instanceof` check to see if the upstream type is `FlowableCreate`.

Note that this requires a direct upstream `create` and any intermediate operator re-enables the default behavior. It is possible to traverse the upstream graph to locate a `FlowableCreate` but it has relatively high cost and thus penalizing all `subscribeOn` usages.

Related: #4735
