### PR TITLE
1.x: support Observable.test()

### DIFF
--- a/src/main/java/rx/Completable.java
+++ b/src/main/java/rx/Completable.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import rx.annotations.*;
 import rx.exceptions.*;
 import rx.functions.*;
+import rx.internal.observers.AssertableSubscriberObservable;
 import rx.internal.operators.*;
 import rx.internal.util.*;
 import rx.observers.*;
@@ -2363,5 +2364,27 @@ public class Completable {
                 });
             }
         });
+    }
+    
+    // -------------------------------------------------------------------------
+    // Fluent test support, super handy and reduces test preparation boilerplate
+    // -------------------------------------------------------------------------
+    /**
+     * Creates an AssertableSubscriber that requests {@code Long.MAX_VALUE} and subscribes
+     * it to this Observable.
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned AssertableSubscriber consumes this Observable in an unbounded fashion.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new AssertableSubscriber instance
+     * @since 1.2.3
+     */
+    @Experimental
+    public final AssertableSubscriber<Void> test() {
+        AssertableSubscriberObservable<Void> ts = AssertableSubscriberObservable.create(Long.MAX_VALUE);
+        subscribe(ts);
+        return ts;
     }
 }

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -18,10 +18,12 @@ import java.util.concurrent.*;
 import rx.annotations.*;
 import rx.exceptions.*;
 import rx.functions.*;
+import rx.internal.observers.AssertableSubscriberObservable;
 import rx.internal.operators.*;
 import rx.internal.util.*;
 import rx.observables.*;
 import rx.observers.SafeSubscriber;
+import rx.observers.AssertableSubscriber;
 import rx.plugins.*;
 import rx.schedulers.*;
 import rx.subscriptions.Subscriptions;
@@ -12639,5 +12641,46 @@ public class Observable<T> {
     @SuppressWarnings("cast")
     public final <T2, R> Observable<R> zipWith(Observable<? extends T2> other, Func2<? super T, ? super T2, ? extends R> zipFunction) {
         return (Observable<R>)zip(this, other, zipFunction);
+    }
+    
+    // -------------------------------------------------------------------------
+    // Fluent test support, super handy and reduces test preparation boilerplate
+    // -------------------------------------------------------------------------
+    /**
+     * Creates a AssertableSubscriber that requests {@code Long.MAX_VALUE} and subscribes
+     * it to this Observable.
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned AssertableSubscriber consumes this Observable in an unbounded fashion.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new AssertableSubscriber instance
+     * @since 1.2.3
+     */
+    @Experimental
+    public final AssertableSubscriber<T> test() {
+        AssertableSubscriber<T> ts = AssertableSubscriberObservable.create(Long.MAX_VALUE);
+        subscribe(ts);
+        return ts;
+    }
+    
+    /**
+     * Creates an AssertableSubscriber with the initial request amount and subscribes
+     * it to this Observable.
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned AssertableSubscriber requests the given {@code initialRequest} amount upfront.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new AssertableSubscriber instance
+     * @since 1.2.3
+     */
+    @Experimental
+    public final AssertableSubscriber<T> test(long initialRequestAmount) {
+        AssertableSubscriber<T> ts = AssertableSubscriberObservable.create(initialRequestAmount);
+        subscribe(ts);
+        return ts;
     }
 }

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -19,6 +19,7 @@ import rx.Observable.Operator;
 import rx.annotations.*;
 import rx.exceptions.*;
 import rx.functions.*;
+import rx.internal.observers.AssertableSubscriberObservable;
 import rx.internal.operators.*;
 import rx.internal.util.*;
 import rx.observables.ConnectableObservable;
@@ -2674,5 +2675,27 @@ public class Single<T> {
             throw new NullPointerException();
         }
         return create(new SingleOnSubscribeDelaySubscriptionOther<T>(this, other));
+    }
+
+    // -------------------------------------------------------------------------
+    // Fluent test support, super handy and reduces test preparation boilerplate
+    // -------------------------------------------------------------------------
+    /**
+     * Creates an AssertableSubscriber that requests {@code Long.MAX_VALUE} and subscribes
+     * it to this Observable.
+     * <dl>
+     *  <dt><b>Backpressure:</b><dt>
+     *  <dd>The returned AssertableSubscriber consumes this Observable in an unbounded fashion.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new AssertableSubscriber instance
+     * @since 1.2.3
+     */
+    @Experimental
+    public final AssertableSubscriber<T> test() {
+        AssertableSubscriberObservable<T> ts = AssertableSubscriberObservable.create(Long.MAX_VALUE);
+        subscribe(ts);
+        return ts;
     }
 }

--- a/src/main/java/rx/internal/observers/AssertableSubscriberObservable.java
+++ b/src/main/java/rx/internal/observers/AssertableSubscriberObservable.java
@@ -1,0 +1,310 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.internal.observers;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import rx.Producer;
+import rx.Subscriber;
+import rx.annotations.Experimental;
+import rx.functions.Action0;
+import rx.observers.TestSubscriber;
+import rx.observers.AssertableSubscriber;
+
+/**
+ * A {@code AssertableSubscriber} is a variety of {@link Subscriber} that you can use
+ * for unit testing, to perform assertions or inspect received events.
+ * AssertableSubscriber is a duplicate of TestSubscriber but supports method chaining
+ * where possible.
+ * 
+ * @param <T>
+ *            the value type
+ */
+@Experimental
+public class AssertableSubscriberObservable<T> extends Subscriber<T> implements AssertableSubscriber<T> {
+
+    private final TestSubscriber<T> ts;
+
+    public AssertableSubscriberObservable(TestSubscriber<T> ts) {
+        this.ts = ts;
+    }
+
+    public static <T> AssertableSubscriberObservable<T> create(long initialRequest) {
+        TestSubscriber<T> t1 = new TestSubscriber<T>(initialRequest);
+        AssertableSubscriberObservable<T> t2 = new AssertableSubscriberObservable<T>(t1);
+        t2.add(t1);
+        return t2;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#onStart()
+     */
+    @Override
+    public void onStart() {
+        ts.onStart();
+    }
+
+    @Override
+    public void onCompleted() {
+        ts.onCompleted();
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#setProducer(rx.Producer)
+     */
+    @Override
+    public void setProducer(Producer p) {
+        ts.setProducer(p);
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#getCompletions()
+     */
+    @Override
+    public final int getCompletions() {
+        return ts.getCompletions();
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        ts.onError(e);
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#getOnErrorEvents()
+     */
+    @Override
+    public List<Throwable> getOnErrorEvents() {
+        return ts.getOnErrorEvents();
+    }
+
+    @Override
+    public void onNext(T t) {
+        ts.onNext(t);
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#getValueCount()
+     */
+    @Override
+    public final int getValueCount() {
+        return ts.getValueCount();
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#requestMore(long)
+     */
+    @Override
+    public AssertableSubscriber<T> requestMore(long n) {
+        ts.requestMore(n);
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#getOnNextEvents()
+     */
+    @Override
+    public List<T> getOnNextEvents() {
+        return ts.getOnNextEvents();
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertReceivedOnNext(java.util.List)
+     */
+    @Override
+    public AssertableSubscriber<T> assertReceivedOnNext(List<T> items) {
+        ts.assertReceivedOnNext(items);
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#awaitValueCount(int, long, java.util.concurrent.TimeUnit)
+     */
+    @Override
+    public final boolean awaitValueCount(int expected, long timeout, TimeUnit unit) {
+        return ts.awaitValueCount(expected, timeout, unit);
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertTerminalEvent()
+     */
+    @Override
+    public AssertableSubscriber<T> assertTerminalEvent() {
+        ts.assertTerminalEvent();
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertUnsubscribed()
+     */
+    @Override
+    public AssertableSubscriber<T> assertUnsubscribed() {
+        ts.assertUnsubscribed();
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertNoErrors()
+     */
+    @Override
+    public AssertableSubscriber<T> assertNoErrors() {
+        ts.assertNoErrors();
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#awaitTerminalEvent()
+     */
+    @Override
+    public AssertableSubscriber<T> awaitTerminalEvent() {
+        ts.awaitTerminalEvent();
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#awaitTerminalEvent(long, java.util.concurrent.TimeUnit)
+     */
+    @Override
+    public AssertableSubscriber<T> awaitTerminalEvent(long timeout, TimeUnit unit) {
+        ts.awaitTerminalEvent(timeout, unit);
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#awaitTerminalEventAndUnsubscribeOnTimeout(long, java.util.concurrent.TimeUnit)
+     */
+    @Override
+    public AssertableSubscriber<T> awaitTerminalEventAndUnsubscribeOnTimeout(long timeout,
+            TimeUnit unit) {
+        ts.awaitTerminalEventAndUnsubscribeOnTimeout(timeout, unit);
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#getLastSeenThread()
+     */
+    @Override
+    public Thread getLastSeenThread() {
+        return ts.getLastSeenThread();
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertCompleted()
+     */
+    @Override
+    public AssertableSubscriber<T> assertCompleted() {
+        ts.assertCompleted();
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertNotCompleted()
+     */
+    @Override
+    public AssertableSubscriber<T> assertNotCompleted() {
+        ts.assertNotCompleted();
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertError(java.lang.Class)
+     */
+    @Override
+    public AssertableSubscriber<T> assertError(Class<? extends Throwable> clazz) {
+        ts.assertError(clazz);
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertError(java.lang.Throwable)
+     */
+    @Override
+    public AssertableSubscriber<T> assertError(Throwable throwable) {
+        ts.assertError(throwable);
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertNoTerminalEvent()
+     */
+    @Override
+    public AssertableSubscriber<T> assertNoTerminalEvent() {
+        ts.assertNoTerminalEvent();
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertNoValues()
+     */
+    @Override
+    public AssertableSubscriber<T> assertNoValues() {
+        ts.assertNoValues();
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertValueCount(int)
+     */
+    @Override
+    public AssertableSubscriber<T> assertValueCount(int count) {
+        ts.assertValueCount(count);
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertValues(T)
+     */
+    @Override
+    public AssertableSubscriber<T> assertValues(T... values) {
+        ts.assertValues(values);
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertValue(T)
+     */
+    @Override
+    public AssertableSubscriber<T> assertValue(T value) {
+        ts.assertValue(value);
+        return this;
+    }
+    
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#assertValuesAndClear(T, T)
+     */
+    @Override
+    public final AssertableSubscriber<T> assertValuesAndClear(T expectedFirstValue,
+            T... expectedRestValues) {
+        ts.assertValuesAndClear(expectedFirstValue, expectedRestValues);
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see rx.observers.AssertableSubscriber#perform(rx.functions.Action0)
+     */
+    @Override
+    public final AssertableSubscriber<T> perform(Action0 action) {
+        action.call();
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return ts.toString();
+    }
+
+}

--- a/src/main/java/rx/observers/AssertableSubscriber.java
+++ b/src/main/java/rx/observers/AssertableSubscriber.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observers;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import rx.Observer;
+import rx.Producer;
+import rx.functions.Action0;
+
+public interface AssertableSubscriber<T> extends Observer<T> {
+
+    void onStart();
+
+    void setProducer(Producer p);
+
+    int getCompletions();
+
+    List<Throwable> getOnErrorEvents();
+
+    int getValueCount();
+
+    AssertableSubscriber<T> requestMore(long n);
+
+    List<T> getOnNextEvents();
+
+    AssertableSubscriber<T> assertReceivedOnNext(List<T> items);
+
+    boolean awaitValueCount(int expected, long timeout, TimeUnit unit);
+
+    AssertableSubscriber<T> assertTerminalEvent();
+
+    AssertableSubscriber<T> assertUnsubscribed();
+
+    AssertableSubscriber<T> assertNoErrors();
+
+    AssertableSubscriber<T> awaitTerminalEvent();
+
+    AssertableSubscriber<T> awaitTerminalEvent(long timeout, TimeUnit unit);
+
+    AssertableSubscriber<T> awaitTerminalEventAndUnsubscribeOnTimeout(long timeout,
+            TimeUnit unit);
+
+    Thread getLastSeenThread();
+
+    AssertableSubscriber<T> assertCompleted();
+
+    AssertableSubscriber<T> assertNotCompleted();
+
+    AssertableSubscriber<T> assertError(Class<? extends Throwable> clazz);
+
+    AssertableSubscriber<T> assertError(Throwable throwable);
+
+    AssertableSubscriber<T> assertNoTerminalEvent();
+
+    AssertableSubscriber<T> assertNoValues();
+
+    AssertableSubscriber<T> assertValueCount(int count);
+
+    AssertableSubscriber<T> assertValues(T... values);
+
+    AssertableSubscriber<T> assertValue(T value);
+
+    AssertableSubscriber<T> assertValuesAndClear(T expectedFirstValue,
+            T... expectedRestValues);
+
+    AssertableSubscriber<T> perform(Action0 action);
+    
+    void unsubscribe();
+    
+    boolean isUnsubscribed();
+
+}

--- a/src/test/java/rx/observers/AssertableSubscriberTest.java
+++ b/src/test/java/rx/observers/AssertableSubscriberTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import rx.Completable;
+import rx.Observable;
+import rx.Single;
+import rx.functions.Action0;
+import rx.functions.Actions;
+
+public class AssertableSubscriberTest {
+
+    @Test
+    public void testManyMaxValue() {
+        AssertableSubscriber<Integer> ts = Observable.just(1, 2, 3) 
+            .test() 
+            .assertValues(1, 2, 3) 
+            .awaitTerminalEvent()
+            .awaitTerminalEvent(5, TimeUnit.SECONDS)
+            .awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS)
+            .assertCompleted() 
+            .assertTerminalEvent()
+            .assertNoErrors() 
+            .assertUnsubscribed() 
+            .assertReceivedOnNext(Arrays.asList(1, 2, 3)) 
+            .assertValueCount(3);
+        assertEquals(3, ts.getValueCount());
+        assertEquals(1, ts.getCompletions());
+        assertEquals(Thread.currentThread().getName(),  ts.getLastSeenThread().getName());
+        assertEquals(Arrays.asList(1,2,3), ts.getOnNextEvents());
+        assertTrue(ts.awaitValueCount(3, 5, TimeUnit.SECONDS));
+    }
+    
+    @Test
+    public void testManyWithInitialRequest() {
+        AssertableSubscriber<Integer> ts = Observable.just(1, 2, 3) 
+            .test(1) 
+            .assertValue(1)
+            .assertValues(1)
+            .assertValuesAndClear(1)
+            .assertNotCompleted()
+            .assertNoErrors()
+            .assertNoTerminalEvent()
+            .requestMore(1)
+            .assertValuesAndClear(2);
+        ts.unsubscribe();
+        ts.assertUnsubscribed();
+        assertTrue(ts.isUnsubscribed());
+    }
+    
+    @Test
+    public void testEmpty() {
+        Observable.empty()
+            .test()
+            .assertNoValues();
+    }
+
+    @Test
+    public void testError() {
+        IOException e = new IOException();
+        AssertableSubscriber<Object> ts = Observable.error(e)
+            .test()
+            .assertError(e)
+            .assertError(IOException.class);
+        assertEquals(Arrays.asList(e), ts.getOnErrorEvents());
+    }
+    
+    @Test
+    public void toStringIsNotNull() {
+        AssertableSubscriber<Object> ts = Observable.empty().test();
+        assertNotNull(ts.toString());
+    }
+    
+    @Test
+    public void testPerform() {
+        final AtomicBoolean performed = new AtomicBoolean(false);
+        Observable.empty()
+            .test()
+            .perform(new Action0() {
+                @Override
+                public void call() {
+                    performed.set(true);
+                }
+            });
+        assertTrue(performed.get());
+    }
+    
+    @Test
+    public void testCompletable() {
+        AssertableSubscriber<Void> ts = Completable
+            .fromAction(Actions.empty())
+            .test()
+            .assertNoValues()
+            .assertNoErrors()
+            .assertValueCount(0)
+            .assertValues()
+            .assertTerminalEvent()
+            .assertReceivedOnNext(Collections.<Void>emptyList())
+            .awaitTerminalEvent()
+            .awaitTerminalEvent(5, TimeUnit.SECONDS)
+            .awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS)
+            .assertCompleted()
+            .assertUnsubscribed();
+        assertEquals(1, ts.getCompletions());
+        assertEquals(Thread.currentThread().getName(), ts.getLastSeenThread().getName());
+        assertTrue(ts.getOnErrorEvents().isEmpty());
+        assertTrue(ts.getOnNextEvents().isEmpty());
+        assertEquals(0, ts.getValueCount());
+    }
+    
+    @Test
+    public void testSingle() {
+        AssertableSubscriber<Integer> ts = Single
+            .just(10)
+            .test()
+            .assertValue(10)
+            .assertValues(10)
+            .assertValueCount(1)
+            .assertReceivedOnNext(Arrays.asList(10))
+            .assertValuesAndClear(10)
+            .assertNoValues()
+            .assertTerminalEvent()
+            .assertNoErrors()
+            .assertCompleted()
+            .assertUnsubscribed()
+            .awaitTerminalEvent()
+            .awaitTerminalEvent(5, TimeUnit.SECONDS)
+            .awaitTerminalEventAndUnsubscribeOnTimeout(5, TimeUnit.SECONDS);
+       assertEquals(1, ts.getCompletions());
+       assertEquals(Thread.currentThread().getName(), ts.getLastSeenThread().getName());
+       assertTrue(ts.getOnErrorEvents().isEmpty());
+       assertTrue(ts.getOnNextEvents().isEmpty());
+       assertEquals(1, ts.getValueCount());
+    }
+    
+}
+


### PR DESCRIPTION
The new method chaining `TestSubscriber` in 2.x is too good not to have in 1.x as well (while I wait for 2.x to mature and to make my existing unit tests less verbose).

``` java
Observable
  .just(1)
  .test()
  .assertValue(1)
  .assertCompleted();
```

`Observable.test()` returns a `TestSubscriber2` that wraps a `TestSubscriber` and enables method chaining where it can.

I've added tests to get to 100% test coverage though I've been pretty slap-dash about testing some of the details (for example I haven't tested that `awaitXXX` really does wait for stuff).

I've noted it as `@since 1.2.3` but can update to 1.2.2 if you are happy to squeak it into the release.
