### PR TITLE
1.x: Single::takeUntil CancellationException message enh.

### DIFF
--- a/src/main/java/rx/internal/operators/SingleTakeUntilCompletable.java
+++ b/src/main/java/rx/internal/operators/SingleTakeUntilCompletable.java
@@ -86,7 +86,7 @@ public final class SingleTakeUntilCompletable<T> implements Single.OnSubscribe<T
 
         @Override
         public void onCompleted() {
-            onError(new CancellationException("Stream was canceled before emitting a terminal event."));
+            onError(new CancellationException("Single::takeUntil(Completable) - Stream was canceled before emitting a terminal event."));
         }
     }
 }

--- a/src/main/java/rx/internal/operators/SingleTakeUntilObservable.java
+++ b/src/main/java/rx/internal/operators/SingleTakeUntilObservable.java
@@ -96,7 +96,7 @@ public final class SingleTakeUntilObservable<T, U> implements Single.OnSubscribe
 
             @Override
             public void onCompleted() {
-                onError(new CancellationException("Stream was canceled before emitting a terminal event."));
+                onError(new CancellationException("Single::takeUntil(Observable) - Stream was canceled before emitting a terminal event."));
             }
         }
     }

--- a/src/main/java/rx/internal/operators/SingleTakeUntilSingle.java
+++ b/src/main/java/rx/internal/operators/SingleTakeUntilSingle.java
@@ -86,7 +86,7 @@ public final class SingleTakeUntilSingle<T, U> implements Single.OnSubscribe<T> 
         final class OtherSubscriber extends SingleSubscriber<U> {
             @Override
             public void onSuccess(U value) {
-                onError(new CancellationException("Stream was canceled before emitting a terminal event."));
+                onError(new CancellationException("Single::takeUntil(Single) - Stream was canceled before emitting a terminal event."));
             }
 
             @Override

--- a/src/test/java/rx/internal/operators/SingleTakeUntilTest.java
+++ b/src/test/java/rx/internal/operators/SingleTakeUntilTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.operators;
+
+import java.util.concurrent.CancellationException;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import rx.*;
+import rx.observers.AssertableSubscriber;
+
+public class SingleTakeUntilTest {
+
+    @Test
+    public void withSingleMessage() {
+        AssertableSubscriber<Integer> ts = Single.just(1).takeUntil(Single.just(2))
+        .test()
+        .assertFailure(CancellationException.class);
+
+        String message = ts.getOnErrorEvents().get(0).getMessage();
+
+        assertTrue(message, message.startsWith("Single::takeUntil(Single)"));
+    }
+
+    @Test
+    public void withCompletableMessage() {
+        AssertableSubscriber<Integer> ts = Single.just(1).takeUntil(Completable.complete())
+        .test()
+        .assertFailure(CancellationException.class);
+
+        String message = ts.getOnErrorEvents().get(0).getMessage();
+
+        assertTrue(message, message.startsWith("Single::takeUntil(Completable)"));
+    }
+
+    @Test
+    public void withObservableMessage() {
+        AssertableSubscriber<Integer> ts = Single.just(1).takeUntil(Observable.just(1))
+        .test()
+        .assertFailure(CancellationException.class);
+
+        String message = ts.getOnErrorEvents().get(0).getMessage();
+
+        assertTrue(message, message.startsWith("Single::takeUntil(Observable)"));
+    }
+}


### PR DESCRIPTION
This PR modifies the `CancellationException` message to include the operator name and source type.

Relate: #4756