### PR TITLE
2.x: add fluent requestMore to TestSubscriber

### DIFF
--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -16,11 +16,12 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.internal.util.*;
+import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observers.BaseTestConsumer;
 
 /**
@@ -400,6 +401,18 @@ implements Subscriber<T>, Subscription, Disposable {
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }
+        return this;
+    }
+
+    /**
+     * Calls {@link #request(long)} and returns this.
+     * @param n the request amount
+     * @return this
+     * @since 2.0.1 - experimental
+     */
+    @Experimental
+    public final TestSubscriber<T> requestMore(long n) {
+        request(n);
         return this;
     }
 

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -1707,4 +1707,16 @@ public class TestSubscriberTest {
             }
         });
     }
+
+    @Test
+    public void requestMore() {
+        Flowable.range(1, 5)
+        .test(0)
+        .requestMore(1)
+        .assertValue(1)
+        .requestMore(2)
+        .assertValues(1, 2, 3)
+        .requestMore(3)
+        .assertResult(1, 2, 3, 4, 5);
+    }
 }


### PR DESCRIPTION
This PR just adds the `TestSubscriber.requestMore` that calls `request` and returns `this` for method chaining purposes.