### PR TITLE
2.x: doAfterNext - prevent post-error calls to consumer

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
@@ -55,6 +55,9 @@ public final class FlowableDoAfterNext<T> extends AbstractFlowableWithUpstream<T
 
         @Override
         public void onNext(T t) {
+            if (done) {
+                return;
+            }
             actual.onNext(t);
 
             if (sourceMode == NONE) {

--- a/src/test/java/io/reactivex/flowable/FlowableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableDoAfterNextTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.flowable;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import io.reactivex.functions.Consumer;
+
+public class FlowableDoAfterNextTest {
+
+    @Test
+    public void testIfFunctionThrowsThatNoMoreEventsAreProcessed() {
+        final AtomicInteger count = new AtomicInteger();
+        final RuntimeException e = new RuntimeException();
+        Burst.items(1, 2).create()
+            .doAfterNext(new Consumer<Integer>() {
+                @Override
+                public void accept(Integer t) throws Exception {
+                    count.incrementAndGet();
+                    throw e;
+                }})
+            .test()
+            .assertError(e)
+            .assertValue(1);
+        assertEquals(1, count.get());
+    }
+}


### PR DESCRIPTION
This PR
* prevents further calls to the consumer if an error has been thrown