### PR TITLE
2.x: assertNever(T value) / assertNever(Predicate<T> valuePredicate)

### DIFF
--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -304,6 +304,26 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     }
 
     /**
+     * Assert that this TestObserver/TestSubscriber did not receive an onNext value which is equal to
+     * the given value with respect to Objects.equals.
+     *
+     * @param value the value to expect not being received
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertNever(T value) {
+        int s = values.size();
+
+        for (int i = 0; i < s; i++) {
+            T v = this.values.get(i);
+            if (ObjectHelper.equals(v, value)) {
+                throw fail("Value at position " + i + " is equal to " + valueAndClass(value) + "; Expected them to be different");
+            }
+        }
+        return (U) this;
+    }
+
+    /**
      * Asserts that this TestObserver/TestSubscriber received exactly one onNext value for which
      * the provided predicate returns true.
      * @param valuePredicate
@@ -319,6 +339,31 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
             throw fail("Value present but other values as well");
         }
 
+        return (U)this;
+    }
+
+    /**
+     * Asserts that this TestObserver/TestSubscriber did not receive any onNext value for which
+     * the provided predicate returns true.
+     *
+     * @param valuePredicate the predicate that receives the onNext value
+     *                       and should return true for the expected value.
+     * @return this
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertNever(Predicate<T> valuePredicate) {
+        int s = values.size();
+
+        for (int i = 0; i < s; i++) {
+            T v = this.values.get(i);
+            try {
+                if (valuePredicate.test(v)) {
+                    throw fail("Value at position " + i + " matches predicate " + valuePredicate.toString() + ", which was not expected.");
+                }
+            } catch (Exception ex) {
+                throw ExceptionHelper.wrapOrThrow(ex);
+            }
+        }
         return (U)this;
     }
 

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -308,6 +308,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * Assert that this TestObserver/TestSubscriber did not receive an onNext value which is equal to
      * the given value with respect to Objects.equals.
      *
+     * @since 2.0.5 - experimental
      * @param value the value to expect not being received
      * @return this;
      */
@@ -348,13 +349,14 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * Asserts that this TestObserver/TestSubscriber did not receive any onNext value for which
      * the provided predicate returns true.
      *
+     * @since 2.0.5 - experimental
      * @param valuePredicate the predicate that receives the onNext value
      *                       and should return true for the expected value.
      * @return this
      */
     @Experimental
     @SuppressWarnings("unchecked")
-    public final U assertNever(Predicate<T> valuePredicate) {
+    public final U assertNever(Predicate<? super T> valuePredicate) {
         int s = values.size();
 
         for (int i = 0; i < s; i++) {

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -17,6 +17,7 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import io.reactivex.Notification;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Predicate;
@@ -310,6 +311,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * @param value the value to expect not being received
      * @return this;
      */
+    @Experimental
     @SuppressWarnings("unchecked")
     public final U assertNever(T value) {
         int s = values.size();
@@ -350,6 +352,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      *                       and should return true for the expected value.
      * @return this
      */
+    @Experimental
     @SuppressWarnings("unchecked")
     public final U assertNever(Predicate<T> valuePredicate) {
         int s = values.size();

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -87,6 +87,64 @@ public class TestObserverTest {
     }
 
     @Test
+    public void assertNeverAtNotMatchingValue() {
+        Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
+        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
+        oi.subscribe(o);
+
+        o.assertNever(3);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void assertNeverAtMatchingValue() {
+        Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
+        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
+        oi.subscribe(o);
+
+        o.assertValues(1, 2);
+
+        thrown.expect(AssertionError.class);
+
+        o.assertNever(2);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void assertNeverAtMatchingPredicate() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.just(1, 2).subscribe(ts);
+
+        ts.assertValues(1, 2);
+
+        thrown.expect(AssertionError.class);
+
+        ts.assertNever(new Predicate<Integer>() {
+            @Override
+            public boolean test(final Integer o) throws Exception {
+                return o == 1;
+            }
+        });
+    }
+
+    @Test
+    public void assertNeverAtNotMatchingPredicate() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.just(2, 3).subscribe(ts);
+
+        ts.assertNever(new Predicate<Integer>() {
+            @Override
+            public boolean test(final Integer o) throws Exception {
+                return o == 1;
+            }
+        });
+    }
+
+    @Test
     public void testAssertTerminalEventNotReceived() {
         PublishProcessor<Integer> p = PublishProcessor.create();
         TestSubscriber<Integer> o = new TestSubscriber<Integer>();

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -115,7 +115,11 @@ public class TestSubscriberTest {
 
         thrown.expect(AssertionError.class);
 
-        ts.assertNever(o -> o == 1);
+        ts.assertNever(new Predicate<Integer>() {
+            @Override public boolean test(final Integer o) throws Exception {
+                return o == 1;
+            }
+        });
     }
 
     @Test
@@ -124,7 +128,11 @@ public class TestSubscriberTest {
 
         Flowable.just(2, 3).subscribe(ts);
 
-        ts.assertNever(o -> o == 1);
+        ts.assertNever(new Predicate<Integer>() {
+            @Override public boolean test(final Integer o) throws Exception {
+                return o == 1;
+            }
+        });
     }
 
     @Test

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -100,6 +100,8 @@ public class TestSubscriberTest {
         TestSubscriber<Integer> o = new TestSubscriber<Integer>();
         oi.subscribe(o);
 
+        o.assertValues(1, 2);
+
         thrown.expect(AssertionError.class);
 
         o.assertNever(2);
@@ -113,10 +115,13 @@ public class TestSubscriberTest {
 
         Flowable.just(1, 2).subscribe(ts);
 
+        ts.assertValues(1, 2);
+
         thrown.expect(AssertionError.class);
 
         ts.assertNever(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
+            @Override
+            public boolean test(final Integer o) throws Exception {
                 return o == 1;
             }
         });
@@ -129,7 +134,8 @@ public class TestSubscriberTest {
         Flowable.just(2, 3).subscribe(ts);
 
         ts.assertNever(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
+            @Override
+            public boolean test(final Integer o) throws Exception {
                 return o == 1;
             }
         });

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -84,6 +84,50 @@ public class TestSubscriberTest {
     }
 
     @Test
+    public void assertNeverAtNotMatchingValue() {
+        Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
+        TestSubscriber<Integer> o = new TestSubscriber<>();
+        oi.subscribe(o);
+
+        o.assertNever(3);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void assertNeverAtMatchingValue() {
+        Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
+        TestSubscriber<Integer> o = new TestSubscriber<>();
+        oi.subscribe(o);
+
+        thrown.expect(AssertionError.class);
+
+        o.assertNever(2);
+        o.assertValueCount(2);
+        o.assertTerminated();
+    }
+
+    @Test
+    public void assertNeverAtMatchingPredicate() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Flowable.just(1, 2).subscribe(ts);
+
+        thrown.expect(AssertionError.class);
+
+        ts.assertNever(o -> o == 1);
+    }
+
+    @Test
+    public void assertNeverAtNotMatchingPredicate() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Flowable.just(2, 3).subscribe(ts);
+
+        ts.assertNever(o -> o == 1);
+    }
+
+    @Test
     public void testAssertTerminalEventNotReceived() {
         PublishProcessor<Integer> p = PublishProcessor.create();
         TestSubscriber<Integer> o = new TestSubscriber<Integer>();

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -86,7 +86,7 @@ public class TestSubscriberTest {
     @Test
     public void assertNeverAtNotMatchingValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<>();
+        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
         oi.subscribe(o);
 
         o.assertNever(3);
@@ -97,7 +97,7 @@ public class TestSubscriberTest {
     @Test
     public void assertNeverAtMatchingValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<>();
+        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
         oi.subscribe(o);
 
         thrown.expect(AssertionError.class);
@@ -109,7 +109,7 @@ public class TestSubscriberTest {
 
     @Test
     public void assertNeverAtMatchingPredicate() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
         Flowable.just(1, 2).subscribe(ts);
 
@@ -124,7 +124,7 @@ public class TestSubscriberTest {
 
     @Test
     public void assertNeverAtNotMatchingPredicate() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
         Flowable.just(2, 3).subscribe(ts);
 


### PR DESCRIPTION
This pull request adds to any class extending ```BaseConsumerTest``` the ability to assert that a given value was not emitted by the observable it was subscribed to, either with ```assertNever(T value)```or ```assertNever(Predicate<T> valuePredicate)```