### PR TITLE
2.x: fix replay() cancel/dispose NPE

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -873,4 +873,25 @@ public class FlowablePublishTest {
         .test(0L)
         .assertFailure(MissingBackpressureException.class);
     }
+
+    @Test
+    public void delayedUpstreamOnSubscribe() {
+        final Subscriber<?>[] sub = { null };
+
+        new Flowable<Integer>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super Integer> s) {
+                sub[0] = s;
+            }
+        }
+        .publish()
+        .connect()
+        .dispose();
+
+        BooleanSubscription bs = new BooleanSubscription();
+
+        sub[0].onSubscribe(bs);
+
+        assertTrue(bs.isCancelled());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -1711,4 +1711,24 @@ public class FlowableReplayTest {
         Assert.assertFalse(buf.hasError());
     }
 
+    @Test
+    public void delayedUpstreamOnSubscribe() {
+        final Subscriber<?>[] sub = { null };
+
+        new Flowable<Integer>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super Integer> s) {
+                sub[0] = s;
+            }
+        }
+        .replay()
+        .connect()
+        .dispose();
+
+        BooleanSubscription bs = new BooleanSubscription();
+
+        sub[0].onSubscribe(bs);
+
+        assertTrue(bs.isCancelled());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -699,4 +699,25 @@ public class ObservablePublishTest {
 
         assertFalse(ps.hasObservers());
     }
+
+    @Test
+    public void delayedUpstreamOnSubscribe() {
+        final Observer<?>[] sub = { null };
+
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> s) {
+                sub[0] = s;
+            }
+        }
+        .publish()
+        .connect()
+        .dispose();
+
+        Disposable bs = Disposables.empty();
+
+        sub[0].onSubscribe(bs);
+
+        assertTrue(bs.isDisposed());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -21,7 +21,6 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.annotations.NonNull;
 import org.junit.*;
 import org.mockito.InOrder;
 
@@ -29,6 +28,7 @@ import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.Scheduler.Worker;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
@@ -1489,5 +1489,26 @@ public class ObservableReplayTest {
         ps.onNext(1);
 
         to.assertValues(1);
+    }
+
+    @Test
+    public void delayedUpstreamOnSubscribe() {
+        final Observer<?>[] sub = { null };
+
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> s) {
+                sub[0] = s;
+            }
+        }
+        .replay()
+        .connect()
+        .dispose();
+
+        Disposable bs = Disposables.empty();
+
+        sub[0].onSubscribe(bs);
+
+        assertTrue(bs.isDisposed());
     }
 }


### PR DESCRIPTION
This PR fixes both `Flowable.replay()` and `Observable.replay()` throwing a `NullPointerException` if the connection is disconnect before the upstream calls `onSubscribe` on the connection being established. 

In practice, this requires an async cancellation to happen through `refCount().unsubscribeOn()` for example. The validation tests simulate this by not calling `onSubscribe` until the synchronous connect/disconnect happens.

Reported in #5060.