### PR TITLE
2.x: cancel upstream first, dispose worker last

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -177,9 +177,9 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
 
         @Override
         public void cancel() {
-            DisposableHelper.dispose(timer);
-
             s.cancel();
+
+            DisposableHelper.dispose(timer);
         }
 
         @Override
@@ -333,9 +333,9 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
 
         @Override
         public void cancel() {
-            w.dispose();
             clear();
             s.cancel();
+            w.dispose();
         }
 
         void clear() {
@@ -497,17 +497,15 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
 
         @Override
         public void onError(Throwable t) {
-            w.dispose();
             synchronized (this) {
                 buffer = null;
             }
             actual.onError(t);
+            w.dispose();
         }
 
         @Override
         public void onComplete() {
-            w.dispose();
-
             U b;
             synchronized (this) {
                 b = buffer;
@@ -519,6 +517,8 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             if (enter()) {
                 QueueDrainHelper.drainMaxLoop(queue, actual, false, this, this);
             }
+
+            w.dispose();
         }
 
         @Override
@@ -543,11 +543,11 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
 
         @Override
         public void dispose() {
-            w.dispose();
             synchronized (this) {
                 buffer = null;
             }
             s.cancel();
+            w.dispose();
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
@@ -108,8 +108,8 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
                 return;
             }
             done = true;
-            DisposableHelper.dispose(timer);
             actual.onError(t);
+            worker.dispose();
         }
 
         @Override
@@ -127,8 +127,8 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
                     de.emit();
                 }
                 DisposableHelper.dispose(timer);
-                worker.dispose();
                 actual.onComplete();
+                worker.dispose();
             }
         }
 
@@ -141,9 +141,8 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
 
         @Override
         public void cancel() {
-            DisposableHelper.dispose(timer);
-            worker.dispose();
             s.cancel();
+            worker.dispose();
         }
 
         void emit(long idx, T t, DebounceEmitter<T> emitter) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
@@ -121,8 +121,8 @@ public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
 
         @Override
         public void cancel() {
-            w.dispose();
             s.cancel();
+            w.dispose();
         }
 
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTimed.java
@@ -123,8 +123,8 @@ public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUps
                 return;
             }
             done = true;
-            DisposableHelper.dispose(timer);
             actual.onError(t);
+            worker.dispose();
         }
 
         @Override
@@ -133,9 +133,8 @@ public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUps
                 return;
             }
             done = true;
-            DisposableHelper.dispose(timer);
-            worker.dispose();
             actual.onComplete();
+            worker.dispose();
         }
 
         @Override
@@ -147,9 +146,8 @@ public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUps
 
         @Override
         public void cancel() {
-            DisposableHelper.dispose(timer);
-            worker.dispose();
             s.cancel();
+            worker.dispose();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -154,9 +154,8 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
                 return;
             }
             done = true;
-            worker.dispose();
-            DisposableHelper.dispose(timer);
             arbiter.onError(t, s);
+            worker.dispose();
         }
 
         @Override
@@ -165,16 +164,14 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
                 return;
             }
             done = true;
-            worker.dispose();
-            DisposableHelper.dispose(timer);
             arbiter.onComplete(s);
+            worker.dispose();
         }
 
         @Override
         public void dispose() {
-            worker.dispose();
-            DisposableHelper.dispose(timer);
             s.cancel();
+            worker.dispose();
         }
 
         @Override
@@ -256,9 +253,9 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
                 return;
             }
             done = true;
-            dispose();
 
             actual.onError(t);
+            worker.dispose();
         }
 
         @Override
@@ -267,16 +264,15 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
                 return;
             }
             done = true;
-            dispose();
 
             actual.onComplete();
+            worker.dispose();
         }
 
         @Override
         public void dispose() {
-            worker.dispose();
-            DisposableHelper.dispose(timer);
             s.cancel();
+            worker.dispose();
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -159,8 +159,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                 drainLoop();
             }
 
-            dispose();
             actual.onError(t);
+            dispose();
         }
 
         @Override
@@ -170,8 +170,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                 drainLoop();
             }
 
-            dispose();
             actual.onComplete();
+            dispose();
         }
 
         @Override
@@ -396,8 +396,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     } else {
                         window = null;
                         s.cancel();
-                        dispose();
                         actual.onError(new MissingBackpressureException("Could not deliver window due to lack of requests"));
+                        dispose();
                         return;
                     }
                 } else {
@@ -424,8 +424,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                 drainLoop();
             }
 
-            dispose();
             actual.onError(t);
+            dispose();
         }
 
         @Override
@@ -435,8 +435,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                 drainLoop();
             }
 
-            dispose();
             actual.onComplete();
+            dispose();
         }
 
         @Override
@@ -479,13 +479,13 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     if (d && (empty || isHolder)) {
                         window = null;
                         q.clear();
-                        dispose();
                         Throwable err = error;
                         if (err != null) {
                             w.onError(err);
                         } else {
                             w.onComplete();
                         }
+                        dispose();
                         return;
                     }
 
@@ -509,8 +509,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                                 window = null;
                                 queue.clear();
                                 s.cancel();
-                                dispose();
                                 a.onError(new MissingBackpressureException("Could not deliver first window due to lack of requests."));
+                                dispose();
                                 return;
                             }
                         }
@@ -550,8 +550,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                         } else {
                             window = null;
                             s.cancel();
-                            dispose();
                             actual.onError(new MissingBackpressureException("Could not deliver window due to lack of requests"));
+                            dispose();
                             return;
                         }
                     } else {
@@ -683,8 +683,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                 drainLoop();
             }
 
-            dispose();
             actual.onError(t);
+            dispose();
         }
 
         @Override
@@ -694,8 +694,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                 drainLoop();
             }
 
-            dispose();
             actual.onComplete();
+            dispose();
         }
 
         @Override
@@ -747,7 +747,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
                     if (d && (empty || sw)) {
                         q.clear();
-                        dispose();
                         Throwable e = error;
                         if (e != null) {
                             for (UnicastProcessor<T> w : ws) {
@@ -759,6 +758,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                             }
                         }
                         ws.clear();
+                        dispose();
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -143,16 +143,15 @@ extends AbstractObservableWithUpstream<T, U> {
 
         @Override
         public void onError(Throwable t) {
-            DisposableHelper.dispose(timer);
             synchronized (this) {
                 buffer = null;
             }
             actual.onError(t);
+            DisposableHelper.dispose(timer);
         }
 
         @Override
         public void onComplete() {
-            DisposableHelper.dispose(timer);
             U b;
             synchronized (this) {
                 b = buffer;
@@ -165,6 +164,7 @@ extends AbstractObservableWithUpstream<T, U> {
                     QueueDrainHelper.drainLoop(queue, actual, false, this, this);
                 }
             }
+            DisposableHelper.dispose(timer);
         }
 
         @Override
@@ -186,8 +186,8 @@ extends AbstractObservableWithUpstream<T, U> {
                 next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null buffer");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                dispose();
                 actual.onError(e);
+                dispose();
                 return;
             }
 
@@ -249,9 +249,9 @@ extends AbstractObservableWithUpstream<T, U> {
                     b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
-                    w.dispose();
                     s.dispose();
                     EmptyDisposable.error(e, actual);
+                    w.dispose();
                     return;
                 }
 
@@ -286,9 +286,9 @@ extends AbstractObservableWithUpstream<T, U> {
         @Override
         public void onError(Throwable t) {
             done = true;
-            w.dispose();
             clear();
             actual.onError(t);
+            w.dispose();
         }
 
         @Override
@@ -312,9 +312,9 @@ extends AbstractObservableWithUpstream<T, U> {
         public void dispose() {
             if (!cancelled) {
                 cancelled = true;
-                w.dispose();
                 clear();
                 s.dispose();
+                w.dispose();
             }
         }
 
@@ -340,8 +340,8 @@ extends AbstractObservableWithUpstream<T, U> {
                 b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null buffer");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                dispose();
                 actual.onError(e);
+                dispose();
                 return;
             }
 
@@ -414,9 +414,9 @@ extends AbstractObservableWithUpstream<T, U> {
                     b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
-                    w.dispose();
                     s.dispose();
                     EmptyDisposable.error(e, actual);
+                    w.dispose();
                     return;
                 }
 
@@ -457,8 +457,8 @@ extends AbstractObservableWithUpstream<T, U> {
                 b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                dispose();
                 actual.onError(e);
+                dispose();
                 return;
             }
 
@@ -478,11 +478,11 @@ extends AbstractObservableWithUpstream<T, U> {
 
         @Override
         public void onError(Throwable t) {
-            w.dispose();
             synchronized (this) {
                 buffer = null;
             }
             actual.onError(t);
+            w.dispose();
         }
 
         @Override
@@ -512,11 +512,11 @@ extends AbstractObservableWithUpstream<T, U> {
         public void dispose() {
             if (!cancelled) {
                 cancelled = true;
+                s.dispose();
                 w.dispose();
                 synchronized (this) {
                     buffer = null;
                 }
-                s.dispose();
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounceTimed.java
@@ -101,8 +101,8 @@ public final class ObservableDebounceTimed<T> extends AbstractObservableWithUpst
                 return;
             }
             done = true;
-            DisposableHelper.dispose(timer);
             actual.onError(t);
+            worker.dispose();
         }
 
         @Override
@@ -119,22 +119,20 @@ public final class ObservableDebounceTimed<T> extends AbstractObservableWithUpst
                 if (de != null) {
                     de.run();
                 }
-                DisposableHelper.dispose(timer);
-                worker.dispose();
                 actual.onComplete();
+                worker.dispose();
             }
         }
 
         @Override
         public void dispose() {
-            DisposableHelper.dispose(timer);
-            worker.dispose();
             s.dispose();
+            worker.dispose();
         }
 
         @Override
         public boolean isDisposed() {
-            return timer.get() == DisposableHelper.DISPOSED;
+            return worker.isDisposed();
         }
 
         void emit(long idx, T t, DebounceEmitter<T> emitter) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
@@ -116,8 +116,8 @@ public final class ObservableDelay<T> extends AbstractObservableWithUpstream<T, 
 
         @Override
         public void dispose() {
-            w.dispose();
             s.dispose();
+            w.dispose();
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableObserveOn.java
@@ -183,6 +183,7 @@ public final class ObservableObserveOn<T> extends AbstractObservableWithUpstream
                         s.dispose();
                         q.clear();
                         a.onError(ex);
+                        worker.dispose();
                         return;
                     }
                     boolean empty = v == null;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTimed.java
@@ -102,8 +102,8 @@ public final class ObservableThrottleFirstTimed<T> extends AbstractObservableWit
                 RxJavaPlugins.onError(t);
             } else {
                 done = true;
-                DisposableHelper.dispose(this);
                 actual.onError(t);
+                worker.dispose();
             }
         }
 
@@ -111,22 +111,20 @@ public final class ObservableThrottleFirstTimed<T> extends AbstractObservableWit
         public void onComplete() {
             if (!done) {
                 done = true;
-                DisposableHelper.dispose(this);
-                worker.dispose();
                 actual.onComplete();
+                worker.dispose();
             }
         }
 
         @Override
         public void dispose() {
-            DisposableHelper.dispose(this);
-            worker.dispose();
             s.dispose();
+            worker.dispose();
         }
 
         @Override
         public boolean isDisposed() {
-            return DisposableHelper.isDisposed(get());
+            return worker.isDisposed();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
@@ -154,9 +154,8 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
                 return;
             }
             done = true;
-            worker.dispose();
-            DisposableHelper.dispose(this);
             arbiter.onError(t, s);
+            worker.dispose();
         }
 
         @Override
@@ -165,21 +164,19 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
                 return;
             }
             done = true;
-            worker.dispose();
-            DisposableHelper.dispose(this);
             arbiter.onComplete(s);
+            worker.dispose();
         }
 
         @Override
         public void dispose() {
-            worker.dispose();
-            DisposableHelper.dispose(this);
             s.dispose();
+            worker.dispose();
         }
 
         @Override
         public boolean isDisposed() {
-            return DisposableHelper.isDisposed(get());
+            return worker.isDisposed();
         }
     }
 
@@ -241,8 +238,8 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
                     public void run() {
                         if (idx == index) {
                             done = true;
-                            DisposableHelper.dispose(TimeoutTimedObserver.this);
                             s.dispose();
+                            DisposableHelper.dispose(TimeoutTimedObserver.this);
 
                             actual.onError(new TimeoutException());
 
@@ -262,9 +259,9 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
                 return;
             }
             done = true;
-            dispose();
 
             actual.onError(t);
+            dispose();
         }
 
         @Override
@@ -273,21 +270,20 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
                 return;
             }
             done = true;
-            dispose();
 
             actual.onComplete();
+            dispose();
         }
 
         @Override
         public void dispose() {
-            worker.dispose();
-            DisposableHelper.dispose(this);
             s.dispose();
+            worker.dispose();
         }
 
         @Override
         public boolean isDisposed() {
-            return DisposableHelper.isDisposed(get());
+            return worker.isDisposed();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
@@ -367,8 +367,8 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                 drainLoop();
             }
 
-            disposeTimer();
             actual.onError(t);
+            disposeTimer();
         }
 
         @Override
@@ -378,8 +378,8 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                 drainLoop();
             }
 
-            disposeTimer();
             actual.onComplete();
+            disposeTimer();
         }
 
         @Override
@@ -588,8 +588,8 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                 drainLoop();
             }
 
-            disposeWorker();
             actual.onError(t);
+            disposeWorker();
         }
 
         @Override
@@ -599,8 +599,8 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                 drainLoop();
             }
 
-            disposeWorker();
             actual.onComplete();
+            disposeWorker();
         }
 
         @Override
@@ -652,7 +652,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
 
                     if (d && (empty || sw)) {
                         q.clear();
-                        disposeWorker();
                         Throwable e = error;
                         if (e != null) {
                             for (UnicastSubject<T> w : ws) {
@@ -663,6 +662,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                                 w.onComplete();
                             }
                         }
+                        disposeWorker();
                         ws.clear();
                         return;
                     }

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
@@ -158,8 +158,8 @@ public class SchedulerWhen extends Scheduler implements Disposable {
                 // complete the actionQueue when worker is unsubscribed to make
                 // room for the next worker in the workerQueue.
                 if (unsubscribed.compareAndSet(false, true)) {
-                    actualWorker.dispose();
                     actionProcessor.onComplete();
+                    actualWorker.dispose();
                 }
             }
 


### PR DESCRIPTION
This PR makes sure the `Scheduler.Worker` is disposed only after

  - disposing/cancelling the upstream,
  - emitting terminal events.

This may help with situations when the worker-dispose interrupts a thread that is blocked and the InterruptedException handler checks for the stream to be disposed so the exception can be safely ignored (and thus not end up in the RxJavaPlugins.onError handler to crash the app).

Related: #4863