### PR TITLE
2.x: fix cross-boundary invalid fusion with observeOn, flatMap & zip

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -600,7 +600,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                 if (s instanceof QueueSubscription) {
                     @SuppressWarnings("unchecked")
                     QueueSubscription<U> qs = (QueueSubscription<U>) s;
-                    int m = qs.requestFusion(QueueSubscription.ANY);
+                    int m = qs.requestFusion(QueueSubscription.ANY | QueueSubscription.BOUNDARY);
                     if (m == QueueSubscription.SYNC) {
                         fusionMode = m;
                         queue = qs;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableZip.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableZip.java
@@ -357,7 +357,7 @@ public final class FlowableZip<T, R> extends Flowable<R> {
                 if (s instanceof QueueSubscription) {
                     QueueSubscription<T> f = (QueueSubscription<T>) s;
 
-                    int m = f.requestFusion(QueueSubscription.ANY);
+                    int m = f.requestFusion(QueueSubscription.ANY | QueueSubscription.BOUNDARY);
 
                     if (m == QueueSubscription.SYNC) {
                         sourceMode = m;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -532,7 +532,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                     @SuppressWarnings("unchecked")
                     QueueDisposable<U> qd = (QueueDisposable<U>) s;
 
-                    int m = qd.requestFusion(QueueDisposable.ANY);
+                    int m = qd.requestFusion(QueueDisposable.ANY | QueueDisposable.BOUNDARY);
                     if (m == QueueDisposable.SYNC) {
                         fusionMode = m;
                         queue = qd;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -999,8 +1000,8 @@ public class ObservableZipTest {
     public void testDownstreamBackpressureRequestsWithFiniteSyncObservables() {
         AtomicInteger generatedA = new AtomicInteger();
         AtomicInteger generatedB = new AtomicInteger();
-        Observable<Integer> o1 = createInfiniteObservable(generatedA).take(Flowable.bufferSize() * 2);
-        Observable<Integer> o2 = createInfiniteObservable(generatedB).take(Flowable.bufferSize() * 2);
+        Observable<Integer> o1 = createInfiniteObservable(generatedA).take(Observable.bufferSize() * 2);
+        Observable<Integer> o2 = createInfiniteObservable(generatedB).take(Observable.bufferSize() * 2);
 
         TestObserver<String> ts = new TestObserver<String>();
         Observable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
@@ -1010,14 +1011,14 @@ public class ObservableZipTest {
                 return t1 + "-" + t2;
             }
 
-        }).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(ts);
+        }).observeOn(Schedulers.computation()).take(Observable.bufferSize() * 2).subscribe(ts);
 
         ts.awaitTerminalEvent();
         ts.assertNoErrors();
-        assertEquals(Flowable.bufferSize() * 2, ts.valueCount());
+        assertEquals(Observable.bufferSize() * 2, ts.valueCount());
         System.out.println("Generated => A: " + generatedA.get() + " B: " + generatedB.get());
-        assertTrue(generatedA.get() < (Flowable.bufferSize() * 3));
-        assertTrue(generatedB.get() < (Flowable.bufferSize() * 3));
+        assertTrue(generatedA.get() < (Observable.bufferSize() * 3));
+        assertTrue(generatedB.get() < (Observable.bufferSize() * 3));
     }
 
     private Observable<Integer> createInfiniteObservable(final AtomicInteger generated) {
@@ -1358,4 +1359,37 @@ public class ObservableZipTest {
             }
         }));
     }
-}
+
+    @Test
+    public void noCrossBoundaryFusion() {
+        for (int i = 0; i < 500; i++) {
+            TestObserver<List<Object>> ts = Observable.zip(
+                    Observable.just(1).observeOn(Schedulers.single()).map(new Function<Integer, Object>() {
+                        @Override
+                        public Object apply(Integer v) throws Exception {
+                            return Thread.currentThread().getName().substring(0, 4);
+                        }
+                    }),
+                    Observable.just(1).observeOn(Schedulers.computation()).map(new Function<Integer, Object>() {
+                        @Override
+                        public Object apply(Integer v) throws Exception {
+                            return Thread.currentThread().getName().substring(0, 4);
+                        }
+                    }),
+                    new BiFunction<Object, Object, List<Object>>() {
+                        @Override
+                        public List<Object> apply(Object t1, Object t2) throws Exception {
+                            return Arrays.asList(t1, t2);
+                        }
+                    }
+            )
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertValueCount(1);
+
+            List<Object> list = ts.values().get(0);
+
+            assertTrue(list.toString(), list.contains("RxSi"));
+            assertTrue(list.toString(), list.contains("RxCo"));
+        }
+    }}


### PR DESCRIPTION
When `flatMap` and `zip` fuses its sources, it was possible one of the async source polls on another source which executed boundary-sensitive operators (`map`, `filter`) on the wrong thread.

For clarity, here is a diagram showing the execution flow of a classical and fused setup:

![image](https://cloud.githubusercontent.com/assets/1269832/21883621/536a123c-d8b0-11e6-9a7a-b6deb2ffb26b.png)

In the classical flow, everything is push and when flatMap collects the available elements, all side-effects happened inside `map`.

In the fused flow, there are no queues and the onNext call is an indication to `poll()` on the sources inside `flatMap` (or zip). If the first source triggers onNext, that source is correctly polled and `map` executes on the right thread. However, when the flatMap continues to collect other available elements, it polls on the other source and executes that `map` still on the first scheduler, despite that source having its own scheduler specified.

The solution is to mark `flatMap` and `zip`'s inner consumer as boundary sensitive which prevents the fusion above since `map` is also marked as boundary sensitive.

Related: https://github.com/reactor/reactor-core/issues/342