### PR TITLE
2.x: improve the parallel() mode test coverage, improve its code

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -49,7 +49,13 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
         if (FlowableScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
             return;
         }
-        source.subscribe(new MergeSubscriber<T, U>(s, mapper, delayErrors, maxConcurrency, bufferSize));
+        source.subscribe(subscribe(s, mapper, delayErrors, maxConcurrency, bufferSize));
+    }
+
+    public static <T, U> Subscriber<T> subscribe(Subscriber<? super U> s,
+            Function<? super T, ? extends Publisher<? extends U>> mapper,
+            boolean delayErrors, int maxConcurrency, int bufferSize) {
+        return new MergeSubscriber<T, U>(s, mapper, delayErrors, maxConcurrency, bufferSize);
     }
 
     static final class MergeSubscriber<T, U> extends AtomicInteger implements Subscription, Subscriber<T> {

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelConcatMap.java
@@ -63,24 +63,8 @@ public final class ParallelConcatMap<T, R> extends ParallelFlowable<R> {
         @SuppressWarnings("unchecked")
         final Subscriber<T>[] parents = new Subscriber[n];
 
-        // FIXME cheat until we have support from RxJava2 internals
-        Publisher<T> p = new Publisher<T>() {
-            int i;
-
-            @SuppressWarnings("unchecked")
-            @Override
-            public void subscribe(Subscriber<? super T> s) {
-                parents[i++] = (Subscriber<T>)s;
-            }
-        };
-
-        FlowableConcatMap<T, R> op = new FlowableConcatMap<T, R>(p, mapper, prefetch, errorMode);
-
         for (int i = 0; i < n; i++) {
-
-            op.subscribe(subscribers[i]);
-// FIXME needs a FlatMap subscriber
-//            parents[i] = FlowableConcatMap.createSubscriber(s, mapper, prefetch, errorMode);
+            parents[i] = FlowableConcatMap.subscribe(subscribers[i], mapper, prefetch, errorMode);
         }
 
         source.subscribe(parents);

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFlatMap.java
@@ -67,24 +67,8 @@ public final class ParallelFlatMap<T, R> extends ParallelFlowable<R> {
         @SuppressWarnings("unchecked")
         final Subscriber<T>[] parents = new Subscriber[n];
 
-        // FIXME cheat until we have support from RxJava2 internals
-        Publisher<T> p = new Publisher<T>() {
-            int i;
-
-            @SuppressWarnings("unchecked")
-            @Override
-            public void subscribe(Subscriber<? super T> s) {
-                parents[i++] = (Subscriber<T>)s;
-            }
-        };
-
-        FlowableFlatMap<T, R> op = new FlowableFlatMap<T, R>(p, mapper, delayError, maxConcurrency, prefetch);
-
         for (int i = 0; i < n; i++) {
-
-            op.subscribe(subscribers[i]);
-// FIXME needs a FlatMap subscriber
-//            parents[i] = FlowableFlatMap.createSubscriber(s, mapper, delayError, maxConcurrency, prefetch);
+            parents[i] = FlowableFlatMap.subscribe(subscribers[i], mapper, delayError, maxConcurrency, prefetch);
         }
 
         source.subscribe(parents);

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -67,8 +67,9 @@ public abstract class ParallelFlowable<T> {
     protected final boolean validate(Subscriber<?>[] subscribers) {
         int p = parallelism();
         if (subscribers.length != p) {
+            Throwable iae = new IllegalArgumentException("parallelism = " + p + ", subscribers = " + subscribers.length);
             for (Subscriber<?> s : subscribers) {
-                EmptySubscription.error(new IllegalArgumentException("parallelism = " + p + ", subscribers = " + subscribers.length), s);
+                EmptySubscription.error(iae, s);
             }
             return false;
         }
@@ -225,7 +226,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    public final <R> ParallelFlowable<R> reduce(Callable<R> initialSupplier, BiFunction<R, T, R> reducer) {
+    public final <R> ParallelFlowable<R> reduce(Callable<R> initialSupplier, BiFunction<R, ? super T, R> reducer) {
         ObjectHelper.requireNonNull(initialSupplier, "initialSupplier");
         ObjectHelper.requireNonNull(reducer, "reducer");
         return new ParallelReduce<T, R>(this, initialSupplier, reducer);
@@ -513,7 +514,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    public final <C> ParallelFlowable<C> collect(Callable<C> collectionSupplier, BiConsumer<C, T> collector) {
+    public final <C> ParallelFlowable<C> collect(Callable<? extends C> collectionSupplier, BiConsumer<? super C, ? super T> collector) {
         return new ParallelCollect<T, C>(this, collectionSupplier, collector);
     }
 

--- a/src/test/java/io/reactivex/parallel/ParallelCollectTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelCollectTest.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ParallelCollectTest {
+
+    @Test
+    public void subscriberCount() {
+        ParallelFlowableTest.checkSubscriberCount(Flowable.range(1, 5).parallel()
+        .collect(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                return new ArrayList<Integer>();
+            }
+        }, new BiConsumer<List<Integer>, Integer>() {
+            @Override
+            public void accept(List<Integer> a, Integer b) throws Exception {
+                a.add(b);
+            }
+        }));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void initialCrash() {
+        Flowable.range(1, 5)
+        .parallel()
+        .collect(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                throw new TestException();
+            }
+        }, new BiConsumer<List<Integer>, Integer>() {
+            @Override
+            public void accept(List<Integer> a, Integer b) throws Exception {
+                a.add(b);
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void reducerCrash() {
+        Flowable.range(1, 5)
+        .parallel()
+        .collect(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                return new ArrayList<Integer>();
+            }
+        }, new BiConsumer<List<Integer>, Integer>() {
+            @Override
+            public void accept(List<Integer> a, Integer b) throws Exception {
+                if (b == 3) {
+                    throw new TestException();
+                }
+                a.add(b);
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void cancel() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<List<Integer>> ts = pp
+        .parallel()
+        .collect(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                return new ArrayList<Integer>();
+            }
+        }, new BiConsumer<List<Integer>, Integer>() {
+            @Override
+            public void accept(List<Integer> a, Integer b) throws Exception {
+                a.add(b);
+            }
+        })
+        .sequential()
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void error() {
+        Flowable.<Integer>error(new TestException())
+        .parallel()
+        .collect(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                return new ArrayList<Integer>();
+            }
+        }, new BiConsumer<List<Integer>, Integer>() {
+            @Override
+            public void accept(List<Integer> a, Integer b) throws Exception {
+                a.add(b);
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void doubleError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .collect(new Callable<List<Object>>() {
+                @Override
+                public List<Object> call() throws Exception {
+                    return new ArrayList<Object>();
+                }
+            }, new BiConsumer<List<Object>, Object>() {
+                @Override
+                public void accept(List<Object> a, Object b) throws Exception {
+                    a.add(b);
+                }
+            })
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+
+            assertFalse(errors.isEmpty());
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/parallel/ParallelFilterTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFilterTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class ParallelFilterTest {
+
+    @Test
+    public void subscriberCount() {
+        ParallelFlowableTest.checkSubscriberCount(Flowable.range(1, 5).parallel()
+        .filter(Functions.alwaysTrue()));
+    }
+
+    @Test
+    public void doubleFilter() {
+        Flowable.range(1, 10)
+        .parallel()
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 2 == 0;
+            }
+        })
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 3 == 0;
+            }
+        })
+        .sequential()
+        .test()
+        .assertResult(6);
+    }
+
+    @Test
+    public void doubleError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+
+            assertFalse(errors.isEmpty());
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void doubleError2() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .filter(Functions.alwaysTrue())
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+
+            assertFalse(errors.isEmpty());
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void error() {
+        Flowable.error(new TestException())
+        .parallel()
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void predicateThrows() {
+        Flowable.just(1)
+        .parallel()
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/parallel/ParallelFromPublisherTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFromPublisherTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.processors.UnicastProcessor;
+
+public class ParallelFromPublisherTest {
+
+    @Test
+    public void sourceOverflow() {
+        new Flowable<Integer>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super Integer> s) {
+                s.onSubscribe(new BooleanSubscription());
+                for (int i = 0; i < 10; i++) {
+                    s.onNext(i);
+                }
+            }
+        }
+        .parallel(1, 1)
+        .sequential(1)
+        .test(0)
+        .assertFailure(MissingBackpressureException.class);
+    }
+
+    @Test
+    public void fusedFilterBecomesEmpty() {
+        Flowable.just(1)
+        .filter(Functions.alwaysFalse())
+        .parallel()
+        .sequential()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void syncFusedMapCrash() {
+        Flowable.just(1)
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .parallel()
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void asyncFusedMapCrash() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+
+        up.onNext(1);
+
+        up
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .parallel()
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+
+        assertFalse(up.hasSubscribers());
+    }
+}

--- a/src/test/java/io/reactivex/parallel/ParallelInvalid.java
+++ b/src/test/java/io/reactivex/parallel/ParallelInvalid.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+
+/**
+ * Signals two onErrors to each subscriber for testing purposes.
+ */
+public final class ParallelInvalid extends ParallelFlowable<Object> {
+
+    @Override
+    public void subscribe(Subscriber<? super Object>[] subscribers) {
+        TestException ex = new TestException();
+        for (Subscriber<? super Object> s : subscribers) {
+            EmptySubscription.error(ex, s);
+            s.onError(ex);
+            s.onNext(0);
+            s.onComplete();
+            s.onComplete();
+        }
+    }
+
+    @Override
+    public int parallelism() {
+        return 4;
+    }
+
+}

--- a/src/test/java/io/reactivex/parallel/ParallelJoinTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelJoinTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.Flowable;
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ParallelJoinTest {
+
+    @Test
+    public void overflowFastpath() {
+        new ParallelFlowable<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer>[] subscribers) {
+                subscribers[0].onSubscribe(new BooleanSubscription());
+                subscribers[0].onNext(1);
+                subscribers[0].onNext(2);
+                subscribers[0].onNext(3);
+            }
+
+            @Override
+            public int parallelism() {
+                return 1;
+            }
+        }
+        .sequential(1)
+        .test(0)
+        .assertFailure(MissingBackpressureException.class);
+    }
+
+    @Test
+    public void overflowSlowpath() {
+        @SuppressWarnings("unchecked")
+        final Subscriber<? super Integer>[] subs = new Subscriber[1];
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                subs[0].onNext(2);
+                subs[0].onNext(3);
+            }
+        };
+
+        new ParallelFlowable<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer>[] subscribers) {
+                subs[0] = subscribers[0];
+                subscribers[0].onSubscribe(new BooleanSubscription());
+                subscribers[0].onNext(1);
+            }
+
+            @Override
+            public int parallelism() {
+                return 1;
+            }
+        }
+        .sequential(1)
+        .subscribe(ts);
+
+        ts.assertFailure(MissingBackpressureException.class, 1);
+    }
+
+    @Test
+    public void emptyBackpressured() {
+        Flowable.empty()
+        .parallel()
+        .sequential()
+        .test(0)
+        .assertResult();
+    }
+}

--- a/src/test/java/io/reactivex/parallel/ParallelMapTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelMapTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+
+public class ParallelMapTest {
+
+    @Test
+    public void subscriberCount() {
+        ParallelFlowableTest.checkSubscriberCount(Flowable.range(1, 5).parallel()
+        .map(Functions.identity()));
+    }
+
+    @Test
+    public void doubleFilter() {
+        Flowable.range(1, 10)
+        .parallel()
+        .map(Functions.<Integer>identity())
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 2 == 0;
+            }
+        })
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 3 == 0;
+            }
+        })
+        .sequential()
+        .test()
+        .assertResult(6);
+    }
+
+    @Test
+    public void doubleFilterAsync() {
+        Flowable.range(1, 10)
+        .parallel()
+        .runOn(Schedulers.computation())
+        .map(Functions.<Integer>identity())
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 2 == 0;
+            }
+        })
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 3 == 0;
+            }
+        })
+        .sequential()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(6);
+    }
+
+    @Test
+    public void doubleError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .map(Functions.<Object>identity())
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+
+            assertFalse(errors.isEmpty());
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void doubleError2() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .map(Functions.<Object>identity())
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+
+            assertFalse(errors.isEmpty());
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void error() {
+        Flowable.error(new TestException())
+        .parallel()
+        .map(Functions.<Object>identity())
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapCrash() {
+        Flowable.just(1)
+        .parallel()
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapCrashConditional() {
+        Flowable.just(1)
+        .parallel()
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapCrashConditional2() {
+        Flowable.just(1)
+        .parallel()
+        .runOn(Schedulers.computation())
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/parallel/ParallelPeekTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelPeekTest.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class ParallelPeekTest {
+
+    @Test
+    public void subscriberCount() {
+        ParallelFlowableTest.checkSubscriberCount(Flowable.range(1, 5).parallel()
+        .doOnNext(Functions.emptyConsumer()));
+    }
+
+    @Test
+    public void onSubscribeCrash() {
+        Flowable.range(1, 5)
+        .parallel()
+        .doOnSubscribe(new Consumer<Subscription>() {
+            @Override
+            public void accept(Subscription s) throws Exception {
+                throw new TestException();
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void doubleError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .doOnNext(Functions.emptyConsumer())
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+
+            assertFalse(errors.isEmpty());
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void requestCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Flowable.range(1, 5)
+            .parallel()
+            .doOnRequest(new LongConsumer() {
+                @Override
+                public void accept(long n) throws Exception {
+                    throw new TestException();
+                }
+            })
+            .sequential()
+            .test()
+            .assertResult(1, 2, 3, 4, 5);
+
+            assertFalse(errors.isEmpty());
+
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void cancelCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Flowable.<Integer>never()
+            .parallel()
+            .doOnCancel(new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            })
+            .sequential()
+            .test()
+            .cancel();
+
+            assertFalse(errors.isEmpty());
+
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteCrash() {
+        Flowable.just(1)
+        .parallel()
+        .doOnComplete(new Action() {
+            @Override
+            public void run() throws Exception {
+                throw new TestException();
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void onAfterTerminatedCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Flowable.just(1)
+            .parallel()
+            .doAfterTerminated(new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            })
+            .sequential()
+            .test()
+            .assertResult(1);
+
+            assertFalse(errors.isEmpty());
+
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onAfterTerminatedCrash2() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Flowable.<Integer>error(new IOException())
+            .parallel()
+            .doAfterTerminated(new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            })
+            .sequential()
+            .test()
+            .assertFailure(IOException.class);
+
+            assertFalse(errors.isEmpty());
+
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/parallel/ParallelReduceFullTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelReduceFullTest.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ParallelReduceFullTest {
+
+    @Test
+    public void cancel() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp
+        .parallel()
+        .reduce(new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer a, Integer b) throws Exception {
+                return a + b;
+            }
+        })
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+    }
+
+    @Test
+    public void error() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Flowable.<Integer>error(new TestException())
+            .parallel()
+            .reduce(new BiFunction<Integer, Integer, Integer>() {
+                @Override
+                public Integer apply(Integer a, Integer b) throws Exception {
+                    return a + b;
+                }
+            })
+            .test()
+            .assertFailure(TestException.class);
+
+            assertTrue(errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void error2() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            ParallelFlowable.fromArray(Flowable.<Integer>error(new IOException()), Flowable.<Integer>error(new TestException()))
+            .reduce(new BiFunction<Integer, Integer, Integer>() {
+                @Override
+                public Integer apply(Integer a, Integer b) throws Exception {
+                    return a + b;
+                }
+            })
+            .test()
+            .assertFailure(IOException.class);
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void empty() {
+        Flowable.<Integer>empty()
+        .parallel()
+        .reduce(new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer a, Integer b) throws Exception {
+                return a + b;
+            }
+        })
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void doubleError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .reduce(new BiFunction<Object, Object, Object>() {
+                @Override
+                public Object apply(Object a, Object b) throws Exception {
+                    return "" + a + b;
+                }
+            })
+            .test()
+            .assertFailure(TestException.class);
+
+            assertFalse(errors.isEmpty());
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void reducerCrash() {
+        Flowable.range(1, 4)
+        .parallel(2)
+        .reduce(new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer a, Integer b) throws Exception {
+                if (b == 3) {
+                    throw new TestException();
+                }
+                return a + b;
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void reducerCrash2() {
+        Flowable.range(1, 4)
+        .parallel(2)
+        .reduce(new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer a, Integer b) throws Exception {
+                if (a == 1 + 3) {
+                    throw new TestException();
+                }
+                return a + b;
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/parallel/ParallelReduceTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelReduceTest.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import static org.junit.Assert.*;
+import java.util.*;
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ParallelReduceTest {
+
+    @Test
+    public void subscriberCount() {
+        ParallelFlowableTest.checkSubscriberCount(Flowable.range(1, 5).parallel()
+        .reduce(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                return new ArrayList<Integer>();
+            }
+        }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> apply(List<Integer> a, Integer b) throws Exception {
+                a.add(b);
+                return a;
+            }
+        }));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void initialCrash() {
+        Flowable.range(1, 5)
+        .parallel()
+        .reduce(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                throw new TestException();
+            }
+        }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> apply(List<Integer> a, Integer b) throws Exception {
+                a.add(b);
+                return a;
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void reducerCrash() {
+        Flowable.range(1, 5)
+        .parallel()
+        .reduce(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                return new ArrayList<Integer>();
+            }
+        }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> apply(List<Integer> a, Integer b) throws Exception {
+                if (b == 3) {
+                    throw new TestException();
+                }
+                a.add(b);
+                return a;
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void cancel() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<List<Integer>> ts = pp
+        .parallel()
+        .reduce(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                return new ArrayList<Integer>();
+            }
+        }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> apply(List<Integer> a, Integer b) throws Exception {
+                a.add(b);
+                return a;
+            }
+        })
+        .sequential()
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void error() {
+        Flowable.<Integer>error(new TestException())
+        .parallel()
+        .reduce(new Callable<List<Integer>>() {
+            @Override
+            public List<Integer> call() throws Exception {
+                return new ArrayList<Integer>();
+            }
+        }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
+            @Override
+            public List<Integer> apply(List<Integer> a, Integer b) throws Exception {
+                a.add(b);
+                return a;
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void doubleError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .reduce(new Callable<List<Object>>() {
+                @Override
+                public List<Object> call() throws Exception {
+                    return new ArrayList<Object>();
+                }
+            }, new BiFunction<List<Object>, Object, List<Object>>() {
+                @Override
+                public List<Object> apply(List<Object> a, Object b) throws Exception {
+                    a.add(b);
+                    return a;
+                }
+            })
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+
+            assertFalse(errors.isEmpty());
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/parallel/ParallelRunOnTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelRunOnTest.java
@@ -1,0 +1,281 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.schedulers.ImmediateThinScheduler;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ParallelRunOnTest {
+
+    @Test
+    public void subscriberCount() {
+        ParallelFlowableTest.checkSubscriberCount(Flowable.range(1, 5).parallel()
+        .runOn(Schedulers.computation()));
+    }
+
+    @Test
+    public void doubleError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .runOn(ImmediateThinScheduler.INSTANCE)
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+
+            assertFalse(errors.isEmpty());
+            for (Throwable ex : errors) {
+                assertTrue(ex.toString(), ex instanceof TestException);
+            }
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void conditionalPath() {
+        Flowable.range(1, 1000)
+        .parallel(2)
+        .runOn(Schedulers.computation())
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v % 2 == 0;
+            }
+        })
+        .sequential()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(500)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void missingBackpressure() {
+        new ParallelFlowable<Integer>() {
+            @Override
+            public int parallelism() {
+                return 1;
+            }
+
+            @Override
+            public void subscribe(Subscriber<? super Integer>[] subscribers) {
+                subscribers[0].onSubscribe(new BooleanSubscription());
+                subscribers[0].onNext(1);
+                subscribers[0].onNext(2);
+                subscribers[0].onNext(3);
+            }
+        }
+        .runOn(ImmediateThinScheduler.INSTANCE, 1)
+        .sequential(1)
+        .test(0)
+        .assertFailure(MissingBackpressureException.class);
+    }
+
+    @Test
+    public void error() {
+        Flowable.error(new TestException())
+        .parallel(1)
+        .runOn(ImmediateThinScheduler.INSTANCE)
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorBackpressured() {
+        Flowable.error(new TestException())
+        .parallel(1)
+        .runOn(ImmediateThinScheduler.INSTANCE)
+        .sequential(1)
+        .test(0)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorConditional() {
+        Flowable.error(new TestException())
+        .parallel(1)
+        .runOn(ImmediateThinScheduler.INSTANCE)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void errorConditionalBackpressured() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(0L);
+
+        Flowable.error(new TestException())
+        .parallel(1)
+        .runOn(ImmediateThinScheduler.INSTANCE)
+        .filter(Functions.alwaysTrue())
+        .subscribe(new Subscriber[] { ts });
+
+        ts
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void emptyConditionalBackpressured() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(0L);
+
+        Flowable.empty()
+        .parallel(1)
+        .runOn(ImmediateThinScheduler.INSTANCE)
+        .filter(Functions.alwaysTrue())
+        .subscribe(new Subscriber[] { ts });
+
+        ts
+        .assertResult();
+    }
+
+    @Test
+    public void nextCancelRace() {
+        for (int i = 0; i < 1000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            final TestSubscriber<Integer> ts = pp.parallel(1)
+            .runOn(Schedulers.computation())
+            .sequential()
+            .test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void nextCancelRaceBackpressured() {
+        for (int i = 0; i < 1000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            final TestSubscriber<Integer> ts = TestSubscriber.create(0L);
+
+            pp.parallel(1)
+            .runOn(Schedulers.computation())
+            .subscribe(new Subscriber[] { ts });
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+        }
+    }
+
+    @Test
+    public void nextCancelRaceConditional() {
+        for (int i = 0; i < 1000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            final TestSubscriber<Integer> ts = pp.parallel(1)
+            .runOn(Schedulers.computation())
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void nextCancelRaceBackpressuredConditional() {
+        for (int i = 0; i < 1000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            final TestSubscriber<Integer> ts = TestSubscriber.create(0L);
+
+            pp.parallel(1)
+            .runOn(Schedulers.computation())
+            .filter(Functions.alwaysTrue())
+            .subscribe(new Subscriber[] { ts });
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/parallel/ParallelSortedJoinTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelSortedJoinTest.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.*;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ParallelSortedJoinTest {
+
+    @Test
+    public void cancel() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp
+        .parallel()
+        .sorted(Functions.<Integer>naturalComparator())
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+    }
+
+    @Test
+    public void error() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Flowable.<Integer>error(new TestException())
+            .parallel()
+            .sorted(Functions.<Integer>naturalComparator())
+            .test()
+            .assertFailure(TestException.class);
+
+            assertTrue(errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void error3() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            Flowable.<Integer>error(new TestException())
+            .parallel()
+            .sorted(Functions.<Integer>naturalComparator())
+            .test(0)
+            .assertFailure(TestException.class);
+
+            assertTrue(errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void error2() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            ParallelFlowable.fromArray(Flowable.<Integer>error(new IOException()), Flowable.<Integer>error(new TestException()))
+            .sorted(Functions.<Integer>naturalComparator())
+            .test()
+            .assertFailure(IOException.class);
+
+            TestHelper.assertError(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void comparerCrash() {
+        Flowable.fromArray(4, 3, 2, 1)
+        .parallel(2)
+        .sorted(new Comparator<Integer>() {
+            @Override
+            public int compare(Integer o1, Integer o2) {
+                if (o1 == 4 && o2 == 3) {
+                    throw new TestException();
+                }
+                return o1.compareTo(o2);
+            }
+        })
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @Test
+    public void empty() {
+        Flowable.<Integer>empty()
+        .parallel()
+        .sorted(Functions.<Integer>naturalComparator())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void asyncDrain() {
+        Integer[] values = new Integer[100 * 1000];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = values.length - i;
+        }
+
+        TestSubscriber<Integer> ts = Flowable.fromArray(values)
+        .parallel(2)
+        .runOn(Schedulers.computation())
+        .sorted(Functions.naturalComparator())
+        .observeOn(Schedulers.single())
+        .test();
+
+        ts
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(values.length)
+        .assertNoErrors()
+        .assertComplete();
+
+        List<Integer> list = ts.values();
+        for (int i = 0; i < values.length; i++) {
+            assertEquals(i + 1, list.get(i).intValue());
+        }
+    }
+
+    @Test
+    public void sortCancelRace() {
+        for (int i = 0; i < 1000; i++) {
+            final ReplayProcessor<Integer> pp = ReplayProcessor.create();
+            pp.onNext(1);
+            pp.onNext(2);
+
+            final TestSubscriber<Integer> ts = pp.parallel(2)
+            .sorted(Functions.naturalComparator())
+            .test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+        }
+    }
+
+    @Test
+    public void sortCancelRace2() {
+        for (int i = 0; i < 1000; i++) {
+            final ReplayProcessor<Integer> pp = ReplayProcessor.create();
+            pp.onNext(1);
+            pp.onNext(2);
+
+            final TestSubscriber<Integer> ts = pp.parallel(2)
+            .sorted(Functions.naturalComparator())
+            .test(0);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.cancel();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds additional unit tests for the `parallel()` operators, plus:

  - adds conditional fusion to `runOn`, `filter` and `map` operators
  - exposes the `FlowableFlatMap`'s internal `Subscriber` to be reused with `ParallelFlowable.flatMap`
  - uses the `FlowableConcatMap`'s internal `Subscriber` to be reused with `ParallelFlowable.concatMap`
  - fix generics with `collect` and `reduce`
  - change queue overflow errors to `MissingBackpressureException`
  - make sure join-like operators don't emit the same upstream `Throwable` to the `RxJavaPlugins.onError` handler if all rails have the same error reference
