### PR TITLE
2.x: fix Single.takeUntil() other triggering twice

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/single/SingleTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTakeUntil.java
@@ -147,7 +147,7 @@ public final class SingleTakeUntil<T, U> extends Single<T> {
         @Override
         public void onNext(Object t) {
             if (SubscriptionHelper.cancel(this)) {
-                onComplete();
+                parent.otherError(new CancellationException());
             }
         }
 
@@ -158,7 +158,10 @@ public final class SingleTakeUntil<T, U> extends Single<T> {
 
         @Override
         public void onComplete() {
-            parent.otherError(new CancellationException());
+            if (get() != SubscriptionHelper.CANCELLED) {
+                lazySet(SubscriptionHelper.CANCELLED);
+                parent.otherError(new CancellationException());
+            }
         }
 
         public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
@@ -184,4 +184,18 @@ public class MaybeTakeUntilPublisherTest {
             to.assertResult();
         }
     }
+
+    @Test
+    public void otherSignalsAndCompletes() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Maybe.just(1).takeUntil(Flowable.just(1).take(1))
+            .test()
+            .assertResult();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.single;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 
+import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.*;
@@ -257,6 +258,20 @@ public class SingleTakeUntilTest {
             } finally {
                 RxJavaPlugins.reset();
             }
+        }
+    }
+
+    @Test
+    public void otherSignalsAndCompletes() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Single.just(1).takeUntil(Flowable.just(1).take(1))
+            .test()
+            .assertFailure(CancellationException.class);
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
         }
     }
 }


### PR DESCRIPTION
This PR fixes the double termination of `Single.takeUntil(Publisher)` when the `other` fires an item and then completes while ignoring the cancellation in between, trying to signal a `CancellationException` again which is routed to the `RxJavaPlugins.onError` and crashing on Android.

In addition, the `Maybe.takeUntil()` received a unit test verifying this doesn't also happen to it.

Related: #4961.