### PR TITLE
2.x: Add scheduler creation factories

### DIFF
--- a/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
@@ -16,12 +16,12 @@
 
 package io.reactivex.internal.schedulers;
 
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
-
 import io.reactivex.Scheduler;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
 /**
  * Scheduler that creates and caches a set of thread pools and reuses them if possible.
@@ -37,6 +37,7 @@ public final class IoScheduler extends Scheduler {
     private static final TimeUnit KEEP_ALIVE_UNIT = TimeUnit.SECONDS;
 
     static final ThreadWorker SHUTDOWN_THREAD_WORKER;
+    final ThreadFactory threadFactory;
     final AtomicReference<CachedWorkerPool> pool;
 
     /** The name of the system property for setting the thread priority for this Scheduler. */
@@ -44,9 +45,6 @@ public final class IoScheduler extends Scheduler {
 
     static final CachedWorkerPool NONE;
     static {
-        NONE = new CachedWorkerPool(0, null);
-        NONE.shutdown();
-
         SHUTDOWN_THREAD_WORKER = new ThreadWorker(new RxThreadFactory("RxCachedThreadSchedulerShutdown"));
         SHUTDOWN_THREAD_WORKER.dispose();
 
@@ -56,6 +54,9 @@ public final class IoScheduler extends Scheduler {
         WORKER_THREAD_FACTORY = new RxThreadFactory(WORKER_THREAD_NAME_PREFIX, priority);
 
         EVICTOR_THREAD_FACTORY = new RxThreadFactory(EVICTOR_THREAD_NAME_PREFIX, priority);
+
+        NONE = new CachedWorkerPool(0, null, WORKER_THREAD_FACTORY);
+        NONE.shutdown();
     }
 
     static final class CachedWorkerPool implements Runnable {
@@ -64,11 +65,13 @@ public final class IoScheduler extends Scheduler {
         final CompositeDisposable allWorkers;
         private final ScheduledExecutorService evictorService;
         private final Future<?> evictorTask;
+        private final ThreadFactory threadFactory;
 
-        CachedWorkerPool(long keepAliveTime, TimeUnit unit) {
+        CachedWorkerPool(long keepAliveTime, TimeUnit unit, ThreadFactory threadFactory) {
             this.keepAliveTime = unit != null ? unit.toNanos(keepAliveTime) : 0L;
             this.expiringWorkerQueue = new ConcurrentLinkedQueue<ThreadWorker>();
             this.allWorkers = new CompositeDisposable();
+            this.threadFactory = threadFactory;
 
             ScheduledExecutorService evictor = null;
             Future<?> task = null;
@@ -97,7 +100,7 @@ public final class IoScheduler extends Scheduler {
             }
 
             // No cached worker found, so create a new one.
-            ThreadWorker w = new ThreadWorker(WORKER_THREAD_FACTORY);
+            ThreadWorker w = new ThreadWorker(threadFactory);
             allWorkers.add(w);
             return w;
         }
@@ -143,13 +146,22 @@ public final class IoScheduler extends Scheduler {
     }
 
     public IoScheduler() {
+        this(WORKER_THREAD_FACTORY);
+    }
+
+    /**
+     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
+     *                      system properties for configuring new thread creation. Cannot be null.
+     */
+    public IoScheduler(ThreadFactory threadFactory) {
+        this.threadFactory = threadFactory;
         this.pool = new AtomicReference<CachedWorkerPool>(NONE);
         start();
     }
 
     @Override
     public void start() {
-        CachedWorkerPool update = new CachedWorkerPool(KEEP_ALIVE_TIME, KEEP_ALIVE_UNIT);
+        CachedWorkerPool update = new CachedWorkerPool(KEEP_ALIVE_TIME, KEEP_ALIVE_UNIT, threadFactory);
         if (!pool.compareAndSet(NONE, update)) {
             update.shutdown();
         }

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadScheduler.java
@@ -18,15 +18,17 @@ package io.reactivex.internal.schedulers;
 
 import io.reactivex.Scheduler;
 
+import java.util.concurrent.ThreadFactory;
+
 /**
  * Schedules work on a new thread.
  */
 public final class NewThreadScheduler extends Scheduler {
 
+    final ThreadFactory threadFactory;
+
     private static final String THREAD_NAME_PREFIX = "RxNewThreadScheduler";
     private static final RxThreadFactory THREAD_FACTORY;
-
-    private static final NewThreadScheduler INSTANCE = new NewThreadScheduler();
 
     /** The name of the system property for setting the thread priority for this Scheduler. */
     private static final String KEY_NEWTHREAD_PRIORITY = "rx2.newthread-priority";
@@ -38,16 +40,16 @@ public final class NewThreadScheduler extends Scheduler {
         THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX, priority);
     }
 
-    public static NewThreadScheduler instance() {
-        return INSTANCE;
+    public NewThreadScheduler() {
+        this(THREAD_FACTORY);
     }
 
-    private NewThreadScheduler() {
-
+    public NewThreadScheduler(ThreadFactory threadFactory) {
+        this.threadFactory = threadFactory;
     }
 
     @Override
     public Worker createWorker() {
-        return new NewThreadWorker(THREAD_FACTORY);
+        return new NewThreadWorker(threadFactory);
     }
 }

--- a/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
@@ -15,7 +15,6 @@ package io.reactivex.internal.schedulers;
 import io.reactivex.Scheduler;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
-import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 import java.util.concurrent.*;
@@ -57,7 +56,7 @@ public final class SingleScheduler extends Scheduler {
      *                      system properties for configuring new thread creation. Cannot be null.
      */
     public SingleScheduler(ThreadFactory threadFactory) {
-        this.threadFactory = ObjectHelper.requireNonNull(threadFactory, "threadFactory was null");
+        this.threadFactory = threadFactory;
         executor.lazySet(createExecutor(threadFactory));
     }
 

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -12,17 +12,19 @@
  */
 package io.reactivex.plugins;
 
-import java.lang.Thread.UncaughtExceptionHandler;
-import java.util.concurrent.Callable;
-
-import io.reactivex.internal.functions.ObjectHelper;
-import org.reactivestreams.Subscriber;
-
 import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.schedulers.*;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observables.ConnectableObservable;
+import io.reactivex.schedulers.Schedulers;
+import org.reactivestreams.Subscriber;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.concurrent.*;
 
 /**
  * Utility class to inject handlers to certain standard RxJava operations.
@@ -924,6 +926,98 @@ public final class RxJavaPlugins {
             return apply(f, source);
         }
         return source;
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}.
+     * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
+     */
+    @Experimental
+    public static Scheduler newComputation() {
+        return new ComputationScheduler();
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}
+     * except using {@code threadFactory} for thread creation.
+     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
+     *                      system properties for configuring new thread creation. Cannot be null.
+     * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
+     */
+    @Experimental
+    public static Scheduler newComputation(ThreadFactory threadFactory) {
+        return new ComputationScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}.
+     * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
+     */
+    @Experimental
+    public static Scheduler newIo() {
+        return new IoScheduler();
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}
+     * except using {@code threadFactory} for thread creation.
+     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
+     *                      system properties for configuring new thread creation. Cannot be null.
+     * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
+     */
+    @Experimental
+    public static Scheduler newIo(ThreadFactory threadFactory) {
+        return new IoScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}.
+     * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
+     */
+    @Experimental
+    public static Scheduler newNewThread() {
+        return new NewThreadScheduler();
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}
+     * except using {@code threadFactory} for thread creation.
+     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
+     *                      system properties for configuring new thread creation. Cannot be null.
+     * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
+     */
+    @Experimental
+    public static Scheduler newNewThread(ThreadFactory threadFactory) {
+        return new NewThreadScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#single()}.
+     * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
+     */
+    @Experimental
+    public static Scheduler newSingle() {
+        return new SingleScheduler();
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#single()}
+     * except using {@code threadFactory} for thread creation.
+     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
+     *                      system properties for configuring new thread creation. Cannot be null.
+     * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
+     */
+    @Experimental
+    public static Scheduler newSingle(ThreadFactory threadFactory) {
+        return new SingleScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
     /**

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -929,16 +929,6 @@ public final class RxJavaPlugins {
     }
 
     /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newComputation() {
-        return new ComputationScheduler();
-    }
-
-    /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}
      * except using {@code threadFactory} for thread creation.
      * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
@@ -949,16 +939,6 @@ public final class RxJavaPlugins {
     @Experimental
     public static Scheduler newComputation(ThreadFactory threadFactory) {
         return new ComputationScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
-    }
-
-    /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newIo() {
-        return new IoScheduler();
     }
 
     /**
@@ -975,16 +955,6 @@ public final class RxJavaPlugins {
     }
 
     /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newNewThread() {
-        return new NewThreadScheduler();
-    }
-
-    /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}
      * except using {@code threadFactory} for thread creation.
      * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
@@ -995,16 +965,6 @@ public final class RxJavaPlugins {
     @Experimental
     public static Scheduler newNewThread(ThreadFactory threadFactory) {
         return new NewThreadScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
-    }
-
-    /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#single()}.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newSingle() {
-        return new SingleScheduler();
     }
 
     /**

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -937,7 +937,7 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    public static Scheduler newComputation(ThreadFactory threadFactory) {
+    public static Scheduler createComputationScheduler(ThreadFactory threadFactory) {
         return new ComputationScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -950,7 +950,7 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    public static Scheduler newIo(ThreadFactory threadFactory) {
+    public static Scheduler createIoScheduler(ThreadFactory threadFactory) {
         return new IoScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -963,7 +963,7 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    public static Scheduler newNewThread(ThreadFactory threadFactory) {
+    public static Scheduler createNewThreadScheduler(ThreadFactory threadFactory) {
         return new NewThreadScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -976,7 +976,7 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    public static Scheduler newSingle(ThreadFactory threadFactory) {
+    public static Scheduler createSingleScheduler(ThreadFactory threadFactory) {
         return new SingleScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -13,12 +13,13 @@
 
 package io.reactivex.schedulers;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
-
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.schedulers.*;
 import io.reactivex.plugins.RxJavaPlugins;
+
+import java.util.concurrent.*;
 
 /**
  * Static factory methods for returning standard Scheduler instances.
@@ -58,7 +59,7 @@ public final class Schedulers {
     }
 
     static final class NewThreadHolder {
-        static final Scheduler DEFAULT = NewThreadScheduler.instance();
+        static final Scheduler DEFAULT = new NewThreadScheduler();
     }
 
     static {
@@ -177,6 +178,90 @@ public final class Schedulers {
      */
     public static Scheduler from(Executor executor) {
         return new ExecutorScheduler(executor);
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}.
+     * @return the created Scheduler instance
+     */
+    @Experimental
+    public static Scheduler newComputation() {
+        return new ComputationScheduler();
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}
+     * except using {@code threadFactory} for thread creation.
+     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
+     *                      system properties for configuring new thread creation. Cannot be null.
+     * @return the created Scheduler instance
+     */
+    @Experimental
+    public static Scheduler newComputation(ThreadFactory threadFactory) {
+        return new ComputationScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory == null"));
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}.
+     * @return the created Scheduler instance
+     */
+    @Experimental
+    public static Scheduler newIo() {
+        return new IoScheduler();
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}
+     * except using {@code threadFactory} for thread creation.
+     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
+     *                      system properties for configuring new thread creation. Cannot be null.
+     * @return the created Scheduler instance
+     */
+    @Experimental
+    public static Scheduler newIo(ThreadFactory threadFactory) {
+        return new IoScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory == null"));
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}.
+     * @return the created Scheduler instance
+     */
+    @Experimental
+    public static Scheduler newNewThread() {
+        return new NewThreadScheduler();
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}
+     * except using {@code threadFactory} for thread creation.
+     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
+     *                      system properties for configuring new thread creation. Cannot be null.
+     * @return the created Scheduler instance
+     */
+    @Experimental
+    public static Scheduler newNewThread(ThreadFactory threadFactory) {
+        return new NewThreadScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory == null"));
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#single()}.
+     * @return the created Scheduler instance
+     */
+    @Experimental
+    public static Scheduler newSingle() {
+        return new SingleScheduler();
+    }
+
+    /**
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#single()}
+     * except using {@code threadFactory} for thread creation.
+     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
+     *                      system properties for configuring new thread creation. Cannot be null.
+     * @return the created Scheduler instance
+     */
+    @Experimental
+    public static Scheduler newSingle(ThreadFactory threadFactory) {
+        return new SingleScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory == null"));
     }
 
     /**

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -14,8 +14,6 @@
 package io.reactivex.schedulers;
 
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.Experimental;
-import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.schedulers.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -178,98 +176,6 @@ public final class Schedulers {
      */
     public static Scheduler from(Executor executor) {
         return new ExecutorScheduler(executor);
-    }
-
-    /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newComputation() {
-        return new ComputationScheduler();
-    }
-
-    /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}
-     * except using {@code threadFactory} for thread creation.
-     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
-     *                      system properties for configuring new thread creation. Cannot be null.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newComputation(ThreadFactory threadFactory) {
-        return new ComputationScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
-    }
-
-    /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newIo() {
-        return new IoScheduler();
-    }
-
-    /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}
-     * except using {@code threadFactory} for thread creation.
-     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
-     *                      system properties for configuring new thread creation. Cannot be null.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newIo(ThreadFactory threadFactory) {
-        return new IoScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
-    }
-
-    /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newNewThread() {
-        return new NewThreadScheduler();
-    }
-
-    /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}
-     * except using {@code threadFactory} for thread creation.
-     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
-     *                      system properties for configuring new thread creation. Cannot be null.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newNewThread(ThreadFactory threadFactory) {
-        return new NewThreadScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
-    }
-
-    /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#single()}.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newSingle() {
-        return new SingleScheduler();
-    }
-
-    /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#single()}
-     * except using {@code threadFactory} for thread creation.
-     * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
-     *                      system properties for configuring new thread creation. Cannot be null.
-     * @return the created Scheduler instance
-     * @since 2.0.5 - experimental
-     */
-    @Experimental
-    public static Scheduler newSingle(ThreadFactory threadFactory) {
-        return new SingleScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
     /**

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -183,6 +183,7 @@ public final class Schedulers {
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}.
      * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
      */
     @Experimental
     public static Scheduler newComputation() {
@@ -195,6 +196,7 @@ public final class Schedulers {
      * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
      *                      system properties for configuring new thread creation. Cannot be null.
      * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
      */
     @Experimental
     public static Scheduler newComputation(ThreadFactory threadFactory) {
@@ -204,6 +206,7 @@ public final class Schedulers {
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}.
      * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
      */
     @Experimental
     public static Scheduler newIo() {
@@ -216,6 +219,7 @@ public final class Schedulers {
      * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
      *                      system properties for configuring new thread creation. Cannot be null.
      * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
      */
     @Experimental
     public static Scheduler newIo(ThreadFactory threadFactory) {
@@ -225,6 +229,7 @@ public final class Schedulers {
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}.
      * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
      */
     @Experimental
     public static Scheduler newNewThread() {
@@ -237,6 +242,7 @@ public final class Schedulers {
      * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
      *                      system properties for configuring new thread creation. Cannot be null.
      * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
      */
     @Experimental
     public static Scheduler newNewThread(ThreadFactory threadFactory) {
@@ -246,6 +252,7 @@ public final class Schedulers {
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#single()}.
      * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
      */
     @Experimental
     public static Scheduler newSingle() {
@@ -258,6 +265,7 @@ public final class Schedulers {
      * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
      *                      system properties for configuring new thread creation. Cannot be null.
      * @return the created Scheduler instance
+     * @since 2.0.5 - experimental
      */
     @Experimental
     public static Scheduler newSingle(ThreadFactory threadFactory) {

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -200,7 +200,7 @@ public final class Schedulers {
      */
     @Experimental
     public static Scheduler newComputation(ThreadFactory threadFactory) {
-        return new ComputationScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory == null"));
+        return new ComputationScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
     /**
@@ -223,7 +223,7 @@ public final class Schedulers {
      */
     @Experimental
     public static Scheduler newIo(ThreadFactory threadFactory) {
-        return new IoScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory == null"));
+        return new IoScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
     /**
@@ -246,7 +246,7 @@ public final class Schedulers {
      */
     @Experimental
     public static Scheduler newNewThread(ThreadFactory threadFactory) {
-        return new NewThreadScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory == null"));
+        return new NewThreadScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
     /**
@@ -269,7 +269,7 @@ public final class Schedulers {
      */
     @Experimental
     public static Scheduler newSingle(ThreadFactory threadFactory) {
-        return new SingleScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory == null"));
+        return new SingleScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
     /**

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -1891,27 +1891,22 @@ public class RxJavaPluginsTest {
 
     private static void verifyThread(Worker w, Predicate<Thread> threadPredicate) {
         try {
-            try {
-                final AtomicReference<Thread> value = new AtomicReference<>();
-                final CountDownLatch cdl = new CountDownLatch(1);
+            final AtomicReference<Thread> value = new AtomicReference<Thread>();
+            final CountDownLatch cdl = new CountDownLatch(1);
 
-                w.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        value.set(Thread.currentThread());
-                        cdl.countDown();
-                    }
-                });
+            w.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    value.set(Thread.currentThread());
+                    cdl.countDown();
+                }
+            });
 
-                cdl.await();
+            cdl.await();
 
-                Thread t = value.get();
-                assertNotNull(t);
-                assertTrue(threadPredicate.test(t));
-
-            } catch (Exception e) {
-                fail();
-            }
+            Thread t = value.get();
+            assertNotNull(t);
+            assertTrue(threadPredicate.test(t));
         } catch (Exception e) {
             fail();
         } finally {

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -1938,6 +1938,7 @@ public class RxJavaPluginsTest {
         try {
             verifyThread(Schedulers.computation(), name);
         } finally {
+            customScheduler.shutdown();
             RxJavaPlugins.reset();
         }
     }
@@ -1963,6 +1964,7 @@ public class RxJavaPluginsTest {
         try {
             verifyThread(Schedulers.io(), name);
         } finally {
+            customScheduler.shutdown();
             RxJavaPlugins.reset();
         }
     }
@@ -1988,6 +1990,7 @@ public class RxJavaPluginsTest {
         try {
             verifyThread(Schedulers.newThread(), name);
         } finally {
+            customScheduler.shutdown();
             RxJavaPlugins.reset();
         }
     }
@@ -2014,6 +2017,7 @@ public class RxJavaPluginsTest {
         try {
             verifyThread(Schedulers.single(), name);
         } finally {
+            customScheduler.shutdown();
             RxJavaPlugins.reset();
         }
     }


### PR DESCRIPTION
Resolves #4993

This is a pretty vanilla copy from RxJava 1's implementation. Note that I had to tune NewThread scheduler to not be a singleton to support this.

We had talked about borrowing from project reactor's APIs for different overloads, let me know if you think we should add more fine-grained controls through these.
