### PR TITLE
Update codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,13 @@
 coverage:
-  project: 
-    default:
-      target: 95%
-      threshold: 1%
-
-  patch: 
-    default:
-      target: 95%
-      threshold: 1%
-
   status:
+    project: 
+      default:
+        target: 95%
+        threshold: 1%
+
+    patch: 
+      default:
+        target: 95%
+        threshold: 1%
+  
     changes: no


### PR DESCRIPTION
Fix codecov.yml

- `target` is used a "coverage must be greater or equal to the target"
- `threshold` is the acceptable amount of loss to still consider the status as successful.
