### PR TITLE
1.x: add Issue and PR "welcome" templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+Thanks for using RxJava but before you post an issue, please consider the following points:
+
+  - [ ] Please include the library version number, including the minor and patch version, in the issue text. In addition, if you'd include the major version in the title (such as `2.x`) that would be great.
+
+  - [ ] If you think you found a bug, please include a code sample that reproduces the problem. Dumping a stacktrace is usually not enough for us.
+
+  - [ ] RxJava has more than 150 operators, we recommend searching the [javadoc](http://reactivex.io/RxJava/1.x/javadoc/rx/Observable.html) for keywords of what you try to accomplish.
+
+  - [ ] If you have a question/issue about a library/technology built on top of RxJava (such as Retrofit, RxNetty, etc.), please consider asking a question on StackOverflow first (then maybe on their issue list).
+
+  - [ ] Questions like "how do I X with RxJava" are generally better suited for StackOverflow (where it may already have an answer).
+
+  - [ ] Please avoid cross-posting questions on StackOverflow, this issue list, the Gitter room or the mailing list.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:
+
+  - [ ] Please give a description about what and why you are contributing, even if it's trivial.
+
+  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.
+
+  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.


### PR DESCRIPTION
This PR adds a basic GitHub template that is presented for new Issues and PRs. This helps me maintain focus on important issues rather than questions that can be googled or asked on StackOverflow.