### PR TITLE
2.x: add doFinally to the rest of the reactive base classes

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -25,8 +25,7 @@ import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.observers.*;
 import io.reactivex.internal.operators.completable.*;
 import io.reactivex.internal.operators.flowable.FlowableDelaySubscriptionOther;
-import io.reactivex.internal.operators.maybe.MaybeFromCompletable;
-import io.reactivex.internal.operators.maybe.MaybeDelayWithCompletable;
+import io.reactivex.internal.operators.maybe.*;
 import io.reactivex.internal.operators.observable.ObservableDelaySubscriptionOther;
 import io.reactivex.internal.operators.single.SingleDelayWithCompletable;
 import io.reactivex.internal.util.ExceptionHelper;
@@ -1170,6 +1169,27 @@ public abstract class Completable implements CompletableSource {
                 Functions.EMPTY_ACTION,
                 onAfterTerminate,
                 Functions.EMPTY_ACTION);
+    }
+    /**
+     * Calls the specified action after this Completable signals onError or onComplete or gets disposed by
+     * the downstream.
+     * <p>In case of a race between a terminal event and a dispose call, the provided {@code onFinally} action
+     * is executed once per subscription.
+     * <p>Note that the {@code onFinally} action is shared between subscriptions and as such
+     * should be thread-safe.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doFinally} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onFinally the action called when this Completable terminates or gets cancelled
+     * @return the new Completable instance
+     * @since 2.0.1 - experimental
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Completable doFinally(Action onFinally) {
+        ObjectHelper.requireNonNull(onFinally, "onFinally is null");
+        return RxJavaPlugins.onAssembly(new CompletableDoFinally(this, onFinally));
     }
 
     /**

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -7328,7 +7328,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Calls the specified action after this Flowable signals onError or onCompleted or gets cancelled by
      * the downstream.
      * <p>In case of a race between a terminal event and a cancellation, the provided {@code onFinally} action
-     * is executed at once per subscription.
+     * is executed once per subscription.
      * <p>Note that the {@code onFinally} action is shared between subscriptions and as such
      * should be thread-safe.
      * <dl>

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2303,6 +2303,28 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
+     * Calls the specified action after this Maybe signals onSuccess, onError or onComplete or gets disposed by
+     * the downstream.
+     * <p>In case of a race between a terminal event and a dispose call, the provided {@code onFinally} action
+     * is executed once per subscription.
+     * <p>Note that the {@code onFinally} action is shared between subscriptions and as such
+     * should be thread-safe.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doFinally} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onFinally the action called when this Maybe terminates or gets cancelled
+     * @return the new Maybe instance
+     * @since 2.0.1 - experimental
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Maybe<T> doFinally(Action onFinally) {
+        ObjectHelper.requireNonNull(onFinally, "onFinally is null");
+        return RxJavaPlugins.onAssembly(new MaybeDoFinally<T>(this, onFinally));
+    }
+
+    /**
      * Calls the shared runnable if a MaybeObserver subscribed to the current Maybe
      * disposes the common Disposable it received via onSubscribe.
      * <dl>

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -16,7 +16,6 @@ package io.reactivex;
 import java.util.*;
 import java.util.concurrent.*;
 
-import io.reactivex.internal.operators.flowable.FlowableOnBackpressureError;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.annotations.*;
@@ -26,7 +25,7 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.functions.*;
 import io.reactivex.internal.fuseable.ScalarCallable;
 import io.reactivex.internal.observers.*;
-import io.reactivex.internal.operators.flowable.FlowableFromObservable;
+import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.operators.observable.*;
 import io.reactivex.internal.util.*;
 import io.reactivex.observables.*;
@@ -6438,6 +6437,30 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> doAfterTerminate(Action onFinally) {
         ObjectHelper.requireNonNull(onFinally, "onFinally is null");
         return doOnEach(Functions.emptyConsumer(), Functions.emptyConsumer(), Functions.EMPTY_ACTION, onFinally);
+    }
+
+    /**
+     * Calls the specified action after this Observable signals onError or onCompleted or gets disposed by
+     * the downstream.
+     * <p>In case of a race between a terminal event and a dispose call, the provided {@code onFinally} action
+     * is executed once per subscription.
+     * <p>Note that the {@code onFinally} action is shared between subscriptions and as such
+     * should be thread-safe.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doFinally} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <td><b>Operator-fusion:</b></dt>
+     *  <dd>This operator supports boundary-limited synchronous or asynchronous queue-fusion.</dd>
+     * </dl>
+     * @param onFinally the action called when this Observable terminates or gets cancelled
+     * @return the new Observable instance
+     * @since 2.0.1 - experimental
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Observable<T> doFinally(Action onFinally) {
+        ObjectHelper.requireNonNull(onFinally, "onFinally is null");
+        return RxJavaPlugins.onAssembly(new ObservableDoFinally<T>(this, onFinally));
     }
 
     /**

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1717,6 +1717,28 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
+     * Calls the specified action after this Single signals onSuccess or onError or gets disposed by
+     * the downstream.
+     * <p>In case of a race between a terminal event and a dispose call, the provided {@code onFinally} action
+     * is executed once per subscription.
+     * <p>Note that the {@code onFinally} action is shared between subscriptions and as such
+     * should be thread-safe.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doFinally} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onFinally the action called when this Single terminates or gets cancelled
+     * @return the new Single instance
+     * @since 2.0.1 - experimental
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Single<T> doFinally(Action onFinally) {
+        ObjectHelper.requireNonNull(onFinally, "onFinally is null");
+        return RxJavaPlugins.onAssembly(new SingleDoFinally<T>(this, onFinally));
+    }
+
+    /**
      * Calls the shared consumer with the Disposable sent through the onSubscribe for each
      * SingleObserver that subscribes to the current Single.
      * <dl>

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDoFinally.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Action;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Execute an action after an onError, onComplete or a dispose event.
+ *
+ * @since 2.0.1 - experimental
+ */
+@Experimental
+public final class CompletableDoFinally extends Completable {
+
+    final CompletableSource source;
+
+    final Action onFinally;
+
+    public CompletableDoFinally(CompletableSource source, Action onFinally) {
+        this.source = source;
+        this.onFinally = onFinally;
+    }
+
+    @Override
+    protected void subscribeActual(CompletableObserver s) {
+        source.subscribe(new DoFinallyObserver(s, onFinally));
+    }
+
+    static final class DoFinallyObserver extends AtomicInteger implements CompletableObserver, Disposable {
+
+        private static final long serialVersionUID = 4109457741734051389L;
+
+        final CompletableObserver actual;
+
+        final Action onFinally;
+
+        Disposable d;
+
+        DoFinallyObserver(CompletableObserver actual, Action onFinally) {
+            this.actual = actual;
+            this.onFinally = onFinally;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+            runFinally();
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+            runFinally();
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            runFinally();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        void runFinally() {
+            if (compareAndSet(0, 1)) {
+                try {
+                    onFinally.run();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoFinally.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Action;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Execute an action after an onSuccess, onError, onComplete or a dispose event.
+ *
+ * @param <T> the value type
+ * @since 2.0.1 - experimental
+ */
+@Experimental
+public final class MaybeDoFinally<T> extends AbstractMaybeWithUpstream<T, T> {
+
+    final Action onFinally;
+
+    public MaybeDoFinally(MaybeSource<T> source, Action onFinally) {
+        super(source);
+        this.onFinally = onFinally;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> s) {
+        source.subscribe(new DoFinallyObserver<T>(s, onFinally));
+    }
+
+    static final class DoFinallyObserver<T> extends AtomicInteger implements MaybeObserver<T>, Disposable {
+
+        private static final long serialVersionUID = 4109457741734051389L;
+
+        final MaybeObserver<? super T> actual;
+
+        final Action onFinally;
+
+        Disposable d;
+
+        DoFinallyObserver(MaybeObserver<? super T> actual, Action onFinally) {
+            this.actual = actual;
+            this.onFinally = onFinally;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            actual.onSuccess(t);
+            runFinally();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+            runFinally();
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+            runFinally();
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            runFinally();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        void runFinally() {
+            if (compareAndSet(0, 1)) {
+                try {
+                    onFinally.run();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Action;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.observers.BasicIntQueueDisposable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Execute an action after an onError, onComplete or a dispose event.
+ *
+ * @param <T> the value type
+ * @since 2.0.1 - experimental
+ */
+@Experimental
+public final class ObservableDoFinally<T> extends AbstractObservableWithUpstream<T, T> {
+
+    final Action onFinally;
+
+    public ObservableDoFinally(ObservableSource<T> source, Action onFinally) {
+        super(source);
+        this.onFinally = onFinally;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> s) {
+        source.subscribe(new DoFinallyObserver<T>(s, onFinally));
+    }
+
+    static final class DoFinallyObserver<T> extends BasicIntQueueDisposable<T> implements Observer<T> {
+
+        private static final long serialVersionUID = 4109457741734051389L;
+
+        final Observer<? super T> actual;
+
+        final Action onFinally;
+
+        Disposable d;
+
+        QueueDisposable<T> qd;
+
+        boolean syncFused;
+
+        DoFinallyObserver(Observer<? super T> actual, Action onFinally) {
+            this.actual = actual;
+            this.onFinally = onFinally;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+                if (d instanceof QueueDisposable) {
+                    this.qd = (QueueDisposable<T>)d;
+                }
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+            runFinally();
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+            runFinally();
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            runFinally();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            QueueDisposable<T> qd = this.qd;
+            if (qd != null && (mode & BOUNDARY) == 0) {
+                int m = qd.requestFusion(mode);
+                if (m != NONE) {
+                    syncFused = m == SYNC;
+                }
+                return m;
+            }
+            return NONE;
+        }
+
+        @Override
+        public void clear() {
+            qd.clear();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return qd.isEmpty();
+        }
+
+        @Override
+        public T poll() throws Exception {
+            T v = qd.poll();
+            if (v == null && syncFused) {
+                runFinally();
+            }
+            return v;
+        }
+
+        void runFinally() {
+            if (compareAndSet(0, 1)) {
+                try {
+                    onFinally.run();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoFinally.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Action;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Execute an action after an onSuccess, onError or a dispose event.
+ *
+ * @param <T> the value type
+ * @since 2.0.1 - experimental
+ */
+@Experimental
+public final class SingleDoFinally<T> extends Single<T> {
+
+    final SingleSource<T> source;
+
+    final Action onFinally;
+
+    public SingleDoFinally(SingleSource<T> source, Action onFinally) {
+        this.source = source;
+        this.onFinally = onFinally;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super T> s) {
+        source.subscribe(new DoFinallyObserver<T>(s, onFinally));
+    }
+
+    static final class DoFinallyObserver<T> extends AtomicInteger implements SingleObserver<T>, Disposable {
+
+        private static final long serialVersionUID = 4109457741734051389L;
+
+        final SingleObserver<? super T> actual;
+
+        final Action onFinally;
+
+        Disposable d;
+
+        DoFinallyObserver(SingleObserver<? super T> actual, Action onFinally) {
+            this.actual = actual;
+            this.onFinally = onFinally;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            actual.onSuccess(t);
+            runFinally();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+            runFinally();
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+            runFinally();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        void runFinally() {
+            if (compareAndSet(0, 1)) {
+                try {
+                    onFinally.run();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/MaybeNo2Dot0Since.java
+++ b/src/test/java/io/reactivex/MaybeNo2Dot0Since.java
@@ -84,7 +84,7 @@ public class MaybeNo2Dot0Since {
                 }
 
                 if (classDefPassed) {
-                    if (line.contains("@since") && line.contains("2.0")) {
+                    if (line.contains("@since") && line.contains("2.0") && !line.contains("2.0.")) {
                         b.append("java.lang.RuntimeException: @since 2.0 found").append("\r\n")
                         .append(" at io.reactivex.Maybe (Maybe.java:").append(ln).append(")\r\n\r\n");
                         ;

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDoFinallyTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.PublishSubject;
+
+public class CompletableDoFinallyTest implements Action {
+
+    int calls;
+
+    @Override
+    public void run() throws Exception {
+        calls++;
+    }
+
+    @Test
+    public void normalEmpty() {
+        Completable.complete()
+        .doFinally(this)
+        .test()
+        .assertResult();
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalError() {
+        Completable.error(new TestException())
+        .doFinally(this)
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeCompletable(new Function<Completable, Completable>() {
+            @Override
+            public Completable apply(Completable f) throws Exception {
+                return f.doFinally(CompletableDoFinallyTest.this);
+            }
+        });
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullAction() {
+        Completable.complete().doFinally(null);
+    }
+
+    @Test
+    public void actionThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Completable.complete()
+            .doFinally(new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            })
+            .test()
+            .assertResult()
+            .cancel();
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void disposed() {
+        TestHelper.checkDisposed(PublishSubject.create().ignoreElements().doFinally(this));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoFinallyTest.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.PublishSubject;
+
+public class MaybeDoFinallyTest implements Action {
+
+    int calls;
+
+    @Override
+    public void run() throws Exception {
+        calls++;
+    }
+
+    @Test
+    public void normalJust() {
+        Maybe.just(1)
+        .doFinally(this)
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalEmpty() {
+        Maybe.empty()
+        .doFinally(this)
+        .test()
+        .assertResult();
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalError() {
+        Maybe.error(new TestException())
+        .doFinally(this)
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
+            @Override
+            public Maybe<Object> apply(Maybe<Object> f) throws Exception {
+                return f.doFinally(MaybeDoFinallyTest.this);
+            }
+        });
+        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
+            @Override
+            public Maybe<Object> apply(Maybe<Object> f) throws Exception {
+                return f.doFinally(MaybeDoFinallyTest.this).filter(Functions.alwaysTrue());
+            }
+        });
+    }
+
+    @Test
+    public void normalJustConditional() {
+        Maybe.just(1)
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalEmptyConditional() {
+        Maybe.empty()
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .test()
+        .assertResult();
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalErrorConditional() {
+        Maybe.error(new TestException())
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, calls);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullAction() {
+        Maybe.just(1).doFinally(null);
+    }
+
+    @Test
+    public void actionThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Maybe.just(1)
+            .doFinally(new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            })
+            .test()
+            .assertResult(1)
+            .cancel();
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void actionThrowsConditional() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Maybe.just(1)
+            .doFinally(new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            })
+            .filter(Functions.alwaysTrue())
+            .test()
+            .assertResult(1)
+            .cancel();
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void disposed() {
+        TestHelper.checkDisposed(PublishSubject.create().singleElement().doFinally(this));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoFinallyTest.java
@@ -1,0 +1,445 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.observers.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.UnicastSubject;
+
+public class ObservableDoFinallyTest implements Action {
+
+    int calls;
+
+    @Override
+    public void run() throws Exception {
+        calls++;
+    }
+
+    @Test
+    public void normalJust() {
+        Observable.just(1)
+        .doFinally(this)
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalEmpty() {
+        Observable.empty()
+        .doFinally(this)
+        .test()
+        .assertResult();
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalError() {
+        Observable.error(new TestException())
+        .doFinally(this)
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalTake() {
+        Observable.range(1, 10)
+        .doFinally(this)
+        .take(5)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, Observable<Object>>() {
+            @Override
+            public Observable<Object> apply(Observable<Object> f) throws Exception {
+                return f.doFinally(ObservableDoFinallyTest.this);
+            }
+        });
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, Observable<Object>>() {
+            @Override
+            public Observable<Object> apply(Observable<Object> f) throws Exception {
+                return f.doFinally(ObservableDoFinallyTest.this).filter(Functions.alwaysTrue());
+            }
+        });
+    }
+
+    @Test
+    public void syncFused() {
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC);
+
+        Observable.range(1, 5)
+        .doFinally(this)
+        .subscribe(ts);
+
+        ObserverFusion.assertFusion(ts, QueueDisposable.SYNC)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void syncFusedBoundary() {
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC | QueueDisposable.BOUNDARY);
+
+        Observable.range(1, 5)
+        .doFinally(this)
+        .subscribe(ts);
+
+        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void asyncFused() {
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ASYNC);
+
+        UnicastSubject<Integer> up = UnicastSubject.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .doFinally(this)
+        .subscribe(ts);
+
+        ObserverFusion.assertFusion(ts, QueueDisposable.ASYNC)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void asyncFusedBoundary() {
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ASYNC | QueueDisposable.BOUNDARY);
+
+        UnicastSubject<Integer> up = UnicastSubject.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .doFinally(this)
+        .subscribe(ts);
+
+        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+
+    @Test
+    public void normalJustConditional() {
+        Observable.just(1)
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalEmptyConditional() {
+        Observable.empty()
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .test()
+        .assertResult();
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalErrorConditional() {
+        Observable.error(new TestException())
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalTakeConditional() {
+        Observable.range(1, 10)
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .take(5)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void syncFusedConditional() {
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC);
+
+        Observable.range(1, 5)
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .subscribe(ts);
+
+        ObserverFusion.assertFusion(ts, QueueDisposable.SYNC)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void nonFused() {
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC);
+
+        Observable.range(1, 5).hide()
+        .doFinally(this)
+        .subscribe(ts);
+
+        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void nonFusedConditional() {
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC);
+
+        Observable.range(1, 5).hide()
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .subscribe(ts);
+
+        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void syncFusedBoundaryConditional() {
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC | QueueDisposable.BOUNDARY);
+
+        Observable.range(1, 5)
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .subscribe(ts);
+
+        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void asyncFusedConditional() {
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ASYNC);
+
+        UnicastSubject<Integer> up = UnicastSubject.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .subscribe(ts);
+
+        ObserverFusion.assertFusion(ts, QueueDisposable.ASYNC)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void asyncFusedBoundaryConditional() {
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ASYNC | QueueDisposable.BOUNDARY);
+
+        UnicastSubject<Integer> up = UnicastSubject.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .subscribe(ts);
+
+        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullAction() {
+        Observable.just(1).doFinally(null);
+    }
+
+    @Test
+    public void actionThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable.just(1)
+            .doFinally(new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            })
+            .test()
+            .assertResult(1)
+            .cancel();
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void actionThrowsConditional() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable.just(1)
+            .doFinally(new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            })
+            .filter(Functions.alwaysTrue())
+            .test()
+            .assertResult(1)
+            .cancel();
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void clearIsEmpty() {
+        Observable.range(1, 5)
+        .doFinally(this)
+        .subscribe(new Observer<Integer>() {
+
+            @Override
+            public void onSubscribe(Disposable s) {
+                @SuppressWarnings("unchecked")
+                QueueDisposable<Integer> qs = (QueueDisposable<Integer>)s;
+
+                qs.requestFusion(QueueDisposable.ANY);
+
+                assertFalse(qs.isEmpty());
+
+                try {
+                    assertEquals(1, qs.poll().intValue());
+                } catch (Throwable ex) {
+                    throw new RuntimeException(ex);
+                }
+
+                assertFalse(qs.isEmpty());
+
+                qs.clear();
+
+                assertTrue(qs.isEmpty());
+
+                qs.dispose();
+            }
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void clearIsEmptyConditional() {
+        Observable.range(1, 5)
+        .doFinally(this)
+        .filter(Functions.alwaysTrue())
+        .subscribe(new Observer<Integer>() {
+
+            @Override
+            public void onSubscribe(Disposable s) {
+                @SuppressWarnings("unchecked")
+                QueueDisposable<Integer> qs = (QueueDisposable<Integer>)s;
+
+                qs.requestFusion(QueueDisposable.ANY);
+
+                assertFalse(qs.isEmpty());
+
+                assertFalse(qs.isDisposed());
+
+                try {
+                    assertEquals(1, qs.poll().intValue());
+                } catch (Throwable ex) {
+                    throw new RuntimeException(ex);
+                }
+
+                assertFalse(qs.isEmpty());
+
+                qs.clear();
+
+                assertTrue(qs.isEmpty());
+
+                qs.dispose();
+
+                assertTrue(qs.isDisposed());
+            }
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+
+        assertEquals(1, calls);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoFinallyTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.PublishSubject;
+
+public class SingleDoFinallyTest implements Action {
+
+    int calls;
+
+    @Override
+    public void run() throws Exception {
+        calls++;
+    }
+
+    @Test
+    public void normalJust() {
+        Single.just(1)
+        .doFinally(this)
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void normalError() {
+        Single.error(new TestException())
+        .doFinally(this)
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, Single<Object>>() {
+            @Override
+            public Single<Object> apply(Single<Object> f) throws Exception {
+                return f.doFinally(SingleDoFinallyTest.this);
+            }
+        });
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullAction() {
+        Single.just(1).doFinally(null);
+    }
+
+    @Test
+    public void actionThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Single.just(1)
+            .doFinally(new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            })
+            .test()
+            .assertResult(1)
+            .cancel();
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void disposed() {
+        TestHelper.checkDisposed(PublishSubject.create().singleOrError().doFinally(this));
+    }
+}

--- a/src/test/java/io/reactivex/internal/schedulers/SchedulerWhenTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/SchedulerWhenTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.schedulers;
 
 import static io.reactivex.Flowable.just;


### PR DESCRIPTION
This PR adds the `doFinally` operator to the rest of the base reactive classes.