### PR TITLE
2.x: A simple Javadoc typo fix.

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableToObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableToObservable.java
@@ -16,6 +16,11 @@ package io.reactivex.internal.operators.completable;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 
+/**
+ * Wraps a Completable and exposes it as an Observable.
+ *
+ * @param <T> the value type
+ */
 public final class CompletableToObservable<T> extends Observable<T> {
 
     final CompletableSource source;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeToObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeToObservable.java
@@ -20,7 +20,7 @@ import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.internal.observers.DeferredScalarDisposable;
 
 /**
- * Wraps a MaybeSource and exposes it as a Flowable, relaying signals in a backpressure-aware manner
+ * Wraps a MaybeSource and exposes it as an Observable, relaying signals in a backpressure-aware manner
  * and composes cancellation through.
  *
  * @param <T> the value type

--- a/src/main/java/io/reactivex/internal/operators/single/SingleToObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleToObservable.java
@@ -17,7 +17,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
- * Wraps a Single and exposes it as a Flowable.
+ * Wraps a Single and exposes it as an Observable.
  *
  * @param <T> the value type
  */


### PR DESCRIPTION
Fixed Javadoc for SingleToObservable, MaybeToObservable, CompletableToObservable