### PR TITLE
2.x: add doAfterNext & doAfterSuccess to the other types

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2274,6 +2274,25 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
+     * Calls the specified consumer with the success item after this item has been emitted to the downstream.
+     * <p>Note that the {@code onAfterNext} action is shared between subscriptions and as such
+     * should be thread-safe.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doAfterSuccess} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onAfterSuccess the Consumer that will be called after emitting an item from upstream to the downstream
+     * @return the new Maybe instance
+     * @since 2.0.1 - experimental
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Maybe<T> doAfterSuccess(Consumer<? super T> onAfterSuccess) {
+        ObjectHelper.requireNonNull(onAfterSuccess, "doAfterSuccess is null");
+        return RxJavaPlugins.onAssembly(new MaybeDoAfterSuccess<T>(this, onAfterSuccess));
+    }
+
+    /**
      * Registers an {@link Action} to be called when this Maybe invokes either
      * {@link MaybeObserver#onComplete onSuccess},
      * {@link MaybeObserver#onComplete onComplete} or {@link MaybeObserver#onError onError}.

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -6417,6 +6417,27 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
+     * Calls the specified consumer with the current item after this item has been emitted to the downstream.
+     * <p>Note that the {@code onAfterNext} action is shared between subscriptions and as such
+     * should be thread-safe.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doAfterNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <td><b>Operator-fusion:</b></dt>
+     *  <dd>This operator supports boundary-limited synchronous or asynchronous queue-fusion.</dd>
+     * </dl>
+     * @param onAfterNext the Consumer that will be called after emitting an item from upstream to the downstream
+     * @return the new Observable instance
+     * @since 2.0.1 - experimental
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Observable<T> doAfterNext(Consumer<? super T> onAfterNext) {
+        ObjectHelper.requireNonNull(onAfterNext, "onAfterNext is null");
+        return RxJavaPlugins.onAssembly(new ObservableDoAfterNext<T>(this, onAfterNext));
+    }
+
+    /**
      * Registers an {@link Action} to be called when this ObservableSource invokes either
      * {@link Observer#onComplete onComplete} or {@link Observer#onError onError}.
      * <p>

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1717,6 +1717,25 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
+     * Calls the specified consumer with the success item after this item has been emitted to the downstream.
+     * <p>Note that the {@code doAfterSuccess} action is shared between subscriptions and as such
+     * should be thread-safe.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code doAfterSuccess} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onAfterSuccess the Consumer that will be called after emitting an item from upstream to the downstream
+     * @return the new Single instance
+     * @since 2.0.1 - experimental
+     */
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Single<T> doAfterSuccess(Consumer<? super T> onAfterSuccess) {
+        ObjectHelper.requireNonNull(onAfterSuccess, "doAfterSuccess is null");
+        return RxJavaPlugins.onAssembly(new SingleDoAfterSuccess<T>(this, onAfterSuccess));
+    }
+
+    /**
      * Calls the specified action after this Single signals onSuccess or onError or gets disposed by
      * the downstream.
      * <p>In case of a race between a terminal event and a dispose call, the provided {@code onFinally} action

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccess.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccess.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Calls a consumer after pushing the current item to the downstream.
+ * @param <T> the value type
+ * @since 2.0.1 - experimental
+ */
+@Experimental
+public final class MaybeDoAfterSuccess<T> extends AbstractMaybeWithUpstream<T, T> {
+
+    final Consumer<? super T> onAfterSuccess;
+
+    public MaybeDoAfterSuccess(MaybeSource<T> source, Consumer<? super T> onAfterSuccess) {
+        super(source);
+        this.onAfterSuccess = onAfterSuccess;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> s) {
+        source.subscribe(new DoAfterObserver<T>(s, onAfterSuccess));
+    }
+
+    static final class DoAfterObserver<T> implements MaybeObserver<T>, Disposable {
+
+        final MaybeObserver<? super T> actual;
+
+        final Consumer<? super T> onAfterSuccess;
+
+        Disposable d;
+
+        DoAfterObserver(MaybeObserver<? super T> actual, Consumer<? super T> onAfterSuccess) {
+            this.actual = actual;
+            this.onAfterSuccess = onAfterSuccess;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            actual.onSuccess(t);
+
+            try {
+                onAfterSuccess.accept(t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+             // remember, onSuccess is a terminal event and we can't call onError
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.observers.BasicFuseableObserver;
+
+/**
+ * Calls a consumer after pushing the current item to the downstream.
+ * @param <T> the value type
+ * @since 2.0.1 - experimental
+ */
+@Experimental
+public final class ObservableDoAfterNext<T> extends AbstractObservableWithUpstream<T, T> {
+
+    final Consumer<? super T> onAfterNext;
+
+    public ObservableDoAfterNext(ObservableSource<T> source, Consumer<? super T> onAfterNext) {
+        super(source);
+        this.onAfterNext = onAfterNext;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> s) {
+        source.subscribe(new DoAfterObserver<T>(s, onAfterNext));
+    }
+
+    static final class DoAfterObserver<T> extends BasicFuseableObserver<T, T> {
+
+        final Consumer<? super T> onAfterNext;
+
+        DoAfterObserver(Observer<? super T> actual, Consumer<? super T> onAfterNext) {
+            super(actual);
+            this.onAfterNext = onAfterNext;
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+
+            if (sourceMode == NONE) {
+                try {
+                    onAfterNext.accept(t);
+                } catch (Throwable ex) {
+                    fail(ex);
+                }
+            }
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            return transitiveBoundaryFusion(mode);
+        }
+
+        @Override
+        public T poll() throws Exception {
+            T v = qs.poll();
+            if (v != null) {
+                onAfterNext.accept(v);
+            }
+            return v;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoAfterSuccess.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoAfterSuccess.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Calls a consumer after pushing the current item to the downstream.
+ * @param <T> the value type
+ * @since 2.0.1 - experimental
+ */
+@Experimental
+public final class SingleDoAfterSuccess<T> extends Single<T> {
+
+    final SingleSource<T> source;
+
+    final Consumer<? super T> onAfterSuccess;
+
+    public SingleDoAfterSuccess(SingleSource<T> source, Consumer<? super T> onAfterSuccess) {
+        this.source = source;
+        this.onAfterSuccess = onAfterSuccess;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super T> s) {
+        source.subscribe(new DoAfterObserver<T>(s, onAfterSuccess));
+    }
+
+    static final class DoAfterObserver<T> implements SingleObserver<T>, Disposable {
+
+        final SingleObserver<? super T> actual;
+
+        final Consumer<? super T> onAfterSuccess;
+
+        Disposable d;
+
+        DoAfterObserver(SingleObserver<? super T> actual, Consumer<? super T> onAfterSuccess) {
+            this.actual = actual;
+            this.onAfterSuccess = onAfterSuccess;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            actual.onSuccess(t);
+
+            try {
+                onAfterSuccess.accept(t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+             // remember, onSuccess is a terminal event and we can't call onError
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void dispose() {
+            d.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccessTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.PublishSubject;
+
+public class MaybeDoAfterSuccessTest {
+
+    final List<Integer> values = new ArrayList<Integer>();
+
+    final Consumer<Integer> afterSuccess = new Consumer<Integer>() {
+        @Override
+        public void accept(Integer e) throws Exception {
+            values.add(-e);
+        }
+    };
+
+    final TestObserver<Integer> ts = new TestObserver<Integer>() {
+        @Override
+        public void onNext(Integer t) {
+            super.onNext(t);
+            MaybeDoAfterSuccessTest.this.values.add(t);
+        }
+    };
+
+    @Test
+    public void just() {
+        Maybe.just(1)
+        .doAfterSuccess(afterSuccess)
+        .subscribeWith(ts)
+        .assertResult(1);
+
+        assertEquals(Arrays.asList(1, -1), values);
+    }
+
+    @Test
+    public void error() {
+        Maybe.<Integer>error(new TestException())
+        .doAfterSuccess(afterSuccess)
+        .subscribeWith(ts)
+        .assertFailure(TestException.class);
+
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void empty() {
+        Maybe.<Integer>empty()
+        .doAfterSuccess(afterSuccess)
+        .subscribeWith(ts)
+        .assertResult();
+
+        assertTrue(values.isEmpty());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void consumerNull() {
+        Maybe.just(1).doAfterSuccess(null);
+    }
+
+    @Test
+    public void justConditional() {
+        Maybe.just(1)
+        .doAfterSuccess(afterSuccess)
+        .filter(Functions.alwaysTrue())
+        .subscribeWith(ts)
+        .assertResult(1);
+
+        assertEquals(Arrays.asList(1, -1), values);
+    }
+
+    @Test
+    public void errorConditional() {
+        Maybe.<Integer>error(new TestException())
+        .doAfterSuccess(afterSuccess)
+        .filter(Functions.alwaysTrue())
+        .subscribeWith(ts)
+        .assertFailure(TestException.class);
+
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void emptyConditional() {
+        Maybe.<Integer>empty()
+        .doAfterSuccess(afterSuccess)
+        .filter(Functions.alwaysTrue())
+        .subscribeWith(ts)
+        .assertResult();
+
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void consumerThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Maybe.just(1)
+            .doAfterSuccess(new Consumer<Integer>() {
+                @Override
+                public void accept(Integer e) throws Exception {
+                    throw new TestException();
+                }
+            })
+            .test()
+            .assertResult(1);
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishSubject.<Integer>create().singleElement().doAfterSuccess(afterSuccess));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(Maybe<Integer> m) throws Exception {
+                return m.doAfterSuccess(afterSuccess);
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoAfterNextTest.java
@@ -1,0 +1,275 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.Observable;
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.observers.*;
+import io.reactivex.processors.UnicastProcessor;
+import io.reactivex.subscribers.*;
+
+public class ObservableDoAfterNextTest {
+
+    final List<Integer> values = new ArrayList<Integer>();
+
+    final Consumer<Integer> afterNext = new Consumer<Integer>() {
+        @Override
+        public void accept(Integer e) throws Exception {
+            values.add(-e);
+        }
+    };
+
+    final TestObserver<Integer> ts = new TestObserver<Integer>() {
+        @Override
+        public void onNext(Integer t) {
+            super.onNext(t);
+            ObservableDoAfterNextTest.this.values.add(t);
+        }
+    };
+
+    @Test
+    public void just() {
+        Observable.just(1)
+        .doAfterNext(afterNext)
+        .subscribeWith(ts)
+        .assertResult(1);
+
+        assertEquals(Arrays.asList(1, -1), values);
+    }
+
+    @Test
+    public void range() {
+        Observable.range(1, 5)
+        .doAfterNext(afterNext)
+        .subscribeWith(ts)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(Arrays.asList(1, -1, 2, -2, 3, -3, 4, -4, 5, -5), values);
+    }
+
+    @Test
+    public void error() {
+        Observable.<Integer>error(new TestException())
+        .doAfterNext(afterNext)
+        .subscribeWith(ts)
+        .assertFailure(TestException.class);
+
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void empty() {
+        Observable.<Integer>empty()
+        .doAfterNext(afterNext)
+        .subscribeWith(ts)
+        .assertResult();
+
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void syncFused() {
+        TestObserver<Integer> ts0 = ObserverFusion.newTest(QueueSubscription.SYNC);
+
+        Observable.range(1, 5)
+        .doAfterNext(afterNext)
+        .subscribe(ts0);
+
+        ObserverFusion.assertFusion(ts0, QueueSubscription.SYNC)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
+    }
+
+    @Test
+    public void asyncFusedRejected() {
+        TestObserver<Integer> ts0 = ObserverFusion.newTest(QueueSubscription.ASYNC);
+
+        Observable.range(1, 5)
+        .doAfterNext(afterNext)
+        .subscribe(ts0);
+
+        ObserverFusion.assertFusion(ts0, QueueSubscription.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
+    }
+
+    @Test
+    public void asyncFused() {
+        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueSubscription.ASYNC);
+
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .doAfterNext(afterNext)
+        .subscribe(ts0);
+
+        SubscriberFusion.assertFusion(ts0, QueueSubscription.ASYNC)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void consumerNull() {
+        Observable.just(1).doAfterNext(null);
+    }
+
+    @Test
+    public void justConditional() {
+        Observable.just(1)
+        .doAfterNext(afterNext)
+        .filter(Functions.alwaysTrue())
+        .subscribeWith(ts)
+        .assertResult(1);
+
+        assertEquals(Arrays.asList(1, -1), values);
+    }
+
+    @Test
+    public void rangeConditional() {
+        Observable.range(1, 5)
+        .doAfterNext(afterNext)
+        .filter(Functions.alwaysTrue())
+        .subscribeWith(ts)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(Arrays.asList(1, -1, 2, -2, 3, -3, 4, -4, 5, -5), values);
+    }
+
+    @Test
+    public void errorConditional() {
+        Observable.<Integer>error(new TestException())
+        .doAfterNext(afterNext)
+        .filter(Functions.alwaysTrue())
+        .subscribeWith(ts)
+        .assertFailure(TestException.class);
+
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void emptyConditional() {
+        Observable.<Integer>empty()
+        .doAfterNext(afterNext)
+        .filter(Functions.alwaysTrue())
+        .subscribeWith(ts)
+        .assertResult();
+
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void syncFusedConditional() {
+        TestObserver<Integer> ts0 = ObserverFusion.newTest(QueueSubscription.SYNC);
+
+        Observable.range(1, 5)
+        .doAfterNext(afterNext)
+        .filter(Functions.alwaysTrue())
+        .subscribe(ts0);
+
+        ObserverFusion.assertFusion(ts0, QueueSubscription.SYNC)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
+    }
+
+    @Test
+    public void asyncFusedRejectedConditional() {
+        TestObserver<Integer> ts0 = ObserverFusion.newTest(QueueSubscription.ASYNC);
+
+        Observable.range(1, 5)
+        .doAfterNext(afterNext)
+        .filter(Functions.alwaysTrue())
+        .subscribe(ts0);
+
+        ObserverFusion.assertFusion(ts0, QueueSubscription.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
+    }
+
+    @Test
+    public void asyncFusedConditional() {
+        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueSubscription.ASYNC);
+
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .doAfterNext(afterNext)
+        .filter(Functions.alwaysTrue())
+        .subscribe(ts0);
+
+        SubscriberFusion.assertFusion(ts0, QueueSubscription.ASYNC)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
+    }
+
+    @Test
+    public void consumerThrows() {
+        Observable.just(1, 2)
+        .doAfterNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void consumerThrowsConditional() {
+        Observable.just(1, 2)
+        .doAfterNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void consumerThrowsConditional2() {
+        Observable.just(1, 2).hide()
+        .doAfterNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterSuccessTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.PublishSubject;
+
+public class SingleDoAfterSuccessTest {
+
+    final List<Integer> values = new ArrayList<Integer>();
+
+    final Consumer<Integer> afterSuccess = new Consumer<Integer>() {
+        @Override
+        public void accept(Integer e) throws Exception {
+            values.add(-e);
+        }
+    };
+
+    final TestObserver<Integer> ts = new TestObserver<Integer>() {
+        @Override
+        public void onNext(Integer t) {
+            super.onNext(t);
+            SingleDoAfterSuccessTest.this.values.add(t);
+        }
+    };
+
+    @Test
+    public void just() {
+        Single.just(1)
+        .doAfterSuccess(afterSuccess)
+        .subscribeWith(ts)
+        .assertResult(1);
+
+        assertEquals(Arrays.asList(1, -1), values);
+    }
+
+    @Test
+    public void error() {
+        Single.<Integer>error(new TestException())
+        .doAfterSuccess(afterSuccess)
+        .subscribeWith(ts)
+        .assertFailure(TestException.class);
+
+        assertTrue(values.isEmpty());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void consumerNull() {
+        Single.just(1).doAfterSuccess(null);
+    }
+
+    @Test
+    public void justConditional() {
+        Single.just(1)
+        .doAfterSuccess(afterSuccess)
+        .filter(Functions.alwaysTrue())
+        .subscribeWith(ts)
+        .assertResult(1);
+
+        assertEquals(Arrays.asList(1, -1), values);
+    }
+
+    @Test
+    public void errorConditional() {
+        Single.<Integer>error(new TestException())
+        .doAfterSuccess(afterSuccess)
+        .filter(Functions.alwaysTrue())
+        .subscribeWith(ts)
+        .assertFailure(TestException.class);
+
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void consumerThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Single.just(1)
+            .doAfterSuccess(new Consumer<Integer>() {
+                @Override
+                public void accept(Integer e) throws Exception {
+                    throw new TestException();
+                }
+            })
+            .test()
+            .assertResult(1);
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishSubject.<Integer>create().singleOrError().doAfterSuccess(afterSuccess));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Integer>, SingleSource<Integer>>() {
+            @Override
+            public SingleSource<Integer> apply(Single<Integer> m) throws Exception {
+                return m.doAfterSuccess(afterSuccess);
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR adds `Observable.doAfterNext`, `Maybe.doAfterSuccess` and `Single.doAfterSuccess`.