### PR TITLE
1.x: enable TestScheduler with nanosecond periodic scheduling

### DIFF
--- a/src/main/java/rx/internal/schedulers/SchedulePeriodicHelper.java
+++ b/src/main/java/rx/internal/schedulers/SchedulePeriodicHelper.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.schedulers;
+
+import java.util.concurrent.TimeUnit;
+
+import rx.Scheduler.Worker;
+import rx.Subscription;
+import rx.functions.Action0;
+import rx.internal.subscriptions.SequentialSubscription;
+
+/**
+ * Utility method for scheduling tasks periodically (at a fixed rate) by using Worker.schedule(Action0, long, TimeUnit).
+ */
+public final class SchedulePeriodicHelper {
+
+    /** Utility class. */
+    private SchedulePeriodicHelper() {
+        throw new IllegalStateException("No instances!");
+    }
+
+    /**
+     * The tolerance for a clock drift in nanoseconds where the periodic scheduler will rebase.
+     * <p>
+     * The associated system parameter, {@code rx.scheduler.drift-tolerance}, expects its value in minutes.
+     */
+    public static final long CLOCK_DRIFT_TOLERANCE_NANOS;
+    static {
+        CLOCK_DRIFT_TOLERANCE_NANOS = TimeUnit.MINUTES.toNanos(
+                Long.getLong("rx.scheduler.drift-tolerance", 15));
+    }
+
+    /**
+     * Return the current time in nanoseconds. 
+     */
+    public interface NowNanoSupplier {
+        long nowNanos();
+    }
+
+    public static Subscription schedulePeriodically(
+            final Worker worker,
+            final Action0 action, 
+            long initialDelay, long period, TimeUnit unit,
+            final NowNanoSupplier nowNanoSupplier) {
+        final long periodInNanos = unit.toNanos(period);
+        final long firstNowNanos = nowNanoSupplier != null ? nowNanoSupplier.nowNanos() : TimeUnit.MILLISECONDS.toNanos(worker.now());
+        final long firstStartInNanos = firstNowNanos + unit.toNanos(initialDelay);
+
+        final SequentialSubscription first = new SequentialSubscription();
+        final SequentialSubscription mas = new SequentialSubscription(first);
+
+        final Action0 recursiveAction = new Action0() {
+            long count;
+            long lastNowNanos = firstNowNanos;
+            long startInNanos = firstStartInNanos;
+            @Override
+            public void call() {
+                action.call();
+
+                if (!mas.isUnsubscribed()) {
+
+                    long nextTick;
+
+                    long nowNanos = nowNanoSupplier != null ? nowNanoSupplier.nowNanos() : TimeUnit.MILLISECONDS.toNanos(worker.now());
+                    // If the clock moved in a direction quite a bit, rebase the repetition period
+                    if (nowNanos + CLOCK_DRIFT_TOLERANCE_NANOS < lastNowNanos
+                            || nowNanos >= lastNowNanos + periodInNanos + CLOCK_DRIFT_TOLERANCE_NANOS) {
+                        nextTick = nowNanos + periodInNanos;
+                        /*
+                         * Shift the start point back by the drift as if the whole thing
+                         * started count periods ago.
+                         */
+                        startInNanos = nextTick - (periodInNanos * (++count));
+                    } else {
+                        nextTick = startInNanos + (++count * periodInNanos);
+                    }
+                    lastNowNanos = nowNanos;
+
+                    long delay = nextTick - nowNanos;
+                    mas.replace(worker.schedule(this, delay, TimeUnit.NANOSECONDS));
+                }
+            }
+        };
+        first.replace(worker.schedule(recursiveAction, initialDelay, unit));
+        return mas;
+    }
+
+}

--- a/src/main/java/rx/schedulers/TestScheduler.java
+++ b/src/main/java/rx/schedulers/TestScheduler.java
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit;
 import rx.Scheduler;
 import rx.Subscription;
 import rx.functions.Action0;
+import rx.internal.schedulers.SchedulePeriodicHelper;
+import rx.internal.schedulers.SchedulePeriodicHelper.NowNanoSupplier;
 import rx.subscriptions.BooleanSubscription;
 import rx.subscriptions.Subscriptions;
 
@@ -130,7 +132,7 @@ public class TestScheduler extends Scheduler {
         return new InnerTestScheduler();
     }
 
-    final class InnerTestScheduler extends Worker {
+    final class InnerTestScheduler extends Worker implements NowNanoSupplier {
 
         private final BooleanSubscription s = new BooleanSubscription();
 
@@ -173,8 +175,19 @@ public class TestScheduler extends Scheduler {
         }
 
         @Override
+        public Subscription schedulePeriodically(Action0 action, long initialDelay, long period, TimeUnit unit) {
+            return SchedulePeriodicHelper.schedulePeriodically(this, 
+                    action, initialDelay, period, unit, this);
+        }
+        
+        @Override
         public long now() {
             return TestScheduler.this.now();
+        }
+        
+        @Override
+        public long nowNanos() {
+            return TestScheduler.this.time;
         }
 
     }

--- a/src/test/java/rx/SchedulerWorkerTest.java
+++ b/src/test/java/rx/SchedulerWorkerTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import rx.functions.Action0;
+import rx.internal.schedulers.SchedulePeriodicHelper;
 import rx.schedulers.Schedulers;
 
 public class SchedulerWorkerTest {
@@ -85,7 +86,7 @@ public class SchedulerWorkerTest {
 
             Thread.sleep(150);
 
-            s.drift = -1000 - TimeUnit.NANOSECONDS.toMillis(Scheduler.CLOCK_DRIFT_TOLERANCE_NANOS);
+            s.drift = -1000 - TimeUnit.NANOSECONDS.toMillis(SchedulePeriodicHelper.CLOCK_DRIFT_TOLERANCE_NANOS);
 
             Thread.sleep(400);
 
@@ -127,7 +128,7 @@ public class SchedulerWorkerTest {
 
             Thread.sleep(150);
 
-            s.drift = 1000 + TimeUnit.NANOSECONDS.toMillis(Scheduler.CLOCK_DRIFT_TOLERANCE_NANOS);
+            s.drift = 1000 + TimeUnit.NANOSECONDS.toMillis(SchedulePeriodicHelper.CLOCK_DRIFT_TOLERANCE_NANOS);
 
             Thread.sleep(400);
 

--- a/src/test/java/rx/schedulers/TestSchedulerTest.java
+++ b/src/test/java/rx/schedulers/TestSchedulerTest.java
@@ -17,25 +17,18 @@ package rx.schedulers;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
+import org.mockito.*;
 
-import rx.Observable;
+import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.Scheduler;
-import rx.Subscriber;
-import rx.Subscription;
-import rx.functions.Action0;
-import rx.functions.Func1;
+import rx.functions.*;
+import rx.observers.TestSubscriber;
 
 public class TestSchedulerTest {
 
@@ -220,6 +213,26 @@ public class TestSchedulerTest {
             inOrder.verify(calledOp, times(1)).call();
         } finally {
             inner.unsubscribe();
+        }
+    }
+    
+    @Test
+    public void resolution() {
+        for (final TimeUnit unit : TimeUnit.values()) {
+            TestScheduler scheduler = new TestScheduler();
+            TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
+
+            Observable.interval(30, unit, scheduler)
+            .map(new Func1<Long, String>() {
+                @Override
+                public String call(Long v) {
+                    return v + "-" + unit;
+                }
+            })
+            .subscribe(testSubscriber);
+            scheduler.advanceTimeTo(60, unit);
+
+            testSubscriber.assertValues("0-" + unit, "1-" + unit);
         }
     }
 }


### PR DESCRIPTION
The default periodic scheduling code accessed the current worker time as milliseconds which prevents running microsecond and nanosecond scale unit tests with TestScheduler as its internal nanosecond resolution time is always converted, losing precision.

This PR introduces the internal `SchedulePeriodicHelper` class, moves the default scheduling code into a static method and defines a `NowNanoSupplier` interface that is now implemented by TestSchedulerWorker to return the current nano time. The default `Worker.schedulePeriodically` delegates to this static method and given a `null` `noNanoSupplier` the `Worker.now()` is converted to nanoseconds as usual.

Related: #4883