### PR TITLE
2.x: option to fail for using blockingX on the computation scheduler

### DIFF
--- a/src/main/java/io/reactivex/internal/observers/BlockingBaseObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/BlockingBaseObserver.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CountDownLatch;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.internal.util.*;
 
 public abstract class BlockingBaseObserver<T> extends CountDownLatch
 implements Observer<T>, Disposable {
@@ -67,6 +67,7 @@ implements Observer<T>, Disposable {
     public final T blockingGet() {
         if (getCount() != 0) {
             try {
+                BlockingHelper.verifyNonBlocking();
                 await();
             } catch (InterruptedException ex) {
                 dispose();

--- a/src/main/java/io/reactivex/internal/observers/BlockingMultiObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/BlockingMultiObserver.java
@@ -17,7 +17,7 @@ import java.util.concurrent.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.internal.util.*;
 
 /**
  * A combined Observer that awaits the success or error signal via a CountDownLatch.
@@ -79,6 +79,7 @@ implements SingleObserver<T>, CompletableObserver, MaybeObserver<T> {
     public T blockingGet() {
         if (getCount() != 0) {
             try {
+                BlockingHelper.verifyNonBlocking();
                 await();
             } catch (InterruptedException ex) {
                 dispose();
@@ -101,6 +102,7 @@ implements SingleObserver<T>, CompletableObserver, MaybeObserver<T> {
     public T blockingGet(T defaultValue) {
         if (getCount() != 0) {
             try {
+                BlockingHelper.verifyNonBlocking();
                 await();
             } catch (InterruptedException ex) {
                 dispose();
@@ -123,6 +125,7 @@ implements SingleObserver<T>, CompletableObserver, MaybeObserver<T> {
     public Throwable blockingGetError() {
         if (getCount() != 0) {
             try {
+                BlockingHelper.verifyNonBlocking();
                 await();
             } catch (InterruptedException ex) {
                 dispose();
@@ -142,6 +145,7 @@ implements SingleObserver<T>, CompletableObserver, MaybeObserver<T> {
     public Throwable blockingGetError(long timeout, TimeUnit unit) {
         if (getCount() != 0) {
             try {
+                BlockingHelper.verifyNonBlocking();
                 if (!await(timeout, unit)) {
                     dispose();
                     throw ExceptionHelper.wrapOrThrow(new TimeoutException());
@@ -164,6 +168,7 @@ implements SingleObserver<T>, CompletableObserver, MaybeObserver<T> {
     public boolean blockingAwait(long timeout, TimeUnit unit) {
         if (getCount() != 0) {
             try {
+                BlockingHelper.verifyNonBlocking();
                 if (!await(timeout, unit)) {
                     dispose();
                     return false;

--- a/src/main/java/io/reactivex/internal/observers/FutureObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/FutureObserver.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.util.BlockingHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -72,6 +73,7 @@ implements Observer<T>, Future<T>, Disposable {
     @Override
     public T get() throws InterruptedException, ExecutionException {
         if (getCount() != 0) {
+            BlockingHelper.verifyNonBlocking();
             await();
         }
 
@@ -88,6 +90,7 @@ implements Observer<T>, Future<T>, Disposable {
     @Override
     public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         if (getCount() != 0) {
+            BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {
                 throw new TimeoutException();
             }

--- a/src/main/java/io/reactivex/internal/observers/FutureSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/FutureSingleObserver.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.util.BlockingHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -71,6 +72,7 @@ implements SingleObserver<T>, Future<T>, Disposable {
     @Override
     public T get() throws InterruptedException, ExecutionException {
         if (getCount() != 0) {
+            BlockingHelper.verifyNonBlocking();
             await();
         }
 
@@ -87,6 +89,7 @@ implements SingleObserver<T>, Future<T>, Disposable {
     @Override
     public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         if (getCount() != 0) {
+            BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {
                 throw new TimeoutException();
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableIterable.java
@@ -23,7 +23,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.internal.util.*;
 
 public final class BlockingFlowableIterable<T> implements Iterable<T> {
     final Publisher<? extends T> source;
@@ -86,6 +86,7 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
                     }
                 }
                 if (empty) {
+                    BlockingHelper.verifyNonBlocking();
                     lock.lock();
                     try {
                         while (!done && queue.isEmpty()) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.*;
-import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.DisposableSubscriber;
 
@@ -79,6 +79,7 @@ public final class BlockingFlowableLatest<T> implements Iterable<T> {
             if (iteratorNotification == null || iteratorNotification.isOnNext()) {
                 if (iteratorNotification == null) {
                     try {
+                        BlockingHelper.verifyNonBlocking();
                         notify.acquire();
                     } catch (InterruptedException ex) {
                         dispose();

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableNext.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.*;
-import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.DisposableSubscriber;
 
@@ -165,6 +165,7 @@ public final class BlockingFlowableNext<T> implements Iterable<T> {
 
         public Notification<T> takeNext() throws InterruptedException {
             setWaiting();
+            BlockingHelper.verifyNonBlocking();
             return buf.take();
         }
         void setWaiting() {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBlockingSubscribe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBlockingSubscribe.java
@@ -57,6 +57,7 @@ public final class FlowableBlockingSubscribe {
                     if (bs.isCancelled()) {
                         break;
                     }
+                    BlockingHelper.verifyNonBlocking();
                     v = queue.take();
                 }
                 if (bs.isCancelled()) {

--- a/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableIterable.java
@@ -21,7 +21,7 @@ import io.reactivex.ObservableSource;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
-import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.internal.util.*;
 
 public final class BlockingObservableIterable<T> implements Iterable<T> {
     final ObservableSource<? extends T> source;
@@ -78,6 +78,7 @@ public final class BlockingObservableIterable<T> implements Iterable<T> {
                 }
                 if (empty) {
                     try {
+                        BlockingHelper.verifyNonBlocking();
                         lock.lock();
                         try {
                             while (!done && queue.isEmpty()) {

--- a/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableLatest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
 import io.reactivex.Observable;
-import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.internal.util.*;
 import io.reactivex.observers.DisposableObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -79,6 +79,7 @@ public final class BlockingObservableLatest<T> implements Iterable<T> {
             }
             if (iteratorNotification == null) {
                 try {
+                    BlockingHelper.verifyNonBlocking();
                     notify.acquire();
                 } catch (InterruptedException ex) {
                     dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableNext.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableNext.java
@@ -18,7 +18,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
-import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.internal.util.*;
 import io.reactivex.observers.DisposableObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -162,6 +162,7 @@ public final class BlockingObservableNext<T> implements Iterable<T> {
 
         public Notification<T> takeNext() throws InterruptedException {
             setWaiting();
+            BlockingHelper.verifyNonBlocking();
             return buf.take();
         }
         void setWaiting() {

--- a/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
@@ -56,7 +56,7 @@ public final class ComputationScheduler extends Scheduler {
         int priority = Math.max(Thread.MIN_PRIORITY, Math.min(Thread.MAX_PRIORITY,
                 Integer.getInteger(KEY_COMPUTATION_PRIORITY, Thread.NORM_PRIORITY)));
 
-        THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX, priority);
+        THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX, priority, true);
 
         NONE = new FixedSchedulerPool(0, THREAD_FACTORY);
         NONE.shutdown();

--- a/src/main/java/io/reactivex/internal/schedulers/NonBlockingThread.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NonBlockingThread.java
@@ -11,26 +11,12 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.tck;
+package io.reactivex.internal.schedulers;
 
-import java.util.concurrent.TimeUnit;
+/**
+ * Marker interface to indicate blocking is not recommended while running
+ * on a Scheduler with a thread type implementing it.
+ */
+public interface NonBlockingThread {
 
-import org.reactivestreams.Publisher;
-import org.testng.annotations.Test;
-
-import io.reactivex.Flowable;
-
-@Test
-public class DelaySubscriptionTckTest extends BaseTck<Integer> {
-
-    public DelaySubscriptionTckTest() {
-        super(200L);
-    }
-
-    @Override
-    public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
-                Flowable.range(0, (int)elements).delaySubscription(1, TimeUnit.MILLISECONDS)
-        );
-    }
 }

--- a/src/main/java/io/reactivex/internal/schedulers/RxThreadFactory.java
+++ b/src/main/java/io/reactivex/internal/schedulers/RxThreadFactory.java
@@ -28,15 +28,22 @@ public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
 
     final int priority;
 
+    final boolean nonBlocking;
+
 //    static volatile boolean CREATE_TRACE;
 
     public RxThreadFactory(String prefix) {
-        this(prefix, Thread.NORM_PRIORITY);
+        this(prefix, Thread.NORM_PRIORITY, false);
     }
 
     public RxThreadFactory(String prefix, int priority) {
+        this(prefix, priority, false);
+    }
+
+    public RxThreadFactory(String prefix, int priority, boolean nonBlocking) {
         this.prefix = prefix;
         this.priority = priority;
+        this.nonBlocking = nonBlocking;
     }
 
     @Override
@@ -63,7 +70,8 @@ public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
 //            }
 //        }
 
-        Thread t = new Thread(r, nameBuilder.toString());
+        String name = nameBuilder.toString();
+        Thread t = nonBlocking ? new RxCustomThread(r, name) : new Thread(r, name);
         t.setPriority(priority);
         t.setDaemon(true);
         return t;
@@ -72,5 +80,11 @@ public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
     @Override
     public String toString() {
         return "RxThreadFactory[" + prefix + "]";
+    }
+
+    static final class RxCustomThread extends Thread implements NonBlockingThread {
+        RxCustomThread(Runnable run, String name) {
+            super(run, name);
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
@@ -44,7 +44,7 @@ public final class SingleScheduler extends Scheduler {
         int priority = Math.max(Thread.MIN_PRIORITY, Math.min(Thread.MAX_PRIORITY,
                 Integer.getInteger(KEY_SINGLE_PRIORITY, Thread.NORM_PRIORITY)));
 
-        SINGLE_THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX, priority);
+        SINGLE_THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX, priority, true);
     }
 
     public SingleScheduler() {

--- a/src/main/java/io/reactivex/internal/subscribers/BlockingBaseSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/BlockingBaseSubscriber.java
@@ -17,7 +17,7 @@ import java.util.concurrent.CountDownLatch;
 import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.internal.util.*;
 
 public abstract class BlockingBaseSubscriber<T> extends CountDownLatch
 implements Subscriber<T> {
@@ -60,6 +60,7 @@ implements Subscriber<T> {
     public final T blockingGet() {
         if (getCount() != 0) {
             try {
+                BlockingHelper.verifyNonBlocking();
                 await();
             } catch (InterruptedException ex) {
                 Subscription s = this.s;

--- a/src/main/java/io/reactivex/internal/subscribers/FutureSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/FutureSubscriber.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.*;
 
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.BlockingHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -72,6 +73,7 @@ implements Subscriber<T>, Future<T>, Subscription {
     @Override
     public T get() throws InterruptedException, ExecutionException {
         if (getCount() != 0) {
+            BlockingHelper.verifyNonBlocking();
             await();
         }
 
@@ -88,6 +90,7 @@ implements Subscriber<T>, Future<T>, Subscription {
     @Override
     public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         if (getCount() != 0) {
+            BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {
                 throw new TimeoutException();
             }

--- a/src/main/java/io/reactivex/internal/util/BlockingHelper.java
+++ b/src/main/java/io/reactivex/internal/util/BlockingHelper.java
@@ -16,6 +16,8 @@ package io.reactivex.internal.util;
 import java.util.concurrent.CountDownLatch;
 
 import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.schedulers.NonBlockingThread;
+import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Utility methods for helping common blocking operations.
@@ -34,6 +36,7 @@ public final class BlockingHelper {
         }
         // block until the subscription completes and then return
         try {
+            verifyNonBlocking();
             latch.await();
         } catch (InterruptedException e) {
             subscription.dispose();
@@ -45,5 +48,15 @@ public final class BlockingHelper {
         }
     }
 
-
+    /**
+     * Checks if the {@code failOnNonBlockingScheduler} plugin setting is enabled and the current
+     * thread is a Scheduler sensitive to blocking operators.
+     * @throws IllegalStateException if the {@code failOnNonBlockingScheduler} and the current thread is sensitive to blocking
+     */
+    public static void verifyNonBlocking() {
+        if (RxJavaPlugins.isFailOnNonBlockingScheduler()
+                && Thread.currentThread() instanceof NonBlockingThread) {
+            throw new IllegalStateException("Attempt to block on a Scheduler " + Thread.currentThread().getName() + " that doesn't support blocking operators as they may lead to deadlock");
+        }
+    }
 }

--- a/src/main/java/io/reactivex/internal/util/BlockingHelper.java
+++ b/src/main/java/io/reactivex/internal/util/BlockingHelper.java
@@ -55,7 +55,8 @@ public final class BlockingHelper {
      */
     public static void verifyNonBlocking() {
         if (RxJavaPlugins.isFailOnNonBlockingScheduler()
-                && Thread.currentThread() instanceof NonBlockingThread) {
+                && (Thread.currentThread() instanceof NonBlockingThread
+                        || RxJavaPlugins.onBeforeBlocking())) {
             throw new IllegalStateException("Attempt to block on a Scheduler " + Thread.currentThread().getName() + " that doesn't support blocking operators as they may lead to deadlock");
         }
     }

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -89,6 +89,12 @@ public final class RxJavaPlugins {
     static volatile boolean lockdown;
 
     /**
+     * If true, attempting to run a blockingX operation on a (by default)
+     * computation or single scheduler will throw an IllegalStateException.
+     */
+    static volatile boolean failNonBlockingScheduler;
+
+    /**
      * Prevents changing the plugins from then on.
      * <p>This allows container-like environments to prevent clients
      * messing with plugins.
@@ -103,6 +109,31 @@ public final class RxJavaPlugins {
      */
     public static boolean isLockdown() {
         return lockdown;
+    }
+
+    /**
+     * Enables or disables the blockingX operators to fail on a non-blocking
+     * scheduler such as computation or single.
+     * @param enable enable or disable the feature
+     * @since 2.0.5 - experimental
+     */
+    @Experimental
+    public static void setFailOnNonBlockingScheduler(boolean enable) {
+        if (lockdown) {
+            throw new IllegalStateException("Plugins can't be changed anymore");
+        }
+        failNonBlockingScheduler = enable;
+    }
+
+    /**
+     * Returns true if the blockingX operators fail on a non-blocking scheduler
+     * such as computation or single.
+     * @return true if the blockingX operators fail on a non-blocking scheduler
+     * @since 2.0.5 - experimental
+     */
+    @Experimental
+    public static boolean isFailOnNonBlockingScheduler() {
+        return failNonBlockingScheduler;
     }
 
     /**
@@ -378,6 +409,8 @@ public final class RxJavaPlugins {
 
         setOnMaybeAssembly(null);
         setOnMaybeSubscribe(null);
+
+        setFailOnNonBlockingScheduler(false);
     }
 
     /**

--- a/src/test/java/io/reactivex/XFlatMapTest.java
+++ b/src/test/java/io/reactivex/XFlatMapTest.java
@@ -30,6 +30,8 @@ import io.reactivex.subscribers.TestSubscriber;
 
 public class XFlatMapTest {
 
+    static final int SLEEP_AFTER_CANCEL = 200;
+
     final CyclicBarrier cb = new CyclicBarrier(2);
 
     void sleep() throws Exception {
@@ -62,7 +64,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -93,7 +95,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -124,7 +126,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -155,7 +157,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -187,7 +189,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -218,7 +220,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -249,7 +251,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -280,7 +282,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -311,7 +313,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -343,7 +345,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -374,7 +376,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -405,7 +407,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -436,7 +438,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -468,7 +470,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -499,7 +501,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -530,7 +532,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -561,7 +563,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 
@@ -593,7 +595,7 @@ public class XFlatMapTest {
 
             ts.cancel();
 
-            Thread.sleep(150);
+            Thread.sleep(SLEEP_AFTER_CANCEL);
 
             ts.assertEmpty();
 

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -226,11 +226,20 @@ public class RxJavaPluginsTest {
             for (Method m : RxJavaPlugins.class.getMethods()) {
                 if (m.getName().startsWith("set")) {
 
-                    Method getter = RxJavaPlugins.class.getMethod("get" + m.getName().substring(3));
+                    Method getter;
+
+                    if (m.getParameterTypes()[0] == Boolean.TYPE) {
+                        getter = RxJavaPlugins.class.getMethod("is" + m.getName().substring(3));
+                    } else {
+                        getter = RxJavaPlugins.class.getMethod("get" + m.getName().substring(3));
+                    }
 
                     Object before = getter.invoke(null);
 
                     try {
+                        if (m.getParameterTypes()[0].isAssignableFrom(Boolean.TYPE)) {
+                            m.invoke(null, true);
+                        } else
                         if (m.getParameterTypes()[0].isAssignableFrom(Callable.class)) {
                             m.invoke(null, f0);
                         } else
@@ -253,7 +262,11 @@ public class RxJavaPluginsTest {
 
                     Object after = getter.invoke(null);
 
-                    assertSame(m.toString(), before, after);
+                    if (m.getParameterTypes()[0].isPrimitive()) {
+                        assertEquals(m.toString(), before, after);
+                    } else {
+                        assertSame(m.toString(), before, after);
+                    }
                 }
             }
 
@@ -1918,7 +1931,7 @@ public class RxJavaPluginsTest {
     }
 
     @Test
-    public void testCreateComputationScheduler() {
+    public void createComputationScheduler() {
         final String name = "ComputationSchedulerTest";
         ThreadFactory factory = new ThreadFactory() {
             @Override
@@ -1944,7 +1957,7 @@ public class RxJavaPluginsTest {
     }
 
     @Test
-    public void testCreateIoScheduler() {
+    public void createIoScheduler() {
         final String name = "IoSchedulerTest";
         ThreadFactory factory = new ThreadFactory() {
             @Override
@@ -1970,7 +1983,7 @@ public class RxJavaPluginsTest {
     }
 
     @Test
-    public void testCreateNewThreadScheduler() {
+    public void createNewThreadScheduler() {
         final String name = "NewThreadSchedulerTest";
         ThreadFactory factory = new ThreadFactory() {
             @Override
@@ -1996,7 +2009,7 @@ public class RxJavaPluginsTest {
     }
 
     @Test
-    public void testCreateSingleScheduler() {
+    public void createSingleScheduler() {
         final String name = "SingleSchedulerTest";
         ThreadFactory factory = new ThreadFactory() {
             @Override

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -223,12 +223,21 @@ public class RxJavaPluginsTest {
                 }
             };
 
+            BooleanSupplier bs = new BooleanSupplier() {
+                @Override
+                public boolean getAsBoolean() throws Exception {
+                    return true;
+                }
+            };
+
             for (Method m : RxJavaPlugins.class.getMethods()) {
                 if (m.getName().startsWith("set")) {
 
                     Method getter;
 
-                    if (m.getParameterTypes()[0] == Boolean.TYPE) {
+                    Class<?> paramType = m.getParameterTypes()[0];
+
+                    if (paramType == Boolean.TYPE) {
                         getter = RxJavaPlugins.class.getMethod("is" + m.getName().substring(3));
                     } else {
                         getter = RxJavaPlugins.class.getMethod("get" + m.getName().substring(3));
@@ -237,17 +246,20 @@ public class RxJavaPluginsTest {
                     Object before = getter.invoke(null);
 
                     try {
-                        if (m.getParameterTypes()[0].isAssignableFrom(Boolean.TYPE)) {
+                        if (paramType.isAssignableFrom(Boolean.TYPE)) {
                             m.invoke(null, true);
                         } else
-                        if (m.getParameterTypes()[0].isAssignableFrom(Callable.class)) {
+                        if (paramType.isAssignableFrom(Callable.class)) {
                             m.invoke(null, f0);
                         } else
-                        if (m.getParameterTypes()[0].isAssignableFrom(Function.class)) {
+                        if (paramType.isAssignableFrom(Function.class)) {
                             m.invoke(null, f1);
                         } else
-                        if (m.getParameterTypes()[0].isAssignableFrom(Consumer.class)) {
+                        if (paramType.isAssignableFrom(Consumer.class)) {
                             m.invoke(null, a1);
+                        } else
+                        if (paramType.isAssignableFrom(BooleanSupplier.class)) {
+                            m.invoke(null, bs);
                         } else {
                             m.invoke(null, f2);
                         }
@@ -262,7 +274,7 @@ public class RxJavaPluginsTest {
 
                     Object after = getter.invoke(null);
 
-                    if (m.getParameterTypes()[0].isPrimitive()) {
+                    if (paramType.isPrimitive()) {
                         assertEquals(m.toString(), before, after);
                     } else {
                         assertSame(m.toString(), before, after);

--- a/src/test/java/io/reactivex/schedulers/FailOnBlockingTest.java
+++ b/src/test/java/io/reactivex/schedulers/FailOnBlockingTest.java
@@ -1,0 +1,642 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.schedulers;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class FailOnBlockingTest {
+
+    @Test
+    public void failComputationFlowableBlockingFirst() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Flowable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingFirst();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationFlowableBlockingLast() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Flowable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingLast();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationFlowableBlockingIterable() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Flowable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingIterable().iterator().next();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationFlowableBlockingSubscribe() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Flowable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingSubscribe();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationFlowableBlockingSingle() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Flowable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingSingle();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationFlowableBlockingForEach() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Flowable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingForEach(Functions.emptyConsumer());
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationFlowableBlockingLatest() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Flowable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingLatest().iterator().hasNext();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationFlowableBlockingNext() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Flowable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingNext().iterator().hasNext();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationFlowableToFuture() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Flowable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Flowable.just(1).delay(10, TimeUnit.SECONDS).toFuture().get();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationObservableBlockingFirst() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Observable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingFirst();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationObservableBlockingLast() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Observable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingLast();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationObservableBlockingIterable() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Observable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingIterable().iterator().next();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationObservableBlockingSubscribe() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Observable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingSubscribe();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationObservableBlockingSingle() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Observable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingSingle();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationObservableBlockingForEach() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Observable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingForEach(Functions.emptyConsumer());
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationObservableBlockingLatest() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Observable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingLatest().iterator().hasNext();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationObservableBlockingNext() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Observable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingNext().iterator().hasNext();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failComputationObservableToFuture() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Observable.just(1)
+            .subscribeOn(Schedulers.computation())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Observable.just(1).delay(10, TimeUnit.SECONDS).toFuture().get();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failSingleObservableBlockingFirst() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Observable.just(1)
+            .subscribeOn(Schedulers.single())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingFirst();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failSingleSingleBlockingGet() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Single.just(1)
+            .subscribeOn(Schedulers.single())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Single.just(1).delay(10, TimeUnit.SECONDS).blockingGet();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failSingleMaybeBlockingGet() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Maybe.just(1)
+            .subscribeOn(Schedulers.single())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+
+                    Maybe.just(1).delay(10, TimeUnit.SECONDS).blockingGet();
+
+                    return v;
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failSingleCompletableBlockingGet() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Completable.complete()
+            .subscribeOn(Schedulers.single())
+            .doOnComplete(new Action() {
+                @Override
+                public void run() throws Exception {
+                    Completable.complete().delay(10, TimeUnit.SECONDS).blockingGet();
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void failSingleCompletableBlockingAwait() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Completable.complete()
+            .subscribeOn(Schedulers.single())
+            .doOnComplete(new Action() {
+                @Override
+                public void run() throws Exception {
+                    Completable.complete().delay(10, TimeUnit.SECONDS).blockingAwait();
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(IllegalStateException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+    @Test
+    public void dontfailIOObservableBlockingFirst() {
+
+        try {
+            RxJavaPlugins.setFailOnNonBlockingScheduler(true);
+
+            Observable.just(1)
+            .subscribeOn(Schedulers.io())
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Exception {
+                    return Observable.just(2).delay(100, TimeUnit.MILLISECONDS).blockingFirst();
+                }
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(2);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR adds an `RxJavaPlugins` option `failOnNonBlockingScheduler` that triggers an `IllegalStateException` when the user tries to run a blocking method while the execution is on the `computation()` or `single()` `Scheduler`: 

```java
Flowable.just(1)
.subscribeOn(Schedulers.computation())
.map(v -> Flowable.just("query").subscribeOn(Schedulers.io()).blockingFirst())
.doOnNext(v -> someAPI(v).subscribeOn(Schedulers.newThread()).blockingSubscribe());
.blockingFirst();
```

It is an optional setting, default off.

The check is done before going into an await method (and a few other types of blocking). Most blocking operators usually poll the status and try to avoid the actual blocking thus this shouldn't affect synchronous sequences that one extracts a value from.

Detection of a blocking-sensitive scheduler's thread is done by checking the current thread's class for implementing the `NonBlockingThread` marker interface (currently `internal`).

The `RxThreadFactory` has been updated to allow picking a default `Thread` implementation or a custom one for the `newThread()`. Note that since #5002 you can create custom schedulers by providing a `ThreadFactory`.

This works for RxJava's default schedulers but not for `AndroidSchedulers.mainThread()` where similar blocking should be avoided as well. For them, a plugin-callback action would be more suitable. ~~Question is how that callback should behave (throw, return false, should it be always executed or only when the flag is true).~~

My proposed solution is to have a plugin callback `RxJavaPlugins.setOnBeforeBlocking(BooleanSupplier)` that Android users can define the callback for:

```java
RxJavaPlugins.setOnBeforeBlocking(() -> Looper.myLooper() == Looper.getMainLooper())
RxJavaPlugins.setFailOnNonBlockingScheduler(true);
```

This callback is only executed if the `failOnNonBlockingScheduler` is set to true.