### PR TITLE
2.x: compatibility fixes (JDK 9 & IntelliJ 2017.1 EAP)

### DIFF
--- a/src/test/java/io/reactivex/MaybeNo2Dot0Since.java
+++ b/src/test/java/io/reactivex/MaybeNo2Dot0Since.java
@@ -40,13 +40,16 @@ public class MaybeNo2Dot0Since {
 
 //        System.out.println(path);
 
-        int i = path.indexOf("/RxJava/");
+        int i = path.indexOf("/RxJava");
         if (i < 0) {
             System.out.println("Can't find the base RxJava directory");
             return null;
         }
 
-        String p = path.substring(0, i + 8) + "src/main/java/io/reactivex/" + baseClassName + ".java";
+        // find end of any potential postfix to /RxJava
+        int j = path.indexOf("/", i + 6);
+
+        String p = path.substring(0, j + 1) + "src/main/java/io/reactivex/" + baseClassName + ".java";
 
         File f = new File(p);
 

--- a/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
+++ b/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
@@ -141,7 +141,7 @@ public class ExceptionsTest {
             }
         });
         a.onNext(1);
-        assertTrue(depth.get() > MAX_STACK_DEPTH);
+        assertTrue(depth.get() >= MAX_STACK_DEPTH);
     }
 
     @Test(expected = StackOverflowError.class)


### PR DESCRIPTION
1. When the project is checked out into a directory that is not exactly `*/RxJava/` (i.e., `/RxJavaSomething/`) the source-code locator in the unit tests failed with a `NullPointerException`. The locator is now relaxed to expect `/RxJava` prefix.
2. Running the unit tests from IntelliJ 2017.1 EAP, the `ExceptionTests.testStackOverflowWouldOccur` failed with `AssertionError` because the final stack depth was exactly the constant value (800). The check now uses the correct `>=` as the dual of the recursion condition of `<`.