### PR TITLE
Use t instead of value to allow for IDE naming 1.x

### DIFF
--- a/src/main/java/rx/SingleSubscriber.java
+++ b/src/main/java/rx/SingleSubscriber.java
@@ -43,10 +43,10 @@ public abstract class SingleSubscriber<T> implements Subscription {
      * <p>
      * The {@link Single} will not call this method if it calls {@link #onError}.
      *
-     * @param value
+     * @param t
      *          the item emitted by the Single
      */
-    public abstract void onSuccess(T value);
+    public abstract void onSuccess(T t);
 
     /**
      * Notifies the SingleSubscriber that the {@link Single} has experienced an error condition.

--- a/src/main/java/rx/observers/SafeSubscriber.java
+++ b/src/main/java/rx/observers/SafeSubscriber.java
@@ -124,14 +124,14 @@ public class SafeSubscriber<T> extends Subscriber<T> {
      * The {@code Observable} will not call this method again after it calls either {@link #onCompleted} or
      * {@link #onError}.
      *
-     * @param args
+     * @param t
      *          the item emitted by the Observable
      */
     @Override
-    public void onNext(T args) {
+    public void onNext(T t) {
         try {
             if (!done) {
-                actual.onNext(args);
+                actual.onNext(t);
             }
         } catch (Throwable e) {
             // we handle here instead of another method so we don't add stacks to the frame


### PR DESCRIPTION
Same as https://github.com/ReactiveX/RxJava/pull/4907 but for 1.x. Most places already named the variable `t`, there were just a few missing.
