### PR TITLE
2.x: add safeguards to generate()

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
@@ -271,7 +271,7 @@ public class FlowableGenerateTest {
     }
 
     @Test
-    public void multipleOnComlete() {
+    public void multipleOnComplete() {
         Flowable.generate(new Consumer<Emitter<Object>>() {
             @Override
             public void accept(Emitter<Object> e) throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
@@ -236,4 +236,50 @@ public class FlowableGenerateTest {
             ts.assertValueCount(1000);
         }
     }
+
+    @Test
+    public void multipleOnNext() {
+        Flowable.generate(new Consumer<Emitter<Object>>() {
+            @Override
+            public void accept(Emitter<Object> e) throws Exception {
+                e.onNext(1);
+                e.onNext(2);
+            }
+        })
+        .test(1)
+        .assertFailure(IllegalStateException.class, 1);
+    }
+
+    @Test
+    public void multipleOnError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.generate(new Consumer<Emitter<Object>>() {
+                @Override
+                public void accept(Emitter<Object> e) throws Exception {
+                    e.onError(new TestException("First"));
+                    e.onError(new TestException("Second"));
+                }
+            })
+            .test(1)
+            .assertFailure(TestException.class);
+
+            TestHelper.assertError(errors, 0, TestException.class, "Second");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void multipleOnComlete() {
+        Flowable.generate(new Consumer<Emitter<Object>>() {
+            @Override
+            public void accept(Emitter<Object> e) throws Exception {
+                e.onComplete();
+                e.onComplete();
+            }
+        })
+        .test(1)
+        .assertResult();
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
@@ -182,7 +182,7 @@ public class ObservableGenerateTest {
     }
 
     @Test
-    public void multipleOnComlete() {
+    public void multipleOnComplete() {
         Observable.generate(new Consumer<Emitter<Object>>() {
             @Override
             public void accept(Emitter<Object> e) throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
@@ -147,4 +147,50 @@ public class ObservableGenerateTest {
 
         assertEquals(0, call[0]);
     }
+
+    @Test
+    public void multipleOnNext() {
+        Observable.generate(new Consumer<Emitter<Object>>() {
+            @Override
+            public void accept(Emitter<Object> e) throws Exception {
+                e.onNext(1);
+                e.onNext(2);
+            }
+        })
+        .test()
+        .assertFailure(IllegalStateException.class, 1);
+    }
+
+    @Test
+    public void multipleOnError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable.generate(new Consumer<Emitter<Object>>() {
+                @Override
+                public void accept(Emitter<Object> e) throws Exception {
+                    e.onError(new TestException("First"));
+                    e.onError(new TestException("Second"));
+                }
+            })
+            .test()
+            .assertFailure(TestException.class);
+
+            TestHelper.assertError(errors, 0, TestException.class, "Second");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void multipleOnComlete() {
+        Observable.generate(new Consumer<Emitter<Object>>() {
+            @Override
+            public void accept(Emitter<Object> e) throws Exception {
+                e.onComplete();
+                e.onComplete();
+            }
+        })
+        .test()
+        .assertResult();
+    }
 }


### PR DESCRIPTION
`Flowable.generate()` and `Observable.generate()` lacked the safeguards that were present in 1.x. This adds those and adds extra state cleanup.

Related: #4931