### PR TITLE
2.x: fix compilation errors when using Java 8

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -1891,7 +1891,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Flowable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return fromFuture(future, timeout, unit).subscribeOn(scheduler);
+        return fromFuture((Future<T>)future, timeout, unit).subscribeOn(scheduler);
     }
 
     /**
@@ -1928,7 +1928,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Flowable<T> fromFuture(Future<? extends T> future, Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return fromFuture(future).subscribeOn(scheduler);
+        return fromFuture((Future<T>)future).subscribeOn(scheduler);
     }
 
     /**
@@ -4151,7 +4151,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <T, R> Flowable<R> zip(Publisher<? extends Publisher<? extends T>> sources,
             final Function<? super Object[], ? extends R> zipper) {
         ObjectHelper.requireNonNull(zipper, "zipper is null");
-        return fromPublisher(sources).toList().flatMapPublisher(FlowableInternalHelper.<T, R>zipIterable(zipper));
+        return fromPublisher(sources).toList().flatMapPublisher((Function)FlowableInternalHelper.<T, R>zipIterable(zipper));
     }
 
     /**

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -1886,6 +1886,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SuppressWarnings({ "unchecked", "cast" })
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
@@ -1923,6 +1924,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
+    @SuppressWarnings({ "cast", "unchecked" })
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
@@ -4145,6 +4147,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
+    @SuppressWarnings({ "rawtypes", "unchecked", "cast" })
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -1639,9 +1639,9 @@ public class FlowableGroupByTest {
     public void keySelectorAndDelayError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .groupBy(Functions.identity(), true)
-        .flatMap(new Function<GroupedFlowable<Object, Integer>, Flowable<Integer>>() {
+        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(GroupedFlowable<Object, Integer> g) throws Exception {
+            public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
                 return g;
             }
         })
@@ -1653,9 +1653,9 @@ public class FlowableGroupByTest {
     public void keyAndValueSelectorAndDelayError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .groupBy(Functions.identity(), Functions.<Integer>identity(), true)
-        .flatMap(new Function<GroupedFlowable<Object, Integer>, Flowable<Integer>>() {
+        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(GroupedFlowable<Object, Integer> g) throws Exception {
+            public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
                 return g;
             }
         })

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -1638,7 +1638,7 @@ public class FlowableGroupByTest {
     @Test
     public void keySelectorAndDelayError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
-        .groupBy(Functions.identity(), true)
+        .groupBy(Functions.<Integer>identity(), true)
         .flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
@@ -1652,7 +1652,7 @@ public class FlowableGroupByTest {
     @Test
     public void keyAndValueSelectorAndDelayError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
-        .groupBy(Functions.identity(), Functions.<Integer>identity(), true)
+        .groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), true)
         .flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
@@ -1448,7 +1448,7 @@ public class ObservableGroupByTest {
     @Test
     public void keySelectorAndDelayError() {
         Observable.just(1).concatWith(Observable.<Integer>error(new TestException()))
-        .groupBy(Functions.identity(), true)
+        .groupBy(Functions.<Integer>identity(), true)
         .flatMap(new Function<GroupedObservable<Integer, Integer>, ObservableSource<Integer>>() {
             @Override
             public ObservableSource<Integer> apply(GroupedObservable<Integer, Integer> g) throws Exception {
@@ -1462,7 +1462,7 @@ public class ObservableGroupByTest {
     @Test
     public void keyAndValueSelectorAndDelayError() {
         Observable.just(1).concatWith(Observable.<Integer>error(new TestException()))
-        .groupBy(Functions.identity(), Functions.<Integer>identity(), true)
+        .groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), true)
         .flatMap(new Function<GroupedObservable<Integer, Integer>, ObservableSource<Integer>>() {
             @Override
             public ObservableSource<Integer> apply(GroupedObservable<Integer, Integer> g) throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
@@ -1449,9 +1449,9 @@ public class ObservableGroupByTest {
     public void keySelectorAndDelayError() {
         Observable.just(1).concatWith(Observable.<Integer>error(new TestException()))
         .groupBy(Functions.identity(), true)
-        .flatMap(new Function<GroupedObservable<Object, Integer>, ObservableSource<Integer>>() {
+        .flatMap(new Function<GroupedObservable<Integer, Integer>, ObservableSource<Integer>>() {
             @Override
-            public ObservableSource<Integer> apply(GroupedObservable<Object, Integer> g) throws Exception {
+            public ObservableSource<Integer> apply(GroupedObservable<Integer, Integer> g) throws Exception {
                 return g;
             }
         })
@@ -1463,9 +1463,9 @@ public class ObservableGroupByTest {
     public void keyAndValueSelectorAndDelayError() {
         Observable.just(1).concatWith(Observable.<Integer>error(new TestException()))
         .groupBy(Functions.identity(), Functions.<Integer>identity(), true)
-        .flatMap(new Function<GroupedObservable<Object, Integer>, ObservableSource<Integer>>() {
+        .flatMap(new Function<GroupedObservable<Integer, Integer>, ObservableSource<Integer>>() {
             @Override
-            public ObservableSource<Integer> apply(GroupedObservable<Object, Integer> g) throws Exception {
+            public ObservableSource<Integer> apply(GroupedObservable<Integer, Integer> g) throws Exception {
                 return g;
             }
         })


### PR DESCRIPTION
This PR fixes a few compilation errors that happen when the project is compiled with Java 8 target (Eclipse is even slower then).

Some covariant casts don't work in 8 and some type arguments inferred as Object get inferred as a more concrete type in 8. The slight drawback is that with the changes, Java 6 compilation needs extra suppressions.