### PR TITLE
2.x stop distinctUntilChanged from updating its value unless changed

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
@@ -84,10 +84,10 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
                 key = keySelector.apply(t);
                 if (hasValue) {
                     boolean equal = comparer.test(last, key);
-                    last = key;
                     if (equal) {
                         return false;
                     }
+                    last = key;
                 } else {
                     hasValue = true;
                     last = key;
@@ -173,10 +173,10 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
                 key = keySelector.apply(t);
                 if (hasValue) {
                     boolean equal = comparer.test(last, key);
-                    last = key;
                     if (equal) {
                         return false;
                     }
+                    last = key;
                 } else {
                     hasValue = true;
                     last = key;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
@@ -68,10 +68,10 @@ public final class ObservableDistinctUntilChanged<T, K> extends AbstractObservab
                 key = keySelector.apply(t);
                 if (hasValue) {
                     boolean equal = comparer.test(last, key);
-                    last = key;
                     if (equal) {
                         return;
                     }
+                    last = key;
                 } else {
                     hasValue = true;
                     last = key;

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -22,7 +22,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.mockito.Mockito;
+import org.mockito.*;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.reactivestreams.*;
@@ -66,6 +66,31 @@ public enum TestHelper {
                 return null;
             }
         }).when(w).onSubscribe((Subscription)any());
+
+        return w;
+    }
+
+    /**
+     * Mocks a conditional subscriber and prepares it to request Long.MAX_VALUE.
+     *
+     * The subscriber will accept all values.
+     *
+     * @param <T> the value type
+     * @return the mocked subscriber
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> ConditionalSubscriber<T> mockConditionalSubscriber() {
+        ConditionalSubscriber<T> w = mock(ConditionalSubscriber.class);
+
+        Mockito.doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock a) throws Throwable {
+                Subscription s = a.getArgument(0);
+                s.request(Long.MAX_VALUE);
+                return null;
+            }
+        }).when(w).onSubscribe((Subscription)any());
+        Mockito.when(w.tryOnNext(ArgumentMatchers.<T>any())).thenReturn(true);
 
         return w;
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChangedTest.java
@@ -13,8 +13,10 @@
 
 package io.reactivex.internal.operators.observable;
 
+import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.testng.AssertJUnit.assertNotSame;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,7 +28,10 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.operators.observable.ObservableDistinctUntilChanged.DistinctUntilChangedObserver;
 import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.*;
@@ -105,6 +110,21 @@ public class ObservableDistinctUntilChangedTest {
         inOrder.verify(w, times(1)).onComplete();
         inOrder.verify(w, never()).onNext(anyString());
         verify(w, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testDistinctUntilChangedDoesntUpdateReferenceUnlessChanged() {
+        String first = "a";
+        //noinspection RedundantStringConstructorCall
+        String second = new String(first);
+        assertNotSame(first, second);
+        Observable<String> src = Observable.just(first, second);
+        DistinctUntilChangedObserver<String, String> observer = new DistinctUntilChangedObserver<String, String>(w,
+                Functions.<String>identity(),
+                ObjectHelper.<String>equalsPredicate());
+        src.distinctUntilChanged().subscribe(observer);
+        verify(w).onComplete();
+        assertSame(first, observer.last);
     }
 
     @Test


### PR DESCRIPTION
This pull request will make the `FlowableDistinctUntilChanged` and `ObservableDistinctUntilChanged` operators keep the first of equal values.

The reasoning for this is the following code:
```
observable = someSource
    .distinctUntilChanged()
    .replay(1)
    .autoConnect();
```

Currently this code will will cache two values if the last two values are equal. Replay will cache the first of them and `distinctUntilChanged` will cache the second since it will update the internal reference even if the items are equal.