### PR TITLE
2.x: fix LambdaObserver calling dispose when terminating

### DIFF
--- a/src/main/java/io/reactivex/internal/observers/LambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/LambdaObserver.java
@@ -67,7 +67,7 @@ public final class LambdaObserver<T> extends AtomicReference<Disposable> impleme
     @Override
     public void onError(Throwable t) {
         if (!isDisposed()) {
-            dispose();
+            lazySet(DisposableHelper.DISPOSED);
             try {
                 onError.accept(t);
             } catch (Throwable e) {
@@ -80,7 +80,7 @@ public final class LambdaObserver<T> extends AtomicReference<Disposable> impleme
     @Override
     public void onComplete() {
         if (!isDisposed()) {
-            dispose();
+            lazySet(DisposableHelper.DISPOSED);
             try {
                 onComplete.run();
             } catch (Throwable e) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -91,6 +91,8 @@ public class FlowableIgnoreElementsTest {
             public void run() {
                 unsub.set(true);
             }})
+            .ignoreElements()
+            .toFlowable()
             .subscribe().dispose();
 
         assertTrue(unsub.get());
@@ -207,6 +209,7 @@ public class FlowableIgnoreElementsTest {
             public void run() {
                 unsub.set(true);
             }})
+            .ignoreElements()
             .subscribe().dispose();
 
         assertTrue(unsub.get());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
@@ -82,12 +82,16 @@ public class ObservableIgnoreElementsTest {
     @Test
     public void testUnsubscribesFromUpstreamObservable() {
         final AtomicBoolean unsub = new AtomicBoolean();
-        Observable.range(1, 10).doOnDispose(new Action() {
+        Observable.range(1, 10).concatWith(Observable.<Integer>never())
+        .doOnDispose(new Action() {
             @Override
             public void run() {
                 unsub.set(true);
             }})
-            .subscribe();
+            .ignoreElements()
+            .toObservable()
+            .subscribe()
+            .dispose();
         assertTrue(unsub.get());
     }
 
@@ -145,12 +149,15 @@ public class ObservableIgnoreElementsTest {
     @Test
     public void testUnsubscribesFromUpstream() {
         final AtomicBoolean unsub = new AtomicBoolean();
-        Observable.range(1, 10).doOnDispose(new Action() {
+        Observable.range(1, 10).concatWith(Observable.<Integer>never())
+        .doOnDispose(new Action() {
             @Override
             public void run() {
                 unsub.set(true);
             }})
-            .subscribe();
+            .ignoreElements()
+            .subscribe()
+            .dispose();
         assertTrue(unsub.get());
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
@@ -67,8 +67,13 @@ public class ObservableTakeLastOneTest {
                 unsubscribed.set(true);
             }
         };
-        Observable.just(1).doOnDispose(unsubscribeAction)
-                .takeLast(1).subscribe();
+        Observable.just(1)
+        .concatWith(Observable.<Integer>never())
+        .doOnDispose(unsubscribeAction)
+        .takeLast(1)
+        .subscribe()
+        .dispose();
+
         assertTrue(unsubscribed.get());
     }
 


### PR DESCRIPTION
This PR changes the `LambdaObserver` to not dispose the upstream when it receives a terminal event. The `LambdaSubscriber` has been previoulsy updated but apparently not synced.

Reported in #4956.

This PR fixes 2 unit test methods of `Flowable.ignoreElements()` as they were not actually testing the operator (discovered when the `Observable.ignoreElements()` initially failed after the patch to `LambdaObserver`).