### PR TITLE
2.x: Fix typo in DisposableHelper

### DIFF
--- a/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
+++ b/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
@@ -100,7 +100,7 @@ public enum DisposableHelper implements Disposable {
     /**
      * Atomically disposes the Disposable in the field if not already disposed.
      * @param field the target field
-     * @return true if the curren thread managed to dispose the Disposable
+     * @return true if the current thread managed to dispose the Disposable
      */
     public static boolean dispose(AtomicReference<Disposable> field) {
         Disposable current = field.get();


### PR DESCRIPTION
Fixed a typo in DisposableHelper. `curren` -> `current`