### PR TITLE
2.x: add nullable annotation to simple queue (fixes #5053)

### DIFF
--- a/src/main/java/io/reactivex/internal/disposables/EmptyDisposable.java
+++ b/src/main/java/io/reactivex/internal/disposables/EmptyDisposable.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.disposables;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.fuseable.QueueDisposable;
 
 /**
@@ -93,6 +94,7 @@ public enum EmptyDisposable implements QueueDisposable<Object> {
         throw new UnsupportedOperationException("Should not be called!");
     }
 
+    @Nullable
     @Override
     public Object poll() throws Exception {
         return null; // always empty

--- a/src/main/java/io/reactivex/internal/fuseable/SimplePlainQueue.java
+++ b/src/main/java/io/reactivex/internal/fuseable/SimplePlainQueue.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.internal.fuseable;
 
+import io.reactivex.annotations.Nullable;
+
 /**
  * Override of the SimpleQueue interface with no throws Exception on poll.
  *
@@ -20,6 +22,7 @@ package io.reactivex.internal.fuseable;
  */
 public interface SimplePlainQueue<T> extends SimpleQueue<T> {
 
+    @Nullable
     @Override
     T poll();
 }

--- a/src/main/java/io/reactivex/internal/fuseable/SimpleQueue.java
+++ b/src/main/java/io/reactivex/internal/fuseable/SimpleQueue.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.internal.fuseable;
 
+import io.reactivex.annotations.Nullable;
+
 /**
  * A minimalist queue interface without the method bloat of java.util.Collection and java.util.Queue.
  *
@@ -24,6 +26,10 @@ public interface SimpleQueue<T> {
 
     boolean offer(T v1, T v2);
 
+    /**
+     * @return null to indicate an empty queue
+     */
+    @Nullable
     T poll() throws Exception;
 
     boolean isEmpty();

--- a/src/main/java/io/reactivex/internal/observers/DeferredScalarDisposable.java
+++ b/src/main/java/io/reactivex/internal/observers/DeferredScalarDisposable.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.observers;
 
 import io.reactivex.Observer;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -110,6 +111,7 @@ public class DeferredScalarDisposable<T> extends BasicIntQueueDisposable<T> {
         actual.onComplete();
     }
 
+    @Nullable
     @Override
     public final T poll() throws Exception {
         if (get() == FUSED_READY) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import java.util.Iterator;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
@@ -466,6 +467,7 @@ extends Flowable<R> {
             return m;
         }
 
+        @Nullable
         @SuppressWarnings("unchecked")
         @Override
         public R poll() throws Exception {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.Exceptions;
@@ -117,6 +118,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             for (;;) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.functions.*;
@@ -106,6 +107,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             for (;;) {
@@ -195,6 +197,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             for (;;) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.annotations.Experimental;
@@ -74,6 +75,7 @@ public final class FlowableDoAfterNext<T> extends AbstractFlowableWithUpstream<T
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             T v = qs.poll();
@@ -122,6 +124,7 @@ public final class FlowableDoAfterNext<T> extends AbstractFlowableWithUpstream<T
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             T v = qs.poll();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoFinally.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.annotations.Experimental;
@@ -130,6 +131,7 @@ public final class FlowableDoFinally<T> extends AbstractFlowableWithUpstream<T, 
             return qs.isEmpty();
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             T v = qs.poll();
@@ -239,6 +241,7 @@ public final class FlowableDoFinally<T> extends AbstractFlowableWithUpstream<T, 
             return qs.isEmpty();
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             T v = qs.poll();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.*;
@@ -144,6 +145,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             T v = qs.poll();
@@ -276,6 +278,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             T v = qs.poll();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.functions.Predicate;
@@ -79,6 +80,7 @@ public final class FlowableFilter<T> extends AbstractFlowableWithUpstream<T, T> 
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             QueueSubscription<T> qs = this.qs;
@@ -143,6 +145,7 @@ public final class FlowableFilter<T> extends AbstractFlowableWithUpstream<T, T> 
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             QueueSubscription<T> qs = this.qs;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
@@ -174,6 +175,7 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
             // ignored, no values emitted
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             return null; // always empty

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.*;
@@ -413,6 +414,7 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
             return (it != null && !it.hasNext()) || queue.isEmpty();
         }
 
+        @Nullable
         @Override
         public R poll() throws Exception {
             Iterator<? extends R> it = current;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
@@ -55,6 +56,7 @@ public final class FlowableFromArray<T> extends Flowable<T> {
             return mode & SYNC;
         }
 
+        @Nullable
         @Override
         public final T poll() {
             int i = index;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.Iterator;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
@@ -87,6 +88,7 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
             return mode & SYNC;
         }
 
+        @Nullable
         @Override
         public final T poll() {
             if (it == null) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.Exceptions;
@@ -353,6 +354,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             return NONE;
         }
 
+        @Nullable
         @Override
         public GroupedFlowable<K, V> poll() {
             return queue.poll();
@@ -627,6 +629,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             return NONE;
         }
 
+        @Nullable
         @Override
         public T poll() {
             T v = queue.poll();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElements.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElements.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.internal.fuseable.QueueSubscription;
@@ -72,6 +73,7 @@ public final class FlowableIgnoreElements<T> extends AbstractFlowableWithUpstrea
             throw new UnsupportedOperationException("Should not be called!");
         }
 
+        @Nullable
         @Override
         public T poll() {
             return null; // empty, always

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
@@ -14,6 +14,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.functions.Function;
@@ -72,6 +73,7 @@ public final class FlowableMap<T, U> extends AbstractFlowableWithUpstream<T, U> 
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public U poll() throws Exception {
             T t = qs.poll();
@@ -131,6 +133,7 @@ public final class FlowableMap<T, U> extends AbstractFlowableWithUpstream<T, U> 
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public U poll() throws Exception {
             T t = qs.poll();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.Scheduler;
@@ -457,6 +458,7 @@ final Scheduler scheduler;
             }
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             T v = queue.poll();
@@ -695,6 +697,7 @@ final Scheduler scheduler;
             }
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             T v = queue.poll();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.*;
@@ -251,6 +252,7 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
             return NONE;
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             return queue.poll();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
@@ -59,6 +60,7 @@ public final class FlowableRange extends Flowable<Integer> {
             return mode & SYNC;
         }
 
+        @Nullable
         @Override
         public final Integer poll() {
             int i = index;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRangeLong.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRangeLong.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.flowable;
 
 import io.reactivex.Flowable;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.BasicQueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -62,6 +63,7 @@ public final class FlowableRangeLong extends Flowable<Long> {
             return mode & SYNC;
         }
 
+        @Nullable
         @Override
         public final Long poll() {
             long i = index;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowable.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.maybe;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
@@ -277,6 +278,7 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
             return it == null;
         }
 
+        @Nullable
         @Override
         public R poll() throws Exception {
             Iterator<? extends R> iter = it;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservable.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.maybe;
 import java.util.Iterator;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -187,6 +188,7 @@ public final class MaybeFlatMapIterableObservable<T, R> extends Observable<R> {
             return it == null;
         }
 
+        @Nullable
         @Override
         public R poll() throws Exception {
             Iterator<? extends R> iter = it;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeMergeArray.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeMergeArray.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.maybe;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
@@ -107,6 +108,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
             return NONE;
         }
 
+        @Nullable
         @SuppressWarnings("unchecked")
         @Override
         public T poll() throws Exception {
@@ -299,6 +301,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
 
     interface SimpleQueueWithConsumerIndex<T> extends SimpleQueue<T> {
 
+        @Nullable
         @Override
         T poll();
 
@@ -342,6 +345,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
             throw new UnsupportedOperationException();
         }
 
+        @Nullable
         @Override
         public T poll() {
             int ci = consumerIndex;
@@ -422,6 +426,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
             return super.offer(e);
         }
 
+        @Nullable
         @Override
         public T poll() {
             T v = super.poll();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.EmptyDisposable;
@@ -113,6 +114,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             for (;;) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.observers.BasicFuseableObserver;
 
@@ -90,6 +91,7 @@ public final class ObservableDistinctUntilChanged<T, K> extends AbstractObservab
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             for (;;) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.annotations.Experimental;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.observers.BasicFuseableObserver;
 
@@ -65,6 +66,7 @@ public final class ObservableDoAfterNext<T> extends AbstractObservableWithUpstre
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             T v = qs.poll();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.annotations.Experimental;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;
@@ -127,6 +128,7 @@ public final class ObservableDoFinally<T> extends AbstractObservableWithUpstream
             return qd.isEmpty();
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             T v = qd.poll();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.observers.BasicFuseableObserver;
 
@@ -60,6 +61,7 @@ public final class ObservableFilter<T> extends AbstractObservableWithUpstream<T,
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             for (;;) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.observable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -148,6 +149,7 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
             return d.isDisposed();
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             return null; // always empty

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.observers.BasicQueueDisposable;
 
@@ -61,6 +62,7 @@ public final class ObservableFromArray<T> extends Observable<T> {
             return NONE;
         }
 
+        @Nullable
         @Override
         public T poll() {
             int i = index;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.observable;
 import java.util.Iterator;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -122,6 +123,7 @@ public final class ObservableFromIterable<T> extends Observable<T> {
             return NONE;
         }
 
+        @Nullable
         @Override
         public T poll() {
             if (done) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMap.java
@@ -15,6 +15,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.observers.BasicFuseableObserver;
@@ -68,6 +69,7 @@ public final class ObservableMap<T, U> extends AbstractObservableWithUpstream<T,
             return transitiveBoundaryFusion(mode);
         }
 
+        @Nullable
         @Override
         public U poll() throws Exception {
             T t = qs.poll();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableObserveOn.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.DisposableHelper;
@@ -294,6 +295,7 @@ public final class ObservableObserveOn<T> extends AbstractObservableWithUpstream
             return NONE;
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             return queue.poll();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRange.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRange.java
@@ -13,6 +13,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.observers.BasicIntQueueDisposable;
 
 /**
@@ -68,6 +69,7 @@ public final class ObservableRange extends Observable<Integer> {
             }
         }
 
+        @Nullable
         @Override
         public Integer poll() throws Exception {
             long i = index;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRangeLong.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRangeLong.java
@@ -13,6 +13,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.observers.BasicIntQueueDisposable;
 
 public final class ObservableRangeLong extends Observable<Long> {
@@ -65,6 +66,7 @@ public final class ObservableRangeLong extends Observable<Long> {
             }
         }
 
+        @Nullable
         @Override
         public Long poll() throws Exception {
             long i = index;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.EmptyDisposable;
@@ -202,6 +203,7 @@ public final class ObservableScalarXMap {
             throw new UnsupportedOperationException("Should not be called!");
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             if (get() == FUSED) {

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowable.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.single;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
@@ -271,6 +272,7 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
             return it == null;
         }
 
+        @Nullable
         @Override
         public R poll() throws Exception {
             Iterator<? extends R> iter = it;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservable.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.single;
 import java.util.Iterator;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -181,6 +182,7 @@ public final class SingleFlatMapIterableObservable<T, R> extends Observable<R> {
             return it == null;
         }
 
+        @Nullable
         @Override
         public R poll() throws Exception {
             Iterator<? extends R> iter = it;

--- a/src/main/java/io/reactivex/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/MpscLinkedQueue.java
@@ -20,6 +20,7 @@ package io.reactivex.internal.queue;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.fuseable.SimplePlainQueue;
 
 /**
@@ -81,6 +82,7 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
      *
      * @see java.util.Queue#poll()
      */
+    @Nullable
     @Override
     public T poll() {
         LinkedQueueNode<T> currConsumerNode = lpConsumerNode(); // don't load twice, it's alright

--- a/src/main/java/io/reactivex/internal/queue/SpscArrayQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/SpscArrayQueue.java
@@ -20,6 +20,7 @@ package io.reactivex.internal.queue;
 
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.fuseable.SimplePlainQueue;
 import io.reactivex.internal.util.Pow2;
 
@@ -82,6 +83,7 @@ public final class SpscArrayQueue<E> extends AtomicReferenceArray<E> implements 
         return offer(v1) && offer(v2);
     }
 
+    @Nullable
     @Override
     public E poll() {
         final long index = consumerIndex.get();

--- a/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
@@ -20,6 +20,7 @@ package io.reactivex.internal.queue;
 
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.fuseable.SimplePlainQueue;
 import io.reactivex.internal.util.Pow2;
 
@@ -121,6 +122,7 @@ public final class SpscLinkedArrayQueue<T> implements SimplePlainQueue<T> {
      * <p>
      * This implementation is correct for single consumer thread use only.
      */
+    @Nullable
     @SuppressWarnings("unchecked")
     @Override
     public T poll() {

--- a/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.subscriptions;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 /**
@@ -156,6 +157,7 @@ public class DeferredScalarSubscription<T> extends BasicIntQueueSubscription<T> 
         return NONE;
     }
 
+    @Nullable
     @Override
     public final T poll() {
         if (get() == FUSED_READY) {

--- a/src/main/java/io/reactivex/internal/subscriptions/EmptySubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/EmptySubscription.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.subscriptions;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.internal.fuseable.QueueSubscription;
@@ -66,6 +67,7 @@ public enum EmptySubscription implements QueueSubscription<Object> {
         s.onSubscribe(INSTANCE);
         s.onComplete();
     }
+    @Nullable
     @Override
     public Object poll() {
         return null; // always empty

--- a/src/main/java/io/reactivex/internal/subscriptions/ScalarSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/ScalarSubscription.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.subscriptions;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.internal.fuseable.QueueSubscription;
@@ -82,6 +83,7 @@ public final class ScalarSubscription<T> extends AtomicInteger implements QueueS
         throw new UnsupportedOperationException("Should not be called!");
     }
 
+    @Nullable
     @Override
     public T poll() {
         if (get() == NO_REQUEST) {

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -16,6 +16,7 @@ package io.reactivex.processors;
 import io.reactivex.annotations.CheckReturnValue;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.internal.functions.ObjectHelper;
@@ -340,6 +341,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
 
         private static final long serialVersionUID = -4896760517184205454L;
 
+        @Nullable
         @Override
         public T poll() {
             return queue.poll();

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.subjects;
 
+import io.reactivex.annotations.Nullable;
 import io.reactivex.plugins.RxJavaPlugins;
 import java.util.concurrent.atomic.*;
 
@@ -348,6 +349,7 @@ public final class UnicastSubject<T> extends Subject<T> {
             return NONE;
         }
 
+        @Nullable
         @Override
         public T poll() throws Exception {
             return queue.poll();

--- a/src/test/java/io/reactivex/internal/observers/BasicFuseableObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/BasicFuseableObserverTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.observers;
 
+import io.reactivex.annotations.Nullable;
 import org.junit.Test;
 
 import io.reactivex.disposables.Disposables;
@@ -24,6 +25,7 @@ public class BasicFuseableObserverTest {
     public void offer() {
         TestObserver<Integer> to = new TestObserver<Integer>();
         BasicFuseableObserver<Integer, Integer> o = new BasicFuseableObserver<Integer, Integer>(to) {
+            @Nullable
             @Override
             public Integer poll() throws Exception {
                 return null;
@@ -51,6 +53,7 @@ public class BasicFuseableObserverTest {
     @Test(expected = UnsupportedOperationException.class)
     public void offer2() {
         BasicFuseableObserver<Integer, Integer> o = new BasicFuseableObserver<Integer, Integer>(new TestObserver<Integer>()) {
+            @Nullable
             @Override
             public Integer poll() throws Exception {
                 return null;

--- a/src/test/java/io/reactivex/internal/observers/BasicQueueDisposableTest.java
+++ b/src/test/java/io/reactivex/internal/observers/BasicQueueDisposableTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.observers;
 
+import io.reactivex.annotations.Nullable;
 import org.junit.Test;
 
 public class BasicQueueDisposableTest {
@@ -29,6 +30,7 @@ public class BasicQueueDisposableTest {
 
         }
 
+        @Nullable
         @Override
         public Integer poll() throws Exception {
             return null;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.Nullable;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.reactivestreams.*;
@@ -1363,6 +1364,7 @@ public class FlowableObserveOnTest {
                         return false;
                     }
 
+                    @Nullable
                     @Override
                     public Integer poll() throws Exception {
                         throw new TestException();
@@ -1413,6 +1415,7 @@ public class FlowableObserveOnTest {
                         return false;
                     }
 
+                    @Nullable
                     @Override
                     public Integer poll() throws Exception {
                         throw new TestException();
@@ -1464,6 +1467,7 @@ public class FlowableObserveOnTest {
                         return false;
                     }
 
+                    @Nullable
                     @Override
                     public Integer poll() throws Exception {
                         throw new TestException();
@@ -1514,6 +1518,7 @@ public class FlowableObserveOnTest {
                         return false;
                     }
 
+                    @Nullable
                     @Override
                     public Integer poll() throws Exception {
                         throw new TestException();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.annotations.Nullable;
 import org.junit.Test;
 import org.mockito.InOrder;
 
@@ -692,6 +693,7 @@ public class ObservableObserveOnTest {
                         return false;
                     }
 
+                    @Nullable
                     @Override
                     public Integer poll() throws Exception {
                         throw new TestException();

--- a/src/test/java/io/reactivex/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.subscribers;
 
 import static org.junit.Assert.*;
 
+import io.reactivex.annotations.Nullable;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 
@@ -66,6 +67,7 @@ public class BasicFuseableConditionalSubscriberTest {
                 return 0;
             }
 
+            @Nullable
             @Override
             public Integer poll() throws Exception {
                 return null;

--- a/src/test/java/io/reactivex/internal/subscribers/BasicFuseableSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/BasicFuseableSubscriberTest.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.subscribers;
 
 import static org.junit.Assert.*;
 
+import io.reactivex.annotations.Nullable;
 import org.junit.Test;
 
 import io.reactivex.TestHelper;
@@ -36,6 +37,7 @@ public class BasicFuseableSubscriberTest {
                 return 0;
             }
 
+            @Nullable
             @Override
             public Integer poll() throws Exception {
                 return null;

--- a/src/test/java/io/reactivex/internal/subscriptions/QueueSubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/QueueSubscriptionTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.subscriptions;
 
+import io.reactivex.annotations.Nullable;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -28,6 +29,7 @@ public class QueueSubscriptionTest {
             return 0;
         }
 
+        @Nullable
         @Override
         public Integer poll() throws Exception {
             return null;
@@ -64,6 +66,7 @@ public class QueueSubscriptionTest {
             return 0;
         }
 
+        @Nullable
         @Override
         public Integer poll() throws Exception {
             return null;


### PR DESCRIPTION
As explained in https://github.com/ReactiveX/RxJava/issues/5053 SimpleQueue might return null.
To document this behavior a nullable annotation has been added.