### PR TITLE
Fixed detection of TestObserver.assertNotSubscribed()

### DIFF
--- a/src/main/java/io/reactivex/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/observers/TestObserver.java
@@ -255,7 +255,8 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
      */
     @Override
     public final TestObserver<T> assertNotSubscribed() {
-        if (subscription.get() != null) {
+        Disposable disposable = subscription.get();
+        if (disposable != null && disposable != DisposableHelper.DISPOSED) {
             throw fail("Subscribed!");
         } else
         if (!errors.isEmpty()) {

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -974,6 +974,15 @@ public class TestObserverTest {
     }
 
     @Test
+    public void assertNotSubscribedAfterSubscription() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+        UnicastSubject<Integer> up = UnicastSubject.create();
+        up.subscribe(ts);
+        ts.dispose();
+        ts.assertNotSubscribed();
+    }
+
+    @Test
     public void assertErrorMultiple() {
         TestObserver<Integer> ts = new TestObserver<Integer>();
 


### PR DESCRIPTION
It wasn't working post-subscription, but now it checks for DISPOSED

Fixes #4790