### PR TITLE
2.x: don't call the Thread's uncaught handler from RxJavaPlugins.onError

### DIFF
--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -12,15 +12,14 @@
  */
 package io.reactivex.plugins;
 
-import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.concurrent.Callable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observables.ConnectableObservable;
 
@@ -274,18 +273,10 @@ public final class RxJavaPlugins {
             } catch (Throwable e) {
                 // Exceptions.throwIfFatal(e); TODO decide
                 e.printStackTrace(); // NOPMD
-                uncaught(e);
             }
         }
 
         error.printStackTrace(); // NOPMD
-        uncaught(error);
-    }
-
-    static void uncaught(Throwable error) {
-        Thread currentThread = Thread.currentThread();
-        UncaughtExceptionHandler handler = currentThread.getUncaughtExceptionHandler();
-        handler.uncaughtException(currentThread, error);
     }
 
     /**

--- a/src/test/java/io/reactivex/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/ScheduledRunnableTest.java
@@ -19,7 +19,7 @@ import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.List;
 import java.util.concurrent.FutureTask;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.TestHelper;
 import io.reactivex.disposables.CompositeDisposable;
@@ -162,6 +162,7 @@ public class ScheduledRunnableTest {
     }
 
     @Test
+    @Ignore("The uncaught handler is no longer invoked.")
     public void pluginCrash() {
         Thread.currentThread().setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
             @Override

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -1038,6 +1038,7 @@ public class RxJavaPluginsTest {
     }
 
     @Test
+    @Ignore("RxJavaPlugins.onError no longer forwards to the uncaught exception handler")
     public void onErrorNoHandler() {
         try {
             final List<Throwable> list = new ArrayList<Throwable>();
@@ -1069,6 +1070,7 @@ public class RxJavaPluginsTest {
     }
 
     @Test
+    @Ignore("RxJavaPlugins.onError no longer forwards to the uncaught exception handler")
     public void onErrorCrashes() {
         try {
             final List<Throwable> list = new ArrayList<Throwable>();
@@ -1104,6 +1106,7 @@ public class RxJavaPluginsTest {
     }
 
     @Test
+    @Ignore("RxJavaPlugins.onError no longer forwards to the uncaught exception handler")
     public void onErrorWithNull() {
         try {
             final List<Throwable> list = new ArrayList<Throwable>();


### PR DESCRIPTION
This PR removes the call to the current thread's uncaught exception handler if there is no `RxJavaPlugins.onError` handler setup. The default behavior of the `UncaughtExceptionHandler` on Android crashes the whole app. Unit tests that expected this call are modified/disabled.