### PR TITLE
2.x: add Flowable.parallel() and parallel operators

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -29,6 +29,7 @@ import io.reactivex.internal.operators.observable.ObservableFromPublisher;
 import io.reactivex.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.internal.subscribers.*;
 import io.reactivex.internal.util.*;
+import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
@@ -10361,6 +10362,100 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onTerminateDetach() {
         return RxJavaPlugins.onAssembly(new FlowableDetach<T>(this));
+    }
+
+    /**
+     * Parallelizes the flow by creating multiple 'rails' (equal to the number of CPUs)
+     * and dispatches the upstream items to them in a round-robin fashion.
+     * <p>
+     * Note that the rails don't execute in parallel on their own and one needs to
+     * apply {@link ParallelFlowable#runOn(Scheduler)} to specify the Scheduler where
+     * each rail will execute.
+     * <p>
+     * To merge the parallel 'rails' back into a single sequence, use {@link ParallelFlowable#sequential()}.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flowable.parallel.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator requires the upstream to honor backpressure and each 'rail' honors backpressure
+     *  as well.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code parallel} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new ParallelFlowable instance
+     * @since 2.0.5 - experimental
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @CheckReturnValue
+    @Experimental
+    public final ParallelFlowable<T> parallel() {
+        return ParallelFlowable.from(this);
+    }
+
+    /**
+     * Parallelizes the flow by creating the specified number of 'rails'
+     * and dispatches the upstream items to them in a round-robin fashion.
+     * <p>
+     * Note that the rails don't execute in parallel on their own and one needs to
+     * apply {@link ParallelFlowable#runOn(Scheduler)} to specify the Scheduler where
+     * each rail will execute.
+     * <p>
+     * To merge the parallel 'rails' back into a single sequence, use {@link ParallelFlowable#sequential()}.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flowable.parallel.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator requires the upstream to honor backpressure and each 'rail' honors backpressure
+     *  as well.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code parallel} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param parallelism the number of 'rails' to use
+     * @return the new ParallelFlowable instance
+     * @since 2.0.5 - experimental
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @CheckReturnValue
+    @Experimental
+    public final ParallelFlowable<T> parallel(int parallelism) {
+        ObjectHelper.verifyPositive(parallelism, "parallelism");
+        return ParallelFlowable.from(this, parallelism);
+    }
+
+    /**
+     * Parallelizes the flow by creating the specified number of 'rails'
+     * and dispatches the upstream items to them in a round-robin fashion and
+     * uses the defined per-'rail' prefetch amount.
+     * <p>
+     * Note that the rails don't execute in parallel on their own and one needs to
+     * apply {@link ParallelFlowable#runOn(Scheduler)} to specify the Scheduler where
+     * each rail will execute.
+     * <p>
+     * To merge the parallel 'rails' back into a single sequence, use {@link ParallelFlowable#sequential()}.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flowable.parallel.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator requires the upstream to honor backpressure and each 'rail' honors backpressure
+     *  as well.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code parallel} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param parallelism the number of 'rails' to use
+     * @param prefetch the number of items each 'rail' should prefetch
+     * @return the new ParallelFlowable instance
+     * @since 2.0.5 - experimental
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @CheckReturnValue
+    @Experimental
+    public final ParallelFlowable<T> parallel(int parallelism, int prefetch) {
+        ObjectHelper.verifyPositive(parallelism, "parallelism");
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
+        return ParallelFlowable.from(this, parallelism, prefetch);
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelCollect.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import java.util.concurrent.Callable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BiConsumer;
+import io.reactivex.internal.subscribers.DeferredScalarSubscriber;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Reduce the sequence of values in each 'rail' to a single value.
+ *
+ * @param <T> the input value type
+ * @param <C> the collection type
+ */
+public final class ParallelCollect<T, C> extends ParallelFlowable<C> {
+
+    final ParallelFlowable<? extends T> source;
+
+    final Callable<C> initialCollection;
+
+    final BiConsumer<C, T> collector;
+
+    public ParallelCollect(ParallelFlowable<? extends T> source,
+            Callable<C> initialCollection, BiConsumer<C, T> collector) {
+        this.source = source;
+        this.initialCollection = initialCollection;
+        this.collector = collector;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super C>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+        @SuppressWarnings("unchecked")
+        Subscriber<T>[] parents = new Subscriber[n];
+
+        for (int i = 0; i < n; i++) {
+
+            C initialValue;
+
+            try {
+                initialValue = initialCollection.call();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                reportError(subscribers, ex);
+                return;
+            }
+
+            if (initialValue == null) {
+                reportError(subscribers, new NullPointerException("The initialSupplier returned a null value"));
+                return;
+            }
+
+            parents[i] = new ParallelCollectSubscriber<T, C>(subscribers[i], initialValue, collector);
+        }
+
+        source.subscribe(parents);
+    }
+
+    void reportError(Subscriber<?>[] subscribers, Throwable ex) {
+        for (Subscriber<?> s : subscribers) {
+            EmptySubscription.error(ex, s);
+        }
+    }
+
+    @Override
+    public int parallelism() {
+        return source.parallelism();
+    }
+
+    static final class ParallelCollectSubscriber<T, C> extends DeferredScalarSubscriber<T, C> {
+
+
+        private static final long serialVersionUID = -4767392946044436228L;
+
+        final BiConsumer<C, T> collector;
+
+        C collection;
+
+        boolean done;
+
+        ParallelCollectSubscriber(Subscriber<? super C> subscriber,
+                C initialValue, BiConsumer<C, T> collector) {
+            super(subscriber);
+            this.collection = initialValue;
+            this.collector = collector;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+
+            try {
+                collector.accept(collection, t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                cancel();
+                onError(ex);
+                return;
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            collection = null;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            C c = collection;
+            collection = null;
+            complete(c);
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            s.cancel();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelConcatMap.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import org.reactivestreams.*;
+
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.operators.flowable.FlowableConcatMap;
+import io.reactivex.internal.util.ErrorMode;
+import io.reactivex.parallel.ParallelFlowable;
+
+/**
+ * Concatenates the generated Publishers on each rail.
+ *
+ * @param <T> the input value type
+ * @param <R> the output value type
+ */
+public final class ParallelConcatMap<T, R> extends ParallelFlowable<R> {
+
+    final ParallelFlowable<T> source;
+
+    final Function<? super T, ? extends Publisher<? extends R>> mapper;
+
+    final int prefetch;
+
+    final ErrorMode errorMode;
+
+    public ParallelConcatMap(
+            ParallelFlowable<T> source,
+            Function<? super T, ? extends Publisher<? extends R>> mapper,
+                    int prefetch, ErrorMode errorMode) {
+        this.source = source;
+        this.mapper = ObjectHelper.requireNonNull(mapper, "mapper");
+        this.prefetch = prefetch;
+        this.errorMode = ObjectHelper.requireNonNull(errorMode, "errorMode");
+    }
+
+    @Override
+    public int parallelism() {
+        return source.parallelism();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super R>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+
+        @SuppressWarnings("unchecked")
+        final Subscriber<T>[] parents = new Subscriber[n];
+
+        // FIXME cheat until we have support from RxJava2 internals
+        Publisher<T> p = new Publisher<T>() {
+            int i;
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public void subscribe(Subscriber<? super T> s) {
+                parents[i++] = (Subscriber<T>)s;
+            }
+        };
+
+        FlowableConcatMap<T, R> op = new FlowableConcatMap<T, R>(p, mapper, prefetch, errorMode);
+
+        for (int i = 0; i < n; i++) {
+
+            op.subscribe(subscribers[i]);
+// FIXME needs a FlatMap subscriber
+//            parents[i] = FlowableConcatMap.createSubscriber(s, mapper, prefetch, errorMode);
+        }
+
+        source.subscribe(parents);
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFilter.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import org.reactivestreams.*;
+
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Filters each 'rail' of the source ParallelFlowable with a predicate function.
+ *
+ * @param <T> the input value type
+ */
+public final class ParallelFilter<T> extends ParallelFlowable<T> {
+
+    final ParallelFlowable<T> source;
+
+    final Predicate<? super T> predicate;
+
+    public ParallelFilter(ParallelFlowable<T> source, Predicate<? super T> predicate) {
+        this.source = source;
+        this.predicate = predicate;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+        @SuppressWarnings("unchecked")
+        Subscriber<? super T>[] parents = new Subscriber[n];
+
+        for (int i = 0; i < n; i++) {
+            parents[i] = new ParallelFilterSubscriber<T>(subscribers[i], predicate);
+        }
+
+        source.subscribe(parents);
+    }
+
+    @Override
+    public int parallelism() {
+        return source.parallelism();
+    }
+
+    static final class ParallelFilterSubscriber<T> implements Subscriber<T>, Subscription {
+
+        final Subscriber<? super T> actual;
+
+        final Predicate<? super T> predicate;
+
+        Subscription s;
+
+        boolean done;
+
+        ParallelFilterSubscriber(Subscriber<? super T> actual, Predicate<? super T> predicate) {
+            this.actual = actual;
+            this.predicate = predicate;
+        }
+
+        @Override
+        public void request(long n) {
+            s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            s.cancel();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            boolean b;
+
+            try {
+                b = predicate.test(t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                cancel();
+                onError(ex);
+                return;
+            }
+
+            if (b) {
+                actual.onNext(t);
+            } else {
+                s.request(1);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            actual.onComplete();
+        }
+
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFlatMap.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import io.reactivex.functions.Function;
+
+import org.reactivestreams.*;
+
+import io.reactivex.internal.operators.flowable.FlowableFlatMap;
+import io.reactivex.parallel.ParallelFlowable;
+
+/**
+ * Flattens the generated Publishers on each rail.
+ *
+ * @param <T> the input value type
+ * @param <R> the output value type
+ */
+public final class ParallelFlatMap<T, R> extends ParallelFlowable<R> {
+
+    final ParallelFlowable<T> source;
+
+    final Function<? super T, ? extends Publisher<? extends R>> mapper;
+
+    final boolean delayError;
+
+    final int maxConcurrency;
+
+    final int prefetch;
+
+    public ParallelFlatMap(
+            ParallelFlowable<T> source,
+            Function<? super T, ? extends Publisher<? extends R>> mapper,
+            boolean delayError,
+            int maxConcurrency,
+            int prefetch) {
+        this.source = source;
+        this.mapper = mapper;
+        this.delayError = delayError;
+        this.maxConcurrency = maxConcurrency;
+        this.prefetch = prefetch;
+    }
+
+    @Override
+    public int parallelism() {
+        return source.parallelism();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super R>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+
+        @SuppressWarnings("unchecked")
+        final Subscriber<T>[] parents = new Subscriber[n];
+
+        // FIXME cheat until we have support from RxJava2 internals
+        Publisher<T> p = new Publisher<T>() {
+            int i;
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public void subscribe(Subscriber<? super T> s) {
+                parents[i++] = (Subscriber<T>)s;
+            }
+        };
+
+        FlowableFlatMap<T, R> op = new FlowableFlatMap<T, R>(p, mapper, delayError, maxConcurrency, prefetch);
+
+        for (int i = 0; i < n; i++) {
+
+            op.subscribe(subscribers[i]);
+// FIXME needs a FlatMap subscriber
+//            parents[i] = FlowableFlatMap.createSubscriber(s, mapper, delayError, maxConcurrency, prefetch);
+        }
+
+        source.subscribe(parents);
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromArray.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.parallel.ParallelFlowable;
+
+/**
+ * Wraps multiple Publishers into a ParallelFlowable which runs them
+ * in parallel.
+ *
+ * @param <T> the value type
+ */
+public final class ParallelFromArray<T> extends ParallelFlowable<T> {
+    final Publisher<T>[] sources;
+
+    public ParallelFromArray(Publisher<T>[] sources) {
+        this.sources = sources;
+    }
+
+    @Override
+    public int parallelism() {
+        return sources.length;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+
+        for (int i = 0; i < n; i++) {
+            sources[i].subscribe(subscribers[i]);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromPublisher.java
@@ -1,0 +1,435 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.parallel.ParallelFlowable;
+
+/**
+ * Dispatches the values from upstream in a round robin fashion to subscribers which are
+ * ready to consume elements. A value from upstream is sent to only one of the subscribers.
+ *
+ * @param <T> the value type
+ */
+public final class ParallelFromPublisher<T> extends ParallelFlowable<T> {
+    final Publisher<? extends T> source;
+
+    final int parallelism;
+
+    final int prefetch;
+
+    public ParallelFromPublisher(Publisher<? extends T> source, int parallelism, int prefetch) {
+        this.source = source;
+        this.parallelism = parallelism;
+        this.prefetch = prefetch;
+    }
+
+    @Override
+    public int parallelism() {
+        return parallelism;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        source.subscribe(new ParallelDispatcher<T>(subscribers, prefetch));
+    }
+
+    static final class ParallelDispatcher<T>
+    extends AtomicInteger
+    implements Subscriber<T> {
+
+
+        private static final long serialVersionUID = -4470634016609963609L;
+
+        final Subscriber<? super T>[] subscribers;
+
+        final AtomicLongArray requests;
+
+        final long[] emissions;
+
+        final int prefetch;
+
+        final int limit;
+
+        Subscription s;
+
+        SimpleQueue<T> queue;
+
+        Throwable error;
+
+        volatile boolean done;
+
+        int index;
+
+        volatile boolean cancelled;
+
+        /**
+         * Counts how many subscribers were setup to delay triggering the
+         * drain of upstream until all of them have been setup.
+         */
+        final AtomicInteger subscriberCount = new AtomicInteger();
+
+        int produced;
+
+        int sourceMode;
+
+        ParallelDispatcher(Subscriber<? super T>[] subscribers, int prefetch) {
+            this.subscribers = subscribers;
+            this.prefetch = prefetch;
+            this.limit = prefetch - (prefetch >> 2);
+            this.requests = new AtomicLongArray(subscribers.length);
+            this.emissions = new long[subscribers.length];
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                if (s instanceof QueueSubscription) {
+                    @SuppressWarnings("unchecked")
+                    QueueSubscription<T> qs = (QueueSubscription<T>) s;
+
+                    int m = qs.requestFusion(QueueSubscription.ANY);
+
+                    if (m == QueueSubscription.SYNC) {
+                        sourceMode = m;
+                        queue = qs;
+                        done = true;
+                        setupSubscribers();
+                        drain();
+                        return;
+                    } else
+                    if (m == QueueSubscription.ASYNC) {
+                        sourceMode = m;
+                        queue = qs;
+
+                        setupSubscribers();
+
+                        s.request(prefetch);
+
+                        return;
+                    }
+                }
+
+                queue = new SpscArrayQueue<T>(prefetch);
+
+                setupSubscribers();
+
+                s.request(prefetch);
+            }
+        }
+
+        void setupSubscribers() {
+            final int m = subscribers.length;
+
+            for (int i = 0; i < m; i++) {
+                if (cancelled) {
+                    return;
+                }
+                final int j = i;
+
+                subscriberCount.lazySet(i + 1);
+
+                subscribers[i].onSubscribe(new Subscription() {
+                    @Override
+                    public void request(long n) {
+                        if (SubscriptionHelper.validate(n)) {
+                            AtomicLongArray ra = requests;
+                            for (;;) {
+                                long r = ra.get(j);
+                                if (r == Long.MAX_VALUE) {
+                                    return;
+                                }
+                                long u = BackpressureHelper.addCap(r, n);
+                                if (ra.compareAndSet(j, r, u)) {
+                                    break;
+                                }
+                            }
+                            if (subscriberCount.get() == m) {
+                                drain();
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void cancel() {
+                        ParallelDispatcher.this.cancel();
+                    }
+                });
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (sourceMode == QueueSubscription.NONE) {
+                if (!queue.offer(t)) {
+                    cancel();
+                    onError(new IllegalStateException("Queue is full?"));
+                    return;
+                }
+            }
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+
+        void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                this.s.cancel();
+
+                if (getAndIncrement() == 0) {
+                    queue.clear();
+                }
+            }
+        }
+
+        void drainAsync() {
+            int missed = 1;
+
+            SimpleQueue<T> q = queue;
+            Subscriber<? super T>[] a = this.subscribers;
+            AtomicLongArray r = this.requests;
+            long[] e = this.emissions;
+            int n = e.length;
+            int idx = index;
+            int consumed = produced;
+
+            for (;;) {
+
+                int notReady = 0;
+
+                for (;;) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+
+                    boolean d = done;
+                    if (d) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            q.clear();
+                            for (Subscriber<? super T> s : a) {
+                                s.onError(ex);
+                            }
+                            return;
+                        }
+                    }
+
+                    boolean empty = q.isEmpty();
+
+                    if (d && empty) {
+                        for (Subscriber<? super T> s : a) {
+                            s.onComplete();
+                        }
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    long ridx = r.get(idx);
+                    long eidx = e[idx];
+                    if (ridx != eidx) {
+
+                        T v;
+
+                        try {
+                            v = q.poll();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            s.cancel();
+                            for (Subscriber<? super T> s : a) {
+                                s.onError(ex);
+                            }
+                            return;
+                        }
+
+                        if (v == null) {
+                            break;
+                        }
+
+                        a[idx].onNext(v);
+
+                        e[idx] = eidx + 1;
+
+                        int c = ++consumed;
+                        if (c == limit) {
+                            consumed = 0;
+                            s.request(c);
+                        }
+                        notReady = 0;
+                    } else {
+                        notReady++;
+                    }
+
+                    idx++;
+                    if (idx == n) {
+                        idx = 0;
+                    }
+
+                    if (notReady == n) {
+                        break;
+                    }
+                }
+
+                int w = get();
+                if (w == missed) {
+                    index = idx;
+                    produced = consumed;
+                    missed = addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                } else {
+                    missed = w;
+                }
+            }
+        }
+
+        void drainSync() {
+            int missed = 1;
+
+            SimpleQueue<T> q = queue;
+            Subscriber<? super T>[] a = this.subscribers;
+            AtomicLongArray r = this.requests;
+            long[] e = this.emissions;
+            int n = e.length;
+            int idx = index;
+
+            for (;;) {
+
+                int notReady = 0;
+
+                for (;;) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+
+                    boolean empty;
+
+                    try {
+                        empty = q.isEmpty();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        s.cancel();
+                        for (Subscriber<? super T> s : a) {
+                            s.onError(ex);
+                        }
+                        return;
+                    }
+
+                    if (empty) {
+                        for (Subscriber<? super T> s : a) {
+                            s.onComplete();
+                        }
+                        return;
+                    }
+
+                    long ridx = r.get(idx);
+                    long eidx = e[idx];
+                    if (ridx != eidx) {
+
+                        T v;
+
+                        try {
+                            v = q.poll();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            s.cancel();
+                            for (Subscriber<? super T> s : a) {
+                                s.onError(ex);
+                            }
+                            return;
+                        }
+
+                        if (v == null) {
+                            for (Subscriber<? super T> s : a) {
+                                s.onComplete();
+                            }
+                            return;
+                        }
+
+                        a[idx].onNext(v);
+
+                        e[idx] = eidx + 1;
+
+                        notReady = 0;
+                    } else {
+                        notReady++;
+                    }
+
+                    idx++;
+                    if (idx == n) {
+                        idx = 0;
+                    }
+
+                    if (notReady == n) {
+                        break;
+                    }
+                }
+
+                int w = get();
+                if (w == missed) {
+                    index = idx;
+                    missed = addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                } else {
+                    missed = w;
+                }
+            }
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            if (sourceMode == QueueSubscription.SYNC) {
+                drainSync();
+            } else {
+                drainAsync();
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelJoin.java
@@ -1,0 +1,368 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Merges the individual 'rails' of the source ParallelFlowable, unordered,
+ * into a single regular Publisher sequence (exposed as Px).
+ *
+ * @param <T> the value type
+ */
+public final class ParallelJoin<T> extends Flowable<T> {
+
+    final ParallelFlowable<? extends T> source;
+
+    final int prefetch;
+
+    public ParallelJoin(ParallelFlowable<? extends T> source, int prefetch) {
+        this.source = source;
+        this.prefetch = prefetch;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        JoinSubscription<T> parent = new JoinSubscription<T>(s, source.parallelism(), prefetch);
+        s.onSubscribe(parent);
+        source.subscribe(parent.subscribers);
+    }
+
+    static final class JoinSubscription<T>
+    extends AtomicInteger
+    implements Subscription {
+
+        private static final long serialVersionUID = 3100232009247827843L;
+
+        final Subscriber<? super T> actual;
+
+        final JoinInnerSubscriber<T>[] subscribers;
+
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+
+        final AtomicLong requested = new AtomicLong();
+
+        volatile boolean cancelled;
+
+        final AtomicInteger done = new AtomicInteger();
+
+        JoinSubscription(Subscriber<? super T> actual, int n, int prefetch) {
+            this.actual = actual;
+            @SuppressWarnings("unchecked")
+            JoinInnerSubscriber<T>[] a = new JoinInnerSubscriber[n];
+
+            for (int i = 0; i < n; i++) {
+                a[i] = new JoinInnerSubscriber<T>(this, prefetch);
+            }
+
+            this.subscribers = a;
+            done.lazySet(n);
+        }
+
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+                drain();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+
+                cancelAll();
+
+                if (getAndIncrement() == 0) {
+                    cleanup();
+                }
+            }
+        }
+
+        void cancelAll() {
+            for (JoinInnerSubscriber<T> s : subscribers) {
+                s.cancel();
+            }
+        }
+
+        void cleanup() {
+            for (JoinInnerSubscriber<T> s : subscribers) {
+                s.queue = null;
+            }
+        }
+
+        void onNext(JoinInnerSubscriber<T> inner, T value) {
+            if (get() == 0 && compareAndSet(0, 1)) {
+                if (requested.get() != 0) {
+                    actual.onNext(value);
+                    if (requested.get() != Long.MAX_VALUE) {
+                        requested.decrementAndGet();
+                    }
+                    inner.request(1);
+                } else {
+                    SimpleQueue<T> q = inner.getQueue();
+
+                    if (!q.offer(value)) {
+                        cancelAll();
+                        Throwable mbe = new MissingBackpressureException("Queue full?!");
+                        if (error.compareAndSet(null, mbe)) {
+                            actual.onError(mbe);
+                        } else {
+                            RxJavaPlugins.onError(mbe);
+                        }
+                        return;
+                    }
+                }
+                if (decrementAndGet() == 0) {
+                    return;
+                }
+            } else {
+                SimpleQueue<T> q = inner.getQueue();
+
+                // FIXME overflow handling
+                q.offer(value);
+
+                if (getAndIncrement() != 0) {
+                    return;
+                }
+            }
+
+            drainLoop();
+        }
+
+        void onError(Throwable e) {
+            if (error.compareAndSet(null, e)) {
+                cancelAll();
+                drain();
+            } else {
+                if (e != error.get()) {
+                    RxJavaPlugins.onError(e);
+                }
+            }
+        }
+
+        void onComplete() {
+            done.decrementAndGet();
+            drain();
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            drainLoop();
+        }
+
+        void drainLoop() {
+            int missed = 1;
+
+            JoinInnerSubscriber<T>[] s = this.subscribers;
+            int n = s.length;
+            Subscriber<? super T> a = this.actual;
+
+            for (;;) {
+
+                long r = requested.get();
+                long e = 0;
+
+                middle:
+                while (e != r) {
+                    if (cancelled) {
+                        cleanup();
+                        return;
+                    }
+
+                    Throwable ex = error.get();
+                    if (ex != null) {
+                        cleanup();
+                        a.onError(ex);
+                        return;
+                    }
+
+                    boolean d = done.get() == 0;
+
+                    boolean empty = true;
+
+                    for (int i = 0; i < n; i++) {
+                        JoinInnerSubscriber<T> inner = s[i];
+
+                        SimplePlainQueue<T> q = inner.queue;
+                        if (q != null) {
+                            T v = q.poll();
+
+                            if (v != null) {
+                                empty = false;
+                                a.onNext(v);
+                                inner.requestOne();
+                                if (++e == r) {
+                                    break middle;
+                                }
+                            }
+                        }
+                    }
+
+                    if (d && empty) {
+                        a.onComplete();
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+                }
+
+                if (e == r) {
+                    if (cancelled) {
+                        cleanup();
+                        return;
+                    }
+
+                    Throwable ex = error.get();
+                    if (ex != null) {
+                        cleanup();
+                        a.onError(ex);
+                        return;
+                    }
+
+                    boolean d = done.get() == 0;
+
+                    boolean empty = true;
+
+                    for (int i = 0; i < n; i++) {
+                        JoinInnerSubscriber<T> inner = s[i];
+
+                        SimpleQueue<T> q = inner.queue;
+                        if (q != null && !q.isEmpty()) {
+                            empty = false;
+                            break;
+                        }
+                    }
+
+                    if (d && empty) {
+                        a.onComplete();
+                        return;
+                    }
+                }
+
+                if (e != 0 && r != Long.MAX_VALUE) {
+                    requested.addAndGet(-e);
+                }
+
+                int w = get();
+                if (w == missed) {
+                    missed = addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                } else {
+                    missed = w;
+                }
+            }
+        }
+    }
+
+    static final class JoinInnerSubscriber<T>
+    extends AtomicReference<Subscription>
+    implements Subscriber<T> {
+
+
+        private static final long serialVersionUID = 8410034718427740355L;
+
+        final JoinSubscription<T> parent;
+
+        final int prefetch;
+
+        final int limit;
+
+        long produced;
+
+        volatile SimplePlainQueue<T> queue;
+
+        volatile boolean done;
+
+        JoinInnerSubscriber(JoinSubscription<T> parent, int prefetch) {
+            this.parent = parent;
+            this.prefetch = prefetch ;
+            this.limit = prefetch - (prefetch >> 2);
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(prefetch);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            parent.onNext(this, t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            parent.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            parent.onComplete();
+        }
+
+        public void requestOne() {
+            long p = produced + 1;
+            if (p == limit) {
+                produced = 0;
+                get().request(p);
+            } else {
+                produced = p;
+            }
+        }
+
+        public void request(long n) {
+            long p = produced + n;
+            if (p >= limit) {
+                produced = 0;
+                get().request(p);
+            } else {
+                produced = p;
+            }
+        }
+
+        public void cancel() {
+            SubscriptionHelper.cancel(this);
+        }
+
+        SimplePlainQueue<T> getQueue() {
+            SimplePlainQueue<T> q = queue;
+            if (q == null) {
+                q = new SpscArrayQueue<T>(prefetch);
+                this.queue = q;
+            }
+            return q;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelMap.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelMap.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import org.reactivestreams.*;
+
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Maps each 'rail' of the source ParallelFlowable with a mapper function.
+ *
+ * @param <T> the input value type
+ * @param <R> the output value type
+ */
+public final class ParallelMap<T, R> extends ParallelFlowable<R> {
+
+    final ParallelFlowable<T> source;
+
+    final Function<? super T, ? extends R> mapper;
+
+    public ParallelMap(ParallelFlowable<T> source, Function<? super T, ? extends R> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super R>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+        @SuppressWarnings("unchecked")
+        Subscriber<? super T>[] parents = new Subscriber[n];
+
+        for (int i = 0; i < n; i++) {
+            parents[i] = new ParallelMapSubscriber<T, R>(subscribers[i], mapper);
+        }
+
+        source.subscribe(parents);
+    }
+
+    @Override
+    public int parallelism() {
+        return source.parallelism();
+    }
+
+    static final class ParallelMapSubscriber<T, R> implements Subscriber<T>, Subscription {
+
+        final Subscriber<? super R> actual;
+
+        final Function<? super T, ? extends R> mapper;
+
+        Subscription s;
+
+        boolean done;
+
+        ParallelMapSubscriber(Subscriber<? super R> actual, Function<? super T, ? extends R> mapper) {
+            this.actual = actual;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void request(long n) {
+            s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            s.cancel();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            R v;
+
+            try {
+                v = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null value");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                cancel();
+                onError(ex);
+                return;
+            }
+
+            actual.onNext(v);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            actual.onComplete();
+        }
+
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelPeek.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelPeek.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import org.reactivestreams.*;
+
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Execute a Consumer in each 'rail' for the current element passing through.
+ *
+ * @param <T> the value type
+ */
+public final class ParallelPeek<T> extends ParallelFlowable<T> {
+
+    final ParallelFlowable<T> source;
+
+    final Consumer<? super T> onNext;
+    final Consumer<? super T> onAfterNext;
+    final Consumer<? super Throwable> onError;
+    final Action onComplete;
+    final Action onAfterTerminated;
+    final Consumer<? super Subscription> onSubscribe;
+    final LongConsumer onRequest;
+    final Action onCancel;
+
+    public ParallelPeek(ParallelFlowable<T> source,
+            Consumer<? super T> onNext,
+            Consumer<? super T> onAfterNext,
+            Consumer<? super Throwable> onError,
+            Action onComplete,
+            Action onAfterTerminated,
+            Consumer<? super Subscription> onSubscribe,
+            LongConsumer onRequest,
+            Action onCancel
+    ) {
+        this.source = source;
+
+        this.onNext = ObjectHelper.requireNonNull(onNext, "onNext");
+        this.onAfterNext = ObjectHelper.requireNonNull(onAfterNext, "onAfterNext");
+        this.onError = ObjectHelper.requireNonNull(onError, "onError");
+        this.onComplete = ObjectHelper.requireNonNull(onComplete, "onComplete");
+        this.onAfterTerminated = ObjectHelper.requireNonNull(onAfterTerminated, "onAfterTerminated");
+        this.onSubscribe = ObjectHelper.requireNonNull(onSubscribe, "onSubscribe");
+        this.onRequest = ObjectHelper.requireNonNull(onRequest, "onRequest");
+        this.onCancel = ObjectHelper.requireNonNull(onCancel, "onCancel");
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+        @SuppressWarnings("unchecked")
+        Subscriber<? super T>[] parents = new Subscriber[n];
+
+        for (int i = 0; i < n; i++) {
+            parents[i] = new ParallelPeekSubscriber<T>(subscribers[i], this);
+        }
+
+        source.subscribe(parents);
+    }
+
+    @Override
+    public int parallelism() {
+        return source.parallelism();
+    }
+
+    static final class ParallelPeekSubscriber<T> implements Subscriber<T>, Subscription {
+
+        final Subscriber<? super T> actual;
+
+        final ParallelPeek<T> parent;
+
+        Subscription s;
+
+        boolean done;
+
+        ParallelPeekSubscriber(Subscriber<? super T> actual, ParallelPeek<T> parent) {
+            this.actual = actual;
+            this.parent = parent;
+        }
+
+        @Override
+        public void request(long n) {
+            try {
+                parent.onRequest.accept(n);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                RxJavaPlugins.onError(ex);
+            }
+            s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            try {
+                parent.onCancel.run();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                RxJavaPlugins.onError(ex);
+            }
+            s.cancel();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                try {
+                    parent.onSubscribe.accept(s);
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    s.cancel();
+                    actual.onSubscribe(EmptySubscription.INSTANCE);
+                    onError(ex);
+                    return;
+                }
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+
+            try {
+                parent.onNext.accept(t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                onError(ex);
+                return;
+            }
+
+            actual.onNext(t);
+
+            try {
+                parent.onAfterNext.accept(t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                onError(ex);
+                return;
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+
+            try {
+                parent.onError.accept(t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                t = new CompositeException(t, ex);
+            }
+            actual.onError(t);
+
+            try {
+                parent.onAfterTerminated.run();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            try {
+                parent.onComplete.run();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                actual.onError(ex);
+                return;
+            }
+            actual.onComplete();
+
+            try {
+                parent.onAfterTerminated.run();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelReduce.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelReduce.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import java.util.concurrent.Callable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.internal.subscribers.DeferredScalarSubscriber;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Reduce the sequence of values in each 'rail' to a single value.
+ *
+ * @param <T> the input value type
+ * @param <R> the result value type
+ */
+public final class ParallelReduce<T, R> extends ParallelFlowable<R> {
+
+    final ParallelFlowable<? extends T> source;
+
+    final Callable<R> initialSupplier;
+
+    final BiFunction<R, T, R> reducer;
+
+    public ParallelReduce(ParallelFlowable<? extends T> source, Callable<R> initialSupplier, BiFunction<R, T, R> reducer) {
+        this.source = source;
+        this.initialSupplier = initialSupplier;
+        this.reducer = reducer;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super R>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+        @SuppressWarnings("unchecked")
+        Subscriber<T>[] parents = new Subscriber[n];
+
+        for (int i = 0; i < n; i++) {
+
+            R initialValue;
+
+            try {
+                initialValue = initialSupplier.call();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                reportError(subscribers, ex);
+                return;
+            }
+
+            if (initialValue == null) {
+                reportError(subscribers, new NullPointerException("The initialSupplier returned a null value"));
+                return;
+            }
+
+            parents[i] = new ParallelReduceSubscriber<T, R>(subscribers[i], initialValue, reducer);
+        }
+
+        source.subscribe(parents);
+    }
+
+    void reportError(Subscriber<?>[] subscribers, Throwable ex) {
+        for (Subscriber<?> s : subscribers) {
+            EmptySubscription.error(ex, s);
+        }
+    }
+
+    @Override
+    public int parallelism() {
+        return source.parallelism();
+    }
+
+    static final class ParallelReduceSubscriber<T, R> extends DeferredScalarSubscriber<T, R> {
+
+
+        private static final long serialVersionUID = 8200530050639449080L;
+
+        final BiFunction<R, T, R> reducer;
+
+        R accumulator;
+
+        boolean done;
+
+        ParallelReduceSubscriber(Subscriber<? super R> subscriber, R initialValue, BiFunction<R, T, R> reducer) {
+            super(subscriber);
+            this.accumulator = initialValue;
+            this.reducer = reducer;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+
+            R v;
+
+            try {
+                v = reducer.apply(accumulator, t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                cancel();
+                onError(ex);
+                return;
+            }
+
+            if (v == null) {
+                cancel();
+                onError(new NullPointerException("The reducer returned a null value"));
+                return;
+            }
+
+            accumulator = v;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            accumulator = null;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+
+            R a = accumulator;
+            accumulator = null;
+            complete(a);
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            s.cancel();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelReduceFull.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelReduceFull.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Reduces all 'rails' into a single value which then gets reduced into a single
+ * Publisher sequence.
+ *
+ * @param <T> the value type
+ */
+public final class ParallelReduceFull<T> extends Flowable<T> {
+
+    final ParallelFlowable<? extends T> source;
+
+    final BiFunction<T, T, T> reducer;
+
+    public ParallelReduceFull(ParallelFlowable<? extends T> source, BiFunction<T, T, T> reducer) {
+        this.source = source;
+        this.reducer = reducer;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        ParallelReduceFullMainSubscriber<T> parent = new ParallelReduceFullMainSubscriber<T>(s, source.parallelism(), reducer);
+        s.onSubscribe(parent);
+
+        source.subscribe(parent.subscribers);
+    }
+
+    static final class ParallelReduceFullMainSubscriber<T> extends DeferredScalarSubscription<T> {
+
+
+        private static final long serialVersionUID = -5370107872170712765L;
+
+        final ParallelReduceFullInnerSubscriber<T>[] subscribers;
+
+        final BiFunction<T, T, T> reducer;
+
+        final AtomicReference<SlotPair<T>> current = new AtomicReference<SlotPair<T>>();
+
+        final AtomicInteger remaining = new AtomicInteger();
+
+        final AtomicBoolean once = new AtomicBoolean();
+
+        ParallelReduceFullMainSubscriber(Subscriber<? super T> subscriber, int n, BiFunction<T, T, T> reducer) {
+            super(subscriber);
+            @SuppressWarnings("unchecked")
+            ParallelReduceFullInnerSubscriber<T>[] a = new ParallelReduceFullInnerSubscriber[n];
+            for (int i = 0; i < n; i++) {
+                a[i] = new ParallelReduceFullInnerSubscriber<T>(this, reducer);
+            }
+            this.subscribers = a;
+            this.reducer = reducer;
+            remaining.lazySet(n);
+        }
+
+        SlotPair<T> addValue(T value) {
+            for (;;) {
+                SlotPair<T> curr = current.get();
+
+                if (curr == null) {
+                    curr = new SlotPair<T>();
+                    if (!current.compareAndSet(null, curr)) {
+                        continue;
+                    }
+                }
+
+                int c = curr.tryAcquireSlot();
+                if (c < 0) {
+                    current.compareAndSet(curr, null);
+                    continue;
+                }
+                if (c == 0) {
+                    curr.first = value;
+                } else {
+                    curr.second = value;
+                }
+
+                if (curr.releaseSlot()) {
+                    current.compareAndSet(curr, null);
+                    return curr;
+                }
+                return null;
+            }
+        }
+
+        @Override
+        public void cancel() {
+            for (ParallelReduceFullInnerSubscriber<T> inner : subscribers) {
+                inner.cancel();
+            }
+        }
+
+        void innerError(Throwable ex) {
+            if (once.compareAndSet(false, true)) {
+                cancel();
+                actual.onError(ex);
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        void innerComplete(T value) {
+            if (value != null) {
+                for (;;) {
+                    SlotPair<T> sp = addValue(value);
+
+                    if (sp != null) {
+
+                        try {
+                            value = reducer.apply(sp.first, sp.second);
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            innerError(ex);
+                            return;
+                        }
+
+                        if (value == null) {
+                            innerError(new NullPointerException("The reducer returned a null value"));
+                            return;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            if (remaining.decrementAndGet() == 0) {
+                SlotPair<T> sp = current.get();
+                current.lazySet(null);
+
+                if (sp != null) {
+                    complete(sp.first);
+                } else {
+                    actual.onComplete();
+                }
+            }
+        }
+    }
+
+    static final class ParallelReduceFullInnerSubscriber<T>
+    extends AtomicReference<Subscription>
+    implements Subscriber<T> {
+
+        private static final long serialVersionUID = -7954444275102466525L;
+
+        final ParallelReduceFullMainSubscriber<T> parent;
+
+        final BiFunction<T, T, T> reducer;
+
+        T value;
+
+        boolean done;
+
+        ParallelReduceFullInnerSubscriber(ParallelReduceFullMainSubscriber<T> parent, BiFunction<T, T, T> reducer) {
+            this.parent = parent;
+            this.reducer = reducer;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            T v = value;
+
+            if (v == null) {
+                value = t;
+            } else {
+
+                try {
+                    v = ObjectHelper.requireNonNull(reducer.apply(v, t), "The reducer returned a null value");
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    get().cancel();
+                    onError(ex);
+                    return;
+                }
+
+                value = v;
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            parent.innerError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            parent.innerComplete(value);
+        }
+
+        void cancel() {
+            SubscriptionHelper.cancel(this);
+        }
+    }
+
+    static final class SlotPair<T> {
+
+        T first;
+
+        T second;
+
+        volatile int acquireIndex;
+        @SuppressWarnings("rawtypes")
+        static final AtomicIntegerFieldUpdater<SlotPair> ACQ =
+                AtomicIntegerFieldUpdater.newUpdater(SlotPair.class, "acquireIndex");
+
+
+        volatile int releaseIndex;
+        @SuppressWarnings("rawtypes")
+        static final AtomicIntegerFieldUpdater<SlotPair> REL =
+                AtomicIntegerFieldUpdater.newUpdater(SlotPair.class, "releaseIndex");
+
+        int tryAcquireSlot() {
+            for (;;) {
+                int acquired = acquireIndex;
+                if (acquired >= 2) {
+                    return -1;
+                }
+
+                if (ACQ.compareAndSet(this, acquired, acquired + 1)) {
+                    return acquired;
+                }
+            }
+        }
+
+        boolean releaseSlot() {
+            return REL.incrementAndGet(this) == 2;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelRunOn.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelRunOn.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Scheduler;
+import io.reactivex.Scheduler.Worker;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Ensures each 'rail' from upstream runs on a Worker from a Scheduler.
+ *
+ * @param <T> the value type
+ */
+public final class ParallelRunOn<T> extends ParallelFlowable<T> {
+    final ParallelFlowable<? extends T> source;
+
+    final Scheduler scheduler;
+
+    final int prefetch;
+
+    public ParallelRunOn(ParallelFlowable<? extends T> parent,
+            Scheduler scheduler, int prefetch) {
+        this.source = parent;
+        this.scheduler = scheduler;
+        this.prefetch = prefetch;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+
+        @SuppressWarnings("unchecked")
+        Subscriber<T>[] parents = new Subscriber[n];
+
+        int prefetch = this.prefetch;
+
+        for (int i = 0; i < n; i++) {
+            Subscriber<? super T> a = subscribers[i];
+
+            Worker w = scheduler.createWorker();
+            SpscArrayQueue<T> q = new SpscArrayQueue<T>(prefetch);
+
+            RunOnSubscriber<T> parent = new RunOnSubscriber<T>(a, prefetch, q, w);
+            parents[i] = parent;
+        }
+
+        source.subscribe(parents);
+    }
+
+
+    @Override
+    public int parallelism() {
+        return source.parallelism();
+    }
+
+    static final class RunOnSubscriber<T>
+    extends AtomicInteger
+    implements Subscriber<T>, Subscription, Runnable {
+
+
+        private static final long serialVersionUID = 1075119423897941642L;
+
+        final Subscriber<? super T> actual;
+
+        final int prefetch;
+
+        final int limit;
+
+        final SpscArrayQueue<T> queue;
+
+        final Worker worker;
+
+        Subscription s;
+
+        volatile boolean done;
+
+        Throwable error;
+
+        final AtomicLong requested = new AtomicLong();
+
+        volatile boolean cancelled;
+
+        int consumed;
+
+        RunOnSubscriber(Subscriber<? super T> actual, int prefetch, SpscArrayQueue<T> queue, Worker worker) {
+            this.actual = actual;
+            this.prefetch = prefetch;
+            this.queue = queue;
+            this.limit = prefetch - (prefetch >> 2);
+            this.worker = worker;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+
+                s.request(prefetch);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            if (!queue.offer(t)) {
+                onError(new IllegalStateException("Queue is full?!"));
+                return;
+            }
+            schedule();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            error = t;
+            done = true;
+            schedule();
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            schedule();
+        }
+
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+                schedule();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                s.cancel();
+                worker.dispose();
+
+                if (getAndIncrement() == 0) {
+                    queue.clear();
+                }
+            }
+        }
+
+        void schedule() {
+            if (getAndIncrement() == 0) {
+                worker.schedule(this);
+            }
+        }
+
+        @Override
+        public void run() {
+            int missed = 1;
+            int c = consumed;
+            SpscArrayQueue<T> q = queue;
+            Subscriber<? super T> a = actual;
+            int lim = limit;
+
+            for (;;) {
+
+                long r = requested.get();
+                long e = 0L;
+
+                while (e != r) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+
+                    boolean d = done;
+
+                    if (d) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            q.clear();
+
+                            a.onError(ex);
+
+                            worker.dispose();
+                            return;
+                        }
+                    }
+
+                    T v = q.poll();
+
+                    boolean empty = v == null;
+
+                    if (d && empty) {
+                        a.onComplete();
+
+                        worker.dispose();
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    a.onNext(v);
+
+                    e++;
+
+                    int p = ++c;
+                    if (p == lim) {
+                        c = 0;
+                        s.request(p);
+                    }
+                }
+
+                if (e == r) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+
+                    if (done) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            q.clear();
+
+                            a.onError(ex);
+
+                            worker.dispose();
+                            return;
+                        }
+                        if (q.isEmpty()) {
+                            a.onComplete();
+
+                            worker.dispose();
+                            return;
+                        }
+                    }
+                }
+
+                if (e != 0L && r != Long.MAX_VALUE) {
+                    requested.addAndGet(-e);
+                }
+
+                int w = get();
+                if (w == missed) {
+                    consumed = c;
+                    missed = addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                } else {
+                    missed = w;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelSortedJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelSortedJoin.java
@@ -1,0 +1,289 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Given sorted rail sequences (according to the provided comparator) as List
+ * emit the smallest item from these parallel Lists to the Subscriber.
+ * <p>
+ * It expects the source to emit exactly one list (which could be empty).
+ *
+ * @param <T> the value type
+ */
+public final class ParallelSortedJoin<T> extends Flowable<T> {
+
+    final ParallelFlowable<List<T>> source;
+
+    final Comparator<? super T> comparator;
+
+    public ParallelSortedJoin(ParallelFlowable<List<T>> source, Comparator<? super T> comparator) {
+        this.source = source;
+        this.comparator = comparator;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        SortedJoinSubscription<T> parent = new SortedJoinSubscription<T>(s, source.parallelism(), comparator);
+        s.onSubscribe(parent);
+
+        source.subscribe(parent.subscribers);
+    }
+
+    static final class SortedJoinSubscription<T>
+    extends AtomicInteger
+    implements Subscription {
+
+        private static final long serialVersionUID = 3481980673745556697L;
+
+        final Subscriber<? super T> actual;
+
+        final SortedJoinInnerSubscriber<T>[] subscribers;
+
+        final List<T>[] lists;
+
+        final int[] indexes;
+
+        final Comparator<? super T> comparator;
+
+        final AtomicLong requested = new AtomicLong();
+
+        volatile boolean cancelled;
+
+        final AtomicInteger remaining = new AtomicInteger();
+
+        final AtomicThrowable error = new AtomicThrowable();
+
+        @SuppressWarnings("unchecked")
+        SortedJoinSubscription(Subscriber<? super T> actual, int n, Comparator<? super T> comparator) {
+            this.actual = actual;
+            this.comparator = comparator;
+
+            SortedJoinInnerSubscriber<T>[] s = new SortedJoinInnerSubscriber[n];
+
+            for (int i = 0; i < n; i++) {
+                s[i] = new SortedJoinInnerSubscriber<T>(this, i);
+            }
+            this.subscribers = s;
+            this.lists = new List[n];
+            this.indexes = new int[n];
+            remaining.lazySet(n);
+        }
+
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+                if (remaining.get() == 0) {
+                    drain();
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                cancelAll();
+                if (getAndIncrement() == 0) {
+                    Arrays.fill(lists, null);
+                }
+            }
+        }
+
+        void cancelAll() {
+            for (SortedJoinInnerSubscriber<T> s : subscribers) {
+                s.cancel();
+            }
+        }
+
+        void innerNext(List<T> value, int index) {
+            lists[index] = value;
+            if (remaining.decrementAndGet() == 0) {
+                drain();
+            }
+        }
+
+        void innerError(Throwable e) {
+            if (error.addThrowable(e)) {
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            Subscriber<? super T> a = actual;
+            List<T>[] lists = this.lists;
+            int[] indexes = this.indexes;
+            int n = indexes.length;
+
+            for (;;) {
+
+                long r = requested.get();
+                long e = 0L;
+
+                while (e != r) {
+                    if (cancelled) {
+                        Arrays.fill(lists, null);
+                        return;
+                    }
+
+                    Throwable ex = error.get();
+                    if (ex != null) {
+                        cancelAll();
+                        Arrays.fill(lists, null);
+                        a.onError(error.terminate());
+                        return;
+                    }
+
+                    T min = null;
+                    int minIndex = -1;
+
+                    for (int i = 0; i < n; i++) {
+                        List<T> list = lists[i];
+                        int index = indexes[i];
+
+                        if (list.size() != index) {
+                            if (min == null) {
+                                min = list.get(index);
+                                minIndex = i;
+                            } else {
+                                T b = list.get(index);
+                                if (comparator.compare(min, b) > 0) {
+                                    min = b;
+                                    minIndex = i;
+                                }
+                            }
+                        }
+                    }
+
+                    if (min == null) {
+                        Arrays.fill(lists, null);
+                        a.onComplete();
+                        return;
+                    }
+
+                    a.onNext(min);
+
+                    indexes[minIndex]++;
+
+                    e++;
+                }
+
+                if (e == r) {
+                    if (cancelled) {
+                        Arrays.fill(lists, null);
+                        return;
+                    }
+
+                    Throwable ex = error.get();
+                    if (ex != null) {
+                        cancelAll();
+                        Arrays.fill(lists, null);
+                        a.onError(error.terminate());
+                        return;
+                    }
+
+                    boolean empty = true;
+
+                    for (int i = 0; i < n; i++) {
+                        if (indexes[i] != lists[i].size()) {
+                            empty = false;
+                            break;
+                        }
+                    }
+
+                    if (empty) {
+                        Arrays.fill(lists, null);
+                        a.onComplete();
+                        return;
+                    }
+                }
+
+                if (e != 0 && r != Long.MAX_VALUE) {
+                    requested.addAndGet(-e);
+                }
+
+                int w = get();
+                if (w == missed) {
+                    missed = addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                } else {
+                    missed = w;
+                }
+            }
+        }
+    }
+
+    static final class SortedJoinInnerSubscriber<T>
+    extends AtomicReference<Subscription>
+    implements Subscriber<List<T>> {
+
+
+        private static final long serialVersionUID = 6751017204873808094L;
+
+        final SortedJoinSubscription<T> parent;
+
+        final int index;
+
+        SortedJoinInnerSubscriber(SortedJoinSubscription<T> parent, int index) {
+            this.parent = parent;
+            this.index = index;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(List<T> t) {
+            parent.innerNext(t, index);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            parent.innerError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            // ignored
+        }
+
+        void cancel() {
+            SubscriptionHelper.cancel(this);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/util/ListAddBiConsumer.java
+++ b/src/main/java/io/reactivex/internal/util/ListAddBiConsumer.java
@@ -11,23 +11,25 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.tck;
+package io.reactivex.internal.util;
 
-import io.reactivex.Flowable;
+import java.util.List;
 
-public final class FlowableTck {
-    /** Utility class (remnant).*/
-    private FlowableTck() {
-        throw new IllegalStateException("No instances!");
+import io.reactivex.functions.*;
+
+@SuppressWarnings("rawtypes")
+public enum ListAddBiConsumer implements BiFunction<List, Object, List> {
+    INSTANCE;
+
+    @SuppressWarnings("unchecked")
+    public static <T> BiFunction<List<T>, T, List<T>> instance() {
+        return (BiFunction)INSTANCE;
     }
 
-    /**
-     * Enable strict mode.
-     * @param <T> the value type
-     * @param f the input Flowable
-     * @return the output Flowable
-     */
-    public static <T> Flowable<T> wrap(Flowable<T> f) {
-        return f.strict();
+    @SuppressWarnings("unchecked")
+    @Override
+    public List apply(List t1, Object t2) throws Exception {
+        t1.add(t2);
+        return t1;
     }
 }

--- a/src/main/java/io/reactivex/internal/util/MergerBiFunction.java
+++ b/src/main/java/io/reactivex/internal/util/MergerBiFunction.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.util;
+
+import java.util.*;
+
+import io.reactivex.functions.BiFunction;
+
+/**
+ * A BiFunction that merges two Lists into a new list.
+ * @param <T> the value type
+ */
+public final class MergerBiFunction<T> implements BiFunction<List<T>, List<T>, List<T>> {
+
+    Comparator<? super T> comparator;
+
+    public MergerBiFunction(Comparator<? super T> comparator) {
+        this.comparator = comparator;
+    }
+
+    @Override
+    public List<T> apply(List<T> a, List<T> b) throws Exception {
+        int n = a.size() + b.size();
+        if (n == 0) {
+            return new ArrayList<T>();
+        }
+        List<T> both = new ArrayList<T>(n);
+
+        Iterator<T> at = a.iterator();
+        Iterator<T> bt = b.iterator();
+
+        T s1 = at.hasNext() ? at.next() : null;
+        T s2 = bt.hasNext() ? bt.next() : null;
+
+        while (s1 != null && s2 != null) {
+            if (comparator.compare(s1, s2) < 0) { // s1 comes before s2
+                both.add(s1);
+                s1 = at.hasNext() ? at.next() : null;
+            } else {
+                both.add(s2);
+                s2 = bt.hasNext() ? bt.next() : null;
+            }
+        }
+
+        if (s1 != null) {
+            both.add(s1);
+            while (at.hasNext()) {
+                both.add(at.next());
+            }
+        } else
+        if (s2 != null) {
+            both.add(s2);
+            while (bt.hasNext()) {
+                both.add(bt.next());
+            }
+        }
+
+        return both;
+    }
+}

--- a/src/main/java/io/reactivex/internal/util/SorterFunction.java
+++ b/src/main/java/io/reactivex/internal/util/SorterFunction.java
@@ -11,23 +11,23 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.tck;
+package io.reactivex.internal.util;
 
-import io.reactivex.Flowable;
+import java.util.*;
 
-public final class FlowableTck {
-    /** Utility class (remnant).*/
-    private FlowableTck() {
-        throw new IllegalStateException("No instances!");
+import io.reactivex.functions.Function;
+
+public final class SorterFunction<T> implements Function<List<T>, List<T>> {
+
+    Comparator<? super T> comparator;
+
+    public SorterFunction(Comparator<? super T> comparator) {
+        this.comparator = comparator;
     }
 
-    /**
-     * Enable strict mode.
-     * @param <T> the value type
-     * @param f the input Flowable
-     * @return the output Flowable
-     */
-    public static <T> Flowable<T> wrap(Flowable<T> f) {
-        return f.strict();
+    @Override
+    public List<T> apply(List<T> t) throws Exception {
+        Collections.sort(t, comparator);
+        return t;
     }
 }

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -1,0 +1,701 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import java.util.*;
+import java.util.concurrent.Callable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.annotations.*;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.*;
+import io.reactivex.internal.operators.parallel.*;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Abstract base class for Parallel publishers that take an array of Subscribers.
+ * <p>
+ * Use {@code from()} to start processing a regular Publisher in 'rails'.
+ * Use {@code runOn()} to introduce where each 'rail' shoud run on thread-vise.
+ * Use {@code sequential()} to merge the sources back into a single Flowable.
+ *
+ * @param <T> the value type
+ * @since 2.0.5 - experimental
+ */
+@Experimental
+public abstract class ParallelFlowable<T> {
+
+    /**
+     * Subscribes an array of Subscribers to this ParallelFlowable and triggers
+     * the execution chain for all 'rails'.
+     *
+     * @param subscribers the subscribers array to run in parallel, the number
+     * of items must be equal to the parallelism level of this ParallelFlowable
+     * @see #parallelism()
+     */
+    public abstract void subscribe(Subscriber<? super T>[] subscribers);
+
+    /**
+     * Returns the number of expected parallel Subscribers.
+     * @return the number of expected parallel Subscribers
+     */
+    public abstract int parallelism();
+
+    /**
+     * Validates the number of subscribers and returns true if their number
+     * matches the parallelism level of this ParallelFlowable.
+     *
+     * @param subscribers the array of Subscribers
+     * @return true if the number of subscribers equals to the parallelism level
+     */
+    protected final boolean validate(Subscriber<?>[] subscribers) {
+        int p = parallelism();
+        if (subscribers.length != p) {
+            for (Subscriber<?> s : subscribers) {
+                EmptySubscription.error(new IllegalArgumentException("parallelism = " + p + ", subscribers = " + subscribers.length), s);
+            }
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Take a Publisher and prepare to consume it on multiple 'rails' (number of CPUs)
+     * in a round-robin fashion.
+     * @param <T> the value type
+     * @param source the source Publisher
+     * @return the ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public static <T> ParallelFlowable<T> from(Publisher<? extends T> source) {
+        return from(source, Runtime.getRuntime().availableProcessors(), Flowable.bufferSize());
+    }
+
+    /**
+     * Take a Publisher and prepare to consume it on parallallism number of 'rails' in a round-robin fashion.
+     * @param <T> the value type
+     * @param source the source Publisher
+     * @param parallelism the number of parallel rails
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public static <T> ParallelFlowable<T> from(Publisher<? extends T> source, int parallelism) {
+        return from(source, parallelism, Flowable.bufferSize());
+    }
+
+    /**
+     * Take a Publisher and prepare to consume it on parallallism number of 'rails' ,
+     * possibly ordered and round-robin fashion and use custom prefetch amount and queue
+     * for dealing with the source Publisher's values.
+     * @param <T> the value type
+     * @param source the source Publisher
+     * @param parallelism the number of parallel rails
+     * @param prefetch the number of values to prefetch from the source
+     * the source until there is a rail ready to process it.
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public static <T> ParallelFlowable<T> from(Publisher<? extends T> source,
+            int parallelism, int prefetch) {
+        ObjectHelper.requireNonNull(source, "source");
+        ObjectHelper.verifyPositive(parallelism, "parallelism");
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
+
+        return new ParallelFromPublisher<T>(source, parallelism, prefetch);
+    }
+
+    /**
+     * Maps the source values on each 'rail' to another value.
+     * <p>
+     * Note that the same mapper function may be called from multiple threads concurrently.
+     * @param <R> the output value type
+     * @param mapper the mapper function turning Ts into Us.
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final <R> ParallelFlowable<R> map(Function<? super T, ? extends R> mapper) {
+        ObjectHelper.requireNonNull(mapper, "mapper");
+        return new ParallelMap<T, R>(this, mapper);
+    }
+
+    /**
+     * Filters the source values on each 'rail'.
+     * <p>
+     * Note that the same predicate may be called from multiple threads concurrently.
+     * @param predicate the function returning true to keep a value or false to drop a value
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final ParallelFlowable<T> filter(Predicate<? super T> predicate) {
+        ObjectHelper.requireNonNull(predicate, "predicate");
+        return new ParallelFilter<T>(this, predicate);
+    }
+
+    /**
+     * Specifies where each 'rail' will observe its incoming values with
+     * no work-stealing and default prefetch amount.
+     * <p>
+     * This operator uses the default prefetch size returned by {@code Flowable.bufferSize()}.
+     * <p>
+     * The operator will call {@code Scheduler.createWorker()} as many
+     * times as this ParallelFlowable's parallelism level is.
+     * <p>
+     * No assumptions are made about the Scheduler's parallelism level,
+     * if the Scheduler's parallelism level is lower than the ParallelFlowable's,
+     * some rails may end up on the same thread/worker.
+     * <p>
+     * This operator doesn't require the Scheduler to be trampolining as it
+     * does its own built-in trampolining logic.
+     *
+     * @param scheduler the scheduler to use
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final ParallelFlowable<T> runOn(Scheduler scheduler) {
+        return runOn(scheduler, Flowable.bufferSize());
+    }
+
+    /**
+     * Specifies where each 'rail' will observe its incoming values with
+     * possibly work-stealing and a given prefetch amount.
+     * <p>
+     * This operator uses the default prefetch size returned by {@code Flowable.bufferSize()}.
+     * <p>
+     * The operator will call {@code Scheduler.createWorker()} as many
+     * times as this ParallelFlowable's parallelism level is.
+     * <p>
+     * No assumptions are made about the Scheduler's parallelism level,
+     * if the Scheduler's parallelism level is lower than the ParallelFlowable's,
+     * some rails may end up on the same thread/worker.
+     * <p>
+     * This operator doesn't require the Scheduler to be trampolining as it
+     * does its own built-in trampolining logic.
+     *
+     * @param scheduler the scheduler to use
+     * that rail's worker has run out of work.
+     * @param prefetch the number of values to request on each 'rail' from the source
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final ParallelFlowable<T> runOn(Scheduler scheduler, int prefetch) {
+        ObjectHelper.requireNonNull(scheduler, "scheduler");
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
+        return new ParallelRunOn<T>(this, scheduler, prefetch);
+    }
+
+    /**
+     * Reduces all values within a 'rail' and across 'rails' with a reducer function into a single
+     * sequential value.
+     * <p>
+     * Note that the same reducer function may be called from multiple threads concurrently.
+     * @param reducer the function to reduce two values into one.
+     * @return the new Flowable instance emitting the reduced value or empty if the ParallelFlowable was empty
+     */
+    @CheckReturnValue
+    public final Flowable<T> reduce(BiFunction<T, T, T> reducer) {
+        ObjectHelper.requireNonNull(reducer, "reducer");
+        return RxJavaPlugins.onAssembly(new ParallelReduceFull<T>(this, reducer));
+    }
+
+    /**
+     * Reduces all values within a 'rail' to a single value (with a possibly different type) via
+     * a reducer function that is initialized on each rail from an initialSupplier value.
+     * <p>
+     * Note that the same mapper function may be called from multiple threads concurrently.
+     * @param <R> the reduced output type
+     * @param initialSupplier the supplier for the initial value
+     * @param reducer the function to reduce a previous output of reduce (or the initial value supplied)
+     * with a current source value.
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final <R> ParallelFlowable<R> reduce(Callable<R> initialSupplier, BiFunction<R, T, R> reducer) {
+        ObjectHelper.requireNonNull(initialSupplier, "initialSupplier");
+        ObjectHelper.requireNonNull(reducer, "reducer");
+        return new ParallelReduce<T, R>(this, initialSupplier, reducer);
+    }
+
+    /**
+     * Merges the values from each 'rail' in a round-robin or same-order fashion and
+     * exposes it as a regular Publisher sequence, running with a default prefetch value
+     * for the rails.
+     * <p>
+     * This operator uses the default prefetch size returned by {@code Flowable.bufferSize()}.
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/parallelflowable.sequential.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code sequential} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new Flowable instance
+     * @see ParallelFlowable#sequential(int)
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @CheckReturnValue
+    public final Flowable<T> sequential() {
+        return sequential(Flowable.bufferSize());
+    }
+
+    /**
+     * Merges the values from each 'rail' in a round-robin or same-order fashion and
+     * exposes it as a regular Publisher sequence, running with a give prefetch value
+     * for the rails.
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/parallelflowable.sequential.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code sequential} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param prefetch the prefetch amount to use for each rail
+     * @return the new Flowable instance
+     * @see ParallelFlowable#sequential()
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @CheckReturnValue
+    public final Flowable<T> sequential(int prefetch) {
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
+        return RxJavaPlugins.onAssembly(new ParallelJoin<T>(this, prefetch));
+    }
+
+    /**
+     * Sorts the 'rails' of this ParallelFlowable and returns a Publisher that sequentially
+     * picks the smallest next value from the rails.
+     * <p>
+     * This operator requires a finite source ParallelFlowable.
+     *
+     * @param comparator the comparator to use
+     * @return the new Flowable instance
+     */
+    @CheckReturnValue
+    public final Flowable<T> sorted(Comparator<? super T> comparator) {
+        return sorted(comparator, 16);
+    }
+
+    /**
+     * Sorts the 'rails' of this ParallelFlowable and returns a Publisher that sequentially
+     * picks the smallest next value from the rails.
+     * <p>
+     * This operator requires a finite source ParallelFlowable.
+     *
+     * @param comparator the comparator to use
+     * @param capacityHint the expected number of total elements
+     * @return the new Flowable instance
+     */
+    @CheckReturnValue
+    public final Flowable<T> sorted(Comparator<? super T> comparator, int capacityHint) {
+        int ch = capacityHint / parallelism() + 1;
+        ParallelFlowable<List<T>> railReduced = reduce(Functions.<T>createArrayList(ch), ListAddBiConsumer.<T>instance());
+        ParallelFlowable<List<T>> railSorted = railReduced.map(new SorterFunction<T>(comparator));
+
+        return RxJavaPlugins.onAssembly(new ParallelSortedJoin<T>(railSorted, comparator));
+    }
+
+    /**
+     * Sorts the 'rails' according to the comparator and returns a full sorted list as a Publisher.
+     * <p>
+     * This operator requires a finite source ParallelFlowable.
+     *
+     * @param comparator the comparator to compare elements
+     * @return the new Px instannce
+     */
+    @CheckReturnValue
+    public final Flowable<List<T>> toSortedList(Comparator<? super T> comparator) {
+        return toSortedList(comparator, 16);
+    }
+    /**
+     * Sorts the 'rails' according to the comparator and returns a full sorted list as a Publisher.
+     * <p>
+     * This operator requires a finite source ParallelFlowable.
+     *
+     * @param comparator the comparator to compare elements
+     * @param capacityHint the expected number of total elements
+     * @return the new Px instannce
+     */
+    @CheckReturnValue
+    public final Flowable<List<T>> toSortedList(Comparator<? super T> comparator, int capacityHint) {
+        int ch = capacityHint / parallelism() + 1;
+        ParallelFlowable<List<T>> railReduced = reduce(Functions.<T>createArrayList(ch), ListAddBiConsumer.<T>instance());
+        ParallelFlowable<List<T>> railSorted = railReduced.map(new SorterFunction<T>(comparator));
+
+        Flowable<List<T>> merged = railSorted.reduce(new MergerBiFunction<T>(comparator));
+
+        return RxJavaPlugins.onAssembly(merged);
+    }
+
+    /**
+     * Call the specified consumer with the current element passing through any 'rail'.
+     *
+     * @param onNext the callback
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final ParallelFlowable<T> doOnNext(Consumer<? super T> onNext) {
+        return new ParallelPeek<T>(this,
+                onNext,
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                Functions.EMPTY_ACTION,
+                Functions.EMPTY_ACTION,
+                Functions.emptyConsumer(),
+                Functions.EMPTY_LONG_CONSUMER,
+                Functions.EMPTY_ACTION
+                );
+    }
+
+    /**
+     * Call the specified consumer with the current element passing through any 'rail'
+     * after it has been delivered to downstream within the rail.
+     *
+     * @param onAfterNext the callback
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final ParallelFlowable<T> doAfterNext(Consumer<? super T> onAfterNext) {
+        return new ParallelPeek<T>(this,
+                Functions.emptyConsumer(),
+                onAfterNext,
+                Functions.emptyConsumer(),
+                Functions.EMPTY_ACTION,
+                Functions.EMPTY_ACTION,
+                Functions.emptyConsumer(),
+                Functions.EMPTY_LONG_CONSUMER,
+                Functions.EMPTY_ACTION
+                );
+    }
+
+    /**
+     * Call the specified consumer with the exception passing through any 'rail'.
+     *
+     * @param onError the callback
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final ParallelFlowable<T> doOnError(Consumer<Throwable> onError) {
+        return new ParallelPeek<T>(this,
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                onError,
+                Functions.EMPTY_ACTION,
+                Functions.EMPTY_ACTION,
+                Functions.emptyConsumer(),
+                Functions.EMPTY_LONG_CONSUMER,
+                Functions.EMPTY_ACTION
+                );
+    }
+
+    /**
+     * Run the specified Action when a 'rail' completes.
+     *
+     * @param onComplete the callback
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final ParallelFlowable<T> doOnComplete(Action onComplete) {
+        return new ParallelPeek<T>(this,
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                onComplete,
+                Functions.EMPTY_ACTION,
+                Functions.emptyConsumer(),
+                Functions.EMPTY_LONG_CONSUMER,
+                Functions.EMPTY_ACTION
+                );
+    }
+
+    /**
+     * Run the specified Action when a 'rail' completes or signals an error.
+     *
+     * @param onAfterTerminate the callback
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final ParallelFlowable<T> doAfterTerminated(Action onAfterTerminate) {
+        return new ParallelPeek<T>(this,
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                Functions.EMPTY_ACTION,
+                onAfterTerminate,
+                Functions.emptyConsumer(),
+                Functions.EMPTY_LONG_CONSUMER,
+                Functions.EMPTY_ACTION
+                );
+    }
+
+    /**
+     * Call the specified callback when a 'rail' receives a Subscription from its upstream.
+     *
+     * @param onSubscribe the callback
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final ParallelFlowable<T> doOnSubscribe(Consumer<? super Subscription> onSubscribe) {
+        return new ParallelPeek<T>(this,
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                Functions.EMPTY_ACTION,
+                Functions.EMPTY_ACTION,
+                onSubscribe,
+                Functions.EMPTY_LONG_CONSUMER,
+                Functions.EMPTY_ACTION
+                );
+    }
+
+    /**
+     * Call the specified consumer with the request amount if any rail receives a request.
+     *
+     * @param onRequest the callback
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final ParallelFlowable<T> doOnRequest(LongConsumer onRequest) {
+        return new ParallelPeek<T>(this,
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                Functions.EMPTY_ACTION,
+                Functions.EMPTY_ACTION,
+                Functions.emptyConsumer(),
+                onRequest,
+                Functions.EMPTY_ACTION
+                );
+    }
+
+    /**
+     * Run the specified Action when a 'rail' receives a cancellation.
+     *
+     * @param onCancel the callback
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final ParallelFlowable<T> doOnCancel(Action onCancel) {
+        return new ParallelPeek<T>(this,
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                Functions.emptyConsumer(),
+                Functions.EMPTY_ACTION,
+                Functions.EMPTY_ACTION,
+                Functions.emptyConsumer(),
+                Functions.EMPTY_LONG_CONSUMER,
+                onCancel
+                );
+    }
+
+    /**
+     * Collect the elements in each rail into a collection supplied via a collectionSupplier
+     * and collected into with a collector action, emitting the collection at the end.
+     *
+     * @param <C> the collection type
+     * @param collectionSupplier the supplier of the collection in each rail
+     * @param collector the collector, taking the per-rali collection and the current item
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final <C> ParallelFlowable<C> collect(Callable<C> collectionSupplier, BiConsumer<C, T> collector) {
+        return new ParallelCollect<T, C>(this, collectionSupplier, collector);
+    }
+
+    /**
+     * Wraps multiple Publishers into a ParallelFlowable which runs them
+     * in parallel and unordered.
+     *
+     * @param <T> the value type
+     * @param publishers the array of publishers
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public static <T> ParallelFlowable<T> fromArray(Publisher<T>... publishers) {
+        if (publishers.length == 0) {
+            throw new IllegalArgumentException("Zero publishers not supported");
+        }
+        return new ParallelFromArray<T>(publishers);
+    }
+
+    /**
+     * Perform a fluent transformation to a value via a converter function which
+     * receives this ParallelFlowable.
+     *
+     * @param <U> the output value type
+     * @param converter the converter function from ParallelFlowable to some type
+     * @return the value returned by the converter function
+     */
+    @CheckReturnValue
+    public final <U> U to(Function<? super ParallelFlowable<T>, U> converter) {
+        try {
+            return converter.apply(this);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
+    }
+
+    /**
+     * Allows composing operators, in assembly time, on top of this ParallelFlowable
+     * and returns another ParallelFlowable with composed features.
+     *
+     * @param <U> the output value type
+     * @param composer the composer function from ParallelFlowable (this) to another ParallelFlowable
+     * @return the ParallelFlowable returned by the function
+     */
+    @CheckReturnValue
+    public final <U> ParallelFlowable<U> compose(Function<? super ParallelFlowable<T>, ParallelFlowable<U>> composer) {
+        return to(composer);
+    }
+
+    /**
+     * Generates and flattens Publishers on each 'rail'.
+     * <p>
+     * Errors are not delayed and uses unbounded concurrency along with default inner prefetch.
+     *
+     * @param <R> the result type
+     * @param mapper the function to map each rail's value into a Publisher
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final <R> ParallelFlowable<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+        return flatMap(mapper, false, Integer.MAX_VALUE, Flowable.bufferSize());
+    }
+
+    /**
+     * Generates and flattens Publishers on each 'rail', optionally delaying errors.
+     * <p>
+     * It uses unbounded concurrency along with default inner prefetch.
+     *
+     * @param <R> the result type
+     * @param mapper the function to map each rail's value into a Publisher
+     * @param delayError should the errors from the main and the inner sources delayed till everybody terminates?
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final <R> ParallelFlowable<R> flatMap(
+            Function<? super T, ? extends Publisher<? extends R>> mapper, boolean delayError) {
+        return flatMap(mapper, delayError, Integer.MAX_VALUE, Flowable.bufferSize());
+    }
+
+    /**
+     * Generates and flattens Publishers on each 'rail', optionally delaying errors
+     * and having a total number of simultaneous subscriptions to the inner Publishers.
+     * <p>
+     * It uses a default inner prefetch.
+     *
+     * @param <R> the result type
+     * @param mapper the function to map each rail's value into a Publisher
+     * @param delayError should the errors from the main and the inner sources delayed till everybody terminates?
+     * @param maxConcurrency the maximum number of simultaneous subscriptions to the generated inner Publishers
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final <R> ParallelFlowable<R> flatMap(
+            Function<? super T, ? extends Publisher<? extends R>> mapper, boolean delayError, int maxConcurrency) {
+        return flatMap(mapper, delayError, maxConcurrency, Flowable.bufferSize());
+    }
+
+    /**
+     * Generates and flattens Publishers on each 'rail', optionally delaying errors,
+     * having a total number of simultaneous subscriptions to the inner Publishers
+     * and using the given prefetch amount for the inner Publishers.
+     *
+     * @param <R> the result type
+     * @param mapper the function to map each rail's value into a Publisher
+     * @param delayError should the errors from the main and the inner sources delayed till everybody terminates?
+     * @param maxConcurrency the maximum number of simultaneous subscriptions to the generated inner Publishers
+     * @param prefetch the number of items to prefetch from each inner Publisher
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final <R> ParallelFlowable<R> flatMap(
+            Function<? super T, ? extends Publisher<? extends R>> mapper,
+            boolean delayError, int maxConcurrency, int prefetch) {
+        return new ParallelFlatMap<T, R>(this, mapper, delayError, maxConcurrency, prefetch);
+    }
+
+    /**
+     * Generates and concatenates Publishers on each 'rail', signalling errors immediately
+     * and generating 2 publishers upfront.
+     *
+     * @param <R> the result type
+     * @param mapper the function to map each rail's value into a Publisher
+     * source and the inner Publishers (immediate, boundary, end)
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final <R> ParallelFlowable<R> concatMap(
+            Function<? super T, ? extends Publisher<? extends R>> mapper) {
+        return concatMap(mapper, 2);
+    }
+
+    /**
+     * Generates and concatenates Publishers on each 'rail', signalling errors immediately
+     * and using the given prefetch amount for generating Publishers upfront.
+     *
+     * @param <R> the result type
+     * @param mapper the function to map each rail's value into a Publisher
+     * @param prefetch the number of items to prefetch from each inner Publisher
+     * source and the inner Publishers (immediate, boundary, end)
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final <R> ParallelFlowable<R> concatMap(
+            Function<? super T, ? extends Publisher<? extends R>> mapper,
+                    int prefetch) {
+        return new ParallelConcatMap<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE);
+    }
+
+    /**
+     * Generates and concatenates Publishers on each 'rail', optionally delaying errors
+     * and generating 2 publishers upfront.
+     *
+     * @param <R> the result type
+     * @param mapper the function to map each rail's value into a Publisher
+     * @param tillTheEnd if true all errors from the upstream and inner Publishers are delayed
+     * till all of them terminate, if false, the error is emitted when an inner Publisher terminates.
+     * source and the inner Publishers (immediate, boundary, end)
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final <R> ParallelFlowable<R> concatMapDelayError(
+            Function<? super T, ? extends Publisher<? extends R>> mapper,
+                    boolean tillTheEnd) {
+        return concatMapDelayError(mapper, 2, tillTheEnd);
+    }
+
+    /**
+     * Generates and concatenates Publishers on each 'rail', optionally delaying errors
+     * and using the given prefetch amount for generating Publishers upfront.
+     *
+     * @param <R> the result type
+     * @param mapper the function to map each rail's value into a Publisher
+     * @param prefetch the number of items to prefetch from each inner Publisher
+     * @param tillTheEnd if true all errors from the upstream and inner Publishers are delayed
+     * till all of them terminate, if false, the error is emitted when an inner Publisher terminates.
+     * @return the new ParallelFlowable instance
+     */
+    @CheckReturnValue
+    public final <R> ParallelFlowable<R> concatMapDelayError(
+            Function<? super T, ? extends Publisher<? extends R>> mapper,
+                    int prefetch, boolean tillTheEnd) {
+        return new ParallelConcatMap<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY);
+    }
+}

--- a/src/main/java/io/reactivex/parallel/package-info.java
+++ b/src/main/java/io/reactivex/parallel/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Base type for the parallel type offering a sub-DSL for working with Flowable items
+ * in parallel.
+ */
+package io.reactivex.parallel;

--- a/src/perf/java/io/reactivex/parallel/ParallelPerf.java
+++ b/src/perf/java/io/reactivex/parallel/ParallelPerf.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.flowables.GroupedFlowable;
+import io.reactivex.functions.Function;
+import io.reactivex.schedulers.Schedulers;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1,jvmArgsAppend = { "-XX:MaxInlineLevel=20" })
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class ParallelPerf implements Function<Integer, Integer> {
+
+    @Param({"10000"})
+    public int count;
+
+    @Param({"1", "10", "100", "1000", "10000"})
+    public int compute;
+
+    @Param({"1", "2", "3", "4"})
+    public int parallelism;
+
+    Flowable<Integer> flatMap;
+
+    Flowable<Integer> groupBy;
+
+    Flowable<Integer> parallel;
+
+    @Override
+    public Integer apply(Integer t) throws Exception {
+        Blackhole.consumeCPU(compute);
+        return t;
+    }
+
+    @Setup
+    public void setup() {
+
+        final int cpu = parallelism;
+
+        Integer[] ints = new Integer[count];
+        Arrays.fill(ints, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(ints);
+
+        flatMap = source.flatMap(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer v) throws Exception {
+                return Flowable.just(v).subscribeOn(Schedulers.computation())
+                        .map(ParallelPerf.this);
+            }
+        }, cpu);
+
+        groupBy = source.groupBy(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                return v % cpu;
+            }
+        })
+        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
+                return g.observeOn(Schedulers.computation()).map(ParallelPerf.this);
+            }
+        });
+
+        parallel = source.parallel(cpu).runOn(Schedulers.computation()).map(this).sequential();
+    }
+
+    void subscribe(Flowable<Integer> f, Blackhole bh) {
+        PerfAsyncConsumer consumer = new PerfAsyncConsumer(bh);
+        f.subscribe(consumer);
+        consumer.await(count);
+    }
+
+    @Benchmark
+    public void flatMap(Blackhole bh) {
+        subscribe(flatMap, bh);
+    }
+
+    @Benchmark
+    public void groupBy(Blackhole bh) {
+        subscribe(groupBy, bh);
+    }
+
+    @Benchmark
+    public void parallel(Blackhole bh) {
+        subscribe(parallel, bh);
+    }
+}

--- a/src/perf/java/io/reactivex/parallel/ParallelPerf.java
+++ b/src/perf/java/io/reactivex/parallel/ParallelPerf.java
@@ -73,9 +73,10 @@ public class ParallelPerf implements Function<Integer, Integer> {
         }, cpu);
 
         groupBy = source.groupBy(new Function<Integer, Integer>() {
+            int i;
             @Override
             public Integer apply(Integer v) throws Exception {
-                return v % cpu;
+                return (i++) % cpu;
             }
         })
         .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {

--- a/src/test/java/io/reactivex/TransformerTest.java
+++ b/src/test/java/io/reactivex/TransformerTest.java
@@ -126,8 +126,8 @@ public class TransformerTest {
         Flowable.just(a).compose(TransformerTest.<String>testFlowableTransformerCreator());
     }
 
-    interface A<T, R> {}
-    interface B<T> {}
+    interface A<T, R> { }
+    interface B<T> { }
 
     private static <T> ObservableTransformer<A<T, ?>, B<T>> testObservableTransformerCreator() {
         return new ObservableTransformer<A<T, ?>, B<T>>() {

--- a/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
@@ -1,0 +1,1290 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.*;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.UnicastProcessor;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ParallelFlowableTest {
+
+    @Test
+    public void sequentialMode() {
+        Flowable<Integer> source = Flowable.range(1, 1000000).hide();
+        for (int i = 1; i < 33; i++) {
+            Flowable<Integer> result = ParallelFlowable.from(source, i)
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+                    return v + 1;
+                }
+            })
+            .sequential()
+            ;
+
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+            result.subscribe(ts);
+
+            ts
+            .assertSubscribed()
+            .assertValueCount(1000000)
+            .assertComplete()
+            .assertNoErrors()
+            ;
+        }
+
+    }
+
+    @Test
+    public void sequentialModeFused() {
+        Flowable<Integer> source = Flowable.range(1, 1000000);
+        for (int i = 1; i < 33; i++) {
+            Flowable<Integer> result = ParallelFlowable.from(source, i)
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+                    return v + 1;
+                }
+            })
+            .sequential()
+            ;
+
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+            result.subscribe(ts);
+
+            ts
+            .assertSubscribed()
+            .assertValueCount(1000000)
+            .assertComplete()
+            .assertNoErrors()
+            ;
+        }
+
+    }
+
+    @Test
+    public void parallelMode() {
+        Flowable<Integer> source = Flowable.range(1, 1000000).hide();
+        int ncpu = Math.max(8, Runtime.getRuntime().availableProcessors());
+        for (int i = 1; i < ncpu + 1; i++) {
+
+            ExecutorService exec = Executors.newFixedThreadPool(i);
+
+            Scheduler scheduler = Schedulers.from(exec);
+
+            try {
+                Flowable<Integer> result = ParallelFlowable.from(source, i)
+                .runOn(scheduler)
+                .map(new Function<Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer v) throws Exception {
+                        return v + 1;
+                    }
+                })
+                .sequential()
+                ;
+
+                TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+                result.subscribe(ts);
+
+                ts.awaitDone(10, TimeUnit.SECONDS);
+
+                ts
+                .assertSubscribed()
+                .assertValueCount(1000000)
+                .assertComplete()
+                .assertNoErrors()
+                ;
+            } finally {
+                exec.shutdown();
+            }
+        }
+
+    }
+
+    @Test
+    public void parallelModeFused() {
+        Flowable<Integer> source = Flowable.range(1, 1000000);
+        int ncpu = Math.max(8, Runtime.getRuntime().availableProcessors());
+        for (int i = 1; i < ncpu + 1; i++) {
+
+            ExecutorService exec = Executors.newFixedThreadPool(i);
+
+            Scheduler scheduler = Schedulers.from(exec);
+
+            try {
+                Flowable<Integer> result = ParallelFlowable.from(source, i)
+                .runOn(scheduler)
+                .map(new Function<Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer v) throws Exception {
+                        return v + 1;
+                    }
+                })
+                .sequential()
+                ;
+
+                TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+                result.subscribe(ts);
+
+                ts.awaitDone(10, TimeUnit.SECONDS);
+
+                ts
+                .assertSubscribed()
+                .assertValueCount(1000000)
+                .assertComplete()
+                .assertNoErrors()
+                ;
+            } finally {
+                exec.shutdown();
+            }
+        }
+
+    }
+
+    @Test
+    public void reduceFull() {
+        for (int i = 1; i <= Runtime.getRuntime().availableProcessors() * 2; i++) {
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+            Flowable.range(1, 10)
+            .parallel(i)
+            .reduce(new BiFunction<Integer, Integer, Integer>() {
+                @Override
+                public Integer apply(Integer a, Integer b) throws Exception {
+                    return a + b;
+                }
+            })
+            .subscribe(ts);
+
+            ts.assertResult(55);
+        }
+    }
+
+    @Test
+    public void parallelReduceFull() {
+        int m = 100000;
+        for (int n = 1; n <= m; n *= 10) {
+//            System.out.println(n);
+            for (int i = 1; i <= Runtime.getRuntime().availableProcessors(); i++) {
+//                System.out.println("  " + i);
+
+                ExecutorService exec = Executors.newFixedThreadPool(i);
+
+                Scheduler scheduler = Schedulers.from(exec);
+
+                try {
+                    TestSubscriber<Long> ts = new TestSubscriber<Long>();
+
+                    Flowable.range(1, n)
+                    .map(new Function<Integer, Long>() {
+                        @Override
+                        public Long apply(Integer v) throws Exception {
+                            return (long)v;
+                        }
+                    })
+                    .parallel(i)
+                    .runOn(scheduler)
+                    .reduce(new BiFunction<Long, Long, Long>() {
+                        @Override
+                        public Long apply(Long a, Long b) throws Exception {
+                            return a + b;
+                        }
+                    })
+                    .subscribe(ts);
+
+                    ts.awaitDone(500, TimeUnit.SECONDS);
+
+                    long e = ((long)n) * (1 + n) / 2;
+
+                    ts.assertResult(e);
+                } finally {
+                    exec.shutdown();
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void toSortedList() {
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+        Flowable.fromArray(10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+        .parallel()
+        .toSortedList(Functions.naturalComparator())
+        .subscribe(ts);
+
+        ts.assertResult(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+    }
+
+    @Test
+    public void sorted() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
+
+        Flowable.fromArray(10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+        .parallel()
+        .sorted(Functions.naturalComparator())
+        .subscribe(ts);
+
+        ts.assertNoValues();
+
+        ts.request(2);
+
+        ts.assertValues(1, 2);
+
+        ts.request(5);
+
+        ts.assertValues(1, 2, 3, 4, 5, 6, 7);
+
+        ts.request(3);
+
+        ts.assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void collect() {
+        Callable<List<Integer>> as = new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                return new ArrayList<Integer>();
+            }
+        };
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        Flowable.range(1, 10)
+        .parallel()
+        .collect(as, new BiConsumer<List<Integer>, Integer>() {
+            @Override
+            public void accept(List<Integer> a, Integer b) throws Exception {
+                a.add(b);
+            }
+        })
+        .sequential()
+        .flatMapIterable(new Function<List<Integer>, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(List<Integer> v) throws Exception {
+                return v;
+            }
+        })
+        .subscribe(ts);
+
+        ts.assertValueSet(new HashSet<Integer>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)))
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void from() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        ParallelFlowable.fromArray(Flowable.range(1, 5), Flowable.range(6, 5))
+        .sequential()
+        .subscribe(ts);
+
+        ts.assertValueSet(new HashSet<Integer>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)))
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void concatMapUnordered() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .parallel()
+        .concatMap(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer v) throws Exception {
+                return Flowable.range(v * 10 + 1, 3);
+            }
+        })
+        .sequential()
+        .subscribe(ts);
+
+        ts.assertValueSet(new HashSet<Integer>(Arrays.asList(11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53)))
+        .assertNoErrors()
+        .assertComplete();
+
+    }
+
+    @Test
+    public void flatMapUnordered() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .parallel()
+        .flatMap(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer v) throws Exception {
+                return Flowable.range(v * 10 + 1, 3);
+            }
+        })
+        .sequential()
+        .subscribe(ts);
+
+        ts.assertValueSet(new HashSet<Integer>(Arrays.asList(11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53)))
+        .assertNoErrors()
+        .assertComplete();
+
+    }
+
+    @Test
+    public void collectAsyncFused() {
+        ExecutorService exec = Executors.newFixedThreadPool(3);
+
+        Scheduler s = Schedulers.from(exec);
+
+        try {
+            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+                @Override
+                public List<Integer> call() throws Exception {
+                    return new ArrayList<Integer>();
+                }
+            };
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+            Flowable.range(1, 100000)
+            .parallel(3)
+            .runOn(s)
+            .collect(as, new BiConsumer<List<Integer>, Integer>() {
+                @Override
+                public void accept(List<Integer> a, Integer b) throws Exception {
+                    a.add(b);
+                }
+            })
+            .doOnNext(new Consumer<List<Integer>>() {
+                @Override
+                public void accept(List<Integer> v) throws Exception {
+                    System.out.println(v.size());
+                }
+            })
+            .sequential()
+            .subscribe(ts);
+
+            ts.awaitDone(5, TimeUnit.SECONDS);
+            ts.assertValueCount(3)
+            .assertNoErrors()
+            .assertComplete()
+            ;
+
+            List<List<Integer>> list = ts.values();
+
+            Assert.assertEquals(100000, list.get(0).size() + list.get(1).size() + list.get(2).size());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void collectAsync() {
+        ExecutorService exec = Executors.newFixedThreadPool(3);
+
+        Scheduler s = Schedulers.from(exec);
+
+        try {
+            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+                @Override
+                public List<Integer> call() throws Exception {
+                    return new ArrayList<Integer>();
+                }
+            };
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+            Flowable.range(1, 100000).hide()
+            .parallel(3)
+            .runOn(s)
+            .collect(as, new BiConsumer<List<Integer>, Integer>() {
+                @Override
+                public void accept(List<Integer> a, Integer b) throws Exception {
+                    a.add(b);
+                }
+            })
+            .doOnNext(new Consumer<List<Integer>>() {
+                @Override
+                public void accept(List<Integer> v) throws Exception {
+                    System.out.println(v.size());
+                }
+            })
+            .sequential()
+            .subscribe(ts);
+
+            ts.awaitDone(5, TimeUnit.SECONDS);
+            ts.assertValueCount(3)
+            .assertNoErrors()
+            .assertComplete()
+            ;
+
+            List<List<Integer>> list = ts.values();
+
+            Assert.assertEquals(100000, list.get(0).size() + list.get(1).size() + list.get(2).size());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+
+    @Test
+    public void collectAsync2() {
+        ExecutorService exec = Executors.newFixedThreadPool(3);
+
+        Scheduler s = Schedulers.from(exec);
+
+        try {
+            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+                @Override
+                public List<Integer> call() throws Exception {
+                    return new ArrayList<Integer>();
+                }
+            };
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+            Flowable.range(1, 100000).hide()
+            .observeOn(s)
+            .parallel(3)
+            .runOn(s)
+            .collect(as, new BiConsumer<List<Integer>, Integer>() {
+                @Override
+                public void accept(List<Integer> a, Integer b) throws Exception {
+                    a.add(b);
+                }
+            })
+            .doOnNext(new Consumer<List<Integer>>() {
+                @Override
+                public void accept(List<Integer> v) throws Exception {
+                    System.out.println(v.size());
+                }
+            })
+            .sequential()
+            .subscribe(ts);
+
+            ts.awaitDone(5, TimeUnit.SECONDS);
+            ts.assertValueCount(3)
+            .assertNoErrors()
+            .assertComplete()
+            ;
+
+            List<List<Integer>> list = ts.values();
+
+            Assert.assertEquals(100000, list.get(0).size() + list.get(1).size() + list.get(2).size());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void collectAsync3() {
+        ExecutorService exec = Executors.newFixedThreadPool(3);
+
+        Scheduler s = Schedulers.from(exec);
+
+        try {
+            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+                @Override
+                public List<Integer> call() throws Exception {
+                    return new ArrayList<Integer>();
+                }
+            };
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+            Flowable.range(1, 100000).hide()
+            .observeOn(s)
+            .parallel(3)
+            .runOn(s)
+            .collect(as, new BiConsumer<List<Integer>, Integer>() {
+                @Override
+                public void accept(List<Integer> a, Integer b) throws Exception {
+                    a.add(b);
+                }
+            })
+            .doOnNext(new Consumer<List<Integer>>() {
+                @Override
+                public void accept(List<Integer> v) throws Exception {
+                    System.out.println(v.size());
+                }
+            })
+            .sequential()
+            .subscribe(ts);
+
+            ts.awaitDone(5, TimeUnit.SECONDS);
+            ts.assertValueCount(3)
+            .assertNoErrors()
+            .assertComplete()
+            ;
+
+            List<List<Integer>> list = ts.values();
+
+            Assert.assertEquals(100000, list.get(0).size() + list.get(1).size() + list.get(2).size());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+
+    @Test
+    public void collectAsync3Fused() {
+        ExecutorService exec = Executors.newFixedThreadPool(3);
+
+        Scheduler s = Schedulers.from(exec);
+
+        try {
+            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+                @Override
+                public List<Integer> call() throws Exception {
+                    return new ArrayList<Integer>();
+                }
+            };
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+            Flowable.range(1, 100000)
+            .observeOn(s)
+            .parallel(3)
+            .runOn(s)
+            .collect(as, new BiConsumer<List<Integer>, Integer>() {
+                @Override
+                public void accept(List<Integer> a, Integer b) throws Exception {
+                    a.add(b);
+                }
+            })
+            .doOnNext(new Consumer<List<Integer>>() {
+                @Override
+                public void accept(List<Integer> v) throws Exception {
+                    System.out.println(v.size());
+                }
+            })
+            .sequential()
+            .subscribe(ts);
+
+            ts.awaitDone(5, TimeUnit.SECONDS);
+            ts.assertValueCount(3)
+            .assertNoErrors()
+            .assertComplete()
+            ;
+
+            List<List<Integer>> list = ts.values();
+
+            Assert.assertEquals(100000, list.get(0).size() + list.get(1).size() + list.get(2).size());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void collectAsync3Take() {
+        ExecutorService exec = Executors.newFixedThreadPool(4);
+
+        Scheduler s = Schedulers.from(exec);
+
+        try {
+            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+                @Override
+                public List<Integer> call() throws Exception {
+                    return new ArrayList<Integer>();
+                }
+            };
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+            Flowable.range(1, 100000)
+            .take(1000)
+            .observeOn(s)
+            .parallel(3)
+            .runOn(s)
+            .collect(as, new BiConsumer<List<Integer>, Integer>() {
+                @Override
+                public void accept(List<Integer> a, Integer b) throws Exception {
+                    a.add(b);
+                }
+            })
+            .doOnNext(new Consumer<List<Integer>>() {
+                @Override
+                public void accept(List<Integer> v) throws Exception {
+                    System.out.println(v.size());
+                }
+            })
+            .sequential()
+            .subscribe(ts);
+
+            ts.awaitDone(5, TimeUnit.SECONDS);
+            ts.assertValueCount(3)
+            .assertNoErrors()
+            .assertComplete()
+            ;
+
+            List<List<Integer>> list = ts.values();
+
+            Assert.assertEquals(1000, list.get(0).size() + list.get(1).size() + list.get(2).size());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void collectAsync4Take() {
+        ExecutorService exec = Executors.newFixedThreadPool(3);
+
+        Scheduler s = Schedulers.from(exec);
+
+        try {
+            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+                @Override
+                public List<Integer> call() throws Exception {
+                    return new ArrayList<Integer>();
+                }
+            };
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+
+            UnicastProcessor<Integer> up = UnicastProcessor.create();
+
+            for (int i = 0; i < 1000; i++) {
+                up.onNext(i);
+            }
+
+            up
+            .take(1000)
+            .observeOn(s)
+            .parallel(3)
+            .runOn(s)
+            .collect(as, new BiConsumer<List<Integer>, Integer>() {
+                @Override
+                public void accept(List<Integer> a, Integer b) throws Exception {
+                    a.add(b);
+                }
+            })
+            .doOnNext(new Consumer<List<Integer>>() {
+                @Override
+                public void accept(List<Integer> v) throws Exception {
+                    System.out.println(v.size());
+                }
+            })
+            .sequential()
+            .subscribe(ts);
+
+            ts.awaitDone(5, TimeUnit.SECONDS);
+            ts.assertValueCount(3)
+            .assertNoErrors()
+            .assertComplete()
+            ;
+
+            List<List<Integer>> list = ts.values();
+
+            Assert.assertEquals(1000, list.get(0).size() + list.get(1).size() + list.get(2).size());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void emptySourceZeroRequest() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(0);
+
+        Flowable.range(1, 3).parallel(3).sequential().subscribe(ts);
+
+        ts.request(1);
+
+        ts.assertValue(1);
+    }
+
+    @Test
+    public void parallelismAndPrefetch() {
+        for (int parallelism = 1; parallelism <= 8; parallelism++) {
+            for (int prefetch = 1; prefetch <= 1024; prefetch *= 2) {
+                Flowable.range(1, 1024 * 1024)
+                .parallel(parallelism, prefetch)
+                .map(Functions.<Integer>identity())
+                .sequential()
+                .test()
+                .assertSubscribed()
+                .assertValueCount(1024 * 1024)
+                .assertNoErrors()
+                .assertComplete();
+            }
+        }
+    }
+
+    @Test
+    public void parallelismAndPrefetchAsync() {
+        for (int parallelism = 1; parallelism <= 8; parallelism *= 2) {
+            for (int prefetch = 1; prefetch <= 1024; prefetch *= 2) {
+                System.out.println("parallelismAndPrefetchAsync >> " + parallelism + ", " + prefetch);
+
+                Flowable.range(1, 1024 * 1024)
+                .parallel(parallelism, prefetch)
+                .runOn(Schedulers.computation())
+                .map(Functions.<Integer>identity())
+                .sequential(prefetch)
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertSubscribed()
+                .assertValueCount(1024 * 1024)
+                .assertNoErrors()
+                .assertComplete();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void badParallelismStage() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 10)
+        .parallel(2)
+        .subscribe(new Subscriber[] { ts });
+
+        ts.assertFailure(IllegalArgumentException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void badParallelismStage2() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts3 = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 10)
+        .parallel(2)
+        .subscribe(new Subscriber[] { ts1, ts2, ts3 });
+
+        ts1.assertFailure(IllegalArgumentException.class);
+        ts2.assertFailure(IllegalArgumentException.class);
+        ts3.assertFailure(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void filter() {
+        Flowable.range(1, 20)
+        .parallel()
+        .runOn(Schedulers.computation())
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 2 == 0;
+            }
+        })
+        .sequential()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueSet(Arrays.asList(2, 4, 6, 8, 10, 12, 14, 16, 18, 20))
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void filterThrows() throws Exception {
+        final boolean[] cancelled = { false };
+        Flowable.range(1, 20)
+        .doOnCancel(new Action() {
+            @Override
+            public void run() throws Exception {
+                cancelled[0] = true;
+            }
+        })
+        .parallel()
+        .runOn(Schedulers.computation())
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                if (v == 10) {
+                    throw new TestException();
+                }
+                return v % 2 == 0;
+            }
+        })
+        .sequential()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        Thread.sleep(100);
+
+        assertTrue(cancelled[0]);
+    }
+
+    @Test
+    public void doAfterNext() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel()
+        .doAfterNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                count[0]++;
+            }
+        })
+        .sequential()
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void doOnNextThrows() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel()
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (v == 3) {
+                    throw new TestException();
+                } else {
+                    count[0]++;
+                }
+            }
+        })
+        .sequential()
+        .test()
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        assertTrue("" + count[0], count[0] < 5);
+    }
+
+    @Test
+    public void doAfterNextThrows() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel()
+        .doAfterNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (v == 3) {
+                    throw new TestException();
+                } else {
+                    count[0]++;
+                }
+            }
+        })
+        .sequential()
+        .test()
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        assertTrue("" + count[0], count[0] < 5);
+    }
+
+    @Test
+    public void errorNotRepeating() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.error(new TestException())
+            .parallel()
+            .runOn(Schedulers.computation())
+            .sequential()
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(TestException.class)
+            ;
+
+            Thread.sleep(300);
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void doOnError() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel(2)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                if (v == 3) {
+                    throw new TestException();
+                }
+                return v;
+            }
+        })
+        .doOnError(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                if (e instanceof TestException) {
+                    count[0]++;
+                }
+            }
+        })
+        .sequential()
+        .test()
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        assertEquals(1, count[0]);
+    }
+
+    @Test
+    public void doOnErrorThrows() {
+        TestSubscriber<Integer> ts = Flowable.range(1, 5)
+        .parallel(2)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                if (v == 3) {
+                    throw new TestException();
+                }
+                return v;
+            }
+        })
+        .doOnError(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                if (e instanceof TestException) {
+                    throw new IOException();
+                }
+            }
+        })
+        .sequential()
+        .test()
+        .assertError(CompositeException.class)
+        .assertNotComplete();
+
+        List<Throwable> errors = TestHelper.errorList(ts);
+        TestHelper.assertError(errors, 0, TestException.class);
+        TestHelper.assertError(errors, 1, IOException.class);
+    }
+
+    @Test
+    public void doOnComplete() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel(2)
+        .doOnComplete(new Action() {
+            @Override
+            public void run() throws Exception {
+                count[0]++;
+            }
+        })
+        .sequential()
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(2, count[0]);
+    }
+
+    @Test
+    public void doAfterTerminate() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel(2)
+        .doAfterTerminated(new Action() {
+            @Override
+            public void run() throws Exception {
+                count[0]++;
+            }
+        })
+        .sequential()
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(2, count[0]);
+    }
+
+    @Test
+    public void doOnSubscribe() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel(2)
+        .doOnSubscribe(new Consumer<Subscription>() {
+            @Override
+            public void accept(Subscription s) throws Exception {
+                count[0]++;
+            }
+        })
+        .sequential()
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(2, count[0]);
+    }
+
+    @Test
+    public void doOnRequest() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel(2)
+        .doOnRequest(new LongConsumer() {
+            @Override
+            public void accept(long s) throws Exception {
+                count[0]++;
+            }
+        })
+        .sequential()
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(2, count[0]);
+    }
+
+    @Test
+    public void doOnCancel() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel(2)
+        .doOnCancel(new Action() {
+            @Override
+            public void run() throws Exception {
+                count[0]++;
+            }
+        })
+        .sequential()
+        .take(2)
+        .test()
+        .assertResult(1, 2);
+
+        assertEquals(2, count[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = IllegalArgumentException.class)
+    public void fromPublishers() {
+        ParallelFlowable.fromArray(new Publisher[0]);
+    }
+
+    @Test
+    public void to() {
+        Flowable.range(1, 5)
+        .parallel()
+        .to(new Function<ParallelFlowable<Integer>, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) throws Exception {
+                return pf.sequential();
+            }
+        })
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test(expected = TestException.class)
+    public void toThrows() {
+        Flowable.range(1, 5)
+        .parallel()
+        .to(new Function<ParallelFlowable<Integer>, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) throws Exception {
+                throw new TestException();
+            }
+        });
+    }
+
+    @Test
+    public void compose() {
+        Flowable.range(1, 5)
+        .parallel()
+        .compose(new Function<ParallelFlowable<Integer>, ParallelFlowable<Integer>>() {
+            @Override
+            public ParallelFlowable<Integer> apply(ParallelFlowable<Integer> pf) throws Exception {
+                return pf.map(new Function<Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer v) throws Exception {
+                        return v + 1;
+                    }
+                });
+            }
+        })
+        .sequential()
+        .test()
+        .assertResult(2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void flatMapDelayError() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel(2)
+        .flatMap(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) throws Exception {
+                if (v == 3) {
+                   return Flowable.error(new TestException());
+                }
+                return Flowable.just(v);
+            }
+        }, true)
+        .doOnError(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                if (e instanceof TestException) {
+                    count[0]++;
+                }
+            }
+        })
+        .sequential()
+        .test()
+        .assertValues(1, 2, 4, 5)
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        assertEquals(1, count[0]);
+    }
+
+    @Test
+    public void flatMapDelayErrorMaxConcurrency() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel(2)
+        .flatMap(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) throws Exception {
+                if (v == 3) {
+                   return Flowable.error(new TestException());
+                }
+                return Flowable.just(v);
+            }
+        }, true, 1)
+        .doOnError(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                if (e instanceof TestException) {
+                    count[0]++;
+                }
+            }
+        })
+        .sequential()
+        .test()
+        .assertValues(1, 2, 4, 5)
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        assertEquals(1, count[0]);
+    }
+
+    @Test
+    public void concatMapDelayError() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel(2)
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) throws Exception {
+                if (v == 3) {
+                   return Flowable.error(new TestException());
+                }
+                return Flowable.just(v);
+            }
+        }, true)
+        .doOnError(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                if (e instanceof TestException) {
+                    count[0]++;
+                }
+            }
+        })
+        .sequential()
+        .test()
+        .assertValues(1, 2, 4, 5)
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        assertEquals(1, count[0]);
+    }
+
+    @Test
+    public void concatMapDelayErrorPrefetch() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel(2)
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) throws Exception {
+                if (v == 3) {
+                   return Flowable.error(new TestException());
+                }
+                return Flowable.just(v);
+            }
+        }, 1, true)
+        .doOnError(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                if (e instanceof TestException) {
+                    count[0]++;
+                }
+            }
+        })
+        .sequential()
+        .test()
+        .assertValues(1, 2, 4, 5)
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        assertEquals(1, count[0]);
+    }
+
+    @Test
+    public void concatMapDelayErrorBoundary() {
+        final int[] count = { 0 };
+
+        Flowable.range(1, 5)
+        .parallel(2)
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) throws Exception {
+                if (v == 3) {
+                   return Flowable.error(new TestException());
+                }
+                return Flowable.just(v);
+            }
+        }, false)
+        .doOnError(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                if (e instanceof TestException) {
+                    count[0]++;
+                }
+            }
+        })
+        .sequential()
+        .test()
+        .assertValues(1, 2)
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        assertEquals(1, count[0]);
+    }
+
+}


### PR DESCRIPTION
This PR adds the `parallel()` method to `Flowable` which opens up a sub-DSL with parallel operations. (Note that only a few operators make sense in a parallel settings.)

This parallel sub-DSL is not limited to computation tasks as it allows specifying the parallelism and the `Scheduler` to run the parallel 'rails'. For example, you can have parallel downloads that block:

```java
Flowable.range(1, 100)
.parallel(10)
.runOn(Schedulers.io())
.map(v -> httpClient.blockingGet("http://server/item/" + v))
.sequential()
.observeOn(AndroidSchedulers.mainThread())
.subscribe(...);
```

