### PR TITLE
2.x: ExecutorScheduler.scheduleDirect to report isDisposed on complete

### DIFF
--- a/src/main/java/io/reactivex/disposables/FutureDisposable.java
+++ b/src/main/java/io/reactivex/disposables/FutureDisposable.java
@@ -13,11 +13,12 @@
 package io.reactivex.disposables;
 
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A Disposable container that cancels a Future instance.
  */
-final class FutureDisposable extends ReferenceDisposable<Future<?>> {
+final class FutureDisposable extends AtomicReference<Future<?>> implements Disposable {
 
     private static final long serialVersionUID = 6545242830671168775L;
 
@@ -29,7 +30,16 @@ final class FutureDisposable extends ReferenceDisposable<Future<?>> {
     }
 
     @Override
-    protected void onDisposed(Future<?> value) {
-        value.cancel(allowInterrupt);
+    public boolean isDisposed() {
+        Future<?> f = get();
+        return f == null || f.isDone();
+    }
+
+    @Override
+    public void dispose() {
+        Future<?> f = getAndSet(null);
+        if (f != null) {
+            f.cancel(allowInterrupt);
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/schedulers/SingleSchedulerTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/SingleSchedulerTest.java
@@ -15,14 +15,16 @@ package io.reactivex.internal.schedulers;
 
 import static org.junit.Assert.*;
 
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
-import io.reactivex.disposables.Disposables;
+import io.reactivex.disposables.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.schedulers.SingleScheduler.ScheduledWorker;
+import io.reactivex.schedulers.Schedulers;
 
 public class SingleSchedulerTest {
 
@@ -76,6 +78,43 @@ public class SingleSchedulerTest {
             };
 
             TestHelper.race(r1, r1);
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void runnableDisposedAsync() throws Exception {
+        final Scheduler s = Schedulers.single();
+        Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE);
+
+        while (!d.isDisposed()) {
+            Thread.sleep(1);
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void runnableDisposedAsyncCrash() throws Exception {
+        final Scheduler s = Schedulers.single();
+
+        Disposable d = s.scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                throw new IllegalStateException();
+            }
+        });
+
+        while (!d.isDisposed()) {
+            Thread.sleep(1);
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void runnableDisposedAsyncTimed() throws Exception {
+        final Scheduler s = Schedulers.single();
+
+        Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE, 1, TimeUnit.MILLISECONDS);
+
+        while (!d.isDisposed()) {
+            Thread.sleep(1);
         }
     }
 }

--- a/src/test/java/io/reactivex/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/ExecutorSchedulerTest.java
@@ -484,10 +484,81 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
         });
         Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE);
 
-        assertFalse(d.isDisposed());
-
-        d.dispose();
-
         assertTrue(d.isDisposed());
+    }
+
+    @Test(timeout = 1000)
+    public void runnableDisposedAsync() throws Exception {
+        final Scheduler s = Schedulers.from(new Executor() {
+            @Override
+            public void execute(Runnable r) {
+                new Thread(r).start();
+            }
+        });
+        Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE);
+
+        while (!d.isDisposed()) {
+            Thread.sleep(1);
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void runnableDisposedAsync2() throws Exception {
+        final Scheduler s = Schedulers.from(executor);
+        Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE);
+
+        while (!d.isDisposed()) {
+            Thread.sleep(1);
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void runnableDisposedAsyncCrash() throws Exception {
+        final Scheduler s = Schedulers.from(new Executor() {
+            @Override
+            public void execute(Runnable r) {
+                new Thread(r).start();
+            }
+        });
+        Disposable d = s.scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                throw new IllegalStateException();
+            }
+        });
+
+        while (!d.isDisposed()) {
+            Thread.sleep(1);
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void runnableDisposedAsyncTimed() throws Exception {
+        final Scheduler s = Schedulers.from(new Executor() {
+            @Override
+            public void execute(Runnable r) {
+                new Thread(r).start();
+            }
+        });
+        Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE, 1, TimeUnit.MILLISECONDS);
+
+        while (!d.isDisposed()) {
+            Thread.sleep(1);
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void runnableDisposedAsyncTimed2() throws Exception {
+        ExecutorService executorScheduler = Executors.newScheduledThreadPool(1, new RxThreadFactory("TestCustomPoolTimed"));
+        try {
+            final Scheduler s = Schedulers.from(executorScheduler);
+            Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE, 1, TimeUnit.MILLISECONDS);
+
+            while (!d.isDisposed()) {
+                Thread.sleep(1);
+            }
+        } finally {
+            executorScheduler.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
This PR makes the `Disposable` returned by the `ExecutorScheduler.scheduleDirect()` report `isDisposed` `true` if the task has actually finished, which should now be consistent with the `Worker` behavior of other schedulers.

Reported in #5004.