### PR TITLE
Fix resolveAndroidApiVersion when running under Robolectric

### DIFF
--- a/src/main/java/rx/internal/util/PlatformDependent.java
+++ b/src/main/java/rx/internal/util/PlatformDependent.java
@@ -15,9 +15,6 @@
  */
 package rx.internal.util;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * Allow platform dependent logic such as checks for Android.
  *
@@ -67,29 +64,13 @@ public final class PlatformDependent {
     private static int resolveAndroidApiVersion() {
         try {
             return (Integer) Class
-                    .forName("android.os.Build$VERSION", true, getSystemClassLoader())
+                    .forName("android.os.Build$VERSION")
                     .getField("SDK_INT")
                     .get(null);
         } catch (Exception e) { // NOPMD
             // Can not resolve version of Android API, maybe current platform is not Android
             // or API of resolving current Version of Android API has changed in some release of Android
             return ANDROID_API_VERSION_IS_NOT_ANDROID;
-        }
-    }
-
-    /**
-     * Return the system {@link ClassLoader}.
-     */
-    static ClassLoader getSystemClassLoader() {
-        if (System.getSecurityManager() == null) {
-            return ClassLoader.getSystemClassLoader();
-        } else {
-            return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
-                @Override
-                public ClassLoader run() {
-                    return ClassLoader.getSystemClassLoader();
-                }
-            });
         }
     }
 }

--- a/src/test/java/rx/internal/util/PlatformDependentTest.java
+++ b/src/test/java/rx/internal/util/PlatformDependentTest.java
@@ -19,9 +19,18 @@ import org.junit.Test;
 
 import rx.TestUtil;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 public class PlatformDependentTest {
     @Test
     public void constructorShouldBePrivate() {
         TestUtil.checkUtilityClass(PlatformDependent.class);
+    }
+
+    @Test
+    public void platformShouldNotBeAndroid() {
+        assertFalse(PlatformDependent.isAndroid());
+        assertEquals(0, PlatformDependent.getAndroidApiVersion());
     }
 }


### PR DESCRIPTION
This is addressing issue #4697.

`PlatformDependent.resolveAndroidApiVersion()` tries to determine the Android SDK version by reading the `android.os.Build$VERSION#SDK_INT` field. When running under Robolectric, the class will be found (since Robolectric bundles an original android.jar). However, the method is using the system class loader for loading it (instead of the Robolectric instrumenting class loader), which will not instrument the class to run in the JVM. As a result, static initialization of the class fails with
an UnsatisfiedLinkError when calling `SystemProperties.get()`, which calls native method native_get.

I fixed by using the default class loader instead. This would only make a difference in the extremely rare case that the Android application installs a class loader that's not capable of finding Android classes. I tested that this behaves as expected on a device, fixes the issue with Robolectric, and detects it's not Android otherwise (as proven by the unit test).