### PR TITLE
Fix copyright instructions in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ If you are adding a new file it should have a header like this:
 
 ```
 /**
- * Copyright 2016 Netflix, Inc.
+ * Copyright (c) 2016-present, RxJava Contributors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
After [changing the copyright of the project](https://github.com/ReactiveX/RxJava/issues/4978) the documentation in CONTRIBUTING.md should be adjusted with the updated copyright header