### PR TITLE
Use t instead of value to allow for IDE naming

### DIFF
--- a/src/main/java/io/reactivex/MaybeObserver.java
+++ b/src/main/java/io/reactivex/MaybeObserver.java
@@ -45,10 +45,10 @@ public interface MaybeObserver<T> {
      * <p>
      * The {@link Maybe} will not call this method if it calls {@link #onError}.
      *
-     * @param value
+     * @param t
      *          the item emitted by the Maybe
      */
-    void onSuccess(T value);
+    void onSuccess(T t);
 
     /**
      * Notifies the MaybeObserver that the {@link Maybe} has experienced an error condition.

--- a/src/main/java/io/reactivex/Observer.java
+++ b/src/main/java/io/reactivex/Observer.java
@@ -50,10 +50,10 @@ public interface Observer<T> {
      * The {@code Observable} will not call this method again after it calls either {@link #onComplete} or
      * {@link #onError}.
      *
-     * @param value
+     * @param t
      *          the item emitted by the Observable
      */
-    void onNext(T value);
+    void onNext(T t);
 
     /**
      * Notifies the Observer that the {@link Observable} has experienced an error condition.

--- a/src/main/java/io/reactivex/SingleObserver.java
+++ b/src/main/java/io/reactivex/SingleObserver.java
@@ -47,10 +47,10 @@ public interface SingleObserver<T> {
      * <p>
      * The {@link Single} will not call this method if it calls {@link #onError}.
      *
-     * @param value
+     * @param t
      *          the item emitted by the Single
      */
-    void onSuccess(T value);
+    void onSuccess(T t);
 
     /**
      * Notifies the SingleObserver that the {@link Single} has experienced an error condition.


### PR DESCRIPTION
Naming the value `t` instead of `value` allows the IntelliJ to intelligently name the variable based on the type when autocompleting. 


Before:
```
Single.just(new Dog()).subscribe(new SingleObserver<String>() {
            @Override
            public void onSubscribe(Disposable d) {
                
            }

            @Override
            public void onSuccess(Dog value) {

            }

            @Override
            public void onError(Throwable e) {

            }
        });
```
After:
```
Single.just(new Dog()).subscribe(new SingleObserver<String>() {
            @Override
            public void onSubscribe(Disposable d) {

            }

            @Override
            public void onSuccess(Dog dog) {

            }

            @Override
            public void onError(Throwable e) {

            }
        });
```