### PR TITLE
2.x: fix timeout with fallback not cancelling the main source

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticast.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticast.java
@@ -137,7 +137,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
         final AtomicReference<MulticastSubscription<T>[]> subscribers;
 
         final int prefetch;
-        
+
         final int limit;
 
         final boolean delayError;
@@ -150,7 +150,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
 
         volatile boolean done;
         Throwable error;
-        
+
         int consumed;
 
         @SuppressWarnings("unchecked")
@@ -319,11 +319,11 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
             int missed = 1;
 
             SimpleQueue<T> q = queue;
-            
+
             int upstreamConsumed = consumed;
             int localLimit = limit;
             boolean canRequest = sourceMode != QueueSubscription.SYNC;
-            
+
             for (;;) {
                 MulticastSubscription<T>[] array = subscribers.get();
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -174,6 +174,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
         public void dispose() {
             worker.dispose();
             DisposableHelper.dispose(timer);
+            s.cancel();
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
@@ -174,6 +174,7 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
         public void dispose() {
             worker.dispose();
             DisposableHelper.dispose(this);
+            s.dispose();
         }
 
         @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
@@ -473,7 +473,7 @@ public class FlowablePublishFunctionTest {
                             public boolean test(Integer w) throws Exception {
                                 return w % 2 == 0;
                             }
-                        }), 
+                        }),
                         v.filter(new Predicate<Integer>() {
                             @Override
                             public boolean test(Integer w) throws Exception {
@@ -500,7 +500,7 @@ public class FlowablePublishFunctionTest {
                             public boolean test(Integer w) throws Exception {
                                 return w % 2 == 0;
                             }
-                        }), 
+                        }),
                         v.filter(new Predicate<Integer>() {
                             @Override
                             public boolean test(Integer w) throws Exception {
@@ -528,7 +528,7 @@ public class FlowablePublishFunctionTest {
                             public boolean test(Integer w) throws Exception {
                                 return w % 2 == 0;
                             }
-                        }), 
+                        }),
                         v.filter(new Predicate<Integer>() {
                             @Override
                             public boolean test(Integer w) throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -483,4 +483,39 @@ public class FlowableTimeoutTests {
         }
     }
 
+
+    @Test
+    public void timedTake() {
+        PublishProcessor<Integer> ps = PublishProcessor.create();
+
+        TestSubscriber<Integer> to = ps.timeout(1, TimeUnit.DAYS)
+        .take(1)
+        .test();
+
+        assertTrue(ps.hasSubscribers());
+
+        ps.onNext(1);
+
+        assertFalse(ps.hasSubscribers());
+
+        to.assertResult(1);
+    }
+
+    @Test
+    public void timedFallbackTake() {
+        PublishProcessor<Integer> ps = PublishProcessor.create();
+
+        TestSubscriber<Integer> to = ps.timeout(1, TimeUnit.DAYS, Flowable.just(2))
+        .take(1)
+        .test();
+
+        assertTrue(ps.hasSubscribers());
+
+        ps.onNext(1);
+
+        assertFalse(ps.hasSubscribers());
+
+        to.assertResult(1);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -508,5 +508,41 @@ public class FlowableTimeoutWithSelectorTest {
         .take(1)
         .test()
         .assertResult(1);
+    }
+
+    @Test
+    public void selectorTake() {
+        PublishProcessor<Integer> ps = PublishProcessor.create();
+
+        TestSubscriber<Integer> to = ps
+        .timeout(Functions.justFunction(Flowable.never()))
+        .take(1)
+        .test();
+
+        assertTrue(ps.hasSubscribers());
+
+        ps.onNext(1);
+
+        assertFalse(ps.hasSubscribers());
+
+        to.assertResult(1);
+    }
+
+    @Test
+    public void selectorFallbackTake() {
+        PublishProcessor<Integer> ps = PublishProcessor.create();
+
+        TestSubscriber<Integer> to = ps
+        .timeout(Functions.justFunction(Flowable.never()), Flowable.just(2))
+        .take(1)
+        .test();
+
+        assertTrue(ps.hasSubscribers());
+
+        ps.onNext(1);
+
+        assertFalse(ps.hasSubscribers());
+
+        to.assertResult(1);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
@@ -481,4 +481,38 @@ public class ObservableTimeoutTests {
             RxJavaPlugins.reset();
         }
     }
+
+    @Test
+    public void timedTake() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps.timeout(1, TimeUnit.DAYS)
+        .take(1)
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        assertFalse(ps.hasObservers());
+
+        to.assertResult(1);
+    }
+
+    @Test
+    public void timedFallbackTake() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps.timeout(1, TimeUnit.DAYS, Observable.just(2))
+        .take(1)
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        assertFalse(ps.hasObservers());
+
+        to.assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -509,5 +509,41 @@ public class ObservableTimeoutWithSelectorTest {
         .take(1)
         .test()
         .assertResult(1);
+    }
+
+    @Test
+    public void selectorTake() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps
+        .timeout(Functions.justFunction(Observable.never()))
+        .take(1)
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        assertFalse(ps.hasObservers());
+
+        to.assertResult(1);
+    }
+
+    @Test
+    public void selectorFallbackTake() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps
+        .timeout(Functions.justFunction(Observable.never()), Observable.just(2))
+        .take(1)
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        assertFalse(ps.hasObservers());
+
+        to.assertResult(1);
     }
 }


### PR DESCRIPTION
This PR fixes the lack of dispose/cancel call towards the upstream in the timed+fallback `timeout` operator version.

In addition, the selector version received similar unit tests to ensure they work properly (they did).

Related: #4944.