### PR TITLE
Add which are the other stardard methods of create

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -63,7 +63,7 @@ public class Observable<T> {
 
     /**
      * <strong>This method requires advanced knowledge about building operators and data sources; please consider
-     * other standard methods first;</strong>
+     * other standard methods first, such as {@link Observable#fromEmitter(Action1, Emitter.BackpressureMode)};</strong>
      * Returns an Observable that will execute the specified function when a {@link Subscriber} subscribes to
      * it.
      * <p>


### PR DESCRIPTION
I was using `Observable.create(OnSubscribe)`. I knew about the warning:

> This method requires advanced knowledge about building operators and data sources; please consider other standard methods first

But I didn't know which were the *other stadard methods*. There were no clue in the JavaDoc. With this change the problem is gone.