### PR TITLE
2.x: add sample() overload that can emit the very last buffered item

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSamplePublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSamplePublisher.java
@@ -27,18 +27,25 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
     final Publisher<T> source;
     final Publisher<?> other;
 
-    public FlowableSamplePublisher(Publisher<T> source, Publisher<?> other) {
+    final boolean emitLast;
+
+    public FlowableSamplePublisher(Publisher<T> source, Publisher<?> other, boolean emitLast) {
         this.source = source;
         this.other = other;
+        this.emitLast = emitLast;
     }
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
         SerializedSubscriber<T> serial = new SerializedSubscriber<T>(s);
-        source.subscribe(new SamplePublisherSubscriber<T>(serial, other));
+        if (emitLast) {
+            source.subscribe(new SampleMainEmitLast<T>(serial, other));
+        } else {
+            source.subscribe(new SampleMainNoLast<T>(serial, other));
+        }
     }
 
-    static final class SamplePublisherSubscriber<T> extends AtomicReference<T> implements Subscriber<T>, Subscription {
+    abstract static class SamplePublisherSubscriber<T> extends AtomicReference<T> implements Subscriber<T>, Subscription {
 
         private static final long serialVersionUID = -3517602651313910099L;
 
@@ -83,7 +90,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
         @Override
         public void onComplete() {
             SubscriptionHelper.cancel(other);
-            actual.onComplete();
+            completeMain();
         }
 
         boolean setOther(Subscription o) {
@@ -104,16 +111,16 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
         }
 
         public void error(Throwable e) {
-            cancel();
+            s.cancel();
             actual.onError(e);
         }
 
         public void complete() {
-            cancel();
-            actual.onComplete();
+            s.cancel();
+            completeOther();
         }
 
-        public void emit() {
+        void emit() {
             T value = getAndSet(null);
             if (value != null) {
                 long r = requested.get();
@@ -126,6 +133,12 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
                 }
             }
         }
+
+        abstract void completeMain();
+
+        abstract void completeOther();
+
+        abstract void run();
     }
 
     static final class SamplerSubscriber<T> implements Subscriber<Object> {
@@ -144,7 +157,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
 
         @Override
         public void onNext(Object t) {
-            parent.emit();
+            parent.run();
         }
 
         @Override
@@ -155,6 +168,76 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
         @Override
         public void onComplete() {
             parent.complete();
+        }
+    }
+
+    static final class SampleMainNoLast<T> extends SamplePublisherSubscriber<T> {
+
+        private static final long serialVersionUID = -3029755663834015785L;
+
+        SampleMainNoLast(Subscriber<? super T> actual, Publisher<?> other) {
+            super(actual, other);
+        }
+
+        @Override
+        void completeMain() {
+            actual.onComplete();
+        }
+
+        @Override
+        void completeOther() {
+            actual.onComplete();
+        }
+
+        @Override
+        void run() {
+            emit();
+        }
+    }
+
+    static final class SampleMainEmitLast<T> extends SamplePublisherSubscriber<T> {
+
+        private static final long serialVersionUID = -3029755663834015785L;
+
+        final AtomicInteger wip;
+
+        volatile boolean done;
+
+        SampleMainEmitLast(Subscriber<? super T> actual, Publisher<?> other) {
+            super(actual, other);
+            this.wip = new AtomicInteger();
+        }
+
+        @Override
+        void completeMain() {
+            done = true;
+            if (wip.getAndIncrement() == 0) {
+                emit();
+                actual.onComplete();
+            }
+        }
+
+        @Override
+        void completeOther() {
+            done = true;
+            if (wip.getAndIncrement() == 0) {
+                emit();
+                actual.onComplete();
+            }
+        }
+
+        @Override
+        void run() {
+            if (wip.getAndIncrement() == 0) {
+                do {
+                    boolean d = done;
+                    emit();
+                    if (d) {
+                        actual.onComplete();
+                        return;
+                    }
+                } while (wip.decrementAndGet() != 0);
+            }
         }
     }
 }


### PR DESCRIPTION
The `sample()` operator in 1.x has been changed to always emit the very last buffered item before completion for [1.1.3](https://github.com/ReactiveX/RxJava/releases/tag/v1.1.3): [Discussion](https://github.com/ReactiveX/RxJava/issues/3657), [PR](https://github.com/ReactiveX/RxJava/pull/3757).

This change has been forgotten in 2.x (because 2.x `sample()` was implemented several months earlier) but unlike 1.x, I don't want to break existing use cases, hence the introduction of 6 overloads (3 for each base type) that let's one define the "tail" behavior.

Note that the associated marble diagrams are inconsistent with the operators implemented, we need a new diagram where the timed-sample also emits the last value:

![image](https://cloud.githubusercontent.com/assets/1269832/21642878/891ca42a-d285-11e6-876a-e613de2443db.png)

and one new diagram where the sampler-sample doesn't emit the last value:

![image](https://cloud.githubusercontent.com/assets/1269832/21642917/b4dc257c-d285-11e6-8f25-707043957f26.png)

The default sampler-sample should use this and the `emitLast == true` version can use the current diagram.

(I don't have a Mac thus can't run OmniGraffle).

Related: #4952