### PR TITLE
1.x: add Single.fromEmitter

### DIFF
--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -574,6 +574,46 @@ public class Single<T> {
     }
 
     /**
+     * Provides an API (in a cold Single) that bridges the Single-reactive world
+     * with the callback-based world.
+     * <p>The {@link SingleEmitter} allows registering a callback for
+     * cancellation/unsubscription of a resource.
+     * <p>
+     * Example:
+     * <pre><code>
+     * Single.fromEmitter(emitter -&gt; {
+     *     Callback listener = new Callback() {
+     *         &#64;Override
+     *         public void onEvent(Event e) {
+     *             emitter.onSuccess(e.getData());
+     *         }
+     *
+     *         &#64;Override
+     *         public void onFailure(Exception e) {
+     *             emitter.onError(e);
+     *         }
+     *     };
+     *
+     *     AutoCloseable c = api.someMethod(listener);
+     *
+     *     emitter.setCancellation(c::close);
+     *
+     * });
+     * </code></pre>
+     * <p>All of the SingleEmitter's methods are thread-safe and ensure the
+     * Single's protocol are held.
+     * @param <T> the success value type
+     * @param producer the callback invoked for each incoming SingleSubscriber
+     * @return the new Single instance
+     * @since 1.2.3 - experimental (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     */
+    @Experimental
+    public static <T> Single<T> fromEmitter(Action1<SingleEmitter<T>> producer) {
+        if (producer == null) { throw new NullPointerException("producer is null"); }
+        return create(new SingleFromEmitter<T>(producer));
+    }
+
+    /**
      * Returns a {@code Single} that emits a specified item.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.just.png" alt="">

--- a/src/main/java/rx/SingleEmitter.java
+++ b/src/main/java/rx/SingleEmitter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx;
+
+import rx.annotations.Experimental;
+import rx.functions.Cancellable;
+
+/**
+ * Abstraction over a {@link SingleSubscriber} that gets either an onSuccess or onError
+ * signal and allows registering an cancellation/unsubscription callback.
+ * <p>
+ * All methods are thread-safe; calling onSuccess or onError twice or one after the other has
+ * no effect.
+ * @since 1.2.3 - experimental (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+ * 
+ * @param <T> the success value type
+ */
+@Experimental
+public interface SingleEmitter<T> {
+
+    /**
+     * Notifies the SingleSubscriber that the {@link Single} has completed successfully with
+     * the given value.
+     * <p>
+     * If the {@link Single} calls this method, it will not thereafter call
+     * {@link #onError}.
+     *
+     * @param t the success value
+     */
+    void onSuccess(T t);
+
+    /**
+     * Notifies the SingleSubscriber that the {@link Single} has experienced an error condition.
+     * <p>
+     * If the {@link Single} calls this method, it will not thereafter call
+     * {@link #onSuccess}.
+     *
+     * @param t
+     *          the exception encountered by the Observable
+     */
+    void onError(Throwable t);
+
+    /**
+     * Sets a Subscription on this emitter; any previous Subscription
+     * or Cancellation will be unsubscribed/cancelled.
+     * @param s the subscription, null is allowed
+     */
+    void setSubscription(Subscription s);
+
+    /**
+     * Sets a Cancellable on this emitter; any previous Subscription
+     * or Cancellation will be unsubscribed/cancelled.
+     * @param c the cancellable resource, null is allowed
+     */
+    void setCancellation(Cancellable c);
+
+}

--- a/src/main/java/rx/internal/operators/OnSubscribeFromEmitter.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFromEmitter.java
@@ -20,9 +20,9 @@ import java.util.concurrent.atomic.*;
 
 import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.exceptions.*;
-import rx.functions.Action1;
-import rx.functions.Cancellable;
+import rx.exceptions.MissingBackpressureException;
+import rx.functions.*;
+import rx.internal.subscriptions.CancellableSubscription;
 import rx.internal.util.RxRingBuffer;
 import rx.internal.util.atomic.SpscUnboundedAtomicArrayQueue;
 import rx.internal.util.unsafe.*;
@@ -71,41 +71,6 @@ public final class OnSubscribeFromEmitter<T> implements OnSubscribe<T> {
         t.setProducer(emitter);
         Emitter.call(emitter);
 
-    }
-
-    /**
-     * A Subscription that wraps an Cancellable instance.
-     */
-    static final class CancellableSubscription
-    extends AtomicReference<Cancellable>
-    implements Subscription {
-
-        /** */
-        private static final long serialVersionUID = 5718521705281392066L;
-
-        public CancellableSubscription(Cancellable cancellable) {
-            super(cancellable);
-        }
-
-        @Override
-        public boolean isUnsubscribed() {
-            return get() == null;
-        }
-
-        @Override
-        public void unsubscribe() {
-            if (get() != null) {
-                Cancellable c = getAndSet(null);
-                if (c != null) {
-                    try {
-                        c.cancel();
-                    } catch (Exception ex) {
-                        Exceptions.throwIfFatal(ex);
-                        RxJavaHooks.onError(ex);
-                    }
-                }
-            }
-        }
     }
 
     static abstract class BaseEmitter<T>

--- a/src/main/java/rx/internal/subscriptions/CancellableSubscription.java
+++ b/src/main/java/rx/internal/subscriptions/CancellableSubscription.java
@@ -1,0 +1,43 @@
+package rx.internal.subscriptions;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import rx.Subscription;
+import rx.exceptions.Exceptions;
+import rx.functions.Cancellable;
+import rx.plugins.RxJavaHooks;
+
+/**
+ * A Subscription that wraps an Cancellable instance.
+ */
+public final class CancellableSubscription
+extends AtomicReference<Cancellable>
+implements Subscription {
+
+    /** */
+    private static final long serialVersionUID = 5718521705281392066L;
+
+    public CancellableSubscription(Cancellable cancellable) {
+        super(cancellable);
+    }
+
+    @Override
+    public boolean isUnsubscribed() {
+        return get() == null;
+    }
+
+    @Override
+    public void unsubscribe() {
+        if (get() != null) {
+            Cancellable c = getAndSet(null);
+            if (c != null) {
+                try {
+                    c.cancel();
+                } catch (Exception ex) {
+                    Exceptions.throwIfFatal(ex);
+                    RxJavaHooks.onError(ex);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/rx/internal/operators/SingleFromEmitterTest.java
+++ b/src/test/java/rx/internal/operators/SingleFromEmitterTest.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.junit.*;
+
+import rx.*;
+import rx.exceptions.TestException;
+import rx.functions.*;
+import rx.observers.AssertableSubscriber;
+import rx.plugins.RxJavaHooks;
+
+public class SingleFromEmitterTest implements Cancellable, Action1<Throwable> {
+
+    int calls;
+
+    final List<Throwable> errors = Collections.synchronizedList(new ArrayList<Throwable>());
+
+    @Before
+    public void before() {
+        RxJavaHooks.setOnError(this);
+    }
+
+    @After
+    public void after() {
+        RxJavaHooks.reset();
+    }
+
+    @Override
+    public void cancel() throws Exception {
+        calls++;
+    }
+
+    @Override
+    public void call(Throwable t) {
+        errors.add(t);
+    }
+
+    @Test
+    public void normal() {
+        Single.fromEmitter(new Action1<SingleEmitter<Object>>() {
+            @Override
+            public void call(SingleEmitter<Object> e) {
+                e.setCancellation(SingleFromEmitterTest.this);
+                e.onSuccess(1);
+            }
+        })
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void nullSuccess() {
+        Single.fromEmitter(new Action1<SingleEmitter<Object>>() {
+            @Override
+            public void call(SingleEmitter<Object> e) {
+                e.setCancellation(SingleFromEmitterTest.this);
+                e.onSuccess(null);
+            }
+        })
+        .test()
+        .assertResult((Object)null);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void error() {
+        Single.fromEmitter(new Action1<SingleEmitter<Object>>() {
+            @Override
+            public void call(SingleEmitter<Object> e) {
+                e.setCancellation(SingleFromEmitterTest.this);
+                e.onError(new TestException());
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void nullError() {
+        Single.fromEmitter(new Action1<SingleEmitter<Object>>() {
+            @Override
+            public void call(SingleEmitter<Object> e) {
+                e.setCancellation(SingleFromEmitterTest.this);
+                e.onError(null);
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void crash() {
+        Single.fromEmitter(new Action1<SingleEmitter<Object>>() {
+            @Override
+            public void call(SingleEmitter<Object> e) {
+                e.setCancellation(SingleFromEmitterTest.this);
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, calls);
+    }
+
+    @Test
+    public void crash2() {
+        Single.fromEmitter(new Action1<SingleEmitter<Object>>() {
+            @Override
+            public void call(SingleEmitter<Object> e) {
+                e.setCancellation(SingleFromEmitterTest.this);
+                e.onError(null);
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertEquals(1, calls);
+
+        assertTrue(errors.get(0).toString(), errors.get(0) instanceof TestException);
+    }
+
+    @Test
+    public void unsubscribe() {
+        @SuppressWarnings("unchecked")
+        final SingleEmitter<Object>[] emitter = new SingleEmitter[1];
+
+        AssertableSubscriber<Object> ts = Single.fromEmitter(new Action1<SingleEmitter<Object>>() {
+            @Override
+            public void call(SingleEmitter<Object> e) {
+                emitter[0] = e;
+            }
+        })
+        .test();
+
+        ts.unsubscribe();
+
+        emitter[0].onSuccess(1);
+        emitter[0].onError(new TestException());
+
+        ts.assertNoErrors().assertNotCompleted().assertNoValues();
+
+        assertTrue(errors.get(0).toString(), errors.get(0) instanceof TestException);
+    }
+
+    @Test
+    public void onSuccessThrows() {
+        Single.fromEmitter(new Action1<SingleEmitter<Object>>() {
+            @Override
+            public void call(SingleEmitter<Object> e) {
+                e.setCancellation(SingleFromEmitterTest.this);
+                e.onSuccess(1);
+            }
+        })
+        .subscribe(new SingleSubscriber<Object>() {
+            @Override
+            public void onSuccess(Object value) {
+                throw new TestException();
+            }
+            @Override
+            public void onError(Throwable error) {
+            }
+        });
+
+        assertEquals(1, calls);
+
+        assertTrue(errors.get(0).toString(), errors.get(0) instanceof TestException);
+    }
+
+    @Test
+    public void onErrorThrows() {
+        Single.fromEmitter(new Action1<SingleEmitter<Object>>() {
+            @Override
+            public void call(SingleEmitter<Object> e) {
+                e.setCancellation(SingleFromEmitterTest.this);
+                e.onError(new IOException());
+            }
+        })
+        .subscribe(new SingleSubscriber<Object>() {
+            @Override
+            public void onSuccess(Object value) {
+            }
+            @Override
+            public void onError(Throwable error) {
+                throw new TestException();
+            }
+        });
+
+        assertEquals(1, calls);
+
+        assertTrue(errors.get(0).toString(), errors.get(0) instanceof TestException);
+    }
+}


### PR DESCRIPTION
This PR adds the `Single.fromEmitter` operator, driving a `SingleEmitter` instance similar to `Observable.fromEmitter` and `Completable.fromEmitter`.