### PR TITLE
2.x: fix Observable.concatMapEager bad logic for immediate scalars

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapEager.java
@@ -14,7 +14,6 @@
 package io.reactivex.internal.operators.observable;
 
 import java.util.ArrayDeque;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
@@ -218,7 +217,6 @@ public final class ObservableConcatMapEager<T, R> extends AbstractObservableWith
             drain();
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public void drain() {
             if (getAndIncrement() != 0) {
@@ -274,23 +272,6 @@ public final class ObservableConcatMapEager<T, R> extends AbstractObservableWith
                         error.addThrowable(ex);
                         a.onError(error.terminate());
                         return;
-                    }
-
-                    if (source instanceof Callable) {
-                        R w;
-
-                        try {
-                            w = ((Callable<R>)source).call();
-                        } catch (Throwable ex) {
-                            Exceptions.throwIfFatal(ex);
-                            error.addThrowable(ex);
-                            continue;
-                        }
-
-                        if (w != null) {
-                            a.onNext(w);
-                        }
-                        continue;
                     }
 
                     InnerQueuedObserver<R> inner = new InnerQueuedObserver<R>(this, prefetch);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -1182,7 +1182,6 @@ public class FlowableConcatMapEagerTest {
         .concatMapEager(new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer i) throws Exception {
-                System.out.println("Processing " + i);
                 return i == 3 ? Flowable.just(i) : Flowable
                         .just(i)
                         .delay(1, TimeUnit.MILLISECONDS, Schedulers.io());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -1175,4 +1175,23 @@ public class FlowableConcatMapEagerTest {
         .assertComplete()
         .assertNoErrors();
     }
+
+    @Test
+    public void oneDelayed() {
+        Flowable.just(1, 2, 3, 4, 5)
+        .concatMapEager(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer i) throws Exception {
+                System.out.println("Processing " + i);
+                return i == 3 ? Flowable.just(i) : Flowable
+                        .just(i)
+                        .delay(1, TimeUnit.MILLISECONDS, Schedulers.io());
+            }
+        })
+        .observeOn(Schedulers.io())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5)
+        ;
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -983,4 +983,23 @@ public class ObservableConcatMapEagerTest {
             }
         });
     }
+
+    @Test
+    public void oneDelayed() {
+        Observable.just(1, 2, 3, 4, 5)
+        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer i) throws Exception {
+                System.out.println("Processing " + i);
+                return i == 3 ? Observable.just(i) : Observable
+                        .just(i)
+                        .delay(1, TimeUnit.MILLISECONDS, Schedulers.io());
+            }
+        })
+        .observeOn(Schedulers.io())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5)
+        ;
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -990,7 +990,6 @@ public class ObservableConcatMapEagerTest {
         .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
             @Override
             public ObservableSource<Integer> apply(Integer i) throws Exception {
-                System.out.println("Processing " + i);
                 return i == 3 ? Observable.just(i) : Observable
                         .just(i)
                         .delay(1, TimeUnit.MILLISECONDS, Schedulers.io());


### PR DESCRIPTION
The operator `Observable.concatMapEager` had a bad optimization targeting scalar and callable sources and emitted their values immediately even if it wasn't that particular source's turn for it.

The `Flowable` is not affected, added unit tests for both.

Reported in #4981.