### PR TITLE
Add nullability annotations to io.reactivex.annotations interfaces.

### DIFF
--- a/src/main/java/io/reactivex/annotations/NonNull.java
+++ b/src/main/java/io/reactivex/annotations/NonNull.java
@@ -11,20 +11,20 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.functions;
+package io.reactivex.annotations;
 
-import io.reactivex.annotations.NonNull;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-/**
- * A functional interface (callback) that returns true or false for the given input value.
- * @param <T> the first value
- */
-public interface Predicate<T> {
-    /**
-     * Test the given input value and return a boolean.
-     * @param t the value
-     * @return the boolean result
-     * @throws Exception on error
-     */
-    boolean test(@NonNull T t) throws Exception;
-}
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+@Documented
+@Target(value = {FIELD, METHOD, PARAMETER, LOCAL_VARIABLE})
+@Retention(value = CLASS)
+public @interface NonNull { }
+

--- a/src/main/java/io/reactivex/functions/BiConsumer.java
+++ b/src/main/java/io/reactivex/functions/BiConsumer.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface (callback) that accepts two values (of possibly different types).
  * @param <T1> the first value type
@@ -26,5 +28,5 @@ public interface BiConsumer<T1, T2> {
      * @param t2 the second value
      * @throws Exception on error
      */
-    void accept(T1 t1, T2 t2) throws Exception;
+    void accept(@NonNull T1 t1, @NonNull T2 t2) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/BiFunction.java
+++ b/src/main/java/io/reactivex/functions/BiFunction.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
  * @param <T1> the first value type
@@ -28,5 +30,6 @@ public interface BiFunction<T1, T2, R> {
      * @return the result value
      * @throws Exception on error
      */
-    R apply(T1 t1, T2 t2) throws Exception;
+    @NonNull
+    R apply(@NonNull T1 t1, @NonNull T2 t2) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/BiPredicate.java
+++ b/src/main/java/io/reactivex/functions/BiPredicate.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface (callback) that returns true or false for the given input values.
  * @param <T1> the first value
@@ -27,5 +29,5 @@ public interface BiPredicate<T1, T2> {
      * @return the boolean result
      * @throws Exception on error
      */
-    boolean test(T1 t1, T2 t2) throws Exception;
+    boolean test(@NonNull T1 t1, @NonNull T2 t2) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Consumer.java
+++ b/src/main/java/io/reactivex/functions/Consumer.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface (callback) that accepts a single value.
  * @param <T> the value type
@@ -23,5 +25,5 @@ public interface Consumer<T> {
      * @param t the value
      * @throws Exception on error
      */
-    void accept(T t) throws Exception;
+    void accept(@NonNull T t) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function.java
+++ b/src/main/java/io/reactivex/functions/Function.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface that takes a value and returns another value, possibly with a
  * different type and allows throwing a checked exception.
@@ -27,5 +29,6 @@ public interface Function<T, R> {
      * @return the output value
      * @throws Exception on error
      */
-    R apply(T t) throws Exception;
+    @NonNull
+    R apply(@NonNull T t) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function3.java
+++ b/src/main/java/io/reactivex/functions/Function3.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
  * @param <T1> the first value type
@@ -29,5 +31,6 @@ public interface Function3<T1, T2, T3, R> {
      * @return the result value
      * @throws Exception on error
      */
-    R apply(T1 t1, T2 t2, T3 t3) throws Exception;
+    @NonNull
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function4.java
+++ b/src/main/java/io/reactivex/functions/Function4.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
  * @param <T1> the first value type
@@ -31,5 +33,6 @@ public interface Function4<T1, T2, T3, T4, R> {
      * @return the result value
      * @throws Exception on error
      */
-    R apply(T1 t1, T2 t2, T3 t3, T4 t4) throws Exception;
+    @NonNull
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function5.java
+++ b/src/main/java/io/reactivex/functions/Function5.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
  * @param <T1> the first value type
@@ -33,5 +35,6 @@ public interface Function5<T1, T2, T3, T4, T5, R> {
      * @return the result value
      * @throws Exception on error
      */
-    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) throws Exception;
+    @NonNull
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function6.java
+++ b/src/main/java/io/reactivex/functions/Function6.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
  * @param <T1> the first value type
@@ -35,5 +37,6 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> {
      * @return the result value
      * @throws Exception on error
      */
-    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) throws Exception;
+    @NonNull
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function8.java
+++ b/src/main/java/io/reactivex/functions/Function8.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
  * @param <T1> the first value type
@@ -39,5 +41,6 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> {
      * @return the result value
      * @throws Exception on error
      */
-    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) throws Exception;
+    @NonNull
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6, @NonNull T7 t7, @NonNull T8 t8) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function9.java
+++ b/src/main/java/io/reactivex/functions/Function9.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
  * @param <T1> the first value type
@@ -41,5 +43,6 @@ public interface Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> {
      * @return the result value
      * @throws Exception on error
      */
-    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) throws Exception;
+    @NonNull
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6, @NonNull T7 t7, @NonNull T8 t8, @NonNull T9 t9) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/IntFunction.java
+++ b/src/main/java/io/reactivex/functions/IntFunction.java
@@ -12,6 +12,8 @@
  */
 package io.reactivex.functions;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * A functional interface (callback) that takes a primitive value and return value of type T.
  * @param <T> the returned value type
@@ -23,5 +25,6 @@ public interface IntFunction<T> {
      * @return the result Object
      * @throws Exception on error
      */
+    @NonNull
     T apply(int i) throws Exception;
 }


### PR DESCRIPTION
(Addresses https://github.com/ReactiveX/RxJava/issues/4876)

This pull request annotates everything in the `io.reactivex.annotations` package with a new `@NonNull` annotation defined in RxJava. This doesn’t annotate everything, but I think it’s a good start.

In particular, when migrating a large codebase of RxJava 1.x code to 2.x, catching null returns in these interfaces was very difficult. At best, it’s noticed while migrating, otherwise it’s up to unit tests or a production crash to catch these.

With these new annotations, you get much better IDE support (once you tell IntelliJ about the new annotation):
<img width="563" alt="screen shot 2017-01-27 at 2 30 18 pm" src="https://cloud.githubusercontent.com/assets/23467/22362686/7f172032-e49f-11e6-9fc6-94049c263ceb.png">
^ in this example, `getPhoneNumber()` is marked as `@Nullable`

In addition, support for this annotation can easily be added to static analysis tools like Infer, checker, or any other popular tool.

Open Questions
* Does this even make sense to add? There seem to be some concerns in the issue.
* The `@NonNull` annotation needs JavaDoc - I’m planning on following up with whatever is in existing NonNull annotations floating around unless anyone thinks otherwise.
* There are no tests since this is essentially just metadata. Should there be something that enforces this? I'm not sure if there is any kind of lint tool that runs on this project, but one approach would be to write a check that enforces everything in specific packages in annotated. This would also help keep future changes annotated.
* Is it worth adding this elsewhere? I find these function interfaces to be the easiest place to run into nullability problems, but I'm curious what others think. A simple, but kind of crazy brute force approach would be to require annotations on every public API.