### PR TITLE
2.x: Fix exceptions in javaDoc

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -8598,7 +8598,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            {@link Consumer} to execute for each item.
      * @return
      *            a Disposable that allows cancelling an asynchronous sequence
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onNext} is null
      * @throws RuntimeException
      *             if the Publisher calls {@code onError}
@@ -12070,7 +12070,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
      *         the Publisher has finished sending them
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null
      */
@@ -12101,7 +12101,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *             Publisher
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
      *         the Publisher has finished sending them
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null, or
      *             if {@code onComplete} is null
@@ -12137,7 +12137,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *             the {@code Consumer} that receives the upstream's Subscription
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
      *         the Publisher has finished sending them
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null, or
      *             if {@code onComplete} is null

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3445,7 +3445,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
      *         the Maybe has finished sending them
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onSuccess} is null, or
      *             if {@code onError} is null
      */
@@ -3472,7 +3472,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *             Maybe
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
      *         the Maybe has finished sending them
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onSuccess} is null, or
      *             if {@code onError} is null, or
      *             if {@code onComplete} is null

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -7420,7 +7420,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            {@link Consumer} to execute for each item.
      * @return
      *            a Disposable that allows cancelling an asynchronous sequence
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onNext} is null
      * @throws RuntimeException
      *             if the ObservableSource calls {@code onError}
@@ -10059,7 +10059,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
      *         the ObservableSource has finished sending them
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null
      */
@@ -10086,7 +10086,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *             ObservableSource
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
      *         the ObservableSource has finished sending them
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null, or
      *             if {@code onComplete} is null
@@ -10118,7 +10118,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *             the {@code Consumer} that receives the upstream's Disposable
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
      *         the ObservableSource has finished sending them
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null, or
      *             if {@code onComplete} is null

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2444,7 +2444,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *            (whichever is not null)
      * @return a {@link Disposable} reference can request the {@link Single} stop work.
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onCallback} is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2490,7 +2490,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *            Single
      * @return a {@link Disposable} reference can request the {@link Single} stop work.
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
-     * @throws IllegalArgumentException
+     * @throws NullPointerException
      *             if {@code onSuccess} is null, or
      *             if {@code onError} is null
      */


### PR DESCRIPTION
I've corrected some javadocs for methods that check arguments using `ObjectHelper.requireNonNull(arg, "message")`. It throws `NullPointerException` instead of `IllegalArgumentException`, but as we know copy-pasting is an insidious thing. ;)