### PR TITLE
2.x: fix TestSubscriber/Observer message texts

### DIFF
--- a/src/main/java/io/reactivex/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/observers/TestObserver.java
@@ -149,7 +149,7 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
         values.add(t);
 
         if (t == null) {
-            errors.add(new NullPointerException("onNext received a null Subscription"));
+            errors.add(new NullPointerException("onNext received a null value"));
         }
 
         actual.onNext(t);

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -207,7 +207,7 @@ implements Subscriber<T>, Subscription, Disposable {
         values.add(t);
 
         if (t == null) {
-            errors.add(new NullPointerException("onNext received a null Subscription"));
+            errors.add(new NullPointerException("onNext received a null value"));
         }
 
         actual.onNext(t);
@@ -226,7 +226,7 @@ implements Subscriber<T>, Subscription, Disposable {
             errors.add(t);
 
             if (t == null) {
-                errors.add(new IllegalStateException("onError received a null Subscription"));
+                errors.add(new IllegalStateException("onError received a null Throwable"));
             }
 
             actual.onError(t);


### PR DESCRIPTION
Fix the wrong messages in `TestSubscriber` and `TestObserver`.

Related: #4920.