### PR TITLE
2.x: A.flatMapB to eagerly check for cancellations before subscribing

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -152,24 +152,25 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                 }
             } else {
                 InnerSubscriber<T, U> inner = new InnerSubscriber<T, U>(this, uniqueId++);
-                addInner(inner);
-                p.subscribe(inner);
+                if (addInner(inner)) {
+                    p.subscribe(inner);
+                }
             }
         }
 
-        void addInner(InnerSubscriber<T, U> inner) {
+        boolean addInner(InnerSubscriber<T, U> inner) {
             for (;;) {
                 InnerSubscriber<?, ?>[] a = subscribers.get();
                 if (a == CANCELLED) {
                     inner.dispose();
-                    return;
+                    return false;
                 }
                 int n = a.length;
                 InnerSubscriber<?, ?>[] b = new InnerSubscriber[n + 1];
                 System.arraycopy(a, 0, b, 0, n);
                 b[n] = inner;
                 if (subscribers.compareAndSet(a, b)) {
-                    return;
+                    return true;
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
@@ -116,9 +116,9 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
 
             InnerConsumer inner = new InnerConsumer();
 
-            set.add(inner);
-
-            cs.subscribe(inner);
+            if (set.add(inner)) {
+                cs.subscribe(inner);
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
@@ -124,9 +124,9 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
 
             InnerObserver inner = new InnerObserver();
 
-            set.add(inner);
-
-            cs.subscribe(inner);
+            if (set.add(inner)) {
+                cs.subscribe(inner);
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -128,9 +128,9 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
 
             InnerObserver inner = new InnerObserver();
 
-            set.add(inner);
-
-            ms.subscribe(inner);
+            if (set.add(inner)) {
+                ms.subscribe(inner);
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -128,9 +128,9 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
 
             InnerObserver inner = new InnerObserver();
 
-            set.add(inner);
-
-            ms.subscribe(inner);
+            if (set.add(inner)) {
+                ms.subscribe(inner);
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapCompletable.java
@@ -87,7 +87,9 @@ public final class MaybeFlatMapCompletable<T> extends Completable {
                 return;
             }
 
-            cs.subscribe(this);
+            if (!isDisposed()) {
+                cs.subscribe(this);
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapSingle.java
@@ -91,7 +91,9 @@ public final class MaybeFlatMapSingle<T, R> extends Single<R> {
                 return;
             }
 
-            ss.subscribe(new FlatMapSingleObserver<R>(this, actual));
+            if (!isDisposed()) {
+                ss.subscribe(new FlatMapSingleObserver<R>(this, actual));
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatten.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatten.java
@@ -93,7 +93,9 @@ public final class MaybeFlatten<T, R> extends AbstractMaybeWithUpstream<T, R> {
                 return;
             }
 
-            source.subscribe(new InnerObserver());
+            if (!isDisposed()) {
+                source.subscribe(new InnerObserver());
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -158,26 +158,27 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                     }
                 } else {
                     InnerObserver<T, U> inner = new InnerObserver<T, U>(this, uniqueId++);
-                    addInner(inner);
-                    p.subscribe(inner);
+                    if (addInner(inner)) {
+                        p.subscribe(inner);
+                    }
                     break;
                 }
             }
         }
 
-        void addInner(InnerObserver<T, U> inner) {
+        boolean addInner(InnerObserver<T, U> inner) {
             for (;;) {
                 InnerObserver<?, ?>[] a = observers.get();
                 if (a == CANCELLED) {
                     inner.dispose();
-                    return;
+                    return false;
                 }
                 int n = a.length;
                 InnerObserver<?, ?>[] b = new InnerObserver[n + 1];
                 System.arraycopy(a, 0, b, 0, n);
                 b[n] = inner;
                 if (observers.compareAndSet(a, b)) {
-                    return;
+                    return true;
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
@@ -98,9 +98,9 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
 
             InnerObserver inner = new InnerObserver();
 
-            set.add(inner);
-
-            cs.subscribe(inner);
+            if (set.add(inner)) {
+                cs.subscribe(inner);
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
@@ -104,9 +104,9 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
 
             InnerObserver inner = new InnerObserver();
 
-            set.add(inner);
-
-            cs.subscribe(inner);
+            if (set.add(inner)) {
+                cs.subscribe(inner);
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
@@ -109,9 +109,9 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
 
             InnerObserver inner = new InnerObserver();
 
-            set.add(inner);
-
-            ms.subscribe(inner);
+            if (set.add(inner)) {
+                ms.subscribe(inner);
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
@@ -109,9 +109,9 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
 
             InnerObserver inner = new InnerObserver();
 
-            set.add(inner);
-
-            ms.subscribe(inner);
+            if (set.add(inner)) {
+                ms.subscribe(inner);
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMap.java
@@ -80,7 +80,9 @@ public final class SingleFlatMap<T, R> extends Single<R> {
                 return;
             }
 
-            o.subscribe(new FlatMapSingleObserver<R>(this, actual));
+            if (!isDisposed()) {
+                o.subscribe(new FlatMapSingleObserver<R>(this, actual));
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapCompletable.java
@@ -87,7 +87,9 @@ public final class SingleFlatMapCompletable<T> extends Completable {
                 return;
             }
 
-            cs.subscribe(this);
+            if (!isDisposed()) {
+                cs.subscribe(this);
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapMaybe.java
@@ -85,7 +85,9 @@ public final class SingleFlatMapMaybe<T, R> extends Maybe<R> {
                 return;
             }
 
-            ms.subscribe(new FlatMapMaybeObserver<R>(this, actual));
+            if (!isDisposed()) {
+                ms.subscribe(new FlatMapMaybeObserver<R>(this, actual));
+            }
         }
 
         @Override

--- a/src/test/java/io/reactivex/XFlatMapTest.java
+++ b/src/test/java/io/reactivex/XFlatMapTest.java
@@ -1,0 +1,605 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class XFlatMapTest {
+
+    final CyclicBarrier cb = new CyclicBarrier(2);
+
+    void sleep() throws Exception {
+        cb.await();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ex) {
+            // ignored here
+        }
+    }
+
+    @Test
+    public void flowableFlowable() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestSubscriber<Integer> ts = Flowable.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMap(new Function<Integer, Publisher<Integer>>() {
+                @Override
+                public Publisher<Integer> apply(Integer v) throws Exception {
+                    sleep();
+                    return Flowable.<Integer>error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void flowableSingle() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestSubscriber<Integer> ts = Flowable.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapSingle(new Function<Integer, Single<Integer>>() {
+                @Override
+                public Single<Integer> apply(Integer v) throws Exception {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void flowableMaybe() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestSubscriber<Integer> ts = Flowable.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
+                @Override
+                public Maybe<Integer> apply(Integer v) throws Exception {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void flowableCompletable() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Void> ts = Flowable.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapCompletable(new Function<Integer, Completable>() {
+                @Override
+                public Completable apply(Integer v) throws Exception {
+                    sleep();
+                    return Completable.error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void flowableCompletable2() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestSubscriber<Void> ts = Flowable.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapCompletable(new Function<Integer, Completable>() {
+                @Override
+                public Completable apply(Integer v) throws Exception {
+                    sleep();
+                    return Completable.error(new TestException());
+                }
+            })
+            .<Void>toFlowable()
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void observableFlowable() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Integer> ts = Observable.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMap(new Function<Integer, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> apply(Integer v) throws Exception {
+                    sleep();
+                    return Observable.<Integer>error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void observerSingle() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Integer> ts = Observable.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapSingle(new Function<Integer, Single<Integer>>() {
+                @Override
+                public Single<Integer> apply(Integer v) throws Exception {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void observerMaybe() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Integer> ts = Observable.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
+                @Override
+                public Maybe<Integer> apply(Integer v) throws Exception {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void observerCompletable() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Void> ts = Observable.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapCompletable(new Function<Integer, Completable>() {
+                @Override
+                public Completable apply(Integer v) throws Exception {
+                    sleep();
+                    return Completable.error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void observerCompletable2() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Void> ts = Observable.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapCompletable(new Function<Integer, Completable>() {
+                @Override
+                public Completable apply(Integer v) throws Exception {
+                    sleep();
+                    return Completable.error(new TestException());
+                }
+            })
+            .<Void>toObservable()
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void singleSingle() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Integer> ts = Single.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMap(new Function<Integer, Single<Integer>>() {
+                @Override
+                public Single<Integer> apply(Integer v) throws Exception {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void singleMaybe() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Integer> ts = Single.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
+                @Override
+                public Maybe<Integer> apply(Integer v) throws Exception {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void singleCompletable() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Void> ts = Single.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapCompletable(new Function<Integer, Completable>() {
+                @Override
+                public Completable apply(Integer v) throws Exception {
+                    sleep();
+                    return Completable.error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void singleCompletable2() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Integer> ts = Single.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapCompletable(new Function<Integer, Completable>() {
+                @Override
+                public Completable apply(Integer v) throws Exception {
+                    sleep();
+                    return Completable.error(new TestException());
+                }
+            })
+            .toSingleDefault(0)
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void maybeSingle() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Integer> ts = Maybe.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapSingle(new Function<Integer, Single<Integer>>() {
+                @Override
+                public Single<Integer> apply(Integer v) throws Exception {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void maybeMaybe() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Integer> ts = Maybe.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMap(new Function<Integer, Maybe<Integer>>() {
+                @Override
+                public Maybe<Integer> apply(Integer v) throws Exception {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void maybeCompletable() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Void> ts = Maybe.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapCompletable(new Function<Integer, Completable>() {
+                @Override
+                public Completable apply(Integer v) throws Exception {
+                    sleep();
+                    return Completable.error(new TestException());
+                }
+            })
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void maybeCompletable2() throws Exception {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestObserver<Void> ts = Maybe.just(1)
+            .subscribeOn(Schedulers.io())
+            .flatMapCompletable(new Function<Integer, Completable>() {
+                @Override
+                public Completable apply(Integer v) throws Exception {
+                    sleep();
+                    return Completable.error(new TestException());
+                }
+            })
+            .<Void>toMaybe()
+            .test();
+
+            cb.await();
+
+            Thread.sleep(50);
+
+            ts.cancel();
+
+            Thread.sleep(150);
+
+            ts.assertEmpty();
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}


### PR DESCRIPTION
The `flatMap` implementations always subscribed to the generated inner source even if there was an asynchronous cancel while the function was running. With typical functions, there is only a really tiny window inside function but some users tend to block/sleep in the function and when that returns, the `flatMap` operator is already cancelled. 

If the generated inner source emitted an error disregarding its own cancellation signal (the `error()` operators do this), those errors end up in the `RxJavaPlugins.onError` and crash the app (on Android).

This PR adjusts the `flatMap` implementations to check for the disposed/cancelled state before subscribing to the inner source. For `Observable` and `Flowable`, this has practically no extra overhead as the add/remove already checks for the terminal state and can return a boolean for it. The rest require an explicit `isDisposed()` check.