### PR TITLE
1.x: update sample(time) diagram to indicate emission of last

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -9100,7 +9100,7 @@ public class Observable<T> {
      * Returns an Observable that emits the most recently emitted item (if any) emitted by the source Observable
      * within periodic time intervals.
      * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sample.png" alt="">
+     * <img width="640" height="276" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sample.emitlast.1x.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it uses time to control data flow.</dd>
@@ -9126,7 +9126,7 @@ public class Observable<T> {
      * Returns an Observable that emits the most recently emitted item (if any) emitted by the source Observable
      * within periodic time intervals, where the intervals are defined on a particular Scheduler.
      * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sample.s.png" alt="">
+     * <img width="640" height="276" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sample.s.emitlast.1x.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it uses time to control data flow.</dd>


### PR DESCRIPTION
This PR updates the 1.x `sample(time)` diagram to indicate the last value is emitted when the sequence completes. It is the same (style) as for 2.x:


Default scheduler:
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sample.emitlast.1x.png)

Custom scheduler:
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sample.s.emitlast.1x.png)

Related: #4952