### PR TITLE
Feature/#4876 nonnull annotations

### DIFF
--- a/src/main/java/io/reactivex/Scheduler.java
+++ b/src/main/java/io/reactivex/Scheduler.java
@@ -16,6 +16,7 @@ package io.reactivex;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.annotations.Experimental;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -61,6 +62,7 @@ public abstract class Scheduler {
      *
      * @return a Worker representing a serial queue of actions to be executed
      */
+    @NonNull
     public abstract Worker createWorker();
 
     /**
@@ -69,7 +71,7 @@ public abstract class Scheduler {
      * @return the 'current time'
      * @since 2.0
      */
-    public long now(TimeUnit unit) {
+    public long now(@NonNull TimeUnit unit) {
         return unit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
     }
 
@@ -105,7 +107,8 @@ public abstract class Scheduler {
      * @return the Disposable instance that let's one cancel this particular task.
      * @since 2.0
      */
-    public Disposable scheduleDirect(Runnable run) {
+    @NonNull
+    public Disposable scheduleDirect(@NonNull Runnable run) {
         return scheduleDirect(run, 0L, TimeUnit.NANOSECONDS);
     }
 
@@ -122,7 +125,8 @@ public abstract class Scheduler {
      * @return the Disposable that let's one cancel this particular delayed task.
      * @since 2.0
      */
-    public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
+    @NonNull
+    public Disposable scheduleDirect(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
         final Worker w = createWorker();
 
         final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
@@ -159,7 +163,8 @@ public abstract class Scheduler {
      * @return the Disposable that let's one cancel this particular delayed task.
      * @since 2.0
      */
-    public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
+    @NonNull
+    public Disposable schedulePeriodicallyDirect(@NonNull Runnable run, long initialDelay, long period, @NonNull TimeUnit unit) {
         final Worker w = createWorker();
 
         final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
@@ -249,7 +254,8 @@ public abstract class Scheduler {
      */
     @SuppressWarnings("unchecked")
     @Experimental
-    public <S extends Scheduler & Disposable> S when(Function<Flowable<Flowable<Completable>>, Completable> combine) {
+    @NonNull
+    public <S extends Scheduler & Disposable> S when(@NonNull Function<Flowable<Flowable<Completable>>, Completable> combine) {
         return (S) new SchedulerWhen(combine, this);
     }
 
@@ -268,7 +274,8 @@ public abstract class Scheduler {
          *            Runnable to schedule
          * @return a Disposable to be able to unsubscribe the action (cancel it if not executed)
          */
-        public Disposable schedule(Runnable run) {
+        @NonNull
+        public Disposable schedule(@NonNull Runnable run) {
             return schedule(run, 0L, TimeUnit.NANOSECONDS);
         }
 
@@ -287,7 +294,8 @@ public abstract class Scheduler {
          *            the time unit of {@code delayTime}
          * @return a Disposable to be able to unsubscribe the action (cancel it if not executed)
          */
-        public abstract Disposable schedule(Runnable run, long delay, TimeUnit unit);
+        @NonNull
+        public abstract Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit);
 
         /**
          * Schedules a cancelable action to be executed periodically. This default implementation schedules
@@ -309,7 +317,8 @@ public abstract class Scheduler {
          *            the time unit of {@code period}
          * @return a Disposable to be able to unsubscribe the action (cancel it if not executed)
          */
-        public Disposable schedulePeriodically(Runnable run, final long initialDelay, final long period, final TimeUnit unit) {
+        @NonNull
+        public Disposable schedulePeriodically(@NonNull Runnable run, final long initialDelay, final long period, @NonNull final TimeUnit unit) {
             final SequentialDisposable first = new SequentialDisposable();
 
             final SequentialDisposable sd = new SequentialDisposable(first);
@@ -337,7 +346,7 @@ public abstract class Scheduler {
          * @return the 'current time'
          * @since 2.0
          */
-        public long now(TimeUnit unit) {
+        public long now(@NonNull TimeUnit unit) {
             return unit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
         }
 
@@ -346,15 +355,17 @@ public abstract class Scheduler {
          * of this task has to happen (accounting for clock drifts).
          */
         final class PeriodicTask implements Runnable {
+            @NonNull
             final Runnable decoratedRun;
+            @NonNull
             final SequentialDisposable sd;
             final long periodInNanoseconds;
             long count;
             long lastNowNanoseconds;
             long startInNanoseconds;
 
-            PeriodicTask(long firstStartInNanoseconds, Runnable decoratedRun,
-                    long firstNowNanoseconds, SequentialDisposable sd, long periodInNanoseconds) {
+            PeriodicTask(long firstStartInNanoseconds, @NonNull Runnable decoratedRun,
+                    long firstNowNanoseconds, @NonNull SequentialDisposable sd, long periodInNanoseconds) {
                 this.decoratedRun = decoratedRun;
                 this.sd = sd;
                 this.periodInNanoseconds = periodInNanoseconds;
@@ -395,12 +406,12 @@ public abstract class Scheduler {
     static class PeriodicDirectTask
     implements Runnable, Disposable {
         final Runnable run;
-
+        @NonNull
         final Worker worker;
-
+        @NonNull
         volatile boolean disposed;
 
-        PeriodicDirectTask(Runnable run, Worker worker) {
+        PeriodicDirectTask(@NonNull Runnable run, @NonNull Worker worker) {
             this.run = run;
             this.worker = worker;
         }

--- a/src/main/java/io/reactivex/annotations/NonNull.java
+++ b/src/main/java/io/reactivex/annotations/NonNull.java
@@ -23,6 +23,9 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.CLASS;
 
+/**
+ * Indicates that a field/parameter/variable/return type is never null.
+ */
 @Documented
 @Target(value = {FIELD, METHOD, PARAMETER, LOCAL_VARIABLE})
 @Retention(value = CLASS)

--- a/src/main/java/io/reactivex/annotations/Nullable.java
+++ b/src/main/java/io/reactivex/annotations/Nullable.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+@Documented
+@Target(value = {FIELD, METHOD, PARAMETER, LOCAL_VARIABLE})
+@Retention(value = CLASS)
+public @interface Nullable { }
+

--- a/src/main/java/io/reactivex/annotations/Nullable.java
+++ b/src/main/java/io/reactivex/annotations/Nullable.java
@@ -23,6 +23,9 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.CLASS;
 
+/**
+ * Indicates that a field/parameter/variable/return type may be null.
+ */
 @Documented
 @Target(value = {FIELD, METHOD, PARAMETER, LOCAL_VARIABLE})
 @Retention(value = CLASS)

--- a/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
@@ -16,6 +16,7 @@
 package io.reactivex.internal.schedulers;
 
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.*;
 
@@ -118,19 +119,22 @@ public final class ComputationScheduler extends Scheduler {
         start();
     }
 
+    @NonNull
     @Override
     public Worker createWorker() {
         return new EventLoopWorker(pool.get().getEventLoop());
     }
 
+    @NonNull
     @Override
-    public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
+    public Disposable scheduleDirect(@NonNull Runnable run, long delay, TimeUnit unit) {
         PoolWorker w = pool.get().getEventLoop();
         return w.scheduleDirect(run, delay, unit);
     }
 
+    @NonNull
     @Override
-    public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
+    public Disposable schedulePeriodicallyDirect(@NonNull Runnable run, long initialDelay, long period, TimeUnit unit) {
         PoolWorker w = pool.get().getEventLoop();
         return w.schedulePeriodicallyDirect(run, initialDelay, period, unit);
     }
@@ -188,16 +192,18 @@ public final class ComputationScheduler extends Scheduler {
             return disposed;
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable action) {
+        public Disposable schedule(@NonNull Runnable action) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }
 
             return poolWorker.scheduleActual(action, 0, null, serial);
         }
+        @NonNull
         @Override
-        public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
+        public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }

--- a/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
@@ -17,6 +17,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.MpscLinkedQueue;
@@ -29,21 +30,24 @@ import io.reactivex.schedulers.Schedulers;
  */
 public final class ExecutorScheduler extends Scheduler {
 
+    @NonNull
     final Executor executor;
 
     static final Scheduler HELPER = Schedulers.single();
 
-    public ExecutorScheduler(Executor executor) {
+    public ExecutorScheduler(@NonNull Executor executor) {
         this.executor = executor;
     }
 
+    @NonNull
     @Override
     public Worker createWorker() {
         return new ExecutorWorker(executor);
     }
 
+    @NonNull
     @Override
-    public Disposable scheduleDirect(Runnable run) {
+    public Disposable scheduleDirect(@NonNull Runnable run) {
         Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
         try {
             if (executor instanceof ExecutorService) {
@@ -60,8 +64,9 @@ public final class ExecutorScheduler extends Scheduler {
         }
     }
 
+    @NonNull
     @Override
-    public Disposable scheduleDirect(Runnable run, final long delay, final TimeUnit unit) {
+    public Disposable scheduleDirect(@NonNull Runnable run, final long delay, final TimeUnit unit) {
         final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
         if (executor instanceof ScheduledExecutorService) {
             try {
@@ -87,8 +92,9 @@ public final class ExecutorScheduler extends Scheduler {
         return dr;
     }
 
+    @NonNull
     @Override
-    public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
+    public Disposable schedulePeriodicallyDirect(@NonNull Runnable run, long initialDelay, long period, TimeUnit unit) {
         if (executor instanceof ScheduledExecutorService) {
             Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
             try {
@@ -118,8 +124,9 @@ public final class ExecutorScheduler extends Scheduler {
             this.queue = new MpscLinkedQueue<Runnable>();
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable run) {
+        public Disposable schedule(@NonNull Runnable run) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }
@@ -143,8 +150,9 @@ public final class ExecutorScheduler extends Scheduler {
             return br;
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
+        public Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
             if (delay <= 0) {
                 return schedule(run);
             }

--- a/src/main/java/io/reactivex/internal/schedulers/ImmediateThinScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ImmediateThinScheduler.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.schedulers;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 
 /**
@@ -45,22 +46,26 @@ public final class ImmediateThinScheduler extends Scheduler {
         // singleton class
     }
 
+    @NonNull
     @Override
-    public Disposable scheduleDirect(Runnable run) {
+    public Disposable scheduleDirect(@NonNull Runnable run) {
         run.run();
         return DISPOSED;
     }
 
+    @NonNull
     @Override
-    public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
+    public Disposable scheduleDirect(@NonNull Runnable run, long delay, TimeUnit unit) {
         throw new UnsupportedOperationException("This scheduler doesn't support delayed execution");
     }
 
+    @NonNull
     @Override
-    public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
+    public Disposable schedulePeriodicallyDirect(@NonNull Runnable run, long initialDelay, long period, TimeUnit unit) {
         throw new UnsupportedOperationException("This scheduler doesn't support periodic execution");
     }
 
+    @NonNull
     @Override
     public Worker createWorker() {
         return WORKER;
@@ -78,19 +83,22 @@ public final class ImmediateThinScheduler extends Scheduler {
             return false; // dispose() has no effect
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable run) {
+        public Disposable schedule(@NonNull Runnable run) {
             run.run();
             return DISPOSED;
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
+        public Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
             throw new UnsupportedOperationException("This scheduler doesn't support delayed execution");
         }
 
+        @NonNull
         @Override
-        public Disposable schedulePeriodically(Runnable run, long initialDelay, long period, TimeUnit unit) {
+        public Disposable schedulePeriodically(@NonNull Runnable run, long initialDelay, long period, TimeUnit unit) {
             throw new UnsupportedOperationException("This scheduler doesn't support periodic execution");
         }
     }

--- a/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
@@ -17,6 +17,7 @@
 package io.reactivex.internal.schedulers;
 
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
@@ -180,6 +181,7 @@ public final class IoScheduler extends Scheduler {
         }
     }
 
+    @NonNull
     @Override
     public Worker createWorker() {
         return new EventLoopWorker(pool.get());
@@ -223,8 +225,9 @@ public final class IoScheduler extends Scheduler {
             return once.get();
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
+        public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
             if (tasks.isDisposed()) {
                 // don't schedule, we are unsubscribed
                 return EmptyDisposable.INSTANCE;

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadScheduler.java
@@ -17,6 +17,7 @@
 package io.reactivex.internal.schedulers;
 
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.NonNull;
 
 import java.util.concurrent.ThreadFactory;
 
@@ -48,6 +49,7 @@ public final class NewThreadScheduler extends Scheduler {
         this.threadFactory = threadFactory;
     }
 
+    @NonNull
     @Override
     public Worker createWorker() {
         return new NewThreadWorker(threadFactory);

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.schedulers;
 import java.util.concurrent.*;
 
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -34,13 +35,15 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
         executor = SchedulerPoolFactory.create(threadFactory);
     }
 
+    @NonNull
     @Override
-    public Disposable schedule(final Runnable run) {
+    public Disposable schedule(@NonNull final Runnable run) {
         return schedule(run, 0, null);
     }
 
+    @NonNull
     @Override
-    public Disposable schedule(final Runnable action, long delayTime, TimeUnit unit) {
+    public Disposable schedule(@NonNull final Runnable action, long delayTime, @NonNull TimeUnit unit) {
         if (disposed) {
             return EmptyDisposable.INSTANCE;
         }

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
@@ -25,6 +25,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.reactivex.Scheduler;
 import io.reactivex.annotations.Experimental;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.Exceptions;
@@ -129,6 +130,7 @@ public class SchedulerWhen extends Scheduler implements Disposable {
         return disposable.isDisposed();
     }
 
+    @NonNull
     @Override
     public Worker createWorker() {
         final Worker actualWorker = actualScheduler.createWorker();
@@ -168,16 +170,18 @@ public class SchedulerWhen extends Scheduler implements Disposable {
                 return unsubscribed.get();
             }
 
+            @NonNull
             @Override
-            public Disposable schedule(final Runnable action, final long delayTime, final TimeUnit unit) {
+            public Disposable schedule(@NonNull final Runnable action, final long delayTime, @NonNull final TimeUnit unit) {
                 // send a scheduled action to the actionQueue
                 DelayedAction delayedAction = new DelayedAction(action, delayTime, unit);
                 actionProcessor.onNext(delayedAction);
                 return delayedAction;
             }
 
+            @NonNull
             @Override
-            public Disposable schedule(final Runnable action) {
+            public Disposable schedule(@NonNull final Runnable action) {
                 // send a scheduled action to the actionQueue
                 ImmediateAction immediateAction = new ImmediateAction(action);
                 actionProcessor.onNext(immediateAction);

--- a/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
@@ -13,6 +13,7 @@
 package io.reactivex.internal.schedulers;
 
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -96,13 +97,15 @@ public final class SingleScheduler extends Scheduler {
         }
     }
 
+    @NonNull
     @Override
     public Worker createWorker() {
         return new ScheduledWorker(executor.get());
     }
 
+    @NonNull
     @Override
-    public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
+    public Disposable scheduleDirect(@NonNull Runnable run, long delay, TimeUnit unit) {
         Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
         try {
             Future<?> f;
@@ -118,8 +121,9 @@ public final class SingleScheduler extends Scheduler {
         }
     }
 
+    @NonNull
     @Override
-    public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
+    public Disposable schedulePeriodicallyDirect(@NonNull Runnable run, long initialDelay, long period, TimeUnit unit) {
         Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
         try {
             Future<?> f = executor.get().scheduleAtFixedRate(decoratedRun, initialDelay, period, unit);
@@ -143,8 +147,9 @@ public final class SingleScheduler extends Scheduler {
             this.tasks = new CompositeDisposable();
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
+        public Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }

--- a/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
@@ -20,6 +20,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -36,6 +37,7 @@ public final class TrampolineScheduler extends Scheduler {
         return INSTANCE;
     }
 
+    @NonNull
     @Override
     public Worker createWorker() {
         return new TrampolineWorker();
@@ -44,14 +46,16 @@ public final class TrampolineScheduler extends Scheduler {
     /* package accessible for unit tests */TrampolineScheduler() {
     }
 
+    @NonNull
     @Override
-    public Disposable scheduleDirect(Runnable run) {
+    public Disposable scheduleDirect(@NonNull Runnable run) {
         run.run();
         return EmptyDisposable.INSTANCE;
     }
 
+    @NonNull
     @Override
-    public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
+    public Disposable scheduleDirect(@NonNull Runnable run, long delay, TimeUnit unit) {
         try {
             unit.sleep(delay);
             run.run();
@@ -71,13 +75,15 @@ public final class TrampolineScheduler extends Scheduler {
 
         volatile boolean disposed;
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable action) {
+        public Disposable schedule(@NonNull Runnable action) {
             return enqueue(action, now(TimeUnit.MILLISECONDS));
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
+        public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
             long execTime = now(TimeUnit.MILLISECONDS) + unit.toMillis(delayTime);
 
             return enqueue(new SleepingRunnable(action, this, execTime), execTime);

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -12,84 +12,122 @@
  */
 package io.reactivex.plugins;
 
-import java.lang.Thread.UncaughtExceptionHandler;
-import java.util.concurrent.*;
-
-import org.reactivestreams.Subscriber;
-
-import io.reactivex.*;
+import io.reactivex.Completable;
+import io.reactivex.CompletableObserver;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.Scheduler;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
 import io.reactivex.annotations.Experimental;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.flowables.ConnectableFlowable;
-import io.reactivex.functions.*;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.schedulers.*;
+import io.reactivex.internal.schedulers.ComputationScheduler;
+import io.reactivex.internal.schedulers.IoScheduler;
+import io.reactivex.internal.schedulers.NewThreadScheduler;
+import io.reactivex.internal.schedulers.SingleScheduler;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.schedulers.Schedulers;
+import org.reactivestreams.Subscriber;
 
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadFactory;
 /**
  * Utility class to inject handlers to certain standard RxJava operations.
  */
 public final class RxJavaPlugins {
-
+    @Nullable
     static volatile Consumer<Throwable> errorHandler;
 
+    @Nullable
     static volatile Function<Runnable, Runnable> onScheduleHandler;
 
+    @Nullable
     static volatile Function<Callable<Scheduler>, Scheduler> onInitComputationHandler;
 
+    @Nullable
     static volatile Function<Callable<Scheduler>, Scheduler> onInitSingleHandler;
 
+    @Nullable
     static volatile Function<Callable<Scheduler>, Scheduler> onInitIoHandler;
 
+    @Nullable
     static volatile Function<Callable<Scheduler>, Scheduler> onInitNewThreadHandler;
 
+    @Nullable
     static volatile Function<Scheduler, Scheduler> onComputationHandler;
 
+    @Nullable
     static volatile Function<Scheduler, Scheduler> onSingleHandler;
 
+    @Nullable
     static volatile Function<Scheduler, Scheduler> onIoHandler;
 
+    @Nullable
     static volatile Function<Scheduler, Scheduler> onNewThreadHandler;
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile Function<Flowable, Flowable> onFlowableAssembly;
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile Function<ConnectableFlowable, ConnectableFlowable> onConnectableFlowableAssembly;
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile Function<Observable, Observable> onObservableAssembly;
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile Function<ConnectableObservable, ConnectableObservable> onConnectableObservableAssembly;
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile Function<Maybe, Maybe> onMaybeAssembly;
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile Function<Single, Single> onSingleAssembly;
 
     static volatile Function<Completable, Completable> onCompletableAssembly;
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile Function<ParallelFlowable, ParallelFlowable> onParallelAssembly;
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile BiFunction<Flowable, Subscriber, Subscriber> onFlowableSubscribe;
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile BiFunction<Maybe, MaybeObserver, MaybeObserver> onMaybeSubscribe;
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile BiFunction<Observable, Observer, Observer> onObservableSubscribe;
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile BiFunction<Single, SingleObserver, SingleObserver> onSingleSubscribe;
 
+    @Nullable
     static volatile BiFunction<Completable, CompletableObserver, CompletableObserver> onCompletableSubscribe;
 
+    @Nullable
     static volatile BooleanSupplier onBeforeBlocking;
 
     /** Prevents changing the plugins. */
@@ -149,6 +187,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     public static Function<Scheduler, Scheduler> getComputationSchedulerHandler() {
         return onComputationHandler;
     }
@@ -157,6 +196,7 @@ public final class RxJavaPlugins {
      * Returns the a hook consumer.
      * @return the hook consumer, may be null
      */
+    @Nullable
     public static Consumer<Throwable> getErrorHandler() {
         return errorHandler;
     }
@@ -165,6 +205,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     public static Function<Callable<Scheduler>, Scheduler> getInitComputationSchedulerHandler() {
         return onInitComputationHandler;
     }
@@ -173,6 +214,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     public static Function<Callable<Scheduler>, Scheduler> getInitIoSchedulerHandler() {
         return onInitIoHandler;
     }
@@ -181,6 +223,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     public static Function<Callable<Scheduler>, Scheduler> getInitNewThreadSchedulerHandler() {
         return onInitNewThreadHandler;
     }
@@ -189,6 +232,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     public static Function<Callable<Scheduler>, Scheduler> getInitSingleSchedulerHandler() {
         return onInitSingleHandler;
     }
@@ -197,6 +241,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     public static Function<Scheduler, Scheduler> getIoSchedulerHandler() {
         return onIoHandler;
     }
@@ -205,6 +250,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     public static Function<Scheduler, Scheduler> getNewThreadSchedulerHandler() {
         return onNewThreadHandler;
     }
@@ -213,6 +259,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     public static Function<Runnable, Runnable> getScheduleHandler() {
         return onScheduleHandler;
     }
@@ -221,6 +268,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     public static Function<Scheduler, Scheduler> getSingleSchedulerHandler() {
         return onSingleHandler;
     }
@@ -231,7 +279,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    public static Scheduler initComputationScheduler(Callable<Scheduler> defaultScheduler) {
+    @Nonnull
+    public static Scheduler initComputationScheduler(@Nonnull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Callable<Scheduler>, Scheduler> f = onInitComputationHandler;
         if (f == null) {
@@ -246,7 +295,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    public static Scheduler initIoScheduler(Callable<Scheduler> defaultScheduler) {
+    @Nonnull
+    public static Scheduler initIoScheduler(@Nonnull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Callable<Scheduler>, Scheduler> f = onInitIoHandler;
         if (f == null) {
@@ -261,7 +311,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    public static Scheduler initNewThreadScheduler(Callable<Scheduler> defaultScheduler) {
+    @Nonnull
+    public static Scheduler initNewThreadScheduler(@Nonnull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Callable<Scheduler>, Scheduler> f = onInitNewThreadHandler;
         if (f == null) {
@@ -276,7 +327,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    public static Scheduler initSingleScheduler(Callable<Scheduler> defaultScheduler) {
+    @Nonnull
+    public static Scheduler initSingleScheduler(@Nonnull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Callable<Scheduler>, Scheduler> f = onInitSingleHandler;
         if (f == null) {
@@ -290,7 +342,8 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    public static Scheduler onComputationScheduler(Scheduler defaultScheduler) {
+    @Nonnull
+    public static Scheduler onComputationScheduler(@Nonnull Scheduler defaultScheduler) {
         Function<Scheduler, Scheduler> f = onComputationHandler;
         if (f == null) {
             return defaultScheduler;
@@ -302,7 +355,7 @@ public final class RxJavaPlugins {
      * Called when an undeliverable error occurs.
      * @param error the error to report
      */
-    public static void onError(Throwable error) {
+    public static void onError(@Nonnull Throwable error) {
         Consumer<Throwable> f = errorHandler;
 
         if (error == null) {
@@ -324,7 +377,7 @@ public final class RxJavaPlugins {
         uncaught(error);
     }
 
-    static void uncaught(Throwable error) {
+    static void uncaught(@Nonnull Throwable error) {
         Thread currentThread = Thread.currentThread();
         UncaughtExceptionHandler handler = currentThread.getUncaughtExceptionHandler();
         handler.uncaughtException(currentThread, error);
@@ -335,7 +388,8 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    public static Scheduler onIoScheduler(Scheduler defaultScheduler) {
+    @Nonnull
+    public static Scheduler onIoScheduler(@Nonnull Scheduler defaultScheduler) {
         Function<Scheduler, Scheduler> f = onIoHandler;
         if (f == null) {
             return defaultScheduler;
@@ -348,7 +402,8 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    public static Scheduler onNewThreadScheduler(Scheduler defaultScheduler) {
+    @Nonnull
+    public static Scheduler onNewThreadScheduler(@Nonnull Scheduler defaultScheduler) {
         Function<Scheduler, Scheduler> f = onNewThreadHandler;
         if (f == null) {
             return defaultScheduler;
@@ -361,7 +416,8 @@ public final class RxJavaPlugins {
      * @param run the runnable instance
      * @return the replacement runnable
      */
-    public static Runnable onSchedule(Runnable run) {
+    @Nonnull
+    public static Runnable onSchedule(@Nonnull Runnable run) {
         Function<Runnable, Runnable> f = onScheduleHandler;
         if (f == null) {
             return run;
@@ -374,7 +430,8 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    public static Scheduler onSingleScheduler(Scheduler defaultScheduler) {
+    @Nonnull
+    public static Scheduler onSingleScheduler(@Nonnull Scheduler defaultScheduler) {
         Function<Scheduler, Scheduler> f = onSingleHandler;
         if (f == null) {
             return defaultScheduler;
@@ -429,7 +486,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setComputationSchedulerHandler(Function<Scheduler, Scheduler> handler) {
+    public static void setComputationSchedulerHandler(@Nullable Function<Scheduler, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -440,7 +497,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setErrorHandler(Consumer<Throwable> handler) {
+    public static void setErrorHandler(@Nullable Consumer<Throwable> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -451,7 +508,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitComputationSchedulerHandler(Function<Callable<Scheduler>, Scheduler> handler) {
+    public static void setInitComputationSchedulerHandler(@Nullable Function<Callable<Scheduler>, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -462,7 +519,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitIoSchedulerHandler(Function<Callable<Scheduler>, Scheduler> handler) {
+    public static void setInitIoSchedulerHandler(@Nullable Function<Callable<Scheduler>, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -473,7 +530,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitNewThreadSchedulerHandler(Function<Callable<Scheduler>, Scheduler> handler) {
+    public static void setInitNewThreadSchedulerHandler(@Nullable Function<Callable<Scheduler>, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -484,7 +541,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitSingleSchedulerHandler(Function<Callable<Scheduler>, Scheduler> handler) {
+    public static void setInitSingleSchedulerHandler(@Nullable Function<Callable<Scheduler>, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -495,7 +552,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setIoSchedulerHandler(Function<Scheduler, Scheduler> handler) {
+    public static void setIoSchedulerHandler(@Nullable Function<Scheduler, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -506,7 +563,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setNewThreadSchedulerHandler(Function<Scheduler, Scheduler> handler) {
+    public static void setNewThreadSchedulerHandler(@Nullable Function<Scheduler, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -517,7 +574,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setScheduleHandler(Function<Runnable, Runnable> handler) {
+    public static void setScheduleHandler(@Nullable Function<Runnable, Runnable> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -528,7 +585,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setSingleSchedulerHandler(Function<Scheduler, Scheduler> handler) {
+    public static void setSingleSchedulerHandler(@Nullable Function<Scheduler, Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -546,6 +603,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     public static Function<Completable, Completable> getOnCompletableAssembly() {
         return onCompletableAssembly;
     }
@@ -554,6 +612,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     public static BiFunction<Completable, CompletableObserver, CompletableObserver> getOnCompletableSubscribe() {
         return onCompletableSubscribe;
     }
@@ -563,6 +622,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @SuppressWarnings("rawtypes")
+    @Nullable
     public static Function<Flowable, Flowable> getOnFlowableAssembly() {
         return onFlowableAssembly;
     }
@@ -572,6 +632,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @SuppressWarnings("rawtypes")
+    @Nullable
     public static Function<ConnectableFlowable, ConnectableFlowable> getOnConnectableFlowableAssembly() {
         return onConnectableFlowableAssembly;
     }
@@ -580,6 +641,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     @SuppressWarnings("rawtypes")
     public static BiFunction<Flowable, Subscriber, Subscriber> getOnFlowableSubscribe() {
         return onFlowableSubscribe;
@@ -589,6 +651,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     @SuppressWarnings("rawtypes")
     public static BiFunction<Maybe, MaybeObserver, MaybeObserver> getOnMaybeSubscribe() {
         return onMaybeSubscribe;
@@ -598,6 +661,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     @SuppressWarnings("rawtypes")
     public static Function<Maybe, Maybe> getOnMaybeAssembly() {
         return onMaybeAssembly;
@@ -607,6 +671,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     @SuppressWarnings("rawtypes")
     public static Function<Single, Single> getOnSingleAssembly() {
         return onSingleAssembly;
@@ -616,6 +681,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     @SuppressWarnings("rawtypes")
     public static BiFunction<Single, SingleObserver, SingleObserver> getOnSingleSubscribe() {
         return onSingleSubscribe;
@@ -625,6 +691,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     @SuppressWarnings("rawtypes")
     public static Function<Observable, Observable> getOnObservableAssembly() {
         return onObservableAssembly;
@@ -634,6 +701,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     @SuppressWarnings("rawtypes")
     public static Function<ConnectableObservable, ConnectableObservable> getOnConnectableObservableAssembly() {
         return onConnectableObservableAssembly;
@@ -643,6 +711,7 @@ public final class RxJavaPlugins {
      * Returns the current hook function.
      * @return the hook function, may be null
      */
+    @Nullable
     @SuppressWarnings("rawtypes")
     public static BiFunction<Observable, Observer, Observer> getOnObservableSubscribe() {
         return onObservableSubscribe;
@@ -652,7 +721,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param onCompletableAssembly the hook function to set, null allowed
      */
-    public static void setOnCompletableAssembly(Function<Completable, Completable> onCompletableAssembly) {
+    public static void setOnCompletableAssembly(@Nullable Function<Completable, Completable> onCompletableAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -664,7 +733,7 @@ public final class RxJavaPlugins {
      * @param onCompletableSubscribe the hook function to set, null allowed
      */
     public static void setOnCompletableSubscribe(
-            BiFunction<Completable, CompletableObserver, CompletableObserver> onCompletableSubscribe) {
+            @Nullable BiFunction<Completable, CompletableObserver, CompletableObserver> onCompletableSubscribe) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -676,7 +745,7 @@ public final class RxJavaPlugins {
      * @param onFlowableAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnFlowableAssembly(Function<Flowable, Flowable> onFlowableAssembly) {
+    public static void setOnFlowableAssembly(@Nullable Function<Flowable, Flowable> onFlowableAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -688,7 +757,7 @@ public final class RxJavaPlugins {
      * @param onMaybeAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnMaybeAssembly(Function<Maybe, Maybe> onMaybeAssembly) {
+    public static void setOnMaybeAssembly(@Nullable Function<Maybe, Maybe> onMaybeAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -700,7 +769,7 @@ public final class RxJavaPlugins {
      * @param onConnectableFlowableAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnConnectableFlowableAssembly(Function<ConnectableFlowable, ConnectableFlowable> onConnectableFlowableAssembly) {
+    public static void setOnConnectableFlowableAssembly(@Nullable Function<ConnectableFlowable, ConnectableFlowable> onConnectableFlowableAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -712,7 +781,7 @@ public final class RxJavaPlugins {
      * @param onFlowableSubscribe the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnFlowableSubscribe(BiFunction<Flowable, Subscriber, Subscriber> onFlowableSubscribe) {
+    public static void setOnFlowableSubscribe(@Nullable BiFunction<Flowable, Subscriber, Subscriber> onFlowableSubscribe) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -724,7 +793,7 @@ public final class RxJavaPlugins {
      * @param onMaybeSubscribe the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnMaybeSubscribe(BiFunction<Maybe, MaybeObserver, MaybeObserver> onMaybeSubscribe) {
+    public static void setOnMaybeSubscribe(@Nullable BiFunction<Maybe, MaybeObserver, MaybeObserver> onMaybeSubscribe) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -736,7 +805,7 @@ public final class RxJavaPlugins {
      * @param onObservableAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnObservableAssembly(Function<Observable, Observable> onObservableAssembly) {
+    public static void setOnObservableAssembly(@Nullable Function<Observable, Observable> onObservableAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -748,7 +817,7 @@ public final class RxJavaPlugins {
      * @param onConnectableObservableAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnConnectableObservableAssembly(Function<ConnectableObservable, ConnectableObservable> onConnectableObservableAssembly) {
+    public static void setOnConnectableObservableAssembly(@Nullable Function<ConnectableObservable, ConnectableObservable> onConnectableObservableAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -761,7 +830,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings("rawtypes")
     public static void setOnObservableSubscribe(
-            BiFunction<Observable, Observer, Observer> onObservableSubscribe) {
+            @Nullable BiFunction<Observable, Observer, Observer> onObservableSubscribe) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -773,7 +842,7 @@ public final class RxJavaPlugins {
      * @param onSingleAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnSingleAssembly(Function<Single, Single> onSingleAssembly) {
+    public static void setOnSingleAssembly(@Nullable Function<Single, Single> onSingleAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -785,7 +854,7 @@ public final class RxJavaPlugins {
      * @param onSingleSubscribe the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnSingleSubscribe(BiFunction<Single, SingleObserver, SingleObserver> onSingleSubscribe) {
+    public static void setOnSingleSubscribe(@Nullable BiFunction<Single, SingleObserver, SingleObserver> onSingleSubscribe) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -800,7 +869,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Subscriber<? super T> onSubscribe(Flowable<T> source, Subscriber<? super T> subscriber) {
+    @Nonnull
+    public static <T> Subscriber<? super T> onSubscribe(@Nonnull Flowable<T> source, @Nonnull Subscriber<? super T> subscriber) {
         BiFunction<Flowable, Subscriber, Subscriber> f = onFlowableSubscribe;
         if (f != null) {
             return apply(f, source, subscriber);
@@ -816,7 +886,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Observer<? super T> onSubscribe(Observable<T> source, Observer<? super T> observer) {
+    @Nonnull
+    public static <T> Observer<? super T> onSubscribe(@Nonnull Observable<T> source, @Nonnull Observer<? super T> observer) {
         BiFunction<Observable, Observer, Observer> f = onObservableSubscribe;
         if (f != null) {
             return apply(f, source, observer);
@@ -832,7 +903,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> SingleObserver<? super T> onSubscribe(Single<T> source, SingleObserver<? super T> observer) {
+    @Nonnull
+    public static <T> SingleObserver<? super T> onSubscribe(@Nonnull Single<T> source, @Nonnull SingleObserver<? super T> observer) {
         BiFunction<Single, SingleObserver, SingleObserver> f = onSingleSubscribe;
         if (f != null) {
             return apply(f, source, observer);
@@ -846,7 +918,8 @@ public final class RxJavaPlugins {
      * @param observer the observer
      * @return the value returned by the hook
      */
-    public static CompletableObserver onSubscribe(Completable source, CompletableObserver observer) {
+    @Nonnull
+    public static CompletableObserver onSubscribe(@Nonnull Completable source, @Nonnull CompletableObserver observer) {
         BiFunction<Completable, CompletableObserver, CompletableObserver> f = onCompletableSubscribe;
         if (f != null) {
             return apply(f, source, observer);
@@ -862,7 +935,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> MaybeObserver<? super T> onSubscribe(Maybe<T> source, MaybeObserver<? super T> subscriber) {
+    @Nonnull
+    public static <T> MaybeObserver<? super T> onSubscribe(@Nonnull Maybe<T> source, @Nonnull MaybeObserver<? super T> subscriber) {
         BiFunction<Maybe, MaybeObserver, MaybeObserver> f = onMaybeSubscribe;
         if (f != null) {
             return apply(f, source, subscriber);
@@ -877,7 +951,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Maybe<T> onAssembly(Maybe<T> source) {
+    @Nonnull
+    public static <T> Maybe<T> onAssembly(@Nonnull Maybe<T> source) {
         Function<Maybe, Maybe> f = onMaybeAssembly;
         if (f != null) {
             return apply(f, source);
@@ -892,7 +967,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Flowable<T> onAssembly(Flowable<T> source) {
+    @Nonnull
+    public static <T> Flowable<T> onAssembly(@Nonnull Flowable<T> source) {
         Function<Flowable, Flowable> f = onFlowableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -907,7 +983,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> ConnectableFlowable<T> onAssembly(ConnectableFlowable<T> source) {
+    @Nonnull
+    public static <T> ConnectableFlowable<T> onAssembly(@Nonnull ConnectableFlowable<T> source) {
         Function<ConnectableFlowable, ConnectableFlowable> f = onConnectableFlowableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -922,7 +999,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Observable<T> onAssembly(Observable<T> source) {
+    @Nonnull
+    public static <T> Observable<T> onAssembly(@Nonnull Observable<T> source) {
         Function<Observable, Observable> f = onObservableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -937,7 +1015,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> ConnectableObservable<T> onAssembly(ConnectableObservable<T> source) {
+    @Nonnull
+    public static <T> ConnectableObservable<T> onAssembly(@Nonnull ConnectableObservable<T> source) {
         Function<ConnectableObservable, ConnectableObservable> f = onConnectableObservableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -952,7 +1031,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Single<T> onAssembly(Single<T> source) {
+    @Nonnull
+    public static <T> Single<T> onAssembly(@Nonnull Single<T> source) {
         Function<Single, Single> f = onSingleAssembly;
         if (f != null) {
             return apply(f, source);
@@ -965,7 +1045,8 @@ public final class RxJavaPlugins {
      * @param source the hook's input value
      * @return the value returned by the hook
      */
-    public static Completable onAssembly(Completable source) {
+    @Nonnull
+    public static Completable onAssembly(@Nonnull Completable source) {
         Function<Completable, Completable> f = onCompletableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -980,7 +1061,7 @@ public final class RxJavaPlugins {
      */
     @Experimental
     @SuppressWarnings("rawtypes")
-    public static void setOnParallelAssembly(Function<ParallelFlowable, ParallelFlowable> handler) {
+    public static void setOnParallelAssembly(@Nullable Function<ParallelFlowable, ParallelFlowable> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -994,6 +1075,7 @@ public final class RxJavaPlugins {
      */
     @Experimental
     @SuppressWarnings("rawtypes")
+    @Nullable
     public static Function<ParallelFlowable, ParallelFlowable> getOnParallelAssembly() {
         return onParallelAssembly;
     }
@@ -1007,7 +1089,8 @@ public final class RxJavaPlugins {
      */
     @Experimental
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> ParallelFlowable<T> onAssembly(ParallelFlowable<T> source) {
+    @Nonnull
+    public static <T> ParallelFlowable<T> onAssembly(@Nonnull ParallelFlowable<T> source) {
         Function<ParallelFlowable, ParallelFlowable> f = onParallelAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1047,7 +1130,7 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    public static void setOnBeforeBlocking(BooleanSupplier handler) {
+    public static void setOnBeforeBlocking(@Nullable BooleanSupplier handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -1061,6 +1144,7 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
+    @Nullable
     public static BooleanSupplier getOnBeforeBlocking() {
         return onBeforeBlocking;
     }
@@ -1074,7 +1158,8 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    public static Scheduler createComputationScheduler(ThreadFactory threadFactory) {
+    @Nonnull
+    public static Scheduler createComputationScheduler(@Nonnull ThreadFactory threadFactory) {
         return new ComputationScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1087,7 +1172,8 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    public static Scheduler createIoScheduler(ThreadFactory threadFactory) {
+    @Nonnull
+    public static Scheduler createIoScheduler(@Nonnull ThreadFactory threadFactory) {
         return new IoScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1100,7 +1186,8 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    public static Scheduler createNewThreadScheduler(ThreadFactory threadFactory) {
+    @Nonnull
+    public static Scheduler createNewThreadScheduler(@Nonnull ThreadFactory threadFactory) {
         return new NewThreadScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1113,7 +1200,8 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    public static Scheduler createSingleScheduler(ThreadFactory threadFactory) {
+    @Nonnull
+    public static Scheduler createSingleScheduler(@Nonnull ThreadFactory threadFactory) {
         return new SingleScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1126,7 +1214,8 @@ public final class RxJavaPlugins {
      * @param t the parameter value to the function
      * @return the result of the function call
      */
-    static <T, R> R apply(Function<T, R> f, T t) {
+    @NonNull
+    static <T, R> R apply(@Nonnull Function<T, R> f, @NonNull T t) {
         try {
             return f.apply(t);
         } catch (Throwable ex) {
@@ -1145,7 +1234,8 @@ public final class RxJavaPlugins {
      * @param u the second parameter value to the function
      * @return the result of the function call
      */
-    static <T, U, R> R apply(BiFunction<T, U, R> f, T t, U u) {
+    @Nonnull
+    static <T, U, R> R apply(@Nonnull BiFunction<T, U, R> f, @Nonnull T t, @Nonnull U u) {
         try {
             return f.apply(t, u);
         } catch (Throwable ex) {
@@ -1160,7 +1250,8 @@ public final class RxJavaPlugins {
      * @return the result of the callable call, not null
      * @throws NullPointerException if the callable parameter returns null
      */
-    static Scheduler callRequireNonNull(Callable<Scheduler> s) {
+    @Nonnull
+    static Scheduler callRequireNonNull(@Nonnull Callable<Scheduler> s) {
         try {
             return ObjectHelper.requireNonNull(s.call(), "Scheduler Callable result can't be null");
         } catch (Throwable ex) {
@@ -1176,7 +1267,8 @@ public final class RxJavaPlugins {
      * @return the result of the function call, not null
      * @throws NullPointerException if the function parameter returns null
      */
-    static Scheduler applyRequireNonNull(Function<Callable<Scheduler>, Scheduler> f, Callable<Scheduler> s) {
+    @Nonnull
+    static Scheduler applyRequireNonNull(@Nonnull Function<Callable<Scheduler>, Scheduler> f, Callable<Scheduler> s) {
         return ObjectHelper.requireNonNull(apply(f, s), "Scheduler Callable result can't be null");
     }
 

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -279,8 +279,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    @Nonnull
-    public static Scheduler initComputationScheduler(@Nonnull Callable<Scheduler> defaultScheduler) {
+    @NonNull
+    public static Scheduler initComputationScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Callable<Scheduler>, Scheduler> f = onInitComputationHandler;
         if (f == null) {
@@ -295,8 +295,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    @Nonnull
-    public static Scheduler initIoScheduler(@Nonnull Callable<Scheduler> defaultScheduler) {
+    @NonNull
+    public static Scheduler initIoScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Callable<Scheduler>, Scheduler> f = onInitIoHandler;
         if (f == null) {
@@ -311,8 +311,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    @Nonnull
-    public static Scheduler initNewThreadScheduler(@Nonnull Callable<Scheduler> defaultScheduler) {
+    @NonNull
+    public static Scheduler initNewThreadScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Callable<Scheduler>, Scheduler> f = onInitNewThreadHandler;
         if (f == null) {
@@ -327,8 +327,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    @Nonnull
-    public static Scheduler initSingleScheduler(@Nonnull Callable<Scheduler> defaultScheduler) {
+    @NonNull
+    public static Scheduler initSingleScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<Callable<Scheduler>, Scheduler> f = onInitSingleHandler;
         if (f == null) {
@@ -342,8 +342,8 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    @Nonnull
-    public static Scheduler onComputationScheduler(@Nonnull Scheduler defaultScheduler) {
+    @NonNull
+    public static Scheduler onComputationScheduler(@NonNull Scheduler defaultScheduler) {
         Function<Scheduler, Scheduler> f = onComputationHandler;
         if (f == null) {
             return defaultScheduler;
@@ -355,7 +355,7 @@ public final class RxJavaPlugins {
      * Called when an undeliverable error occurs.
      * @param error the error to report
      */
-    public static void onError(@Nonnull Throwable error) {
+    public static void onError(@NonNull Throwable error) {
         Consumer<Throwable> f = errorHandler;
 
         if (error == null) {
@@ -377,7 +377,7 @@ public final class RxJavaPlugins {
         uncaught(error);
     }
 
-    static void uncaught(@Nonnull Throwable error) {
+    static void uncaught(@NonNull Throwable error) {
         Thread currentThread = Thread.currentThread();
         UncaughtExceptionHandler handler = currentThread.getUncaughtExceptionHandler();
         handler.uncaughtException(currentThread, error);
@@ -388,8 +388,8 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    @Nonnull
-    public static Scheduler onIoScheduler(@Nonnull Scheduler defaultScheduler) {
+    @NonNull
+    public static Scheduler onIoScheduler(@NonNull Scheduler defaultScheduler) {
         Function<Scheduler, Scheduler> f = onIoHandler;
         if (f == null) {
             return defaultScheduler;
@@ -402,8 +402,8 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    @Nonnull
-    public static Scheduler onNewThreadScheduler(@Nonnull Scheduler defaultScheduler) {
+    @NonNull
+    public static Scheduler onNewThreadScheduler(@NonNull Scheduler defaultScheduler) {
         Function<Scheduler, Scheduler> f = onNewThreadHandler;
         if (f == null) {
             return defaultScheduler;
@@ -416,8 +416,8 @@ public final class RxJavaPlugins {
      * @param run the runnable instance
      * @return the replacement runnable
      */
-    @Nonnull
-    public static Runnable onSchedule(@Nonnull Runnable run) {
+    @NonNull
+    public static Runnable onSchedule(@NonNull Runnable run) {
         Function<Runnable, Runnable> f = onScheduleHandler;
         if (f == null) {
             return run;
@@ -430,8 +430,8 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    @Nonnull
-    public static Scheduler onSingleScheduler(@Nonnull Scheduler defaultScheduler) {
+    @NonNull
+    public static Scheduler onSingleScheduler(@NonNull Scheduler defaultScheduler) {
         Function<Scheduler, Scheduler> f = onSingleHandler;
         if (f == null) {
             return defaultScheduler;
@@ -869,8 +869,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Nonnull
-    public static <T> Subscriber<? super T> onSubscribe(@Nonnull Flowable<T> source, @Nonnull Subscriber<? super T> subscriber) {
+    @NonNull
+    public static <T> Subscriber<? super T> onSubscribe(@NonNull Flowable<T> source, @NonNull Subscriber<? super T> subscriber) {
         BiFunction<Flowable, Subscriber, Subscriber> f = onFlowableSubscribe;
         if (f != null) {
             return apply(f, source, subscriber);
@@ -886,8 +886,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Nonnull
-    public static <T> Observer<? super T> onSubscribe(@Nonnull Observable<T> source, @Nonnull Observer<? super T> observer) {
+    @NonNull
+    public static <T> Observer<? super T> onSubscribe(@NonNull Observable<T> source, @NonNull Observer<? super T> observer) {
         BiFunction<Observable, Observer, Observer> f = onObservableSubscribe;
         if (f != null) {
             return apply(f, source, observer);
@@ -903,8 +903,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Nonnull
-    public static <T> SingleObserver<? super T> onSubscribe(@Nonnull Single<T> source, @Nonnull SingleObserver<? super T> observer) {
+    @NonNull
+    public static <T> SingleObserver<? super T> onSubscribe(@NonNull Single<T> source, @NonNull SingleObserver<? super T> observer) {
         BiFunction<Single, SingleObserver, SingleObserver> f = onSingleSubscribe;
         if (f != null) {
             return apply(f, source, observer);
@@ -918,8 +918,8 @@ public final class RxJavaPlugins {
      * @param observer the observer
      * @return the value returned by the hook
      */
-    @Nonnull
-    public static CompletableObserver onSubscribe(@Nonnull Completable source, @Nonnull CompletableObserver observer) {
+    @NonNull
+    public static CompletableObserver onSubscribe(@NonNull Completable source, @NonNull CompletableObserver observer) {
         BiFunction<Completable, CompletableObserver, CompletableObserver> f = onCompletableSubscribe;
         if (f != null) {
             return apply(f, source, observer);
@@ -935,8 +935,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Nonnull
-    public static <T> MaybeObserver<? super T> onSubscribe(@Nonnull Maybe<T> source, @Nonnull MaybeObserver<? super T> subscriber) {
+    @NonNull
+    public static <T> MaybeObserver<? super T> onSubscribe(@NonNull Maybe<T> source, @NonNull MaybeObserver<? super T> subscriber) {
         BiFunction<Maybe, MaybeObserver, MaybeObserver> f = onMaybeSubscribe;
         if (f != null) {
             return apply(f, source, subscriber);
@@ -951,8 +951,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Nonnull
-    public static <T> Maybe<T> onAssembly(@Nonnull Maybe<T> source) {
+    @NonNull
+    public static <T> Maybe<T> onAssembly(@NonNull Maybe<T> source) {
         Function<Maybe, Maybe> f = onMaybeAssembly;
         if (f != null) {
             return apply(f, source);
@@ -967,8 +967,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Nonnull
-    public static <T> Flowable<T> onAssembly(@Nonnull Flowable<T> source) {
+    @NonNull
+    public static <T> Flowable<T> onAssembly(@NonNull Flowable<T> source) {
         Function<Flowable, Flowable> f = onFlowableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -983,8 +983,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Nonnull
-    public static <T> ConnectableFlowable<T> onAssembly(@Nonnull ConnectableFlowable<T> source) {
+    @NonNull
+    public static <T> ConnectableFlowable<T> onAssembly(@NonNull ConnectableFlowable<T> source) {
         Function<ConnectableFlowable, ConnectableFlowable> f = onConnectableFlowableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -999,8 +999,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Nonnull
-    public static <T> Observable<T> onAssembly(@Nonnull Observable<T> source) {
+    @NonNull
+    public static <T> Observable<T> onAssembly(@NonNull Observable<T> source) {
         Function<Observable, Observable> f = onObservableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1015,8 +1015,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Nonnull
-    public static <T> ConnectableObservable<T> onAssembly(@Nonnull ConnectableObservable<T> source) {
+    @NonNull
+    public static <T> ConnectableObservable<T> onAssembly(@NonNull ConnectableObservable<T> source) {
         Function<ConnectableObservable, ConnectableObservable> f = onConnectableObservableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1031,8 +1031,8 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Nonnull
-    public static <T> Single<T> onAssembly(@Nonnull Single<T> source) {
+    @NonNull
+    public static <T> Single<T> onAssembly(@NonNull Single<T> source) {
         Function<Single, Single> f = onSingleAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1045,8 +1045,8 @@ public final class RxJavaPlugins {
      * @param source the hook's input value
      * @return the value returned by the hook
      */
-    @Nonnull
-    public static Completable onAssembly(@Nonnull Completable source) {
+    @NonNull
+    public static Completable onAssembly(@NonNull Completable source) {
         Function<Completable, Completable> f = onCompletableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1089,8 +1089,8 @@ public final class RxJavaPlugins {
      */
     @Experimental
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Nonnull
-    public static <T> ParallelFlowable<T> onAssembly(@Nonnull ParallelFlowable<T> source) {
+    @NonNull
+    public static <T> ParallelFlowable<T> onAssembly(@NonNull ParallelFlowable<T> source) {
         Function<ParallelFlowable, ParallelFlowable> f = onParallelAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1158,8 +1158,8 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    @Nonnull
-    public static Scheduler createComputationScheduler(@Nonnull ThreadFactory threadFactory) {
+    @NonNull
+    public static Scheduler createComputationScheduler(@NonNull ThreadFactory threadFactory) {
         return new ComputationScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1172,8 +1172,8 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    @Nonnull
-    public static Scheduler createIoScheduler(@Nonnull ThreadFactory threadFactory) {
+    @NonNull
+    public static Scheduler createIoScheduler(@NonNull ThreadFactory threadFactory) {
         return new IoScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1186,8 +1186,8 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    @Nonnull
-    public static Scheduler createNewThreadScheduler(@Nonnull ThreadFactory threadFactory) {
+    @NonNull
+    public static Scheduler createNewThreadScheduler(@NonNull ThreadFactory threadFactory) {
         return new NewThreadScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1200,8 +1200,8 @@ public final class RxJavaPlugins {
      * @since 2.0.5 - experimental
      */
     @Experimental
-    @Nonnull
-    public static Scheduler createSingleScheduler(@Nonnull ThreadFactory threadFactory) {
+    @NonNull
+    public static Scheduler createSingleScheduler(@NonNull ThreadFactory threadFactory) {
         return new SingleScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1215,7 +1215,7 @@ public final class RxJavaPlugins {
      * @return the result of the function call
      */
     @NonNull
-    static <T, R> R apply(@Nonnull Function<T, R> f, @NonNull T t) {
+    static <T, R> R apply(@NonNull Function<T, R> f, @NonNull T t) {
         try {
             return f.apply(t);
         } catch (Throwable ex) {
@@ -1234,8 +1234,8 @@ public final class RxJavaPlugins {
      * @param u the second parameter value to the function
      * @return the result of the function call
      */
-    @Nonnull
-    static <T, U, R> R apply(@Nonnull BiFunction<T, U, R> f, @Nonnull T t, @Nonnull U u) {
+    @NonNull
+    static <T, U, R> R apply(@NonNull BiFunction<T, U, R> f, @NonNull T t, @NonNull U u) {
         try {
             return f.apply(t, u);
         } catch (Throwable ex) {
@@ -1250,8 +1250,8 @@ public final class RxJavaPlugins {
      * @return the result of the callable call, not null
      * @throws NullPointerException if the callable parameter returns null
      */
-    @Nonnull
-    static Scheduler callRequireNonNull(@Nonnull Callable<Scheduler> s) {
+    @NonNull
+    static Scheduler callRequireNonNull(@NonNull Callable<Scheduler> s) {
         try {
             return ObjectHelper.requireNonNull(s.call(), "Scheduler Callable result can't be null");
         } catch (Throwable ex) {
@@ -1267,8 +1267,8 @@ public final class RxJavaPlugins {
      * @return the result of the function call, not null
      * @throws NullPointerException if the function parameter returns null
      */
-    @Nonnull
-    static Scheduler applyRequireNonNull(@Nonnull Function<Callable<Scheduler>, Scheduler> f, Callable<Scheduler> s) {
+    @NonNull
+    static Scheduler applyRequireNonNull(@NonNull Function<Callable<Scheduler>, Scheduler> f, Callable<Scheduler> s) {
         return ObjectHelper.requireNonNull(apply(f, s), "Scheduler Callable result can't be null");
     }
 

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -14,6 +14,7 @@
 package io.reactivex.schedulers;
 
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.internal.schedulers.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -34,14 +35,19 @@ import java.util.concurrent.*;
  * </ul>
  */
 public final class Schedulers {
+    @NonNull
     static final Scheduler SINGLE;
 
+    @NonNull
     static final Scheduler COMPUTATION;
 
+    @NonNull
     static final Scheduler IO;
 
+    @NonNull
     static final Scheduler TRAMPOLINE;
 
+    @NonNull
     static final Scheduler NEW_THREAD;
 
     static final class SingleHolder {
@@ -108,6 +114,7 @@ public final class Schedulers {
      *
      * @return a {@link Scheduler} meant for computation-bound work
      */
+    @NonNull
     public static Scheduler computation() {
         return RxJavaPlugins.onComputationScheduler(COMPUTATION);
     }
@@ -125,6 +132,7 @@ public final class Schedulers {
      *
      * @return a {@link Scheduler} meant for IO-bound work
      */
+    @NonNull
     public static Scheduler io() {
         return RxJavaPlugins.onIoScheduler(IO);
     }
@@ -135,6 +143,7 @@ public final class Schedulers {
      *
      * @return a {@link Scheduler} that queues work on the current thread
      */
+    @NonNull
     public static Scheduler trampoline() {
         return TRAMPOLINE;
     }
@@ -146,6 +155,7 @@ public final class Schedulers {
      *
      * @return a {@link Scheduler} that creates new threads
      */
+    @NonNull
     public static Scheduler newThread() {
         return RxJavaPlugins.onNewThreadScheduler(NEW_THREAD);
     }
@@ -163,6 +173,7 @@ public final class Schedulers {
      * @return a {@link Scheduler} that shares a single backing thread.
      * @since 2.0
      */
+    @NonNull
     public static Scheduler single() {
         return RxJavaPlugins.onSingleScheduler(SINGLE);
     }
@@ -174,7 +185,8 @@ public final class Schedulers {
      *          the executor to wrap
      * @return the new Scheduler wrapping the Executor
      */
-    public static Scheduler from(Executor executor) {
+    @NonNull
+    public static Scheduler from(@NonNull Executor executor) {
         return new ExecutorScheduler(executor);
     }
 

--- a/src/main/java/io/reactivex/schedulers/TestScheduler.java
+++ b/src/main/java/io/reactivex/schedulers/TestScheduler.java
@@ -17,6 +17,7 @@ import java.util.Queue;
 import java.util.concurrent.*;
 
 import io.reactivex.Scheduler;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -63,7 +64,7 @@ public final class TestScheduler extends Scheduler {
     }
 
     @Override
-    public long now(TimeUnit unit) {
+    public long now(@NonNull TimeUnit unit) {
         return unit.convert(time, TimeUnit.NANOSECONDS);
     }
 
@@ -118,6 +119,7 @@ public final class TestScheduler extends Scheduler {
         time = targetTimeInNanoseconds;
     }
 
+    @NonNull
     @Override
     public Worker createWorker() {
         return new TestWorker();
@@ -137,8 +139,9 @@ public final class TestScheduler extends Scheduler {
             return disposed;
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable run, long delayTime, TimeUnit unit) {
+        public Disposable schedule(@NonNull Runnable run, long delayTime, @NonNull TimeUnit unit) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }
@@ -153,8 +156,9 @@ public final class TestScheduler extends Scheduler {
             });
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable run) {
+        public Disposable schedule(@NonNull Runnable run) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }
@@ -169,7 +173,7 @@ public final class TestScheduler extends Scheduler {
         }
 
         @Override
-        public long now(TimeUnit unit) {
+        public long now(@NonNull TimeUnit unit) {
             return TestScheduler.this.now(unit);
         }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.NonNull;
 import org.junit.*;
 import org.mockito.InOrder;
 import org.reactivestreams.*;
@@ -708,14 +709,16 @@ public class FlowableReplayTest {
             this.mockDisposable = mockDisposable;
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable action) {
+        public Disposable schedule(@NonNull Runnable action) {
             action.run();
             return mockDisposable; // this subscription is returned but discarded
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
+        public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
             action.run();
             return mockDisposable;
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.NonNull;
 import org.junit.*;
 import org.reactivestreams.*;
 
@@ -122,6 +123,7 @@ public class FlowableSubscribeOnTest {
             this.unit = unit;
         }
 
+        @NonNull
         @Override
         public Worker createWorker() {
             return new SlowInner(actual.createWorker());
@@ -145,13 +147,15 @@ public class FlowableSubscribeOnTest {
                 return actualInner.isDisposed();
             }
 
+            @NonNull
             @Override
-            public Disposable schedule(final Runnable action) {
+            public Disposable schedule(@NonNull final Runnable action) {
                 return actualInner.schedule(action, delay, unit);
             }
 
+            @NonNull
             @Override
-            public Disposable schedule(final Runnable action, final long delayTime, final TimeUnit delayUnit) {
+            public Disposable schedule(@NonNull final Runnable action, final long delayTime, @NonNull final TimeUnit delayUnit) {
                 TimeUnit common = delayUnit.compareTo(unit) < 0 ? delayUnit : unit;
                 long t = common.convert(delayTime, delayUnit) + common.convert(delay, unit);
                 return actualInner.schedule(action, t, common);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.annotations.NonNull;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -177,6 +178,7 @@ public class FlowableUnsubscribeOnTest {
             }
         }
 
+        @NonNull
         @Override
         public Worker createWorker() {
             return eventLoop.createWorker();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.annotations.NonNull;
 import org.junit.*;
 import org.mockito.InOrder;
 
@@ -689,14 +690,16 @@ public class ObservableReplayTest {
             this.mockDisposable = mockDisposable;
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable action) {
+        public Disposable schedule(@NonNull Runnable action) {
             action.run();
             return mockDisposable; // this subscription is returned but discarded
         }
 
+        @NonNull
         @Override
-        public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
+        public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
             action.run();
             return mockDisposable;
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.annotations.NonNull;
 import org.junit.*;
 
 import io.reactivex.*;
@@ -117,6 +118,7 @@ public class ObservableSubscribeOnTest {
             this.unit = unit;
         }
 
+        @NonNull
         @Override
         public Worker createWorker() {
             return new SlowInner(actual.createWorker());
@@ -140,13 +142,15 @@ public class ObservableSubscribeOnTest {
                 return actualInner.isDisposed();
             }
 
+            @NonNull
             @Override
-            public Disposable schedule(final Runnable action) {
+            public Disposable schedule(@NonNull final Runnable action) {
                 return actualInner.schedule(action, delay, unit);
             }
 
+            @NonNull
             @Override
-            public Disposable schedule(final Runnable action, final long delayTime, final TimeUnit delayUnit) {
+            public Disposable schedule(@NonNull final Runnable action, final long delayTime, @NonNull final TimeUnit delayUnit) {
                 TimeUnit common = delayUnit.compareTo(unit) < 0 ? delayUnit : unit;
                 long t = common.convert(delayTime, delayUnit) + common.convert(delay, unit);
                 return actualInner.schedule(action, t, common);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOnTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.NonNull;
 import org.junit.Test;
 
 import io.reactivex.*;
@@ -179,6 +180,7 @@ public class ObservableUnsubscribeOnTest {
             }
         }
 
+        @NonNull
         @Override
         public Worker createWorker() {
             return eventLoop.createWorker();

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -1349,14 +1349,6 @@ public class RxJavaPluginsTest {
 //
 //            assertSame(cop, RxJavaPlugins.onCompletableLift(cop));
 
-            assertNull(RxJavaPlugins.onComputationScheduler(null));
-
-            assertNull(RxJavaPlugins.onIoScheduler(null));
-
-            assertNull(RxJavaPlugins.onNewThreadScheduler(null));
-
-            assertNull(RxJavaPlugins.onSingleScheduler(null));
-
             final Scheduler s = ImmediateThinScheduler.INSTANCE;
             Callable<Scheduler> c = new Callable<Scheduler>() {
                 @Override

--- a/src/test/java/io/reactivex/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import io.reactivex.annotations.NonNull;
 import org.junit.Test;
 
 import io.reactivex.*;
@@ -248,11 +249,13 @@ public class SchedulerTest {
     @Test
     public void defaultSchedulePeriodicallyDirectRejects() {
         Scheduler s = new Scheduler() {
+            @NonNull
             @Override
             public Worker createWorker() {
                 return new Worker() {
+                    @NonNull
                     @Override
-                    public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
+                    public Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
                         return EmptyDisposable.INSTANCE;
                     }
 

--- a/src/test/java/io/reactivex/schedulers/SchedulerWorkerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerWorkerTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import io.reactivex.annotations.NonNull;
 import org.junit.Test;
 
 import io.reactivex.Scheduler;
@@ -27,6 +28,7 @@ public class SchedulerWorkerTest {
 
     static final class CustomDriftScheduler extends Scheduler {
         public volatile long drift;
+        @NonNull
         @Override
         public Worker createWorker() {
             final Worker w = Schedulers.computation().createWorker();
@@ -42,13 +44,15 @@ public class SchedulerWorkerTest {
                     return w.isDisposed();
                 }
 
+                @NonNull
                 @Override
-                public Disposable schedule(Runnable action) {
+                public Disposable schedule(@NonNull Runnable action) {
                     return w.schedule(action);
                 }
 
+                @NonNull
                 @Override
-                public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
+                public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
                     return w.schedule(action, delayTime, unit);
                 }
 
@@ -60,7 +64,7 @@ public class SchedulerWorkerTest {
         }
 
         @Override
-        public long now(TimeUnit unit) {
+        public long now(@NonNull TimeUnit unit) {
             return super.now(unit) + unit.convert(drift, TimeUnit.NANOSECONDS);
         }
     }


### PR DESCRIPTION
Issue: #4876

Starting to add @NonNull and @Nullable annotations.

I decided to add a compileOnly dependency to findbugs:jsr305 artifact.

We could also use "io.reactivex.annotations.NonNull" which already exists. But there is no "io.reactivex.annotations.Nullable" annotation which is at least as important in my experience.

Since these are only annotations, it is no problem when the class files are missing at compile time (JLS 9.6.1.2 Retention).


I have started to add annotations in the Scheduler and RxJavaPlugins.
The test RxJavaPlugins contains some invalid checks using null (lines 1353 and following).


This pull request is work in progress and should be discussed.


Questions so far:
- use jsr305 (compileOnly) or existing annotation in io.reactivex?
- (if not using jsr305): Use own @Nullable annotation or try to get one added to "io.reactivex"? Or skip these completely (which misses the point of the static code analysis)
- Why has there been tests calling the RxJavaPlugins.on*Scheduler with null arguments? Can these be removed securely?
