### PR TITLE
Override RS dependency to compile, replace owner info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,3 +198,26 @@ findbugsMain {
     }
 }
 */
+
+// from https://discuss.gradle.org/t/maven-publish-plugin-generated-pom-making-dependency-scope-runtime/7494/10
+
+publishing.publications.all {
+  pom.withXml {
+    asNode().dependencies.'*'.findAll() {
+      it.scope.text() == 'runtime' && project.configurations.compile.allDependencies.find { dep ->
+        dep.name == it.artifactId.text()
+      }
+    }.each { it.scope*.value = 'compile'}
+
+    asNode().developers.'*'.findAll() {
+       it.id.text() == 'benjchristensen'
+    } .each {
+       it.id*.value = 'akarnokd'
+       it.name*.value = 'David Karnok'
+       it.email*.value = 'akarnokd@gmail.com'
+    }
+    
+    asNode().properties.nebula_Module_Owner*.value = 'akarnokd@gmail.com'
+    asNode().properties.nebula_Module_Email*.value = 'akarnokd@gmail.com'
+  }
+}


### PR DESCRIPTION
This PR overrides the dependency of Reactive-Streams in the generated POM.xml from `runtime` to `compile` to avoid trouble with plain maven users.

In addition, I took the liberty of overriding the responsible owner references which seem to be hard-coded in the `rxjava-nebula` plugin.

Related: #4813, #5014