### PR TITLE
Added assertForEachValue for TestSubscriber usage

### DIFF
--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -475,6 +475,26 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     }
 
     /**
+     * Assert that this TestObserver/TestSubscriber receives only values for which the provided predicate
+     * returns true.
+     * @param forEachPredicate the predicate that receives every onNext value and should return true
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertForEachValue(Predicate<T> forEachPredicate) {
+        for (T v : this.values) {
+            try {
+                if (!forEachPredicate.test(v)) {
+                    throw fail("Value " + valueAndClass(v) + " fails predicate assertion");
+                }
+            } catch (Exception ex) {
+                throw ExceptionHelper.wrapOrThrow(ex);
+            }
+        }
+        return (U)this;
+    }
+
+    /**
      * Assert that the TestObserver/TestSubscriber terminated (i.e., the terminal latch reached zero).
      * @return this;
      */


### PR DESCRIPTION
Example implementation for a proposed `testForEachValue` method, rf #4867, which can be applied to fluently test whether all emitted values adhere to some predicate.

If there is interest and the project maintainers/contributors see use in its addition, I will also write tests for the method.