### PR TITLE
Improve compose() generics

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -6483,11 +6483,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return the source Publisher, transformed by the transformer function
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
+    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> compose(FlowableTransformer<T, R> composer) {
-        return fromPublisher(composer.apply(this));
+    public final <R> Flowable<R> compose(FlowableTransformer<? super T, ? extends R> composer) {
+        return fromPublisher(((FlowableTransformer<T, R>) composer).apply(this));
     }
 
     /**

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2074,10 +2074,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe, transformed by the transformer function
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
+    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Maybe<R> compose(MaybeTransformer<T, R> transformer) {
-        return wrap(transformer.apply(this));
+    public final <R> Maybe<R> compose(MaybeTransformer<? super T, ? extends R> transformer) {
+        return wrap(((MaybeTransformer<T, R>) transformer).apply(this));
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -5722,10 +5722,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the source ObservableSource, transformed by the transformer function
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
+    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> compose(ObservableTransformer<T, R> composer) {
-        return wrap(composer.apply(this));
+    public final <R> Observable<R> compose(ObservableTransformer<? super T, ? extends R> composer) {
+        return wrap(((ObservableTransformer<T, R>) composer).apply(this));
     }
 
     /**

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1540,10 +1540,11 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the source Single, transformed by the transformer function
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
+    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> compose(SingleTransformer<T, R> transformer) {
-        return wrap(transformer.apply(this));
+    public final <R> Single<R> compose(SingleTransformer<? super T, ? extends R> transformer) {
+        return wrap(((SingleTransformer<T, R>) transformer).apply(this));
     }
 
     /**

--- a/src/test/java/io/reactivex/TransformerTest.java
+++ b/src/test/java/io/reactivex/TransformerTest.java
@@ -13,12 +13,11 @@
 
 package io.reactivex;
 
-import static org.junit.Assert.*;
-
+import io.reactivex.exceptions.TestException;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 
-import io.reactivex.exceptions.TestException;
+import static org.junit.Assert.*;
 
 public class TransformerTest {
 
@@ -83,7 +82,7 @@ public class TransformerTest {
     }
 
     @Test
-    public void completabeTransformerThrows() {
+    public void completableTransformerThrows() {
         try {
             Completable.complete().compose(new CompletableTransformer() {
                 @Override
@@ -95,5 +94,74 @@ public class TransformerTest {
         } catch (TestException ex) {
             assertEquals("Forced failure", ex.getMessage());
         }
+    }
+
+    // Test demos for signature generics in compose() methods. Just needs to compile.
+
+    @Test
+    public void observableGenericsSignatureTest() {
+        A<String, Integer> a = new A<String, Integer>() { };
+
+        Observable.just(a).compose(TransformerTest.<String>testObservableTransformerCreator());
+    }
+
+    @Test
+    public void singleGenericsSignatureTest() {
+        A<String, Integer> a = new A<String, Integer>() { };
+
+        Single.just(a).compose(TransformerTest.<String>testSingleTransformerCreator());
+    }
+
+    @Test
+    public void maybeGenericsSignatureTest() {
+        A<String, Integer> a = new A<String, Integer>() { };
+
+        Maybe.just(a).compose(TransformerTest.<String>testMaybeTransformerCreator());
+    }
+
+    @Test
+    public void flowableGenericsSignatureTest() {
+        A<String, Integer> a = new A<String, Integer>() { };
+
+        Flowable.just(a).compose(TransformerTest.<String>testFlowableTransformerCreator());
+    }
+
+    interface A<T, R> {}
+    interface B<T> {}
+
+    private static <T> ObservableTransformer<A<T, ?>, B<T>> testObservableTransformerCreator() {
+        return new ObservableTransformer<A<T, ?>, B<T>>() {
+            @Override
+            public ObservableSource<B<T>> apply(Observable<A<T, ?>> a) {
+                return Observable.empty();
+            }
+        };
+    }
+
+    private static <T> SingleTransformer<A<T, ?>, B<T>> testSingleTransformerCreator() {
+        return new SingleTransformer<A<T, ?>, B<T>>() {
+            @Override
+            public SingleSource<B<T>> apply(Single<A<T, ?>> a) {
+                return Single.never();
+            }
+        };
+    }
+
+    private static <T> MaybeTransformer<A<T, ?>, B<T>> testMaybeTransformerCreator() {
+        return new MaybeTransformer<A<T, ?>, B<T>>() {
+            @Override
+            public MaybeSource<B<T>> apply(Maybe<A<T, ?>> a) {
+                return Maybe.empty();
+            }
+        };
+    }
+
+    private static <T> FlowableTransformer<A<T, ?>, B<T>> testFlowableTransformerCreator() {
+        return new FlowableTransformer<A<T, ?>, B<T>>() {
+            @Override
+            public Publisher<B<T>> apply(Flowable<A<T, ?>> a) {
+                return Flowable.empty();
+            }
+        };
     }
 }


### PR DESCRIPTION
Resolves #4950

I tested and built with the added tests on Java 6, 7, and 8. Not sure if you want to keep them in before merging since they're not really functional in nature, just there to make sure they compile.

