### PR TITLE
2.x: dedicated reduce() op implementations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.1.0'
 
-    perfCompile 'org.openjdk.jmh:jmh-core:1.13'
-    perfCompile 'org.openjdk.jmh:jmh-generator-annprocess:1.13'
+    perfCompile 'org.openjdk.jmh:jmh-core:1.16'
+    perfCompile 'org.openjdk.jmh:jmh-generator-annprocess:1.16'
 
     testCompile 'org.reactivestreams:reactive-streams-tck:1.0.0'
     testCompile group: 'org.testng', name: 'testng', version: '6.9.10'

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -10516,7 +10516,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Single<R> reduce(R seed, BiFunction<R, ? super T, R> reducer) {
-        return RxJavaPlugins.onAssembly(new FlowableSingleSingle<R>(scan(seed, reducer).takeLast(1), null)); // TODO dedicated operator
+        ObjectHelper.requireNonNull(seed, "seed is null");
+        ObjectHelper.requireNonNull(reducer, "reducer is null");
+        return RxJavaPlugins.onAssembly(new FlowableReduceSeedSingle<T, R>(this, seed, reducer));
     }
 
     /**
@@ -10567,7 +10569,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Single<R> reduceWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
-        return RxJavaPlugins.onAssembly(new FlowableSingleSingle<R>(scanWith(seedSupplier, reducer).takeLast(1), null)); // TODO dedicated operator
+        ObjectHelper.requireNonNull(seedSupplier, "seedSupplier is null");
+        ObjectHelper.requireNonNull(reducer, "reducer is null");
+        return RxJavaPlugins.onAssembly(new FlowableReduceWithSingle<T, R>(this, seedSupplier, reducer));
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -8685,7 +8685,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> reduce(BiFunction<T, T, T> reducer) {
-        return scan(reducer).takeLast(1).singleElement();
+        ObjectHelper.requireNonNull(reducer, "reducer is null");
+        return RxJavaPlugins.onAssembly(new ObservableReduceMaybe<T>(this, reducer));
     }
 
     /**
@@ -8732,7 +8733,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Single<R> reduce(R seed, BiFunction<R, ? super T, R> reducer) {
-        return RxJavaPlugins.onAssembly(new ObservableSingleSingle<R>(scan(seed, reducer).takeLast(1), null));
+        ObjectHelper.requireNonNull(seed, "seed is null");
+        ObjectHelper.requireNonNull(reducer, "reducer is null");
+        return RxJavaPlugins.onAssembly(new ObservableReduceSeedSingle<T, R>(this, seed, reducer));
     }
 
     /**
@@ -8779,7 +8782,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Single<R> reduceWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
-        return RxJavaPlugins.onAssembly(new ObservableSingleSingle<R>(scanWith(seedSupplier, reducer).takeLast(1), null));
+        ObjectHelper.requireNonNull(seedSupplier, "seedSupplier is null");
+        ObjectHelper.requireNonNull(reducer, "reducer is null");
+        return RxJavaPlugins.onAssembly(new ObservableReduceWithSingle<T, R>(this, seedSupplier, reducer));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceSeedSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceSeedSingle.java
@@ -79,13 +79,14 @@ public final class FlowableReduceSeedSingle<T, R> extends Single<R> {
         @Override
         public void onNext(T value) {
             R v = this.value;
-
-            try {
-                this.value = ObjectHelper.requireNonNull(reducer.apply(v, value), "The reducer returned a null value");
-            } catch (Throwable ex) {
-                Exceptions.throwIfFatal(ex);
-                s.cancel();
-                onError(ex);
+            if (v != null) {
+                try {
+                    this.value = ObjectHelper.requireNonNull(reducer.apply(v, value), "The reducer returned a null value");
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    s.cancel();
+                    onError(ex);
+                }
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceSeedSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceSeedSingle.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Reduce a sequence of values, starting from a seed value and by using
+ * an accumulator function and return the last accumulated value.
+ *
+ * @param <T> the source value type
+ * @param <R> the accumulated result type
+ */
+public final class FlowableReduceSeedSingle<T, R> extends Single<R> {
+
+    final Publisher<T> source;
+    
+    final R seed;
+    
+    final BiFunction<R, ? super T, R> reducer;
+
+    public FlowableReduceSeedSingle(Publisher<T> source, R seed, BiFunction<R, ? super T, R> reducer) {
+        this.source = source;
+        this.seed = seed;
+        this.reducer = reducer;
+    }
+    
+    @Override
+    protected void subscribeActual(SingleObserver<? super R> observer) {
+        source.subscribe(new ReduceSeedObserver<T, R>(observer, reducer, seed));
+    }
+    
+    static final class ReduceSeedObserver<T, R> implements Subscriber<T>, Disposable {
+        
+        final SingleObserver<? super R> actual;
+        
+        final BiFunction<R, ? super T, R> reducer;
+        
+        R value;
+        
+        Subscription s;
+
+        public ReduceSeedObserver(SingleObserver<? super R> actual, BiFunction<R, ? super T, R> reducer, R value) {
+            this.actual = actual;
+            this.value = value;
+            this.reducer = reducer;
+            this.value = value;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+                
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T value) {
+            R v = this.value;
+            
+            try {
+                this.value = ObjectHelper.requireNonNull(reducer.apply(v, value), "The reducer returned a null value");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                s.cancel();
+                onError(ex);
+            }
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            R v = value;
+            value = null;
+            if (v != null) {
+                s = SubscriptionHelper.CANCELLED;
+                actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+        
+        @Override
+        public void onComplete() {
+            R v = value;
+            value = null;
+            if (v != null) {
+                s = SubscriptionHelper.CANCELLED;
+                actual.onSuccess(v);
+            }
+        }
+        
+        @Override
+        public void dispose() {
+            s.cancel();
+            s = SubscriptionHelper.CANCELLED;
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return s == SubscriptionHelper.CANCELLED;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceSeedSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceSeedSingle.java
@@ -33,9 +33,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 public final class FlowableReduceSeedSingle<T, R> extends Single<R> {
 
     final Publisher<T> source;
-    
+
     final R seed;
-    
+
     final BiFunction<R, ? super T, R> reducer;
 
     public FlowableReduceSeedSingle(Publisher<T> source, R seed, BiFunction<R, ? super T, R> reducer) {
@@ -43,27 +43,26 @@ public final class FlowableReduceSeedSingle<T, R> extends Single<R> {
         this.seed = seed;
         this.reducer = reducer;
     }
-    
+
     @Override
     protected void subscribeActual(SingleObserver<? super R> observer) {
         source.subscribe(new ReduceSeedObserver<T, R>(observer, reducer, seed));
     }
-    
+
     static final class ReduceSeedObserver<T, R> implements Subscriber<T>, Disposable {
-        
+
         final SingleObserver<? super R> actual;
-        
+
         final BiFunction<R, ? super T, R> reducer;
-        
+
         R value;
-        
+
         Subscription s;
 
         public ReduceSeedObserver(SingleObserver<? super R> actual, BiFunction<R, ? super T, R> reducer, R value) {
             this.actual = actual;
             this.value = value;
             this.reducer = reducer;
-            this.value = value;
         }
 
         @Override
@@ -72,7 +71,7 @@ public final class FlowableReduceSeedSingle<T, R> extends Single<R> {
                 this.s = s;
 
                 actual.onSubscribe(this);
-                
+
                 s.request(Long.MAX_VALUE);
             }
         }
@@ -80,7 +79,7 @@ public final class FlowableReduceSeedSingle<T, R> extends Single<R> {
         @Override
         public void onNext(T value) {
             R v = this.value;
-            
+
             try {
                 this.value = ObjectHelper.requireNonNull(reducer.apply(v, value), "The reducer returned a null value");
             } catch (Throwable ex) {
@@ -89,7 +88,7 @@ public final class FlowableReduceSeedSingle<T, R> extends Single<R> {
                 onError(ex);
             }
         }
-        
+
         @Override
         public void onError(Throwable e) {
             R v = value;
@@ -101,7 +100,7 @@ public final class FlowableReduceSeedSingle<T, R> extends Single<R> {
                 RxJavaPlugins.onError(e);
             }
         }
-        
+
         @Override
         public void onComplete() {
             R v = value;
@@ -111,13 +110,13 @@ public final class FlowableReduceSeedSingle<T, R> extends Single<R> {
                 actual.onSuccess(v);
             }
         }
-        
+
         @Override
         public void dispose() {
             s.cancel();
             s = SubscriptionHelper.CANCELLED;
         }
-        
+
         @Override
         public boolean isDisposed() {
             return s == SubscriptionHelper.CANCELLED;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceWithSingle.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.Callable;
+
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.operators.flowable.FlowableReduceSeedSingle.ReduceSeedObserver;
+
+/**
+ * Reduce a sequence of values, starting from a generated seed value and by using
+ * an accumulator function and return the last accumulated value.
+ *
+ * @param <T> the source value type
+ * @param <R> the accumulated result type
+ */
+public final class FlowableReduceWithSingle<T, R> extends Single<R> {
+
+    final Publisher<T> source;
+    
+    final Callable<R> seedSupplier;
+    
+    final BiFunction<R, ? super T, R> reducer;
+
+    public FlowableReduceWithSingle(Publisher<T> source, Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
+        this.source = source;
+        this.seedSupplier = seedSupplier;
+        this.reducer = reducer;
+    }
+    
+    @Override
+    protected void subscribeActual(SingleObserver<? super R> observer) {
+        R seed;
+        
+        try {
+            seed = ObjectHelper.requireNonNull(seedSupplier.call(), "The seedSupplier returned a null value");
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+        source.subscribe(new ReduceSeedObserver<T, R>(observer, reducer, seed));
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceWithSingle.java
@@ -34,9 +34,9 @@ import io.reactivex.internal.operators.flowable.FlowableReduceSeedSingle.ReduceS
 public final class FlowableReduceWithSingle<T, R> extends Single<R> {
 
     final Publisher<T> source;
-    
+
     final Callable<R> seedSupplier;
-    
+
     final BiFunction<R, ? super T, R> reducer;
 
     public FlowableReduceWithSingle(Publisher<T> source, Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
@@ -44,11 +44,11 @@ public final class FlowableReduceWithSingle<T, R> extends Single<R> {
         this.seedSupplier = seedSupplier;
         this.reducer = reducer;
     }
-    
+
     @Override
     protected void subscribeActual(SingleObserver<? super R> observer) {
         R seed;
-        
+
         try {
             seed = ObjectHelper.requireNonNull(seedSupplier.call(), "The seedSupplier returned a null value");
         } catch (Throwable ex) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceMaybe.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Reduce a sequence of values into a single value via an aggregator function and emit the final value or complete
+ * if the source is empty.
+ *
+ * @param <T> the source and result value type
+ */
+public final class ObservableReduceMaybe<T> extends Maybe<T> {
+
+    final ObservableSource<T> source;
+    
+    final BiFunction<T, T, T> reducer;
+
+    public ObservableReduceMaybe(ObservableSource<T> source, BiFunction<T, T, T> reducer) {
+        this.source = source;
+        this.reducer = reducer;
+    }
+    
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new ReduceObserver<T>(observer, reducer));
+    }
+    
+    static final class ReduceObserver<T> implements Observer<T>, Disposable {
+        
+        final MaybeObserver<? super T> actual;
+        
+        final BiFunction<T, T, T> reducer;
+        
+        boolean done;
+        
+        T value;
+        
+        Disposable d;
+
+        public ReduceObserver(MaybeObserver<? super T> observer, BiFunction<T, T, T> reducer) {
+            this.actual = observer;
+            this.reducer = reducer;
+        }
+        
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+                
+                actual.onSubscribe(this);
+            }
+        }
+        
+        @Override
+        public void onNext(T value) {
+            if (!done) {
+                T v = this.value;
+                
+                if (v == null) {
+                    this.value = value;
+                } else {
+                    try {
+                        this.value = ObjectHelper.requireNonNull(reducer.apply(v, value), "The reducer returned a null value");
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        d.dispose();
+                        onError(ex);
+                    }
+                }
+            }
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            if (done) {
+                RxJavaPlugins.onError(e);
+                return;
+            }
+            value = null;
+            actual.onError(e);
+        }
+        
+        @Override
+        public void onComplete() {
+            T v = value;
+            value = null;
+            if (v != null) {
+                actual.onSuccess(v);
+            } else {
+                actual.onComplete();
+            }
+        }
+        
+        @Override
+        public void dispose() {
+            d.dispose();
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceMaybe.java
@@ -94,12 +94,17 @@ public final class ObservableReduceMaybe<T> extends Maybe<T> {
                 RxJavaPlugins.onError(e);
                 return;
             }
+            done = true;
             value = null;
             actual.onError(e);
         }
 
         @Override
         public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
             T v = value;
             value = null;
             if (v != null) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceMaybe.java
@@ -30,50 +30,50 @@ import io.reactivex.plugins.RxJavaPlugins;
 public final class ObservableReduceMaybe<T> extends Maybe<T> {
 
     final ObservableSource<T> source;
-    
+
     final BiFunction<T, T, T> reducer;
 
     public ObservableReduceMaybe(ObservableSource<T> source, BiFunction<T, T, T> reducer) {
         this.source = source;
         this.reducer = reducer;
     }
-    
+
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
         source.subscribe(new ReduceObserver<T>(observer, reducer));
     }
-    
+
     static final class ReduceObserver<T> implements Observer<T>, Disposable {
-        
+
         final MaybeObserver<? super T> actual;
-        
+
         final BiFunction<T, T, T> reducer;
-        
+
         boolean done;
-        
+
         T value;
-        
+
         Disposable d;
 
         public ReduceObserver(MaybeObserver<? super T> observer, BiFunction<T, T, T> reducer) {
             this.actual = observer;
             this.reducer = reducer;
         }
-        
+
         @Override
         public void onSubscribe(Disposable d) {
             if (DisposableHelper.validate(this.d, d)) {
                 this.d = d;
-                
+
                 actual.onSubscribe(this);
             }
         }
-        
+
         @Override
         public void onNext(T value) {
             if (!done) {
                 T v = this.value;
-                
+
                 if (v == null) {
                     this.value = value;
                 } else {
@@ -87,7 +87,7 @@ public final class ObservableReduceMaybe<T> extends Maybe<T> {
                 }
             }
         }
-        
+
         @Override
         public void onError(Throwable e) {
             if (done) {
@@ -97,7 +97,7 @@ public final class ObservableReduceMaybe<T> extends Maybe<T> {
             value = null;
             actual.onError(e);
         }
-        
+
         @Override
         public void onComplete() {
             T v = value;
@@ -108,12 +108,12 @@ public final class ObservableReduceMaybe<T> extends Maybe<T> {
                 actual.onComplete();
             }
         }
-        
+
         @Override
         public void dispose() {
             d.dispose();
         }
-        
+
         @Override
         public boolean isDisposed() {
             return d.isDisposed();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceSeedSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceSeedSingle.java
@@ -31,9 +31,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 public final class ObservableReduceSeedSingle<T, R> extends Single<R> {
 
     final ObservableSource<T> source;
-    
+
     final R seed;
-    
+
     final BiFunction<R, ? super T, R> reducer;
 
     public ObservableReduceSeedSingle(ObservableSource<T> source, R seed, BiFunction<R, ? super T, R> reducer) {
@@ -41,27 +41,26 @@ public final class ObservableReduceSeedSingle<T, R> extends Single<R> {
         this.seed = seed;
         this.reducer = reducer;
     }
-    
+
     @Override
     protected void subscribeActual(SingleObserver<? super R> observer) {
         source.subscribe(new ReduceSeedObserver<T, R>(observer, reducer, seed));
     }
-    
+
     static final class ReduceSeedObserver<T, R> implements Observer<T>, Disposable {
-        
+
         final SingleObserver<? super R> actual;
-        
+
         final BiFunction<R, ? super T, R> reducer;
-        
+
         R value;
-        
+
         Disposable d;
 
         public ReduceSeedObserver(SingleObserver<? super R> actual, BiFunction<R, ? super T, R> reducer, R value) {
             this.actual = actual;
             this.value = value;
             this.reducer = reducer;
-            this.value = value;
         }
 
         @Override
@@ -76,7 +75,7 @@ public final class ObservableReduceSeedSingle<T, R> extends Single<R> {
         @Override
         public void onNext(T value) {
             R v = this.value;
-            
+
             try {
                 this.value = ObjectHelper.requireNonNull(reducer.apply(v, value), "The reducer returned a null value");
             } catch (Throwable ex) {
@@ -85,7 +84,7 @@ public final class ObservableReduceSeedSingle<T, R> extends Single<R> {
                 onError(ex);
             }
         }
-        
+
         @Override
         public void onError(Throwable e) {
             R v = value;
@@ -96,7 +95,7 @@ public final class ObservableReduceSeedSingle<T, R> extends Single<R> {
                 RxJavaPlugins.onError(e);
             }
         }
-        
+
         @Override
         public void onComplete() {
             R v = value;
@@ -105,12 +104,12 @@ public final class ObservableReduceSeedSingle<T, R> extends Single<R> {
                 actual.onSuccess(v);
             }
         }
-        
+
         @Override
         public void dispose() {
             d.dispose();
         }
-        
+
         @Override
         public boolean isDisposed() {
             return d.isDisposed();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceSeedSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceSeedSingle.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Reduce a sequence of values, starting from a seed value and by using
+ * an accumulator function and return the last accumulated value.
+ *
+ * @param <T> the source value type
+ * @param <R> the accumulated result type
+ */
+public final class ObservableReduceSeedSingle<T, R> extends Single<R> {
+
+    final ObservableSource<T> source;
+    
+    final R seed;
+    
+    final BiFunction<R, ? super T, R> reducer;
+
+    public ObservableReduceSeedSingle(ObservableSource<T> source, R seed, BiFunction<R, ? super T, R> reducer) {
+        this.source = source;
+        this.seed = seed;
+        this.reducer = reducer;
+    }
+    
+    @Override
+    protected void subscribeActual(SingleObserver<? super R> observer) {
+        source.subscribe(new ReduceSeedObserver<T, R>(observer, reducer, seed));
+    }
+    
+    static final class ReduceSeedObserver<T, R> implements Observer<T>, Disposable {
+        
+        final SingleObserver<? super R> actual;
+        
+        final BiFunction<R, ? super T, R> reducer;
+        
+        R value;
+        
+        Disposable d;
+
+        public ReduceSeedObserver(SingleObserver<? super R> actual, BiFunction<R, ? super T, R> reducer, R value) {
+            this.actual = actual;
+            this.value = value;
+            this.reducer = reducer;
+            this.value = value;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T value) {
+            R v = this.value;
+            
+            try {
+                this.value = ObjectHelper.requireNonNull(reducer.apply(v, value), "The reducer returned a null value");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                d.dispose();
+                onError(ex);
+            }
+        }
+        
+        @Override
+        public void onError(Throwable e) {
+            R v = value;
+            value = null;
+            if (v != null) {
+                actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+        
+        @Override
+        public void onComplete() {
+            R v = value;
+            value = null;
+            if (v != null) {
+                actual.onSuccess(v);
+            }
+        }
+        
+        @Override
+        public void dispose() {
+            d.dispose();
+        }
+        
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceSeedSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceSeedSingle.java
@@ -75,13 +75,14 @@ public final class ObservableReduceSeedSingle<T, R> extends Single<R> {
         @Override
         public void onNext(T value) {
             R v = this.value;
-
-            try {
-                this.value = ObjectHelper.requireNonNull(reducer.apply(v, value), "The reducer returned a null value");
-            } catch (Throwable ex) {
-                Exceptions.throwIfFatal(ex);
-                d.dispose();
-                onError(ex);
+            if (v != null) {
+                try {
+                    this.value = ObjectHelper.requireNonNull(reducer.apply(v, value), "The reducer returned a null value");
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    d.dispose();
+                    onError(ex);
+                }
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceWithSingle.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.Callable;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.operators.observable.ObservableReduceSeedSingle.ReduceSeedObserver;
+
+/**
+ * Reduce a sequence of values, starting from a generated seed value and by using
+ * an accumulator function and return the last accumulated value.
+ *
+ * @param <T> the source value type
+ * @param <R> the accumulated result type
+ */
+public final class ObservableReduceWithSingle<T, R> extends Single<R> {
+
+    final ObservableSource<T> source;
+    
+    final Callable<R> seedSupplier;
+    
+    final BiFunction<R, ? super T, R> reducer;
+
+    public ObservableReduceWithSingle(ObservableSource<T> source, Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
+        this.source = source;
+        this.seedSupplier = seedSupplier;
+        this.reducer = reducer;
+    }
+    
+    @Override
+    protected void subscribeActual(SingleObserver<? super R> observer) {
+        R seed;
+        
+        try {
+            seed = ObjectHelper.requireNonNull(seedSupplier.call(), "The seedSupplier returned a null value");
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+        source.subscribe(new ReduceSeedObserver<T, R>(observer, reducer, seed));
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceWithSingle.java
@@ -32,9 +32,9 @@ import io.reactivex.internal.operators.observable.ObservableReduceSeedSingle.Red
 public final class ObservableReduceWithSingle<T, R> extends Single<R> {
 
     final ObservableSource<T> source;
-    
+
     final Callable<R> seedSupplier;
-    
+
     final BiFunction<R, ? super T, R> reducer;
 
     public ObservableReduceWithSingle(ObservableSource<T> source, Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
@@ -42,11 +42,11 @@ public final class ObservableReduceWithSingle<T, R> extends Single<R> {
         this.seedSupplier = seedSupplier;
         this.reducer = reducer;
     }
-    
+
     @Override
     protected void subscribeActual(SingleObserver<? super R> observer) {
         R seed;
-        
+
         try {
             seed = ObjectHelper.requireNonNull(seedSupplier.call(), "The seedSupplier returned a null value");
         } catch (Throwable ex) {

--- a/src/perf/java/io/reactivex/ReducePerf.java
+++ b/src/perf/java/io/reactivex/ReducePerf.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.functions.BiFunction;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsAppend = { "-XX:MaxInlineLevel=20" })
+@State(Scope.Thread)
+public class ReducePerf implements BiFunction<Integer, Integer, Integer> {
+    @Param({ "1", "1000", "1000000" })
+    public int times;
+
+    Single<Integer> obsSingle;
+    
+    Single<Integer> flowSingle;
+    
+    Maybe<Integer> obsMaybe;
+    
+    Maybe<Integer> flowMaybe;
+    
+    @Override
+    public Integer apply(Integer t1, Integer t2) throws Exception {
+        return t1 + t2;
+    }
+    
+    @Setup
+    public void setup() {
+        Integer[] array = new Integer[times];
+        Arrays.fill(array, 777);
+
+        obsSingle = Observable.fromArray(array).reduce(0, this);
+        
+        obsMaybe = Observable.fromArray(array).reduce(this);
+        
+        flowSingle = Flowable.fromArray(array).reduce(0, this);
+        
+        flowMaybe = Flowable.fromArray(array).reduce(this);
+    }
+
+    @Benchmark
+    public void obsSingle(Blackhole bh) {
+        obsSingle.subscribe(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public void flowSingle(Blackhole bh) {
+        flowSingle.subscribe(new PerfConsumer(bh));
+    }
+    
+    @Benchmark
+    public void obsMaybe(Blackhole bh) {
+        obsMaybe.subscribe(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public void flowMaybe(Blackhole bh) {
+        flowMaybe.subscribe(new PerfConsumer(bh));
+    }
+}

--- a/src/perf/java/io/reactivex/ReducePerf.java
+++ b/src/perf/java/io/reactivex/ReducePerf.java
@@ -32,29 +32,29 @@ public class ReducePerf implements BiFunction<Integer, Integer, Integer> {
     public int times;
 
     Single<Integer> obsSingle;
-    
+
     Single<Integer> flowSingle;
-    
+
     Maybe<Integer> obsMaybe;
-    
+
     Maybe<Integer> flowMaybe;
-    
+
     @Override
     public Integer apply(Integer t1, Integer t2) throws Exception {
         return t1 + t2;
     }
-    
+
     @Setup
     public void setup() {
         Integer[] array = new Integer[times];
         Arrays.fill(array, 777);
 
         obsSingle = Observable.fromArray(array).reduce(0, this);
-        
+
         obsMaybe = Observable.fromArray(array).reduce(this);
-        
+
         flowSingle = Flowable.fromArray(array).reduce(0, this);
-        
+
         flowMaybe = Flowable.fromArray(array).reduce(this);
     }
 
@@ -67,7 +67,7 @@ public class ReducePerf implements BiFunction<Integer, Integer, Integer> {
     public void flowSingle(Blackhole bh) {
         flowSingle.subscribe(new PerfConsumer(bh));
     }
-    
+
     @Benchmark
     public void obsMaybe(Blackhole bh) {
         obsMaybe.subscribe(new PerfConsumer(bh));

--- a/src/test/java/io/reactivex/InternalWrongNaming.java
+++ b/src/test/java/io/reactivex/InternalWrongNaming.java
@@ -173,6 +173,8 @@ public class InternalWrongNaming {
                 "FlowableLastMaybe",
                 "FlowableIgnoreElementsCompletable",
                 "FlowableReduceMaybe",
+                "FlowableReduceWithSingle",
+                "FlowableReduceSeedSingle",
                 "FlowableFlatMapCompletable",
                 "FlowableFlatMapCompletableCompletable",
                 "FlowableFlatMapSingle",

--- a/src/test/java/io/reactivex/processors/DelayedFlowableProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/DelayedFlowableProcessorTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.processors;
 
 import io.reactivex.subscribers.TestSubscriber;

--- a/src/test/java/io/reactivex/processors/FlowableProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/FlowableProcessorTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.processors;
 
 import org.junit.Test;


### PR DESCRIPTION
This PR adds dedicated operator implementations to

  - `Flowable.reduce(seed, reducer)` (returns `Single`),
  - `Flowable.reduceWith(seedSupplier, reducer)`  (returns `Single`),
  - `Observable.reduce(reducer)` (returns `Maybe`),
  - `Observable.reduce(seed, reducer)`  (returns `Single`) and
  - `Observable.reduceWith(seedSupplier, reducer)`  (returns `Single`)

instead of using `scan().takeLast(1)` (`Flowable.reduce(reducer)` already had a dedicated operator).

Comparison (Celeron 1005M, 4GB RAM, Windows 7 x64, Java 8u112, JMH 1.16):

![image](https://cloud.githubusercontent.com/assets/1269832/20644317/a411f9ba-b430-11e6-8fa7-0db5195f4ddd.png)

The new `ReducePerf` benchmark does a simple sum over a list of integer values. Unfortunately, this creates a lot of garbage for longer sequences (plus the CPU/RAM is not really suited for such benchmarks; the `flowMaybe` lines should be roughly the same since the code didn't change but there is a significant run-to-run variance).