### PR TITLE
2x: Removed documentation leftover

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -1708,8 +1708,6 @@ public abstract class Completable implements CompletableSource {
      * If the Completable emits an error, it is wrapped into an
      * {@link io.reactivex.exceptions.OnErrorNotImplementedException OnErrorNotImplementedException}
      * and routed to the RxJavaPlugins.onError handler.
-     * <p>
-     * If this Completable emits an error, it is sent to RxJavaPlugins.onError and gets swallowed.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
...that wrongly states that the error will be swallowed.

As discussed in #5036