### PR TITLE
2.x: wrap undeliverable errors

### DIFF
--- a/src/main/java/io/reactivex/exceptions/ProtocolViolationException.java
+++ b/src/main/java/io/reactivex/exceptions/ProtocolViolationException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.exceptions;
+
+import io.reactivex.annotations.Experimental;
+
+/**
+ * Explicitly named exception to indicate a Reactive-Streams
+ * protocol violation.
+ * @since 2.0.6 - experimental
+ */
+@Experimental
+public final class ProtocolViolationException extends IllegalStateException {
+
+    private static final long serialVersionUID = 1644750035281290266L;
+
+    /**
+     * Creates an instance with the given message.
+     * @param message the message
+     */
+    public ProtocolViolationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/reactivex/exceptions/UndeliverableException.java
+++ b/src/main/java/io/reactivex/exceptions/UndeliverableException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.exceptions;
+
+import io.reactivex.annotations.Experimental;
+
+/**
+ * Wrapper for Throwable errors that are sent to `RxJavaPlugins.onError`.
+ * @since 2.0.6 - experimental
+ */
+@Experimental
+public final class UndeliverableException extends IllegalStateException {
+
+    private static final long serialVersionUID = 1644750035281290266L;
+
+    /**
+     * Construct an instance by wrapping the given, non-null
+     * cause Throwable.
+     * @param cause the cause, not null
+     */
+    public UndeliverableException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
+++ b/src/main/java/io/reactivex/internal/disposables/DisposableHelper.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.disposables;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.ProtocolViolationException;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -152,7 +153,7 @@ public enum DisposableHelper implements Disposable {
      * Reports that the disposable is already set to the RxJavaPlugins error handler.
      */
     public static void reportDisposableSet() {
-        RxJavaPlugins.onError(new IllegalStateException("Disposable already set!"));
+        RxJavaPlugins.onError(new ProtocolViolationException("Disposable already set!"));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.Subscription;
 
+import io.reactivex.exceptions.ProtocolViolationException;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -67,7 +68,7 @@ public enum SubscriptionHelper implements Subscription {
      * which is an indication of a onSubscribe management bug.
      */
     public static void reportSubscriptionSet() {
-        RxJavaPlugins.onError(new IllegalStateException("Subscription already set!"));
+        RxJavaPlugins.onError(new ProtocolViolationException("Subscription already set!"));
     }
 
     /**
@@ -89,7 +90,7 @@ public enum SubscriptionHelper implements Subscription {
      * @param n the overproduction amount
      */
     public static void reportMoreProduced(long n) {
-        RxJavaPlugins.onError(new IllegalStateException("More produced than requested: " + n));
+        RxJavaPlugins.onError(new ProtocolViolationException("More produced than requested: " + n));
     }
     /**
      * Check if the given subscription is the common cancelled subscription.

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -414,6 +414,10 @@ public final class RxJavaPlugins {
         if (error instanceof IllegalArgumentException) {
             return true;
         }
+        // Crash while handling an exception
+        if (error instanceof CompositeException) {
+            return true;
+        }
         // everything else is probably due to lifecycle limits
         return false;
     }

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -154,11 +154,46 @@ public enum TestHelper {
         }
     }
 
+    public static void assertUndeliverable(List<Throwable> list, int index, Class<? extends Throwable> clazz) {
+        Throwable ex = list.get(index);
+        if (!(ex instanceof UndeliverableException)) {
+            AssertionError err = new AssertionError("Outer exception UndeliverableException expected but got " + list.get(index));
+            err.initCause(list.get(index));
+            throw err;
+        }
+        ex = ex.getCause();
+        if (!clazz.isInstance(ex)) {
+            AssertionError err = new AssertionError("Inner exception " + clazz + " expected but got " + list.get(index));
+            err.initCause(list.get(index));
+            throw err;
+        }
+    }
+
     public static void assertError(List<Throwable> list, int index, Class<? extends Throwable> clazz, String message) {
         Throwable ex = list.get(index);
         if (!clazz.isInstance(ex)) {
             AssertionError err = new AssertionError("Type " + clazz + " expected but got " + ex);
             err.initCause(ex);
+            throw err;
+        }
+        if (!ObjectHelper.equals(message, ex.getMessage())) {
+            AssertionError err = new AssertionError("Message " + message + " expected but got " + ex.getMessage());
+            err.initCause(ex);
+            throw err;
+        }
+    }
+
+    public static void assertUndeliverable(List<Throwable> list, int index, Class<? extends Throwable> clazz, String message) {
+        Throwable ex = list.get(index);
+        if (!(ex instanceof UndeliverableException)) {
+            AssertionError err = new AssertionError("Outer exception UndeliverableException expected but got " + list.get(index));
+            err.initCause(list.get(index));
+            throw err;
+        }
+        ex = ex.getCause();
+        if (!clazz.isInstance(ex)) {
+            AssertionError err = new AssertionError("Inner exception " + clazz + " expected but got " + list.get(index));
+            err.initCause(list.get(index));
             throw err;
         }
         if (!ObjectHelper.equals(message, ex.getMessage())) {
@@ -386,6 +421,9 @@ public enum TestHelper {
      * @return the list of Throwables
      */
     public static List<Throwable> compositeList(Throwable ex) {
+        if (ex instanceof UndeliverableException) {
+            ex = ex.getCause();
+        }
         return ((CompositeException)ex).getExceptions();
     }
 
@@ -2428,7 +2466,7 @@ public enum TestHelper {
                 }
             }
 
-            assertError(errors, 0, TestException.class, "second");
+            assertUndeliverable(errors, 0, TestException.class, "second");
         } catch (AssertionError ex) {
             throw ex;
         } catch (Throwable ex) {
@@ -2587,7 +2625,7 @@ public enum TestHelper {
                 }
             }
 
-            assertError(errors, 0, TestException.class, "second");
+            assertUndeliverable(errors, 0, TestException.class, "second");
         } catch (AssertionError ex) {
             throw ex;
         } catch (Throwable ex) {

--- a/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
@@ -120,7 +120,9 @@ public final class FlowableCollectTest {
                     .test() //
                     .assertError(e1) //
                     .assertNotComplete();
-            assertEquals(Arrays.asList(e2), list);
+
+            assertEquals(1, list.size());
+            assertEquals(e2, list.get(0).getCause());
         } finally {
             RxJavaPlugins.reset();
         }
@@ -272,7 +274,9 @@ public final class FlowableCollectTest {
                     .test() //
                     .assertError(e1) //
                     .assertNotComplete();
-            assertEquals(Arrays.asList(e2), list);
+
+            assertEquals(1, list.size());
+            assertEquals(e2, list.get(0).getCause());
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/flowable/FlowableScanTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableScanTests.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.flowable;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -21,7 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
+import io.reactivex.exceptions.UndeliverableException;
 import io.reactivex.flowable.FlowableEventStream.Event;
 import io.reactivex.functions.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -65,7 +66,10 @@ public class FlowableScanTests {
               .test()
               .assertNoValues()
               .assertError(e);
-            assertEquals(Arrays.asList(e2), list);
+
+            assertEquals("" + list, 1, list.size());
+            assertTrue("" + list, list.get(0) instanceof UndeliverableException);
+            assertEquals(e2, list.get(0).getCause());
         } finally {
             RxJavaPlugins.reset();
         }
@@ -142,7 +146,10 @@ public class FlowableScanTests {
               .test()
               .assertValue(1)
               .assertError(e);
-            assertEquals(Arrays.asList(e2), list);
+
+            assertEquals("" + list, 1, list.size());
+            assertTrue("" + list, list.get(0) instanceof UndeliverableException);
+            assertEquals(e2, list.get(0).getCause());
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
@@ -688,7 +688,7 @@ public class FlowableSubscriberTest {
 
             s.onError(new TestException("Outer"));
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> cel = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(cel, 0, TestException.class, "Outer");
             TestHelper.assertError(cel, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
@@ -688,7 +688,7 @@ public class FlowableSubscriberTest {
 
             s.onError(new TestException("Outer"));
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> cel = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(cel, 0, TestException.class, "Outer");
             TestHelper.assertError(cel, 1, TestException.class, "Inner");
@@ -722,7 +722,7 @@ public class FlowableSubscriberTest {
 
             s.onComplete();
 
-            TestHelper.assertError(list, 0, TestException.class, "Inner");
+            TestHelper.assertUndeliverable(list, 0, TestException.class, "Inner");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/disposables/CancellableDisposableTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/CancellableDisposableTest.java
@@ -72,7 +72,7 @@ public class CancellableDisposableTest {
             cd.dispose();
             cd.dispose();
 
-            TestHelper.assertError(list, 0, TestException.class);
+            TestHelper.assertUndeliverable(list, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/disposables/ObserverFullArbiterTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/ObserverFullArbiterTest.java
@@ -73,7 +73,7 @@ public class ObserverFullArbiterTest {
         try {
             fa.onError(new TestException(), bs);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -90,7 +90,7 @@ public class ObserverFullArbiterTest {
             fa.dispose();
 
             fa.drain();
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
@@ -139,7 +139,7 @@ public class LambdaObserverTest {
 
             assertTrue(o.isDisposed());
 
-            TestHelper.assertError(errors, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(errors, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(errors.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "Outer");
             TestHelper.assertError(ce, 1, TestException.class, "Inner");
@@ -185,7 +185,7 @@ public class LambdaObserverTest {
 
             assertTrue(o.isDisposed());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
@@ -139,7 +139,7 @@ public class LambdaObserverTest {
 
             assertTrue(o.isDisposed());
 
-            TestHelper.assertUndeliverable(errors, 0, CompositeException.class);
+            TestHelper.assertError(errors, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(errors.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "Outer");
             TestHelper.assertError(ce, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableAmbTest.java
@@ -100,7 +100,7 @@ public class CompletableAmbTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
@@ -104,7 +104,7 @@ public class CompletableConcatTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDisposeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDisposeOnTest.java
@@ -88,7 +88,7 @@ public class CompletableDisposeOnTest {
 
             to.assertEmpty();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDoFinallyTest.java
@@ -84,7 +84,7 @@ public class CompletableDoFinallyTest implements Action {
             .assertResult()
             .cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeIterableTest.java
@@ -57,7 +57,7 @@ public class CompletableMergeIterableTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
@@ -94,7 +94,7 @@ public class CompletableMergeTest {
 
             co[0].onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -236,7 +236,7 @@ public class CompletableMergeTest {
                     to.assertFailure(TestException.class);
 
                     if (!errors.isEmpty()) {
-                        TestHelper.assertError(errors, 0, TestException.class);
+                        TestHelper.assertUndeliverable(errors, 0, TestException.class);
                     }
                 }
             } finally {
@@ -396,7 +396,7 @@ public class CompletableMergeTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -420,7 +420,7 @@ public class CompletableMergeTest {
 
             o[0].onError(new TestException("Second"));
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -477,7 +477,7 @@ public class CompletableMergeTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletablePeekTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletablePeekTest.java
@@ -38,7 +38,7 @@ public class CompletablePeekTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
@@ -138,7 +138,7 @@ public class CompletableTimeoutTest {
                 to.assertTerminated();
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
 
             } finally {

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
@@ -242,7 +242,7 @@ public class CompletableUsingTest {
             .test()
             .assertFailureAndMessage(TestException.class, "Main");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Disposer");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Disposer");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -299,7 +299,7 @@ public class CompletableUsingTest {
 
             to.cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatestTest.java
@@ -226,7 +226,7 @@ public class BlockingFlowableLatestTest {
         try {
             ((Subscriber<Object>)it).onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -348,7 +348,7 @@ public class BlockingFlowableNextTest {
         try {
             no.onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
@@ -410,7 +410,7 @@ public class FlowableAllTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -441,7 +441,7 @@ public class FlowableAllTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -655,7 +655,7 @@ public class FlowableAmbTest {
 
             to.assertFailure(TestException.class);
             if (!errors.isEmpty()) {
-                TestHelper.assertError(errors, 0, TestException.class);
+                TestHelper.assertUndeliverable(errors, 0, TestException.class);
             }
         }
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
@@ -604,7 +604,7 @@ public class FlowableAnyTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -629,7 +629,7 @@ public class FlowableAnyTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
@@ -249,7 +249,7 @@ public class FlowableBlockingTest {
 
             assertEquals(1, source.blockingFirst().intValue());
 
-            TestHelper.assertError(list, 0, TestException.class);
+            TestHelper.assertUndeliverable(list, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1310,7 +1310,7 @@ public class FlowableCombineLatestTest {
                 }
 
                 for (Throwable e : errors) {
-                    assertTrue(e.toString(), e instanceof TestException);
+                    assertTrue(e.toString(), e.getCause() instanceof TestException);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -900,7 +900,7 @@ public class FlowableConcatMapEagerTest {
                 } else {
                     to.assertError(TestException.class);
                     if (!errors.isEmpty()) {
-                        TestHelper.assertError(errors, 0, TestException.class);
+                        TestHelper.assertUndeliverable(errors, 0, TestException.class);
                     }
                 }
             } finally {
@@ -1084,7 +1084,7 @@ public class FlowableConcatMapEagerTest {
 
             sub[0].onError(new TestException("Second"));
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -1112,7 +1112,7 @@ public class FlowableConcatMapEagerTest {
             .test(0L)
             .assertFailure(MissingBackpressureException.class);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -1413,7 +1413,7 @@ public class FlowableConcatTest {
         try {
             ts0[0].onError(new TestException("Second"));
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -1439,7 +1439,7 @@ public class FlowableConcatTest {
         try {
             ts0[0].onError(new TestException("Second"));
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
@@ -350,7 +350,7 @@ public class FlowableDebounceTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
@@ -170,8 +170,8 @@ public class FlowableDematerializeTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class, "First");
-            TestHelper.assertError(errors, 1, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "First");
+            TestHelper.assertUndeliverable(errors, 1, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
@@ -246,7 +246,7 @@ public class FlowableDistinctTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
@@ -337,7 +337,7 @@ public class FlowableDistinctUntilChangedTest {
             .test()
             .assertFailure(TestException.class, 1);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoFinallyTest.java
@@ -318,7 +318,7 @@ public class FlowableDoFinallyTest implements Action {
             .assertResult(1)
             .cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -340,7 +340,7 @@ public class FlowableDoFinallyTest implements Action {
             .assertResult(1)
             .cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
@@ -248,7 +248,7 @@ public class FlowableDoOnEachTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -275,7 +275,7 @@ public class FlowableDoOnEachTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -302,7 +302,7 @@ public class FlowableDoOnEachTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -352,7 +352,7 @@ public class FlowableDoOnEachTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -384,7 +384,7 @@ public class FlowableDoOnEachTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -412,7 +412,7 @@ public class FlowableDoOnEachTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -456,7 +456,7 @@ public class FlowableDoOnEachTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
@@ -104,7 +104,7 @@ public class FlowableDoOnLifecycleTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -127,7 +127,7 @@ public class FlowableDoOnLifecycleTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
@@ -263,7 +263,7 @@ public class FlowableElementAtTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -326,7 +326,7 @@ public class FlowableElementAtTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -351,7 +351,7 @@ public class FlowableElementAtTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFilterTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFilterTest.java
@@ -371,7 +371,7 @@ public class FlowableFilterTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -407,7 +407,7 @@ public class FlowableFilterTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -477,7 +477,7 @@ public class FlowableFilterTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -508,7 +508,7 @@ public class FlowableFilterTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -540,7 +540,7 @@ public class FlowableFilterTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -391,7 +391,7 @@ public class FlowableFlatMapMaybeTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -413,7 +413,7 @@ public class FlowableFlatMapMaybeTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -341,7 +341,7 @@ public class FlowableFlatMapSingleTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -363,7 +363,7 @@ public class FlowableFlatMapSingleTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
@@ -109,7 +109,7 @@ public class FlowableGenerateTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -264,7 +264,7 @@ public class FlowableGenerateTest {
             .test(1)
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -568,7 +568,7 @@ public class FlowableGroupJoinTest {
                 }
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();
@@ -641,7 +641,7 @@ public class FlowableGroupJoinTest {
                 }
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
@@ -404,7 +404,7 @@ public class FlowableJoinTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -441,7 +441,7 @@ public class FlowableJoinTest {
             to
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
@@ -541,7 +541,7 @@ public class FlowableMapTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -601,7 +601,7 @@ public class FlowableMapTest {
            .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -668,7 +668,7 @@ public class FlowableMapTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -1179,7 +1179,7 @@ public class FlowableObserveOnTest {
 
             to.assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -664,7 +664,7 @@ public class FlowablePublishTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -678,7 +678,7 @@ public class FlowablePublishTest {
 
             co.connect();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
@@ -261,7 +261,7 @@ public class FlowableReduceTest {
             .test()
             .assertFailureAndMessage(TestException.class, "Reducer");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Source");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Source");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -1443,7 +1443,7 @@ public class FlowableReplayTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -477,7 +477,7 @@ public class FlowableSequenceEqualTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -578,7 +578,7 @@ public class FlowableSequenceEqualTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
@@ -721,7 +721,7 @@ public class FlowableSingleTest {
                 }
             }).singleElement().test().assertComplete();
 
-            assertSame(exception, error.get());
+            assertSame(exception, error.get().getCause());
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -976,7 +976,7 @@ public class FlowableSwitchTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -1016,7 +1016,7 @@ public class FlowableSwitchTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
@@ -202,7 +202,7 @@ public class FlowableTakeUntilPredicateTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
@@ -187,7 +187,7 @@ public class FlowableThrottleFirstTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -451,7 +451,7 @@ public class FlowableTimeoutTests {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -477,7 +477,7 @@ public class FlowableTimeoutTests {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -447,7 +447,7 @@ public class FlowableTimeoutWithSelectorTest {
 
             to.assertFailureAndMessage(TestException.class, "First", 1);
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -476,7 +476,7 @@ public class FlowableTimeoutWithSelectorTest {
 
             to.assertFailureAndMessage(TestException.class, "First", 1);
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
@@ -263,7 +263,7 @@ public class FlowableUnsubscribeOnTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
@@ -622,7 +622,7 @@ public class FlowableUsingTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -649,7 +649,7 @@ public class FlowableWithLatestFromTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -676,7 +676,7 @@ public class FlowableWithLatestFromTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipIterableTest.java
@@ -424,7 +424,7 @@ public class FlowableZipIterableTest {
             .test()
             .assertResult(2);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
@@ -1654,7 +1654,7 @@ public class FlowableZipTest {
 
             sub[0].onError(new TestException("Second"));
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeAmbTest.java
@@ -101,7 +101,7 @@ public class MaybeAmbTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserverTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserverTest.java
@@ -63,7 +63,7 @@ public class MaybeCallbackObserverTest {
 
             mo.onSuccess(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -87,7 +87,7 @@ public class MaybeCallbackObserverTest {
 
             mo.onError(new TestException("Outer"));
 
-            TestHelper.assertError(errors, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(errors, 0, CompositeException.class);
 
             List<Throwable> ce = TestHelper.compositeList(errors.get(0));
 
@@ -116,7 +116,7 @@ public class MaybeCallbackObserverTest {
 
             mo.onComplete();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserverTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserverTest.java
@@ -87,7 +87,7 @@ public class MaybeCallbackObserverTest {
 
             mo.onError(new TestException("Outer"));
 
-            TestHelper.assertUndeliverable(errors, 0, CompositeException.class);
+            TestHelper.assertError(errors, 0, CompositeException.class);
 
             List<Throwable> ce = TestHelper.compositeList(errors.get(0));
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayTest.java
@@ -151,7 +151,7 @@ public class MaybeConcatArrayTest {
             o[0].onError(new TestException());
 
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
@@ -135,7 +135,7 @@ public class MaybeDelaySubscriptionTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccessTest.java
@@ -128,7 +128,7 @@ public class MaybeDoAfterSuccessTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoFinallyTest.java
@@ -134,7 +134,7 @@ public class MaybeDoFinallyTest implements Action {
             .assertResult(1)
             .cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -156,7 +156,7 @@ public class MaybeDoFinallyTest implements Action {
             .assertResult(1)
             .cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
@@ -151,7 +151,7 @@ public class MaybeFromActionTest {
                 Thread.sleep(100);
             }
 
-            TestHelper.assertError(errors, 0, InterruptedException.class);
+            TestHelper.assertUndeliverable(errors, 0, InterruptedException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
@@ -155,7 +155,7 @@ public class MaybeFromCallableTest {
                 Thread.sleep(100);
             }
 
-            TestHelper.assertError(errors, 0, InterruptedException.class);
+            TestHelper.assertUndeliverable(errors, 0, InterruptedException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
@@ -153,9 +153,9 @@ public class MaybeFromRunnableTest {
                 Thread.sleep(100);
             }
 
-            TestHelper.assertError(errors, 0, RuntimeException.class);
+            TestHelper.assertUndeliverable(errors, 0, RuntimeException.class);
 
-            assertTrue(errors.get(0).toString(), errors.get(0).getCause() instanceof InterruptedException);
+            assertTrue(errors.get(0).toString(), errors.get(0).getCause().getCause() instanceof InterruptedException);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeArrayTest.java
@@ -164,7 +164,7 @@ public class MaybeMergeArrayTest {
                 ts.assertFailure(Throwable.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybePeekTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybePeekTest.java
@@ -68,7 +68,7 @@ public class MaybePeekTest {
             })
             .test();
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
 
             assertTrue("" + err, err[0] instanceof TestException);
             assertEquals("First", err[0].getMessage());
@@ -139,7 +139,7 @@ public class MaybePeekTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
@@ -148,7 +148,7 @@ public class MaybeTakeUntilPublisherTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
 
             } finally {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilTest.java
@@ -176,7 +176,7 @@ public class MaybeTakeUntilTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
 
             } finally {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
@@ -242,7 +242,7 @@ public class MaybeUsingTest {
             .test()
             .assertFailureAndMessage(TestException.class, "Main");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Disposer");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Disposer");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -299,7 +299,7 @@ public class MaybeUsingTest {
 
             to.cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipArrayTest.java
@@ -143,7 +143,7 @@ public class MaybeZipArrayTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipIterableTest.java
@@ -145,7 +145,7 @@ public class MaybeZipIterableTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableLatestTest.java
@@ -221,7 +221,7 @@ public class BlockingObservableLatestTest {
         try {
             ((Observer<Object>)it).onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableNextTest.java
@@ -348,7 +348,7 @@ public class BlockingObservableNextTest {
         try {
             no.onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAllTest.java
@@ -330,7 +330,7 @@ public class ObservableAllTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -360,7 +360,7 @@ public class ObservableAllTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
@@ -359,7 +359,7 @@ public class ObservableAmbTest {
 
             to.assertFailure(TestException.class);
             if (!errors.isEmpty()) {
-                TestHelper.assertError(errors, 0, TestException.class);
+                TestHelper.assertUndeliverable(errors, 0, TestException.class);
             }
         }
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAnyTest.java
@@ -533,7 +533,7 @@ public class ObservableAnyTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -558,7 +558,7 @@ public class ObservableAnyTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
@@ -95,7 +95,9 @@ public final class ObservableCollectTest {
                     .test() //
                     .assertError(e1) //
                     .assertNotComplete();
-            assertEquals(Arrays.asList(e2), list);
+
+            assertEquals(1, list.size());
+            assertEquals(e2, list.get(0).getCause());
         } finally {
             RxJavaPlugins.reset();
         }
@@ -218,7 +220,9 @@ public final class ObservableCollectTest {
                     .test() //
                     .assertError(e1) //
                     .assertNotComplete();
-            assertEquals(Arrays.asList(e2), list);
+
+            assertEquals(1, list.size());
+            assertEquals(e2, list.get(0).getCause());
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
@@ -1010,7 +1010,7 @@ public class ObservableCombineLatestTest {
                 }
 
                 for (Throwable e : errors) {
-                    assertTrue(e.toString(), e instanceof TestException);
+                    assertTrue(e.toString(), e.getCause() instanceof TestException);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -851,7 +851,7 @@ public class ObservableConcatMapEagerTest {
                 } else {
                     to.assertError(TestException.class);
                     if (!errors.isEmpty()) {
-                        TestHelper.assertError(errors, 0, TestException.class);
+                        TestHelper.assertUndeliverable(errors, 0, TestException.class);
                     }
                 }
             } finally {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapTest.java
@@ -164,7 +164,7 @@ public class ObservableConcatMapTest {
             .test()
             .assertResult(1, 2);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -195,7 +195,7 @@ public class ObservableConcatMapTest {
             .test()
             .assertResult(1, 2);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -362,7 +362,7 @@ public class ObservableConcatMapTest {
 
             o[0].onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
@@ -337,7 +337,7 @@ public class ObservableDebounceTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDematerializeTest.java
@@ -169,8 +169,8 @@ public class ObservableDematerializeTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class, "First");
-            TestHelper.assertError(errors, 1, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "First");
+            TestHelper.assertUndeliverable(errors, 1, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctTest.java
@@ -247,7 +247,7 @@ public class ObservableDistinctTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChangedTest.java
@@ -243,7 +243,7 @@ public class ObservableDistinctUntilChangedTest {
             .test()
             .assertFailure(TestException.class, 1);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoFinallyTest.java
@@ -320,7 +320,7 @@ public class ObservableDoFinallyTest implements Action {
             .assertResult(1)
             .cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -342,7 +342,7 @@ public class ObservableDoFinallyTest implements Action {
             .assertResult(1)
             .cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
@@ -247,7 +247,7 @@ public class ObservableDoOnEachTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -274,7 +274,7 @@ public class ObservableDoOnEachTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -301,7 +301,7 @@ public class ObservableDoOnEachTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -351,7 +351,7 @@ public class ObservableDoOnEachTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -379,7 +379,7 @@ public class ObservableDoOnEachTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -423,7 +423,7 @@ public class ObservableDoOnEachTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableElementAtTest.java
@@ -245,7 +245,7 @@ public class ObservableElementAtTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -270,7 +270,7 @@ public class ObservableElementAtTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -295,7 +295,7 @@ public class ObservableElementAtTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -332,7 +332,7 @@ public class ObservableFlatMapMaybeTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -354,7 +354,7 @@ public class ObservableFlatMapMaybeTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -282,7 +282,7 @@ public class ObservableFlatMapSingleTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -304,7 +304,7 @@ public class ObservableFlatMapSingleTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableForEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableForEachTest.java
@@ -131,7 +131,7 @@ public class ObservableForEachTest {
                 }
             });
 
-            TestHelper.assertError(errors, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(errors, 0, CompositeException.class);
 
             List<Throwable> ce = TestHelper.compositeList(errors.get(0));
 
@@ -154,7 +154,7 @@ public class ObservableForEachTest {
                         }
                     });
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableForEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableForEachTest.java
@@ -131,7 +131,7 @@ public class ObservableForEachTest {
                 }
             });
 
-            TestHelper.assertUndeliverable(errors, 0, CompositeException.class);
+            TestHelper.assertError(errors, 0, CompositeException.class);
 
             List<Throwable> ce = TestHelper.compositeList(errors.get(0));
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromCompletableTest.java
@@ -76,7 +76,7 @@ public class ObservableFromCompletableTest {
 
             to.assertEmpty();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
@@ -107,7 +107,7 @@ public class ObservableGenerateTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -175,7 +175,7 @@ public class ObservableGenerateTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupJoinTest.java
@@ -569,7 +569,7 @@ public class ObservableGroupJoinTest {
                 }
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();
@@ -642,7 +642,7 @@ public class ObservableGroupJoinTest {
                 }
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableJoinTest.java
@@ -403,7 +403,7 @@ public class ObservableJoinTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -440,7 +440,7 @@ public class ObservableJoinTest {
             to
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
@@ -510,7 +510,7 @@ public class ObservableObserveOnTest {
 
             to.assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -598,7 +598,7 @@ public class ObservablePublishTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -612,7 +612,7 @@ public class ObservablePublishTest {
 
             co.connect();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -1310,7 +1310,7 @@ public class ObservableReplayTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
@@ -479,7 +479,7 @@ public class ObservableSingleTest {
                 }
             }).singleElement().test().assertComplete();
 
-            assertSame(exception, error.get());
+            assertSame(exception, error.get().getCause());
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
@@ -800,7 +800,7 @@ public class ObservableSwitchTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -840,7 +840,7 @@ public class ObservableSwitchTest {
             .test()
             .assertFailure(TestException.class);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicateTest.java
@@ -186,7 +186,7 @@ public class ObservableTakeUntilPredicateTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleFirstTest.java
@@ -184,7 +184,7 @@ public class ObservableThrottleFirstTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
@@ -450,7 +450,7 @@ public class ObservableTimeoutTests {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -476,7 +476,7 @@ public class ObservableTimeoutTests {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -448,7 +448,7 @@ public class ObservableTimeoutWithSelectorTest {
 
             to.assertFailureAndMessage(TestException.class, "First", 1);
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -477,7 +477,7 @@ public class ObservableTimeoutWithSelectorTest {
 
             to.assertFailureAndMessage(TestException.class, "First", 1);
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOnTest.java
@@ -252,7 +252,7 @@ public class ObservableUnsubscribeOnTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
@@ -552,7 +552,7 @@ public class ObservableUsingTest {
             .test()
             .assertResult();
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromTest.java
@@ -615,7 +615,7 @@ public class ObservableWithLatestFromTest {
             .test()
             .assertFailureAndMessage(TestException.class, "First");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Second");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableZipIterableTest.java
@@ -425,7 +425,7 @@ public class ObservableZipIterableTest {
             .test()
             .assertResult(2);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
@@ -202,7 +202,7 @@ public class SingleAmbTest {
                 TestHelper.race(r1, r2, Schedulers.single());
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();
@@ -243,7 +243,7 @@ public class SingleAmbTest {
                 TestHelper.race(r1, r2, Schedulers.single());
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
@@ -161,7 +161,7 @@ public class SingleDelayTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -197,7 +197,7 @@ public class SingleDelayTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterSuccessTest.java
@@ -107,7 +107,7 @@ public class SingleDoAfterSuccessTest {
             .test()
             .assertResult(1);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoFinallyTest.java
@@ -84,7 +84,7 @@ public class SingleDoFinallyTest implements Action {
             .assertResult(1)
             .cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
@@ -147,7 +147,7 @@ public class SingleDoOnTest {
             .test()
             .assertFailureAndMessage(TestException.class, "Inner");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Outer");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Outer");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -292,7 +292,7 @@ public class SingleDoOnTest {
             .test()
             .cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleEqualsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleEqualsTest.java
@@ -31,7 +31,7 @@ public class SingleEqualsTest {
             .test()
             .assertFailureAndMessage(TestException.class, "One");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Two");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Two");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFromPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFromPublisherTest.java
@@ -101,7 +101,7 @@ public class SingleFromPublisherTest {
             .assertResult(1);
 
             TestHelper.assertError(errors, 0, IllegalStateException.class, "Subscription already set!");
-            TestHelper.assertError(errors, 1, TestException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
@@ -253,7 +253,7 @@ public class SingleTakeUntilTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
@@ -121,7 +121,7 @@ public class SingleUsingTest {
             .test()
             .assertFailureAndMessage(TestException.class, "Mapper");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Disposer");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Disposer");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -175,7 +175,7 @@ public class SingleUsingTest {
             Single.using(Functions.justCallable(Disposables.empty()), mapper, disposerThrows, false)
             .test()
             .assertResult(1);
-            TestHelper.assertError(errors, 0, TestException.class, "Disposer");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Disposer");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -212,7 +212,7 @@ public class SingleUsingTest {
             }, disposerThrows, false)
             .test()
             .assertFailure(TestException.class);
-            TestHelper.assertError(errors, 0, TestException.class, "Disposer");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Disposer");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleZipArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleZipArrayTest.java
@@ -143,7 +143,7 @@ public class SingleZipArrayTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/operators/single/SingleZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleZipIterableTest.java
@@ -145,7 +145,7 @@ public class SingleZipIterableTest {
                 to.assertFailure(TestException.class);
 
                 if (!errors.isEmpty()) {
-                    TestHelper.assertError(errors, 0, TestException.class);
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/ScheduledRunnableTest.java
@@ -212,7 +212,7 @@ public class ScheduledRunnableTest {
 
             assertEquals(0, set.size());
 
-            TestHelper.assertError(errors, 0, TestException.class, "First");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "First");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/subscribers/EmptyComponentTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/EmptyComponentTest.java
@@ -67,7 +67,7 @@ public class EmptyComponentTest {
 
             c.cancel();
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/subscribers/FutureSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/FutureSubscriberTest.java
@@ -87,7 +87,7 @@ public class FutureSubscriberTest {
                 assertEquals("One", ex.getCause().getMessage());
             }
 
-            TestHelper.assertError(errors, 0, TestException.class, "Two");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Two");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
@@ -140,7 +140,7 @@ public class LambdaSubscriberTest {
 
             assertTrue(o.isDisposed());
 
-            TestHelper.assertError(errors, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(errors, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(errors.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "Outer");
             TestHelper.assertError(ce, 1, TestException.class, "Inner");
@@ -187,7 +187,7 @@ public class LambdaSubscriberTest {
 
             assertTrue(o.isDisposed());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
@@ -140,7 +140,7 @@ public class LambdaSubscriberTest {
 
             assertTrue(o.isDisposed());
 
-            TestHelper.assertUndeliverable(errors, 0, CompositeException.class);
+            TestHelper.assertError(errors, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(errors.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "Outer");
             TestHelper.assertError(ce, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/internal/subscriptions/FullArbiterTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/FullArbiterTest.java
@@ -89,7 +89,7 @@ public class FullArbiterTest {
         try {
             fa.onError(new TestException(), bs);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -106,7 +106,7 @@ public class FullArbiterTest {
             fa.cancel();
 
             fa.drain();
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -872,7 +872,7 @@ public class MaybeTest {
             .assertNoErrors()
             .assertNotComplete();
 
-            TestHelper.assertError(list, 0, TestException.class);
+            TestHelper.assertUndeliverable(list, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -2679,7 +2679,7 @@ public class MaybeTest {
         try {
             Maybe.sequenceEqual(Maybe.error(new TestException("One")), Maybe.error(new TestException("Two"))).test().assertFailureAndMessage(TestException.class, "One");
 
-            TestHelper.assertError(errors, 0, TestException.class, "Two");
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Two");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SafeObserverTest.java
@@ -689,7 +689,7 @@ public class SafeObserverTest {
 
             so.onNext(1);
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "onNext(1)");
             TestHelper.assertError(ce, 1, TestException.class, "onError(io.reactivex.exceptions.TestException: onNext(1))");
@@ -736,7 +736,7 @@ public class SafeObserverTest {
             SafeObserver<Object> so = cd.toSafe();
             so.onSubscribe(cd);
 
-            TestHelper.assertError(list, 0, TestException.class, "onSubscribe()");
+            TestHelper.assertUndeliverable(list, 0, TestException.class, "onSubscribe()");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -751,7 +751,7 @@ public class SafeObserverTest {
             SafeObserver<Object> so = cd.toSafe();
             so.onSubscribe(cd);
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "onSubscribe()");
             TestHelper.assertError(ce, 1, TestException.class, "dispose()");
@@ -770,7 +770,7 @@ public class SafeObserverTest {
 
             so.onNext(1);
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
@@ -801,7 +801,7 @@ public class SafeObserverTest {
 
             so.onNext(1);
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onError(java.lang.NullPointerException: Subscription not set!)");
@@ -831,7 +831,7 @@ public class SafeObserverTest {
 
             so.onError(new TestException());
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
@@ -850,7 +850,7 @@ public class SafeObserverTest {
 
             so.onError(new TestException());
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
@@ -872,7 +872,7 @@ public class SafeObserverTest {
 
             so.onComplete();
 
-            TestHelper.assertError(list, 0, TestException.class, "onComplete()");
+            TestHelper.assertUndeliverable(list, 0, TestException.class, "onComplete()");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -888,7 +888,7 @@ public class SafeObserverTest {
 
             so.onComplete();
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
@@ -907,7 +907,7 @@ public class SafeObserverTest {
 
             so.onComplete();
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class);

--- a/src/test/java/io/reactivex/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SafeObserverTest.java
@@ -689,7 +689,7 @@ public class SafeObserverTest {
 
             so.onNext(1);
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "onNext(1)");
             TestHelper.assertError(ce, 1, TestException.class, "onError(io.reactivex.exceptions.TestException: onNext(1))");
@@ -751,7 +751,7 @@ public class SafeObserverTest {
             SafeObserver<Object> so = cd.toSafe();
             so.onSubscribe(cd);
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "onSubscribe()");
             TestHelper.assertError(ce, 1, TestException.class, "dispose()");
@@ -770,7 +770,7 @@ public class SafeObserverTest {
 
             so.onNext(1);
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
@@ -801,7 +801,7 @@ public class SafeObserverTest {
 
             so.onNext(1);
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onError(java.lang.NullPointerException: Subscription not set!)");
@@ -831,7 +831,7 @@ public class SafeObserverTest {
 
             so.onError(new TestException());
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
@@ -850,7 +850,7 @@ public class SafeObserverTest {
 
             so.onError(new TestException());
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
@@ -888,7 +888,7 @@ public class SafeObserverTest {
 
             so.onComplete();
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
@@ -907,7 +907,7 @@ public class SafeObserverTest {
 
             so.onComplete();
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class);

--- a/src/test/java/io/reactivex/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SerializedObserverTest.java
@@ -1219,7 +1219,7 @@ public class SerializedObserverTest {
                 }
 
                 for (Throwable e : errors) {
-                    assertTrue(e.toString(), e instanceof TestException);
+                    assertTrue(e.toString(), e.getCause() instanceof TestException);
                 }
             } finally {
                 RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/parallel/ParallelCollectTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelCollectTest.java
@@ -161,7 +161,7 @@ public class ParallelCollectTest {
 
             assertFalse(errors.isEmpty());
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/parallel/ParallelFilterTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFilterTest.java
@@ -66,7 +66,7 @@ public class ParallelFilterTest {
 
             assertFalse(errors.isEmpty());
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();
@@ -86,7 +86,7 @@ public class ParallelFilterTest {
 
             assertFalse(errors.isEmpty());
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/parallel/ParallelMapTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelMapTest.java
@@ -93,7 +93,7 @@ public class ParallelMapTest {
 
             assertFalse(errors.isEmpty());
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();
@@ -113,7 +113,7 @@ public class ParallelMapTest {
 
             assertFalse(errors.isEmpty());
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/parallel/ParallelPeekTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelPeekTest.java
@@ -62,7 +62,7 @@ public class ParallelPeekTest {
 
             assertFalse(errors.isEmpty());
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();
@@ -89,7 +89,7 @@ public class ParallelPeekTest {
             assertFalse(errors.isEmpty());
 
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();
@@ -116,7 +116,7 @@ public class ParallelPeekTest {
             assertFalse(errors.isEmpty());
 
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();
@@ -158,7 +158,7 @@ public class ParallelPeekTest {
             assertFalse(errors.isEmpty());
 
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();
@@ -185,7 +185,7 @@ public class ParallelPeekTest {
             assertFalse(errors.isEmpty());
 
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/parallel/ParallelReduceFullTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelReduceFullTest.java
@@ -88,7 +88,7 @@ public class ParallelReduceFullTest {
             .test()
             .assertFailure(IOException.class);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -124,7 +124,7 @@ public class ParallelReduceFullTest {
 
             assertFalse(errors.isEmpty());
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/parallel/ParallelReduceTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelReduceTest.java
@@ -166,7 +166,7 @@ public class ParallelReduceTest {
 
             assertFalse(errors.isEmpty());
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/parallel/ParallelRunOnTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelRunOnTest.java
@@ -52,7 +52,7 @@ public class ParallelRunOnTest {
 
             assertFalse(errors.isEmpty());
             for (Throwable ex : errors) {
-                assertTrue(ex.toString(), ex instanceof TestException);
+                assertTrue(ex.toString(), ex.getCause() instanceof TestException);
             }
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/parallel/ParallelSortedJoinTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelSortedJoinTest.java
@@ -92,7 +92,7 @@ public class ParallelSortedJoinTest {
             .test()
             .assertFailure(IOException.class);
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -18,7 +18,7 @@ package io.reactivex.plugins;
 
 import static org.junit.Assert.*;
 
-import java.io.IOException;
+import java.io.*;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.reflect.*;
 import java.util.*;
@@ -33,7 +33,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.*;
-import io.reactivex.exceptions.TestException;
+import io.reactivex.exceptions.*;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
@@ -2237,5 +2237,22 @@ public class RxJavaPluginsTest {
         .sequential()
         .test()
         .assertResult(1);
+    }
+
+    @Test
+    public void isBug() {
+        assertFalse(RxJavaPlugins.isBug(new RuntimeException()));
+        assertFalse(RxJavaPlugins.isBug(new IOException()));
+        assertFalse(RxJavaPlugins.isBug(new InterruptedException()));
+        assertFalse(RxJavaPlugins.isBug(new InterruptedIOException()));
+
+        assertTrue(RxJavaPlugins.isBug(new NullPointerException()));
+        assertTrue(RxJavaPlugins.isBug(new IllegalArgumentException()));
+        assertTrue(RxJavaPlugins.isBug(new IllegalStateException()));
+        assertTrue(RxJavaPlugins.isBug(new MissingBackpressureException()));
+        assertTrue(RxJavaPlugins.isBug(new ProtocolViolationException("")));
+        assertTrue(RxJavaPlugins.isBug(new UndeliverableException(new TestException())));
+        assertTrue(RxJavaPlugins.isBug(new CompositeException(new TestException())));
+        assertTrue(RxJavaPlugins.isBug(new OnErrorNotImplementedException(new TestException())));
     }
 }

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -1032,7 +1032,7 @@ public class RxJavaPluginsTest {
             RxJavaPlugins.onError(new TestException("Forced failure"));
 
             assertEquals(1, list.size());
-            assertTestException(list, 0, "Forced failure");
+            assertUndeliverableTestException(list, 0, "Forced failure");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -1087,7 +1087,7 @@ public class RxJavaPluginsTest {
             RxJavaPlugins.onError(new TestException("Forced failure 3"));
 
             assertEquals(1, list.size());
-            assertTestException(list, 0, "Forced failure");
+            assertUndeliverableTestException(list, 0, "Forced failure");
         } finally {
             RxJavaPlugins.reset();
             Thread.currentThread().setUncaughtExceptionHandler(null);
@@ -1119,7 +1119,7 @@ public class RxJavaPluginsTest {
 
             assertEquals(2, list.size());
             assertTestException(list, 0, "Forced failure 2");
-            assertTestException(list, 1, "Forced failure");
+            assertUndeliverableTestException(list, 1, "Forced failure");
 
             Thread.currentThread().setUncaughtExceptionHandler(null);
 
@@ -1525,6 +1525,11 @@ public class RxJavaPluginsTest {
     static void assertTestException(List<Throwable> list, int index, String message) {
         assertTrue(list.get(index).toString(), list.get(index) instanceof TestException);
         assertEquals(message, list.get(index).getMessage());
+    }
+
+    static void assertUndeliverableTestException(List<Throwable> list, int index, String message) {
+        assertTrue(list.get(index).toString(), list.get(index).getCause() instanceof TestException);
+        assertEquals(message, list.get(index).getCause().getMessage());
     }
 
     static void assertNPE(List<Throwable> list, int index) {

--- a/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
@@ -614,7 +614,7 @@ public class BehaviorProcessorTest extends DelayedFlowableProcessorTest<Object> 
         try {
             p.onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
@@ -419,7 +419,7 @@ public class SerializedProcessorTest {
         try {
             s.onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -636,7 +636,7 @@ public class SerializedProcessorTest {
 
                 ts.assertFailure(TestException.class);
 
-                TestHelper.assertError(errors, 0, TestException.class);
+                TestHelper.assertUndeliverable(errors, 0, TestException.class);
             } finally {
                 RxJavaPlugins.reset();
             }

--- a/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
@@ -184,7 +184,7 @@ public class UnicastProcessorTest extends DelayedFlowableProcessorTest<Object> {
         try {
             p.onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/ExecutorSchedulerTest.java
@@ -345,9 +345,9 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
             assertSame(EmptyDisposable.INSTANCE, s.schedulePeriodicallyDirect(Functions.EMPTY_RUNNABLE, 10, 10, TimeUnit.MILLISECONDS));
 
-            TestHelper.assertError(errors, 0, RejectedExecutionException.class);
-            TestHelper.assertError(errors, 1, RejectedExecutionException.class);
-            TestHelper.assertError(errors, 2, RejectedExecutionException.class);
+            TestHelper.assertUndeliverable(errors, 0, RejectedExecutionException.class);
+            TestHelper.assertUndeliverable(errors, 1, RejectedExecutionException.class);
+            TestHelper.assertUndeliverable(errors, 2, RejectedExecutionException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -370,9 +370,9 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
             s = Schedulers.from(exec).createWorker();
             assertSame(EmptyDisposable.INSTANCE, s.schedulePeriodically(Functions.EMPTY_RUNNABLE, 10, 10, TimeUnit.MILLISECONDS));
 
-            TestHelper.assertError(errors, 0, RejectedExecutionException.class);
-            TestHelper.assertError(errors, 1, RejectedExecutionException.class);
-            TestHelper.assertError(errors, 2, RejectedExecutionException.class);
+            TestHelper.assertUndeliverable(errors, 0, RejectedExecutionException.class);
+            TestHelper.assertUndeliverable(errors, 1, RejectedExecutionException.class);
+            TestHelper.assertUndeliverable(errors, 2, RejectedExecutionException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerTest.java
@@ -234,7 +234,7 @@ public class SchedulerTest {
             Thread.sleep(250);
 
             assertEquals(1, list.size());
-            TestHelper.assertError(list, 0, TestException.class, null);
+            TestHelper.assertUndeliverable(list, 0, TestException.class, null);
 
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/single/SingleSubscribeTest.java
+++ b/src/test/java/io/reactivex/single/SingleSubscribeTest.java
@@ -160,7 +160,7 @@ public class SingleSubscribeTest {
                 }
             });
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> cel = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(cel, 0, TestException.class, "Outer failure");
             TestHelper.assertError(cel, 1, TestException.class, "Inner failure");
@@ -200,7 +200,7 @@ public class SingleSubscribeTest {
                 }
             });
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> cel = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(cel, 0, TestException.class, "Outer failure");
             TestHelper.assertError(cel, 1, TestException.class, "Inner failure");

--- a/src/test/java/io/reactivex/single/SingleSubscribeTest.java
+++ b/src/test/java/io/reactivex/single/SingleSubscribeTest.java
@@ -140,7 +140,7 @@ public class SingleSubscribeTest {
                 }
             });
 
-            TestHelper.assertError(list, 0, TestException.class);
+            TestHelper.assertUndeliverable(list, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -160,7 +160,7 @@ public class SingleSubscribeTest {
                 }
             });
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> cel = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(cel, 0, TestException.class, "Outer failure");
             TestHelper.assertError(cel, 1, TestException.class, "Inner failure");
@@ -181,7 +181,7 @@ public class SingleSubscribeTest {
                 }
             });
 
-            TestHelper.assertError(list, 0, TestException.class);
+            TestHelper.assertUndeliverable(list, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -200,7 +200,7 @@ public class SingleSubscribeTest {
                 }
             });
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> cel = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(cel, 0, TestException.class, "Outer failure");
             TestHelper.assertError(cel, 1, TestException.class, "Inner failure");

--- a/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
@@ -663,7 +663,7 @@ public class BehaviorSubjectTest {
         try {
             p.onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/subjects/CompletableSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/CompletableSubjectTest.java
@@ -40,7 +40,7 @@ public class CompletableSubjectTest {
         try {
             cs.onError(new IOException());
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/subjects/MaybeSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/MaybeSubjectTest.java
@@ -83,7 +83,7 @@ public class MaybeSubjectTest {
         try {
             ms.onError(new IOException());
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
@@ -420,7 +420,7 @@ public class SerializedSubjectTest {
         try {
             s.onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -637,7 +637,7 @@ public class SerializedSubjectTest {
 
                 ts.assertFailure(TestException.class);
 
-                TestHelper.assertError(errors, 0, TestException.class);
+                TestHelper.assertUndeliverable(errors, 0, TestException.class);
             } finally {
                 RxJavaPlugins.reset();
             }

--- a/src/test/java/io/reactivex/subjects/SingleSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/SingleSubjectTest.java
@@ -80,7 +80,7 @@ public class SingleSubjectTest {
         try {
             ss.onError(new IOException());
 
-            TestHelper.assertError(errors, 0, IOException.class);
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
@@ -235,7 +235,7 @@ public class UnicastSubjectTest {
         try {
             p.onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -341,7 +341,7 @@ public class UnicastSubjectTest {
         try {
             us.onError(new TestException());
 
-            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
@@ -824,7 +824,7 @@ public class SafeSubscriberTest {
 
             so.onNext(1);
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "onNext(1)");
             TestHelper.assertError(ce, 1, TestException.class, "onError(io.reactivex.exceptions.TestException: onNext(1))");
@@ -886,7 +886,7 @@ public class SafeSubscriberTest {
             SafeSubscriber<Object> so = cd.toSafe();
             so.onSubscribe(cd);
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "onSubscribe()");
             TestHelper.assertError(ce, 1, TestException.class, "cancel()");
@@ -905,7 +905,7 @@ public class SafeSubscriberTest {
 
             so.onNext(1);
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
@@ -936,7 +936,7 @@ public class SafeSubscriberTest {
 
             so.onNext(1);
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onError(java.lang.NullPointerException: Subscription not set!)");
@@ -966,7 +966,7 @@ public class SafeSubscriberTest {
 
             so.onError(new TestException());
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
@@ -985,7 +985,7 @@ public class SafeSubscriberTest {
 
             so.onError(new TestException());
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
@@ -1023,7 +1023,7 @@ public class SafeSubscriberTest {
 
             so.onComplete();
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
@@ -1042,7 +1042,7 @@ public class SafeSubscriberTest {
 
             so.onComplete();
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class);
@@ -1097,7 +1097,7 @@ public class SafeSubscriberTest {
 
             so.request(1);
 
-            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
+            TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
            TestHelper.assertError(ce, 0, TestException.class, "request()");
             TestHelper.assertError(ce, 1, TestException.class, "cancel()");

--- a/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
@@ -824,7 +824,7 @@ public class SafeSubscriberTest {
 
             so.onNext(1);
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "onNext(1)");
             TestHelper.assertError(ce, 1, TestException.class, "onError(io.reactivex.exceptions.TestException: onNext(1))");
@@ -871,7 +871,7 @@ public class SafeSubscriberTest {
             SafeSubscriber<Object> so = cd.toSafe();
             so.onSubscribe(cd);
 
-            TestHelper.assertError(list, 0, TestException.class, "onSubscribe()");
+            TestHelper.assertUndeliverable(list, 0, TestException.class, "onSubscribe()");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -886,7 +886,7 @@ public class SafeSubscriberTest {
             SafeSubscriber<Object> so = cd.toSafe();
             so.onSubscribe(cd);
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class, "onSubscribe()");
             TestHelper.assertError(ce, 1, TestException.class, "cancel()");
@@ -905,7 +905,7 @@ public class SafeSubscriberTest {
 
             so.onNext(1);
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
@@ -936,7 +936,7 @@ public class SafeSubscriberTest {
 
             so.onNext(1);
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onError(java.lang.NullPointerException: Subscription not set!)");
@@ -966,7 +966,7 @@ public class SafeSubscriberTest {
 
             so.onError(new TestException());
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
@@ -985,7 +985,7 @@ public class SafeSubscriberTest {
 
             so.onError(new TestException());
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
@@ -1007,7 +1007,7 @@ public class SafeSubscriberTest {
 
             so.onComplete();
 
-            TestHelper.assertError(list, 0, TestException.class, "onComplete()");
+            TestHelper.assertUndeliverable(list, 0, TestException.class, "onComplete()");
         } finally {
             RxJavaPlugins.reset();
         }
@@ -1023,7 +1023,7 @@ public class SafeSubscriberTest {
 
             so.onComplete();
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
@@ -1042,7 +1042,7 @@ public class SafeSubscriberTest {
 
             so.onComplete();
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class);
@@ -1062,7 +1062,7 @@ public class SafeSubscriberTest {
 
             so.request(1);
 
-            TestHelper.assertError(list, 0, TestException.class);
+            TestHelper.assertUndeliverable(list, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -1079,7 +1079,7 @@ public class SafeSubscriberTest {
 
             so.cancel();
 
-            TestHelper.assertError(list, 0, TestException.class);
+            TestHelper.assertUndeliverable(list, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -1097,7 +1097,7 @@ public class SafeSubscriberTest {
 
             so.request(1);
 
-            TestHelper.assertError(list, 0, CompositeException.class);
+            TestHelper.assertUndeliverable(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
            TestHelper.assertError(ce, 0, TestException.class, "request()");
             TestHelper.assertError(ce, 1, TestException.class, "cancel()");


### PR DESCRIPTION
This PR adds the `UndeliverableException` and `ProtocolViolationException`. The former wraps exceptions that happen beyond the lifecycle of a flow and the latter is added to distinguish validation bugs.

The `RxJavaPlugins.onError` wraps errors into `UndeliverableException` unless `RxJavaPlugins.isBug()` returns true when the `Throwable` is relayed to the (default) handler.

Having the `UndeliverableException` should help with understanding the source of a crash and by having its own stack trace, help locating the offending positions (for example, a missed `isDisposed()` check in a 3rd party library).