### PR TITLE
When declaring Functions/BiFunctions as parameter, ? super / ? extends is used

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -10650,7 +10650,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> reduce(BiFunction<T, T, T> reducer) {
+    public final Maybe<T> reduce(BiFunction<? super T, ? super  T, ? extends T> reducer) {
         ObjectHelper.requireNonNull(reducer, "reducer is null");
         return RxJavaPlugins.onAssembly(new FlowableReduceMaybe<T>(this, reducer));
     }
@@ -11916,7 +11916,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> scan(BiFunction<T, T, T> accumulator) {
+    public final Flowable<T> scan(BiFunction<? super T, ? super T, ? extends T> accumulator) {
         ObjectHelper.requireNonNull(accumulator, "accumulator is null");
         return RxJavaPlugins.onAssembly(new FlowableScan<T>(this, accumulator));
     }

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -14668,7 +14668,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Single<Map<K, Collection<T>>> toMultimap(Function<? super T, ? extends K> keySelector) {
-        Function<T, T> valueSelector = Functions.identity();
+        Function<? super T, ? extends T> valueSelector = Functions.identity();
         Callable<Map<K, Collection<T>>> mapSupplier = HashMapSupplier.asCallable();
         Function<K, List<T>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -8768,7 +8768,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> reduce(BiFunction<T, T, T> reducer) {
+    public final Maybe<T> reduce(BiFunction<? super T, ? super T, ? extends T> reducer) {
         ObjectHelper.requireNonNull(reducer, "reducer is null");
         return RxJavaPlugins.onAssembly(new ObservableReduceMaybe<T>(this, reducer));
     }
@@ -9870,7 +9870,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> scan(BiFunction<T, T, T> accumulator) {
+    public final Observable<T> scan(BiFunction<? super T, ? super T, ? extends T> accumulator) {
         ObjectHelper.requireNonNull(accumulator, "accumulator is null");
         return RxJavaPlugins.onAssembly(new ObservableScan<T>(this, accumulator));
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduce.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduce.java
@@ -29,9 +29,9 @@ import io.reactivex.plugins.RxJavaPlugins;
  */
 public final class FlowableReduce<T> extends AbstractFlowableWithUpstream<T, T> {
 
-    final BiFunction<T, T, T> reducer;
+    final BiFunction<? super T, ? super T, ? extends T> reducer;
 
-    public FlowableReduce(Publisher<T> source, BiFunction<T, T, T> reducer) {
+    public FlowableReduce(Publisher<T> source, BiFunction<? super T, ? super T, ? extends T> reducer) {
         super(source);
         this.reducer = reducer;
     }
@@ -45,11 +45,11 @@ public final class FlowableReduce<T> extends AbstractFlowableWithUpstream<T, T> 
 
         private static final long serialVersionUID = -4663883003264602070L;
 
-        final BiFunction<T, T, T> reducer;
+        final BiFunction<? super T, ? super T, ? extends T> reducer;
 
         Subscription s;
 
-        ReduceSubscriber(Subscriber<? super T> actual, BiFunction<T, T, T> reducer) {
+        ReduceSubscriber(Subscriber<? super T> actual, BiFunction<? super T, ? super T, ? extends T> reducer) {
             super(actual);
             this.reducer = reducer;
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceMaybe.java
@@ -35,9 +35,9 @@ implements HasUpstreamPublisher<T>, FuseToFlowable<T> {
 
     final Flowable<T> source;
 
-    final BiFunction<T, T, T> reducer;
+    final BiFunction<? super T, ? super T, ? extends T> reducer;
 
-    public FlowableReduceMaybe(Flowable<T> source, BiFunction<T, T, T> reducer) {
+    public FlowableReduceMaybe(Flowable<T> source, BiFunction<? super T, ? super T, ? extends T> reducer) {
         this.source = source;
         this.reducer = reducer;
     }
@@ -60,7 +60,7 @@ implements HasUpstreamPublisher<T>, FuseToFlowable<T> {
     static final class ReduceSubscriber<T> implements Subscriber<T>, Disposable {
         final MaybeObserver<? super T> actual;
 
-        final BiFunction<T, T, T> reducer;
+        final BiFunction<? super T, ? super T, ? extends T> reducer;
 
         T value;
 
@@ -68,7 +68,7 @@ implements HasUpstreamPublisher<T>, FuseToFlowable<T> {
 
         boolean done;
 
-        ReduceSubscriber(MaybeObserver<? super T> actual, BiFunction<T, T, T> reducer) {
+        ReduceSubscriber(MaybeObserver<? super T> actual, BiFunction<? super T, ? super T, ? extends T> reducer) {
             this.actual = actual;
             this.reducer = reducer;
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
@@ -22,8 +22,8 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableScan<T> extends AbstractFlowableWithUpstream<T, T> {
-    final BiFunction<T, T, T> accumulator;
-    public FlowableScan(Publisher<T> source, BiFunction<T, T, T> accumulator) {
+    final BiFunction<? super T, ? super T, ? extends T> accumulator;
+    public FlowableScan(Publisher<T> source, BiFunction<? super T, ? super T, ? extends T> accumulator) {
         super(source);
         this.accumulator = accumulator;
     }
@@ -35,7 +35,7 @@ public final class FlowableScan<T> extends AbstractFlowableWithUpstream<T, T> {
 
     static final class ScanSubscriber<T> implements Subscriber<T>, Subscription {
         final Subscriber<? super T> actual;
-        final BiFunction<T, T, T> accumulator;
+        final BiFunction<? super T, ? super T, ? extends T> accumulator;
 
         Subscription s;
 
@@ -43,7 +43,7 @@ public final class FlowableScan<T> extends AbstractFlowableWithUpstream<T, T> {
 
         boolean done;
 
-        ScanSubscriber(Subscriber<? super T> actual, BiFunction<T, T, T> accumulator) {
+        ScanSubscriber(Subscriber<? super T> actual, BiFunction<? super T, ? super T, ? extends T> accumulator) {
             this.actual = actual;
             this.accumulator = accumulator;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceMaybe.java
@@ -31,9 +31,9 @@ public final class ObservableReduceMaybe<T> extends Maybe<T> {
 
     final ObservableSource<T> source;
 
-    final BiFunction<T, T, T> reducer;
+    final BiFunction<? super T, ? super T, ? extends T> reducer;
 
-    public ObservableReduceMaybe(ObservableSource<T> source, BiFunction<T, T, T> reducer) {
+    public ObservableReduceMaybe(ObservableSource<T> source, BiFunction<? super T, ? super T, ? extends T> reducer) {
         this.source = source;
         this.reducer = reducer;
     }
@@ -47,7 +47,7 @@ public final class ObservableReduceMaybe<T> extends Maybe<T> {
 
         final MaybeObserver<? super T> actual;
 
-        final BiFunction<T, T, T> reducer;
+        final BiFunction<? super T, ? super T, ? extends T> reducer;
 
         boolean done;
 
@@ -55,7 +55,7 @@ public final class ObservableReduceMaybe<T> extends Maybe<T> {
 
         Disposable d;
 
-        ReduceObserver(MaybeObserver<? super T> observer, BiFunction<T, T, T> reducer) {
+        ReduceObserver(MaybeObserver<? super T> observer, BiFunction<? super T, ? super T, ? extends T> reducer) {
             this.actual = observer;
             this.reducer = reducer;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScan.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScan.java
@@ -22,8 +22,8 @@ import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableScan<T> extends AbstractObservableWithUpstream<T, T> {
-    final BiFunction<T, T, T> accumulator;
-    public ObservableScan(ObservableSource<T> source, BiFunction<T, T, T> accumulator) {
+    final BiFunction<? super T, ? super T, ? extends T> accumulator;
+    public ObservableScan(ObservableSource<T> source, BiFunction<? super T, ? super T, ? extends T> accumulator) {
         super(source);
         this.accumulator = accumulator;
     }
@@ -35,7 +35,7 @@ public final class ObservableScan<T> extends AbstractObservableWithUpstream<T, T
 
     static final class ScanObserver<T> implements Observer<T>, Disposable {
         final Observer<? super T> actual;
-        final BiFunction<T, T, T> accumulator;
+        final BiFunction<? super T, ? super T, ? extends T> accumulator;
 
         Disposable s;
 
@@ -43,7 +43,7 @@ public final class ObservableScan<T> extends AbstractObservableWithUpstream<T, T
 
         boolean done;
 
-        ScanObserver(Observer<? super T> actual, BiFunction<T, T, T> accumulator) {
+        ScanObserver(Observer<? super T> actual, BiFunction<? super T, ? super T, ? extends T> accumulator) {
             this.actual = actual;
             this.accumulator = accumulator;
         }

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelReduceFull.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelReduceFull.java
@@ -35,9 +35,9 @@ public final class ParallelReduceFull<T> extends Flowable<T> {
 
     final ParallelFlowable<? extends T> source;
 
-    final BiFunction<T, T, T> reducer;
+    final BiFunction<? super T, ? super T, ? extends T> reducer;
 
-    public ParallelReduceFull(ParallelFlowable<? extends T> source, BiFunction<T, T, T> reducer) {
+    public ParallelReduceFull(ParallelFlowable<? extends T> source, BiFunction<? super T, ? super T, ? extends T> reducer) {
         this.source = source;
         this.reducer = reducer;
     }
@@ -57,7 +57,7 @@ public final class ParallelReduceFull<T> extends Flowable<T> {
 
         final ParallelReduceFullInnerSubscriber<T>[] subscribers;
 
-        final BiFunction<T, T, T> reducer;
+        final BiFunction<? super T, ? super T, ? extends T> reducer;
 
         final AtomicReference<SlotPair<T>> current = new AtomicReference<SlotPair<T>>();
 
@@ -65,7 +65,7 @@ public final class ParallelReduceFull<T> extends Flowable<T> {
 
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
 
-        ParallelReduceFullMainSubscriber(Subscriber<? super T> subscriber, int n, BiFunction<T, T, T> reducer) {
+        ParallelReduceFullMainSubscriber(Subscriber<? super T> subscriber, int n, BiFunction<? super T, ? super T, ? extends T> reducer) {
             super(subscriber);
             @SuppressWarnings("unchecked")
             ParallelReduceFullInnerSubscriber<T>[] a = new ParallelReduceFullInnerSubscriber[n];
@@ -167,13 +167,13 @@ public final class ParallelReduceFull<T> extends Flowable<T> {
 
         final ParallelReduceFullMainSubscriber<T> parent;
 
-        final BiFunction<T, T, T> reducer;
+        final BiFunction<? super T, ? super T, ? extends T> reducer;
 
         T value;
 
         boolean done;
 
-        ParallelReduceFullInnerSubscriber(ParallelReduceFullMainSubscriber<T> parent, BiFunction<T, T, T> reducer) {
+        ParallelReduceFullInnerSubscriber(ParallelReduceFullMainSubscriber<T> parent, BiFunction<? super T, ? super T, ? extends T> reducer) {
             this.parent = parent;
             this.reducer = reducer;
         }

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -209,7 +209,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new Flowable instance emitting the reduced value or empty if the ParallelFlowable was empty
      */
     @CheckReturnValue
-    public final Flowable<T> reduce(BiFunction<T, T, T> reducer) {
+    public final Flowable<T> reduce(BiFunction<? super T, ? super T, ? extends T> reducer) {
         ObjectHelper.requireNonNull(reducer, "reducer");
         return RxJavaPlugins.onAssembly(new ParallelReduceFull<T>(this, reducer));
     }

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -52,7 +52,7 @@ public final class RxJavaPlugins {
     static volatile Consumer<? super Throwable> errorHandler;
 
     @Nullable
-    static volatile Function<Runnable, Runnable> onScheduleHandler;
+    static volatile Function<? super Runnable, ? extends Runnable> onScheduleHandler;
 
     @Nullable
     static volatile Function<Callable<Scheduler>, Scheduler> onInitComputationHandler;
@@ -260,7 +260,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<Runnable, Runnable> getScheduleHandler() {
+    public static Function<? super Runnable, ? extends Runnable> getScheduleHandler() {
         return onScheduleHandler;
     }
 
@@ -418,7 +418,7 @@ public final class RxJavaPlugins {
      */
     @NonNull
     public static Runnable onSchedule(@NonNull Runnable run) {
-        Function<Runnable, Runnable> f = onScheduleHandler;
+        Function<? super Runnable, ? extends Runnable> f = onScheduleHandler;
         if (f == null) {
             return run;
         }

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -49,7 +49,7 @@ import java.util.concurrent.ThreadFactory;
  */
 public final class RxJavaPlugins {
     @Nullable
-    static volatile Consumer<Throwable> errorHandler;
+    static volatile Consumer<? super Throwable> errorHandler;
 
     @Nullable
     static volatile Function<Runnable, Runnable> onScheduleHandler;
@@ -197,7 +197,7 @@ public final class RxJavaPlugins {
      * @return the hook consumer, may be null
      */
     @Nullable
-    public static Consumer<Throwable> getErrorHandler() {
+    public static Consumer<? super Throwable> getErrorHandler() {
         return errorHandler;
     }
 
@@ -356,7 +356,7 @@ public final class RxJavaPlugins {
      * @param error the error to report
      */
     public static void onError(@NonNull Throwable error) {
-        Consumer<Throwable> f = errorHandler;
+        Consumer<? super Throwable> f = errorHandler;
 
         if (error == null) {
             error = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
@@ -497,7 +497,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setErrorHandler(@Nullable Consumer<Throwable> handler) {
+    public static void setErrorHandler(@Nullable Consumer<? super Throwable> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -55,77 +55,77 @@ public final class RxJavaPlugins {
     static volatile Function<? super Runnable, ? extends Runnable> onScheduleHandler;
 
     @Nullable
-    static volatile Function<Callable<Scheduler>, Scheduler> onInitComputationHandler;
+    static volatile Function<? super Callable<Scheduler>, ? extends Scheduler> onInitComputationHandler;
 
     @Nullable
-    static volatile Function<Callable<Scheduler>, Scheduler> onInitSingleHandler;
+    static volatile Function<? super Callable<Scheduler>, ? extends Scheduler> onInitSingleHandler;
 
     @Nullable
-    static volatile Function<Callable<Scheduler>, Scheduler> onInitIoHandler;
+    static volatile Function<? super Callable<Scheduler>, ? extends Scheduler> onInitIoHandler;
 
     @Nullable
-    static volatile Function<Callable<Scheduler>, Scheduler> onInitNewThreadHandler;
+    static volatile Function<? super Callable<Scheduler>, ? extends Scheduler> onInitNewThreadHandler;
 
     @Nullable
-    static volatile Function<Scheduler, Scheduler> onComputationHandler;
+    static volatile Function<? super Scheduler, ? extends Scheduler> onComputationHandler;
 
     @Nullable
-    static volatile Function<Scheduler, Scheduler> onSingleHandler;
+    static volatile Function<? super Scheduler, ? extends Scheduler> onSingleHandler;
 
     @Nullable
-    static volatile Function<Scheduler, Scheduler> onIoHandler;
+    static volatile Function<? super Scheduler, ? extends Scheduler> onIoHandler;
 
     @Nullable
-    static volatile Function<Scheduler, Scheduler> onNewThreadHandler;
+    static volatile Function<? super Scheduler, ? extends Scheduler> onNewThreadHandler;
 
     @SuppressWarnings("rawtypes")
     @Nullable
-    static volatile Function<Flowable, Flowable> onFlowableAssembly;
+    static volatile Function<? super Flowable, ? extends Flowable> onFlowableAssembly;
 
     @SuppressWarnings("rawtypes")
     @Nullable
-    static volatile Function<ConnectableFlowable, ConnectableFlowable> onConnectableFlowableAssembly;
+    static volatile Function<? super ConnectableFlowable, ? extends ConnectableFlowable> onConnectableFlowableAssembly;
 
     @SuppressWarnings("rawtypes")
     @Nullable
-    static volatile Function<Observable, Observable> onObservableAssembly;
+    static volatile Function<? super Observable, ? extends Observable> onObservableAssembly;
 
     @SuppressWarnings("rawtypes")
     @Nullable
-    static volatile Function<ConnectableObservable, ConnectableObservable> onConnectableObservableAssembly;
+    static volatile Function<? super ConnectableObservable, ? extends ConnectableObservable> onConnectableObservableAssembly;
 
     @SuppressWarnings("rawtypes")
     @Nullable
-    static volatile Function<Maybe, Maybe> onMaybeAssembly;
+    static volatile Function<? super Maybe, ? extends Maybe> onMaybeAssembly;
 
     @SuppressWarnings("rawtypes")
     @Nullable
-    static volatile Function<Single, Single> onSingleAssembly;
+    static volatile Function<? super Single, ? extends Single> onSingleAssembly;
 
-    static volatile Function<Completable, Completable> onCompletableAssembly;
-
-    @SuppressWarnings("rawtypes")
-    @Nullable
-    static volatile Function<ParallelFlowable, ParallelFlowable> onParallelAssembly;
+    static volatile Function<? super Completable, ? extends Completable> onCompletableAssembly;
 
     @SuppressWarnings("rawtypes")
     @Nullable
-    static volatile BiFunction<Flowable, Subscriber, Subscriber> onFlowableSubscribe;
+    static volatile Function<? super ParallelFlowable, ? extends ParallelFlowable> onParallelAssembly;
 
     @SuppressWarnings("rawtypes")
     @Nullable
-    static volatile BiFunction<Maybe, MaybeObserver, MaybeObserver> onMaybeSubscribe;
+    static volatile BiFunction<? super Flowable, ? super Subscriber, ? extends Subscriber> onFlowableSubscribe;
 
     @SuppressWarnings("rawtypes")
     @Nullable
-    static volatile BiFunction<Observable, Observer, Observer> onObservableSubscribe;
+    static volatile BiFunction<? super Maybe, ? super MaybeObserver, ? extends MaybeObserver> onMaybeSubscribe;
 
     @SuppressWarnings("rawtypes")
     @Nullable
-    static volatile BiFunction<Single, SingleObserver, SingleObserver> onSingleSubscribe;
+    static volatile BiFunction<? super Observable, ? super Observer, ? extends Observer> onObservableSubscribe;
+
+    @SuppressWarnings("rawtypes")
+    @Nullable
+    static volatile BiFunction<? super Single, ? super SingleObserver, ? extends SingleObserver> onSingleSubscribe;
 
     @Nullable
-    static volatile BiFunction<Completable, CompletableObserver, CompletableObserver> onCompletableSubscribe;
+    static volatile BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> onCompletableSubscribe;
 
     @Nullable
     static volatile BooleanSupplier onBeforeBlocking;
@@ -188,7 +188,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<Scheduler, Scheduler> getComputationSchedulerHandler() {
+    public static Function<? super Scheduler, ? extends Scheduler> getComputationSchedulerHandler() {
         return onComputationHandler;
     }
 
@@ -206,7 +206,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<Callable<Scheduler>, Scheduler> getInitComputationSchedulerHandler() {
+    public static Function<? super Callable<Scheduler>, ? extends Scheduler> getInitComputationSchedulerHandler() {
         return onInitComputationHandler;
     }
 
@@ -215,7 +215,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<Callable<Scheduler>, Scheduler> getInitIoSchedulerHandler() {
+    public static Function<? super Callable<Scheduler>, ? extends Scheduler> getInitIoSchedulerHandler() {
         return onInitIoHandler;
     }
 
@@ -224,7 +224,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<Callable<Scheduler>, Scheduler> getInitNewThreadSchedulerHandler() {
+    public static Function<? super Callable<Scheduler>, ? extends Scheduler> getInitNewThreadSchedulerHandler() {
         return onInitNewThreadHandler;
     }
 
@@ -233,7 +233,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<Callable<Scheduler>, Scheduler> getInitSingleSchedulerHandler() {
+    public static Function<? super Callable<Scheduler>, ? extends Scheduler> getInitSingleSchedulerHandler() {
         return onInitSingleHandler;
     }
 
@@ -242,7 +242,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<Scheduler, Scheduler> getIoSchedulerHandler() {
+    public static Function<? super Scheduler, ? extends Scheduler> getIoSchedulerHandler() {
         return onIoHandler;
     }
 
@@ -251,7 +251,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<Scheduler, Scheduler> getNewThreadSchedulerHandler() {
+    public static Function<? super Scheduler, ? extends Scheduler> getNewThreadSchedulerHandler() {
         return onNewThreadHandler;
     }
 
@@ -269,7 +269,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<Scheduler, Scheduler> getSingleSchedulerHandler() {
+    public static Function<? super Scheduler, ? extends Scheduler> getSingleSchedulerHandler() {
         return onSingleHandler;
     }
 
@@ -282,7 +282,7 @@ public final class RxJavaPlugins {
     @NonNull
     public static Scheduler initComputationScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<Callable<Scheduler>, Scheduler> f = onInitComputationHandler;
+        Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitComputationHandler;
         if (f == null) {
             return callRequireNonNull(defaultScheduler);
         }
@@ -298,7 +298,7 @@ public final class RxJavaPlugins {
     @NonNull
     public static Scheduler initIoScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<Callable<Scheduler>, Scheduler> f = onInitIoHandler;
+        Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitIoHandler;
         if (f == null) {
             return callRequireNonNull(defaultScheduler);
         }
@@ -314,7 +314,7 @@ public final class RxJavaPlugins {
     @NonNull
     public static Scheduler initNewThreadScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<Callable<Scheduler>, Scheduler> f = onInitNewThreadHandler;
+        Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitNewThreadHandler;
         if (f == null) {
             return callRequireNonNull(defaultScheduler);
         }
@@ -330,7 +330,7 @@ public final class RxJavaPlugins {
     @NonNull
     public static Scheduler initSingleScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<Callable<Scheduler>, Scheduler> f = onInitSingleHandler;
+        Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitSingleHandler;
         if (f == null) {
             return callRequireNonNull(defaultScheduler);
         }
@@ -344,7 +344,7 @@ public final class RxJavaPlugins {
      */
     @NonNull
     public static Scheduler onComputationScheduler(@NonNull Scheduler defaultScheduler) {
-        Function<Scheduler, Scheduler> f = onComputationHandler;
+        Function<? super Scheduler, ? extends Scheduler> f = onComputationHandler;
         if (f == null) {
             return defaultScheduler;
         }
@@ -390,7 +390,7 @@ public final class RxJavaPlugins {
      */
     @NonNull
     public static Scheduler onIoScheduler(@NonNull Scheduler defaultScheduler) {
-        Function<Scheduler, Scheduler> f = onIoHandler;
+        Function<? super Scheduler, ? extends Scheduler> f = onIoHandler;
         if (f == null) {
             return defaultScheduler;
         }
@@ -404,7 +404,7 @@ public final class RxJavaPlugins {
      */
     @NonNull
     public static Scheduler onNewThreadScheduler(@NonNull Scheduler defaultScheduler) {
-        Function<Scheduler, Scheduler> f = onNewThreadHandler;
+        Function<? super Scheduler, ? extends Scheduler> f = onNewThreadHandler;
         if (f == null) {
             return defaultScheduler;
         }
@@ -432,7 +432,7 @@ public final class RxJavaPlugins {
      */
     @NonNull
     public static Scheduler onSingleScheduler(@NonNull Scheduler defaultScheduler) {
-        Function<Scheduler, Scheduler> f = onSingleHandler;
+        Function<? super Scheduler, ? extends Scheduler> f = onSingleHandler;
         if (f == null) {
             return defaultScheduler;
         }
@@ -486,7 +486,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setComputationSchedulerHandler(@Nullable Function<Scheduler, Scheduler> handler) {
+    public static void setComputationSchedulerHandler(@Nullable Function<? super Scheduler, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -508,7 +508,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitComputationSchedulerHandler(@Nullable Function<Callable<Scheduler>, Scheduler> handler) {
+    public static void setInitComputationSchedulerHandler(@Nullable Function<? super Callable<Scheduler>, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -519,7 +519,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitIoSchedulerHandler(@Nullable Function<Callable<Scheduler>, Scheduler> handler) {
+    public static void setInitIoSchedulerHandler(@Nullable Function<? super Callable<Scheduler>, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -530,7 +530,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitNewThreadSchedulerHandler(@Nullable Function<Callable<Scheduler>, Scheduler> handler) {
+    public static void setInitNewThreadSchedulerHandler(@Nullable Function<? super Callable<Scheduler>, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -541,7 +541,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitSingleSchedulerHandler(@Nullable Function<Callable<Scheduler>, Scheduler> handler) {
+    public static void setInitSingleSchedulerHandler(@Nullable Function<? super Callable<Scheduler>, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -552,7 +552,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setIoSchedulerHandler(@Nullable Function<Scheduler, Scheduler> handler) {
+    public static void setIoSchedulerHandler(@Nullable Function<? super Scheduler, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -563,7 +563,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setNewThreadSchedulerHandler(@Nullable Function<Scheduler, Scheduler> handler) {
+    public static void setNewThreadSchedulerHandler(@Nullable Function<? super Scheduler, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -574,7 +574,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setScheduleHandler(@Nullable Function<Runnable, Runnable> handler) {
+    public static void setScheduleHandler(@Nullable Function<? super Runnable, ? extends Runnable> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -585,7 +585,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setSingleSchedulerHandler(@Nullable Function<Scheduler, Scheduler> handler) {
+    public static void setSingleSchedulerHandler(@Nullable Function<? super Scheduler, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -604,7 +604,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<Completable, Completable> getOnCompletableAssembly() {
+    public static Function<? super Completable, ? extends Completable> getOnCompletableAssembly() {
         return onCompletableAssembly;
     }
 
@@ -613,7 +613,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static BiFunction<Completable, CompletableObserver, CompletableObserver> getOnCompletableSubscribe() {
+    public static BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> getOnCompletableSubscribe() {
         return onCompletableSubscribe;
     }
 
@@ -623,7 +623,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings("rawtypes")
     @Nullable
-    public static Function<Flowable, Flowable> getOnFlowableAssembly() {
+    public static Function<? super Flowable, ? extends Flowable> getOnFlowableAssembly() {
         return onFlowableAssembly;
     }
 
@@ -633,7 +633,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings("rawtypes")
     @Nullable
-    public static Function<ConnectableFlowable, ConnectableFlowable> getOnConnectableFlowableAssembly() {
+    public static Function<? super ConnectableFlowable, ? extends ConnectableFlowable> getOnConnectableFlowableAssembly() {
         return onConnectableFlowableAssembly;
     }
 
@@ -643,7 +643,7 @@ public final class RxJavaPlugins {
      */
     @Nullable
     @SuppressWarnings("rawtypes")
-    public static BiFunction<Flowable, Subscriber, Subscriber> getOnFlowableSubscribe() {
+    public static BiFunction<? super Flowable, ? super Subscriber, ? extends Subscriber> getOnFlowableSubscribe() {
         return onFlowableSubscribe;
     }
 
@@ -653,7 +653,7 @@ public final class RxJavaPlugins {
      */
     @Nullable
     @SuppressWarnings("rawtypes")
-    public static BiFunction<Maybe, MaybeObserver, MaybeObserver> getOnMaybeSubscribe() {
+    public static BiFunction<? super Maybe, ? super MaybeObserver, ? extends MaybeObserver> getOnMaybeSubscribe() {
         return onMaybeSubscribe;
     }
 
@@ -663,7 +663,7 @@ public final class RxJavaPlugins {
      */
     @Nullable
     @SuppressWarnings("rawtypes")
-    public static Function<Maybe, Maybe> getOnMaybeAssembly() {
+    public static Function<? super Maybe, ? extends Maybe> getOnMaybeAssembly() {
         return onMaybeAssembly;
     }
 
@@ -673,7 +673,7 @@ public final class RxJavaPlugins {
      */
     @Nullable
     @SuppressWarnings("rawtypes")
-    public static Function<Single, Single> getOnSingleAssembly() {
+    public static Function<? super Single, ? extends Single> getOnSingleAssembly() {
         return onSingleAssembly;
     }
 
@@ -683,7 +683,7 @@ public final class RxJavaPlugins {
      */
     @Nullable
     @SuppressWarnings("rawtypes")
-    public static BiFunction<Single, SingleObserver, SingleObserver> getOnSingleSubscribe() {
+    public static BiFunction<? super Single, ? super SingleObserver, ? extends SingleObserver> getOnSingleSubscribe() {
         return onSingleSubscribe;
     }
 
@@ -693,7 +693,7 @@ public final class RxJavaPlugins {
      */
     @Nullable
     @SuppressWarnings("rawtypes")
-    public static Function<Observable, Observable> getOnObservableAssembly() {
+    public static Function<? super Observable, ? extends Observable> getOnObservableAssembly() {
         return onObservableAssembly;
     }
 
@@ -703,7 +703,7 @@ public final class RxJavaPlugins {
      */
     @Nullable
     @SuppressWarnings("rawtypes")
-    public static Function<ConnectableObservable, ConnectableObservable> getOnConnectableObservableAssembly() {
+    public static Function<? super ConnectableObservable, ? extends ConnectableObservable> getOnConnectableObservableAssembly() {
         return onConnectableObservableAssembly;
     }
 
@@ -713,7 +713,7 @@ public final class RxJavaPlugins {
      */
     @Nullable
     @SuppressWarnings("rawtypes")
-    public static BiFunction<Observable, Observer, Observer> getOnObservableSubscribe() {
+    public static BiFunction<? super Observable, ? super Observer, ? extends Observer> getOnObservableSubscribe() {
         return onObservableSubscribe;
     }
 
@@ -721,7 +721,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param onCompletableAssembly the hook function to set, null allowed
      */
-    public static void setOnCompletableAssembly(@Nullable Function<Completable, Completable> onCompletableAssembly) {
+    public static void setOnCompletableAssembly(@Nullable Function<? super Completable, ? extends Completable> onCompletableAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -733,7 +733,7 @@ public final class RxJavaPlugins {
      * @param onCompletableSubscribe the hook function to set, null allowed
      */
     public static void setOnCompletableSubscribe(
-            @Nullable BiFunction<Completable, CompletableObserver, CompletableObserver> onCompletableSubscribe) {
+            @Nullable BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> onCompletableSubscribe) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -745,7 +745,7 @@ public final class RxJavaPlugins {
      * @param onFlowableAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnFlowableAssembly(@Nullable Function<Flowable, Flowable> onFlowableAssembly) {
+    public static void setOnFlowableAssembly(@Nullable Function<? super Flowable, ? extends Flowable> onFlowableAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -757,7 +757,7 @@ public final class RxJavaPlugins {
      * @param onMaybeAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnMaybeAssembly(@Nullable Function<Maybe, Maybe> onMaybeAssembly) {
+    public static void setOnMaybeAssembly(@Nullable Function<? super Maybe, ? extends Maybe> onMaybeAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -769,7 +769,7 @@ public final class RxJavaPlugins {
      * @param onConnectableFlowableAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnConnectableFlowableAssembly(@Nullable Function<ConnectableFlowable, ConnectableFlowable> onConnectableFlowableAssembly) {
+    public static void setOnConnectableFlowableAssembly(@Nullable Function<? super ConnectableFlowable, ? extends ConnectableFlowable> onConnectableFlowableAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -781,7 +781,7 @@ public final class RxJavaPlugins {
      * @param onFlowableSubscribe the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnFlowableSubscribe(@Nullable BiFunction<Flowable, Subscriber, Subscriber> onFlowableSubscribe) {
+    public static void setOnFlowableSubscribe(@Nullable BiFunction<? super Flowable, ? super Subscriber, ? extends Subscriber> onFlowableSubscribe) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -793,7 +793,7 @@ public final class RxJavaPlugins {
      * @param onMaybeSubscribe the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnMaybeSubscribe(@Nullable BiFunction<Maybe, MaybeObserver, MaybeObserver> onMaybeSubscribe) {
+    public static void setOnMaybeSubscribe(@Nullable BiFunction<? super Maybe, MaybeObserver, ? extends MaybeObserver> onMaybeSubscribe) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -805,7 +805,7 @@ public final class RxJavaPlugins {
      * @param onObservableAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnObservableAssembly(@Nullable Function<Observable, Observable> onObservableAssembly) {
+    public static void setOnObservableAssembly(@Nullable Function<? super Observable, ? extends Observable> onObservableAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -817,7 +817,7 @@ public final class RxJavaPlugins {
      * @param onConnectableObservableAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnConnectableObservableAssembly(@Nullable Function<ConnectableObservable, ConnectableObservable> onConnectableObservableAssembly) {
+    public static void setOnConnectableObservableAssembly(@Nullable Function<? super ConnectableObservable, ? extends ConnectableObservable> onConnectableObservableAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -830,7 +830,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings("rawtypes")
     public static void setOnObservableSubscribe(
-            @Nullable BiFunction<Observable, Observer, Observer> onObservableSubscribe) {
+            @Nullable BiFunction<? super Observable, ? super Observer, ? extends Observer> onObservableSubscribe) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -842,7 +842,7 @@ public final class RxJavaPlugins {
      * @param onSingleAssembly the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnSingleAssembly(@Nullable Function<Single, Single> onSingleAssembly) {
+    public static void setOnSingleAssembly(@Nullable Function<? super Single, ? extends Single> onSingleAssembly) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -854,7 +854,7 @@ public final class RxJavaPlugins {
      * @param onSingleSubscribe the hook function to set, null allowed
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnSingleSubscribe(@Nullable BiFunction<Single, SingleObserver, SingleObserver> onSingleSubscribe) {
+    public static void setOnSingleSubscribe(@Nullable BiFunction<? super Single, ? super SingleObserver, ? extends SingleObserver> onSingleSubscribe) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -871,7 +871,7 @@ public final class RxJavaPlugins {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> Subscriber<? super T> onSubscribe(@NonNull Flowable<T> source, @NonNull Subscriber<? super T> subscriber) {
-        BiFunction<Flowable, Subscriber, Subscriber> f = onFlowableSubscribe;
+        BiFunction<? super Flowable, ? super Subscriber, ? extends Subscriber> f = onFlowableSubscribe;
         if (f != null) {
             return apply(f, source, subscriber);
         }
@@ -888,7 +888,7 @@ public final class RxJavaPlugins {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> Observer<? super T> onSubscribe(@NonNull Observable<T> source, @NonNull Observer<? super T> observer) {
-        BiFunction<Observable, Observer, Observer> f = onObservableSubscribe;
+        BiFunction<? super Observable, ? super Observer, ? extends Observer> f = onObservableSubscribe;
         if (f != null) {
             return apply(f, source, observer);
         }
@@ -905,7 +905,7 @@ public final class RxJavaPlugins {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> SingleObserver<? super T> onSubscribe(@NonNull Single<T> source, @NonNull SingleObserver<? super T> observer) {
-        BiFunction<Single, SingleObserver, SingleObserver> f = onSingleSubscribe;
+        BiFunction<? super Single, ? super SingleObserver, ? extends SingleObserver> f = onSingleSubscribe;
         if (f != null) {
             return apply(f, source, observer);
         }
@@ -920,7 +920,7 @@ public final class RxJavaPlugins {
      */
     @NonNull
     public static CompletableObserver onSubscribe(@NonNull Completable source, @NonNull CompletableObserver observer) {
-        BiFunction<Completable, CompletableObserver, CompletableObserver> f = onCompletableSubscribe;
+        BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> f = onCompletableSubscribe;
         if (f != null) {
             return apply(f, source, observer);
         }
@@ -937,7 +937,7 @@ public final class RxJavaPlugins {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> MaybeObserver<? super T> onSubscribe(@NonNull Maybe<T> source, @NonNull MaybeObserver<? super T> subscriber) {
-        BiFunction<Maybe, MaybeObserver, MaybeObserver> f = onMaybeSubscribe;
+        BiFunction<? super Maybe, ? super MaybeObserver, ? extends MaybeObserver> f = onMaybeSubscribe;
         if (f != null) {
             return apply(f, source, subscriber);
         }
@@ -953,7 +953,7 @@ public final class RxJavaPlugins {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> Maybe<T> onAssembly(@NonNull Maybe<T> source) {
-        Function<Maybe, Maybe> f = onMaybeAssembly;
+        Function<? super Maybe, ? extends Maybe> f = onMaybeAssembly;
         if (f != null) {
             return apply(f, source);
         }
@@ -969,7 +969,7 @@ public final class RxJavaPlugins {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> Flowable<T> onAssembly(@NonNull Flowable<T> source) {
-        Function<Flowable, Flowable> f = onFlowableAssembly;
+        Function<? super Flowable, ? extends Flowable> f = onFlowableAssembly;
         if (f != null) {
             return apply(f, source);
         }
@@ -985,7 +985,7 @@ public final class RxJavaPlugins {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> ConnectableFlowable<T> onAssembly(@NonNull ConnectableFlowable<T> source) {
-        Function<ConnectableFlowable, ConnectableFlowable> f = onConnectableFlowableAssembly;
+        Function<? super ConnectableFlowable, ? extends ConnectableFlowable> f = onConnectableFlowableAssembly;
         if (f != null) {
             return apply(f, source);
         }
@@ -1001,7 +1001,7 @@ public final class RxJavaPlugins {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> Observable<T> onAssembly(@NonNull Observable<T> source) {
-        Function<Observable, Observable> f = onObservableAssembly;
+        Function<? super Observable, ? extends Observable> f = onObservableAssembly;
         if (f != null) {
             return apply(f, source);
         }
@@ -1017,7 +1017,7 @@ public final class RxJavaPlugins {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> ConnectableObservable<T> onAssembly(@NonNull ConnectableObservable<T> source) {
-        Function<ConnectableObservable, ConnectableObservable> f = onConnectableObservableAssembly;
+        Function<? super ConnectableObservable, ? extends ConnectableObservable> f = onConnectableObservableAssembly;
         if (f != null) {
             return apply(f, source);
         }
@@ -1033,7 +1033,7 @@ public final class RxJavaPlugins {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> Single<T> onAssembly(@NonNull Single<T> source) {
-        Function<Single, Single> f = onSingleAssembly;
+        Function<? super Single, ? extends Single> f = onSingleAssembly;
         if (f != null) {
             return apply(f, source);
         }
@@ -1047,7 +1047,7 @@ public final class RxJavaPlugins {
      */
     @NonNull
     public static Completable onAssembly(@NonNull Completable source) {
-        Function<Completable, Completable> f = onCompletableAssembly;
+        Function<? super Completable, ? extends Completable> f = onCompletableAssembly;
         if (f != null) {
             return apply(f, source);
         }
@@ -1061,7 +1061,7 @@ public final class RxJavaPlugins {
      */
     @Experimental
     @SuppressWarnings("rawtypes")
-    public static void setOnParallelAssembly(@Nullable Function<ParallelFlowable, ParallelFlowable> handler) {
+    public static void setOnParallelAssembly(@Nullable Function<? super ParallelFlowable, ? extends ParallelFlowable> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -1076,7 +1076,7 @@ public final class RxJavaPlugins {
     @Experimental
     @SuppressWarnings("rawtypes")
     @Nullable
-    public static Function<ParallelFlowable, ParallelFlowable> getOnParallelAssembly() {
+    public static Function<? super ParallelFlowable, ? extends ParallelFlowable> getOnParallelAssembly() {
         return onParallelAssembly;
     }
 
@@ -1091,7 +1091,7 @@ public final class RxJavaPlugins {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> ParallelFlowable<T> onAssembly(@NonNull ParallelFlowable<T> source) {
-        Function<ParallelFlowable, ParallelFlowable> f = onParallelAssembly;
+        Function<? super ParallelFlowable, ? extends ParallelFlowable> f = onParallelAssembly;
         if (f != null) {
             return apply(f, source);
         }
@@ -1268,7 +1268,7 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the function parameter returns null
      */
     @NonNull
-    static Scheduler applyRequireNonNull(@NonNull Function<Callable<Scheduler>, Scheduler> f, Callable<Scheduler> s) {
+    static Scheduler applyRequireNonNull(@NonNull Function<? super Callable<Scheduler>, ? extends Scheduler> f, Callable<Scheduler> s) {
         return ObjectHelper.requireNonNull(apply(f, s), "Scheduler Callable result can't be null");
     }
 

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -1235,7 +1235,7 @@ public final class RxJavaPlugins {
      * @return the result of the function call
      */
     @NonNull
-    static <T, U, R> R apply(@NonNull BiFunction<T, U, R> f, @NonNull T t, @NonNull U u) {
+    static <T, U, R> R apply(@NonNull BiFunction<? super T, ? super U, ? extends R> f, @NonNull T t, @NonNull U u) {
         try {
             return f.apply(t, u);
         } catch (Throwable ex) {

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -1215,7 +1215,7 @@ public final class RxJavaPlugins {
      * @return the result of the function call
      */
     @NonNull
-    static <T, R> R apply(@NonNull Function<T, R> f, @NonNull T t) {
+    static <T, R> R apply(@NonNull Function<? super T, ? extends R> f, @NonNull T t) {
         try {
             return f.apply(t);
         } catch (Throwable ex) {

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -1168,7 +1168,28 @@ public class RxJavaPluginsTest {
         }
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    /**
+     * Ensure setErrorHandler() accepts a consumer with "? super Throwable"
+     */
+    @Test
+    public void onErrorWithSuper() throws Exception {
+        try {
+            Consumer<? super Throwable> errorHandler = new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable t) {
+                    throw new TestException("Forced failure 2");
+                }
+            };
+            RxJavaPlugins.setErrorHandler(errorHandler);
+
+            Consumer<? super Throwable> errorHandler1 = RxJavaPlugins.getErrorHandler();
+            assertSame(errorHandler, errorHandler1);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked" })
     @Test
     public void clearIsPassthrough() {
         try {

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -16,14 +16,26 @@
 
 package io.reactivex.plugins;
 
-import io.reactivex.*;
+import io.reactivex.Completable;
+import io.reactivex.CompletableObserver;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.Scheduler;
 import io.reactivex.Scheduler.Worker;
-import io.reactivex.disposables.*;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.flowables.ConnectableFlowable;
-import io.reactivex.functions.*;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.completable.CompletableError;
 import io.reactivex.internal.operators.flowable.FlowableRange;
@@ -37,14 +49,20 @@ import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.schedulers.Schedulers;
 import org.junit.*;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
-import java.lang.reflect.*;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.*;
 
@@ -1169,7 +1187,7 @@ public class RxJavaPluginsTest {
     }
 
     /**
-     * Ensure setErrorHandler() accepts a consumer with "? super Throwable"
+     * Ensure set*() accepts a consumers/functions with wider bounds
      */
     @Test
     public void onErrorWithSuper() throws Exception {
@@ -1184,6 +1202,127 @@ public class RxJavaPluginsTest {
 
             Consumer<? super Throwable> errorHandler1 = RxJavaPlugins.getErrorHandler();
             assertSame(errorHandler, errorHandler1);
+
+            Function<? super Scheduler, ? extends Scheduler> scheduler2scheduler = new Function<Scheduler, Scheduler>() {
+                @Override
+                public Scheduler apply(Scheduler scheduler) throws Exception {
+                    return scheduler;
+                }
+            };
+            Function<? super Callable<Scheduler>, ? extends Scheduler> callable2scheduler = new Function<Callable<Scheduler>, Scheduler>() {
+                @Override
+                public Scheduler apply(Callable<Scheduler> schedulerCallable) throws Exception {
+                    return schedulerCallable.call();
+                }
+            };
+            Function<? super ConnectableFlowable, ? extends ConnectableFlowable> connectableFlowable2ConnectableFlowable = new Function<ConnectableFlowable, ConnectableFlowable>() {
+                @Override
+                public ConnectableFlowable apply(ConnectableFlowable connectableFlowable) throws Exception {
+                    return connectableFlowable;
+                }
+            };
+            Function<? super ConnectableObservable, ? extends ConnectableObservable> connectableObservable2ConnectableObservable = new Function<ConnectableObservable, ConnectableObservable>() {
+                @Override
+                public ConnectableObservable apply(ConnectableObservable connectableObservable) throws Exception {
+                    return connectableObservable;
+                }
+            };
+            Function<? super Flowable, ? extends Flowable> flowable2Flowable = new Function<Flowable, Flowable>() {
+                @Override
+                public Flowable apply(Flowable flowable) throws Exception {
+                    return flowable;
+                }
+            };
+            BiFunction<? super Flowable, ? super Subscriber, ? extends Subscriber> flowable2subscriber = new BiFunction<Flowable, Subscriber, Subscriber>() {
+                @Override
+                public Subscriber apply(Flowable flowable, Subscriber subscriber) throws Exception {
+                    return subscriber;
+                }
+            };
+            Function<Maybe, Maybe> maybe2maybe = new Function<Maybe, Maybe>() {
+                @Override
+                public Maybe apply(Maybe maybe) throws Exception {
+                    return maybe;
+                }
+            };
+            BiFunction<Maybe, MaybeObserver, MaybeObserver> maybe2observer = new BiFunction<Maybe, MaybeObserver, MaybeObserver>() {
+                @Override
+                public MaybeObserver apply(Maybe maybe, MaybeObserver maybeObserver) throws Exception {
+                    return maybeObserver;
+                }
+            };
+            Function<Observable, Observable> observable2observable = new Function<Observable, Observable>() {
+                @Override
+                public Observable apply(Observable observable) throws Exception {
+                    return observable;
+                }
+            };
+            BiFunction<? super Observable, ? super Observer, ? extends Observer> observable2observer = new BiFunction<Observable, Observer, Observer>() {
+                @Override
+                public Observer apply(Observable observable, Observer observer) throws Exception {
+                    return observer;
+                }
+            };
+            Function<? super ParallelFlowable, ? extends ParallelFlowable> parallelFlowable2parallelFlowable = new Function<ParallelFlowable, ParallelFlowable>() {
+                @Override
+                public ParallelFlowable apply(ParallelFlowable parallelFlowable) throws Exception {
+                    return parallelFlowable;
+                }
+            };
+            Function<Single, Single> single2single = new Function<Single, Single>() {
+                @Override
+                public Single apply(Single single) throws Exception {
+                    return single;
+                }
+            };
+            BiFunction<? super Single, ? super SingleObserver, ? extends SingleObserver> single2observer = new BiFunction<Single, SingleObserver, SingleObserver>() {
+                @Override
+                public SingleObserver apply(Single single, SingleObserver singleObserver) throws Exception {
+                    return singleObserver;
+                }
+            };
+            Function<? super Runnable, ? extends Runnable> runnable2runnable = new Function<Runnable, Runnable>() {
+                @Override
+                public Runnable apply(Runnable runnable) throws Exception {
+                    return runnable;
+                }
+            };
+            BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> completableObserver2completableObserver = new BiFunction<Completable, CompletableObserver, CompletableObserver>() {
+                @Override
+                public CompletableObserver apply(Completable completable, CompletableObserver completableObserver) throws Exception {
+                    return completableObserver;
+                }
+            };
+            Function<? super Completable, ? extends Completable> completable2completable = new Function<Completable, Completable>() {
+                @Override
+                public Completable apply(Completable completable) throws Exception {
+                    return completable;
+                }
+            };
+
+
+            RxJavaPlugins.setInitComputationSchedulerHandler(callable2scheduler);
+            RxJavaPlugins.setComputationSchedulerHandler(scheduler2scheduler);
+            RxJavaPlugins.setIoSchedulerHandler(scheduler2scheduler);
+            RxJavaPlugins.setNewThreadSchedulerHandler(scheduler2scheduler);
+            RxJavaPlugins.setOnConnectableFlowableAssembly(connectableFlowable2ConnectableFlowable);
+            RxJavaPlugins.setOnConnectableObservableAssembly(connectableObservable2ConnectableObservable);
+            RxJavaPlugins.setOnFlowableAssembly(flowable2Flowable);
+            RxJavaPlugins.setOnFlowableSubscribe(flowable2subscriber);
+            RxJavaPlugins.setOnMaybeAssembly(maybe2maybe);
+            RxJavaPlugins.setOnMaybeSubscribe(maybe2observer);
+            RxJavaPlugins.setOnObservableAssembly(observable2observable);
+            RxJavaPlugins.setOnObservableSubscribe(observable2observer);
+            RxJavaPlugins.setOnParallelAssembly(parallelFlowable2parallelFlowable);
+            RxJavaPlugins.setOnSingleAssembly(single2single);
+            RxJavaPlugins.setOnSingleSubscribe(single2observer);
+            RxJavaPlugins.setScheduleHandler(runnable2runnable);
+            RxJavaPlugins.setSingleSchedulerHandler(scheduler2scheduler);
+            RxJavaPlugins.setOnCompletableSubscribe(completableObserver2completableObserver);
+            RxJavaPlugins.setOnCompletableAssembly(completable2completable);
+            RxJavaPlugins.setInitSingleSchedulerHandler(callable2scheduler);
+            RxJavaPlugins.setInitNewThreadSchedulerHandler(callable2scheduler);
+            RxJavaPlugins.setInitIoSchedulerHandler(callable2scheduler);
         } finally {
             RxJavaPlugins.reset();
         }


### PR DESCRIPTION
I think a function should never be declared without "super/extends" as method parameter.
I have found a few instances where this has been the case.

In the most common cases this shouldn't make a difference, but sometimes it helps a lot...