### PR TITLE
1.x: replace non-serializable value of OnNextValue with its toString

### DIFF
--- a/src/main/java/rx/exceptions/OnErrorThrowable.java
+++ b/src/main/java/rx/exceptions/OnErrorThrowable.java
@@ -15,11 +15,10 @@
  */
 package rx.exceptions;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.io.*;
+import java.util.*;
 
-import rx.plugins.RxJavaErrorHandler;
-import rx.plugins.RxJavaPlugins;
+import rx.plugins.*;
 
 /**
  * Represents a {@code Throwable} that an {@code Observable} might notify its subscribers of, but that then can
@@ -43,7 +42,17 @@ public final class OnErrorThrowable extends RuntimeException {
     private OnErrorThrowable(Throwable exception, Object value) {
         super(exception);
         hasValue = true;
-        this.value = value;
+        Object v;
+        if (value instanceof Serializable) {
+            v = value;
+        } else {
+            try {
+                v = String.valueOf(value);
+            } catch (Throwable ex) {
+                v = ex.getMessage();
+            }
+        }
+        this.value = v;
     }
 
     /**
@@ -150,7 +159,17 @@ public final class OnErrorThrowable extends RuntimeException {
          */
         public OnNextValue(Object value) {
             super("OnError while emitting onNext value: " + renderValue(value));
-            this.value = value;
+            Object v;
+            if (value instanceof Serializable) {
+                v = value;
+            } else {
+                try {
+                    v = String.valueOf(value);
+                } catch (Throwable ex) {
+                    v = ex.getMessage();
+                }
+            }
+            this.value = v;
         }
 
         /**
@@ -177,7 +196,7 @@ public final class OnErrorThrowable extends RuntimeException {
          * @return a string version of the object if primitive or managed through error plugin,
          *        otherwise the class name of the object
          */
-        static String renderValue(Object value){
+        static String renderValue(Object value) {
             if (value == null) {
                 return "null";
             }

--- a/src/test/java/rx/exceptions/OnNextValueTest.java
+++ b/src/test/java/rx/exceptions/OnNextValueTest.java
@@ -15,19 +15,15 @@
  */
 package rx.exceptions;
 
+import static org.junit.Assert.*;
+
+import java.io.*;
+
 import org.junit.Test;
 
-import rx.Observable;
-import rx.Observer;
+import rx.*;
 import rx.exceptions.OnErrorThrowable.OnNextValue;
 import rx.functions.Func1;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * ```java
@@ -165,5 +161,33 @@ public final class OnNextValueTest {
     @Test
     public void testRenderVoid() {
         assertEquals("null", OnNextValue.renderValue((Void) null));
+    }
+
+    static class Value {
+        @Override
+        public String toString() {
+            return "Value";
+        }
+    }
+
+    @Test
+    public void nonSerializableValue() throws Exception {
+        Throwable e = OnErrorThrowable.addValueAsLastCause(new RuntimeException(), new Value());
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bout);
+        oos.writeObject(e);
+        oos.close();
+
+        ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bin);
+
+        Throwable f = (Throwable)ois.readObject();
+
+        ois.close();
+
+        Object v = ((OnNextValue)f.getCause()).getValue();
+
+        assertEquals("Value", v);
     }
 }


### PR DESCRIPTION
When certain operators crash, they attach the current value to the exception via `OnErrorThrowable.addValueAsLastCause`, however, the value may not be serializable and the Throwable itself is, that causes a serialization exception.

This PR replaces such values with their `String.valueOf` representation or the crash message if `toString` failed on that object.

This was reported in #4562 with the suggestion of making the internal field `transient`. The problem with that is that upon deserialization, the field is null and there is no way of knowing if the original value was really null or just not serializable. Using `String.valueOf` at least gives a chance to know it was non-null and gets across some information about the original value.