### PR TITLE
1.x: deprecate create(), add alternatives

### DIFF
--- a/src/main/java/rx/Completable.java
+++ b/src/main/java/rx/Completable.java
@@ -2249,7 +2249,7 @@ public class Completable {
      * @return the new Observable created
      */
     public final <T> Observable<T> toObservable() {
-        return Observable.create(new Observable.OnSubscribe<T>() {
+        return Observable.unsafeCreate(new Observable.OnSubscribe<T>() {
             @Override
             public void call(Subscriber<? super T> s) {
                 unsafeSubscribe(s);

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -202,7 +202,7 @@ public class Single<T> {
      */
     private static <T> Observable<T> asObservable(Single<T> t) {
         // is this sufficient, or do I need to keep the outer Single and subscribe to it?
-        return Observable.create(new SingleToObservable<T>(t.onSubscribe));
+        return Observable.unsafeCreate(new SingleToObservable<T>(t.onSubscribe));
     }
 
     /* *********************************************************************************************************

--- a/src/main/java/rx/internal/operators/EmptyObservableHolder.java
+++ b/src/main/java/rx/internal/operators/EmptyObservableHolder.java
@@ -28,7 +28,7 @@ public enum EmptyObservableHolder implements OnSubscribe<Object> {
     ;
 
     /** The singleton instance. */
-    static final Observable<Object> EMPTY = Observable.create(INSTANCE);
+    static final Observable<Object> EMPTY = Observable.unsafeCreate(INSTANCE);
 
 
     /**

--- a/src/main/java/rx/internal/operators/NeverObservableHolder.java
+++ b/src/main/java/rx/internal/operators/NeverObservableHolder.java
@@ -28,7 +28,7 @@ public enum NeverObservableHolder implements OnSubscribe<Object> {
     ;
 
     /** The singleton instance. */
-    static final Observable<Object> NEVER = Observable.create(INSTANCE);
+    static final Observable<Object> NEVER = Observable.unsafeCreate(INSTANCE);
 
     /**
      * Returns a type-corrected singleton instance of the never Observable.

--- a/src/main/java/rx/internal/operators/OnSubscribeCreate.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeCreate.java
@@ -29,13 +29,13 @@ import rx.internal.util.unsafe.*;
 import rx.plugins.RxJavaHooks;
 import rx.subscriptions.SerialSubscription;
 
-public final class OnSubscribeFromEmitter<T> implements OnSubscribe<T> {
+public final class OnSubscribeCreate<T> implements OnSubscribe<T> {
 
     final Action1<Emitter<T>> Emitter;
 
     final Emitter.BackpressureMode backpressure;
 
-    public OnSubscribeFromEmitter(Action1<Emitter<T>> Emitter, Emitter.BackpressureMode backpressure) {
+    public OnSubscribeCreate(Action1<Emitter<T>> Emitter, Emitter.BackpressureMode backpressure) {
         this.Emitter = Emitter;
         this.backpressure = backpressure;
     }
@@ -268,7 +268,7 @@ public final class OnSubscribeFromEmitter<T> implements OnSubscribe<T> {
 
         @Override
         void onOverflow() {
-            onError(new MissingBackpressureException("fromEmitter: could not emit value due to lack of requests"));
+            onError(new MissingBackpressureException("create: could not emit value due to lack of requests"));
         }
 
     }

--- a/src/main/java/rx/internal/operators/OnSubscribeFlattenIterable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFlattenIterable.java
@@ -70,9 +70,9 @@ public final class OnSubscribeFlattenIterable<T, R> implements OnSubscribe<R> {
             Func1<? super T, ? extends Iterable<? extends R>> mapper, int prefetch) {
         if (source instanceof ScalarSynchronousObservable) {
             T scalar = ((ScalarSynchronousObservable<? extends T>) source).get();
-            return Observable.create(new OnSubscribeScalarFlattenIterable<T, R>(scalar, mapper));
+            return Observable.unsafeCreate(new OnSubscribeScalarFlattenIterable<T, R>(scalar, mapper));
         }
-        return Observable.create(new OnSubscribeFlattenIterable<T, R>(source, mapper, prefetch));
+        return Observable.unsafeCreate(new OnSubscribeFlattenIterable<T, R>(source, mapper, prefetch));
     }
 
     static final class FlattenIterableSubscriber<T, R> extends Subscriber<T> {

--- a/src/main/java/rx/internal/operators/OnSubscribeGroupJoin.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeGroupJoin.java
@@ -170,7 +170,7 @@ public final class OnSubscribeGroupJoin<T1, T2, D1, D2, R> implements OnSubscrib
                         leftMap().put(id, subjSerial);
                     }
 
-                    Observable<T2> window = Observable.create(new WindowObservableFunc<T2>(subj, cancel));
+                    Observable<T2> window = Observable.unsafeCreate(new WindowObservableFunc<T2>(subj, cancel));
 
                     Observable<D1> duration = leftDuration.call(args);
 

--- a/src/main/java/rx/internal/operators/OnSubscribeRedo.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRedo.java
@@ -31,7 +31,7 @@ package rx.internal.operators;
  * limitations under the License.
  */
 
-import static rx.Observable.create; // NOPMD
+import static rx.Observable.unsafeCreate; // NOPMD
 
 import java.util.concurrent.atomic.*;
 
@@ -133,11 +133,11 @@ public final class OnSubscribeRedo<T> implements OnSubscribe<T> {
     }
 
     public static <T> Observable<T> retry(Observable<T> source, Func1<? super Observable<? extends Notification<?>>, ? extends Observable<?>> notificationHandler) {
-        return create(new OnSubscribeRedo<T>(source, notificationHandler, true, false, Schedulers.trampoline()));
+        return unsafeCreate(new OnSubscribeRedo<T>(source, notificationHandler, true, false, Schedulers.trampoline()));
     }
 
     public static <T> Observable<T> retry(Observable<T> source, Func1<? super Observable<? extends Notification<?>>, ? extends Observable<?>> notificationHandler, Scheduler scheduler) {
-        return create(new OnSubscribeRedo<T>(source, notificationHandler, true, false, scheduler));
+        return unsafeCreate(new OnSubscribeRedo<T>(source, notificationHandler, true, false, scheduler));
     }
 
     public static <T> Observable<T> repeat(Observable<T> source) {
@@ -163,15 +163,15 @@ public final class OnSubscribeRedo<T> implements OnSubscribe<T> {
     }
 
     public static <T> Observable<T> repeat(Observable<T> source, Func1<? super Observable<? extends Notification<?>>, ? extends Observable<?>> notificationHandler) {
-        return create(new OnSubscribeRedo<T>(source, notificationHandler, false, true, Schedulers.trampoline()));
+        return unsafeCreate(new OnSubscribeRedo<T>(source, notificationHandler, false, true, Schedulers.trampoline()));
     }
 
     public static <T> Observable<T> repeat(Observable<T> source, Func1<? super Observable<? extends Notification<?>>, ? extends Observable<?>> notificationHandler, Scheduler scheduler) {
-        return create(new OnSubscribeRedo<T>(source, notificationHandler, false, true, scheduler));
+        return unsafeCreate(new OnSubscribeRedo<T>(source, notificationHandler, false, true, scheduler));
     }
 
     public static <T> Observable<T> redo(Observable<T> source, Func1<? super Observable<? extends Notification<?>>, ? extends Observable<?>> notificationHandler, Scheduler scheduler) {
-        return create(new OnSubscribeRedo<T>(source, notificationHandler, false, false, scheduler));
+        return unsafeCreate(new OnSubscribeRedo<T>(source, notificationHandler, false, false, scheduler));
     }
 
     private OnSubscribeRedo(Observable<T> source, Func1<? super Observable<? extends Notification<?>>, ? extends Observable<?>> f, boolean stopOnComplete, boolean stopOnError,

--- a/src/main/java/rx/internal/operators/OperatorPublish.java
+++ b/src/main/java/rx/internal/operators/OperatorPublish.java
@@ -123,7 +123,7 @@ public final class OperatorPublish<T> extends ConnectableObservable<T> {
 
     public static <T, R> Observable<R> create(final Observable<? extends T> source,
             final Func1<? super Observable<T>, ? extends Observable<R>> selector, final boolean delayError) {
-        return create(new OnSubscribe<R>() {
+        return unsafeCreate(new OnSubscribe<R>() {
             @Override
             public void call(final Subscriber<? super R> child) {
                 final OnSubscribePublishMulticast<T> op = new OnSubscribePublishMulticast<T>(RxRingBuffer.SIZE, delayError);
@@ -155,7 +155,7 @@ public final class OperatorPublish<T> extends ConnectableObservable<T> {
                 child.add(op);
                 child.add(subscriber);
 
-                selector.call(Observable.create(op)).unsafeSubscribe(subscriber);
+                selector.call(Observable.unsafeCreate(op)).unsafeSubscribe(subscriber);
 
                 source.unsafeSubscribe(op.subscriber());
             }

--- a/src/main/java/rx/internal/operators/OperatorReplay.java
+++ b/src/main/java/rx/internal/operators/OperatorReplay.java
@@ -58,7 +58,7 @@ public final class OperatorReplay<T> extends ConnectableObservable<T> {
     public static <T, U, R> Observable<R> multicastSelector(
             final Func0<? extends ConnectableObservable<U>> connectableFactory,
             final Func1<? super Observable<U>, ? extends Observable<R>> selector) {
-        return Observable.create(new OnSubscribe<R>() {
+        return Observable.unsafeCreate(new OnSubscribe<R>() {
             @Override
             public void call(final Subscriber<? super R> child) {
                 ConnectableObservable<U> co;

--- a/src/main/java/rx/internal/util/ScalarSynchronousObservable.java
+++ b/src/main/java/rx/internal/util/ScalarSynchronousObservable.java
@@ -122,7 +122,7 @@ public final class ScalarSynchronousObservable<T> extends Observable<T> {
             };
         }
 
-        return create(new ScalarAsyncOnSubscribe<T>(t, onSchedule));
+        return unsafeCreate(new ScalarAsyncOnSubscribe<T>(t, onSchedule));
     }
 
     /** The OnSubscribe callback for the Observable constructor. */
@@ -225,7 +225,7 @@ public final class ScalarSynchronousObservable<T> extends Observable<T> {
      * @return the new observable
      */
     public <R> Observable<R> scalarFlatMap(final Func1<? super T, ? extends Observable<? extends R>> func) {
-        return create(new OnSubscribe<R>() {
+        return unsafeCreate(new OnSubscribe<R>() {
             @Override
             public void call(final Subscriber<? super R> child) {
                 Observable<? extends R> o = func.call(t);

--- a/src/main/java/rx/observables/AsyncOnSubscribe.java
+++ b/src/main/java/rx/observables/AsyncOnSubscribe.java
@@ -33,7 +33,7 @@ import rx.subscriptions.CompositeSubscription;
 /**
  * A utility class to create {@code OnSubscribe<T>} functions that respond correctly to back
  * pressure requests from subscribers. This is an improvement over
- * {@link rx.Observable#create(OnSubscribe) Observable.create(OnSubscribe)} which does not provide
+ * {@link rx.Observable#unsafeCreate(OnSubscribe) Observable.create(OnSubscribe)} which does not provide
  * any means of managing back pressure requests out-of-the-box. This variant of an OnSubscribe
  * function allows for the asynchronous processing of requests.
  *

--- a/src/main/java/rx/observables/ConnectableObservable.java
+++ b/src/main/java/rx/observables/ConnectableObservable.java
@@ -76,7 +76,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      * @see <a href="http://reactivex.io/documentation/operators/refcount.html">ReactiveX documentation: RefCount</a>
      */
     public Observable<T> refCount() {
-        return create(new OnSubscribeRefCount<T>(this));
+        return unsafeCreate(new OnSubscribeRefCount<T>(this));
     }
 
     /**
@@ -125,6 +125,6 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
             this.connect(connection);
             return this;
         }
-        return create(new OnSubscribeAutoConnect<T>(this, numberOfSubscribers, connection));
+        return unsafeCreate(new OnSubscribeAutoConnect<T>(this, numberOfSubscribers, connection));
     }
 }

--- a/src/main/java/rx/observables/SyncOnSubscribe.java
+++ b/src/main/java/rx/observables/SyncOnSubscribe.java
@@ -29,7 +29,7 @@ import rx.plugins.RxJavaHooks;
 /**
  * A utility class to create {@code OnSubscribe<T>} functions that responds correctly to back
  * pressure requests from subscribers. This is an improvement over
- * {@link rx.Observable#create(OnSubscribe) Observable.create(OnSubscribe)} which does not provide
+ * {@link rx.Observable#unsafeCreate(OnSubscribe) Observable.create(OnSubscribe)} which does not provide
  * any means of managing back pressure requests out-of-the-box.
  *
  * @param <S>

--- a/src/main/java/rx/plugins/RxJavaObservableExecutionHook.java
+++ b/src/main/java/rx/plugins/RxJavaObservableExecutionHook.java
@@ -41,7 +41,7 @@ import rx.functions.Func1;
  */
 public abstract class RxJavaObservableExecutionHook { // NOPMD
     /**
-     * Invoked during the construction by {@link Observable#create(OnSubscribe)}
+     * Invoked during the construction by {@link Observable#unsafeCreate(OnSubscribe)}
      * <p>
      * This can be used to decorate or replace the <code>onSubscribe</code> function or just perform extra
      * logging, metrics and other such things and pass through the function.

--- a/src/perf/java/rx/OneItemPerf.java
+++ b/src/perf/java/rx/OneItemPerf.java
@@ -70,7 +70,7 @@ public class OneItemPerf {
     @Setup
     public void setup() {
         scalar = Observable.just(1);
-        one = Observable.create(new OnSubscribe<Integer>() {
+        one = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t) {
                 t.setProducer(new SingleProducer<Integer>(t, 1));

--- a/src/perf/java/rx/jmh/InputWithIncrementingInteger.java
+++ b/src/perf/java/rx/jmh/InputWithIncrementingInteger.java
@@ -44,7 +44,7 @@ public abstract class InputWithIncrementingInteger {
         final int size = getSize();
         observable = Observable.range(0, size);
 
-        firehose = Observable.create(new OnSubscribe<Integer>() {
+        firehose = Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {

--- a/src/perf/java/rx/operators/FromComparison.java
+++ b/src/perf/java/rx/operators/FromComparison.java
@@ -49,8 +49,8 @@ public class FromComparison {
 
         Arrays.fill(array, 1);
 
-        iterableSource = Observable.create(new OnSubscribeFromIterable<Integer>(Arrays.asList(array)));
-        arraySource = Observable.create(new OnSubscribeFromArray<Integer>(array));
+        iterableSource = Observable.unsafeCreate(new OnSubscribeFromIterable<Integer>(Arrays.asList(array)));
+        arraySource = Observable.unsafeCreate(new OnSubscribeFromArray<Integer>(array));
     }
 
     @Benchmark

--- a/src/perf/java/rx/operators/OperatorRangePerf.java
+++ b/src/perf/java/rx/operators/OperatorRangePerf.java
@@ -43,7 +43,7 @@ public class OperatorRangePerf {
 
         @Setup
         public void setup(final Blackhole bh) {
-            observable = Observable.create(new OnSubscribeRange(0, size));
+            observable = Observable.unsafeCreate(new OnSubscribeRange(0, size));
             this.bh = bh;
         }
 
@@ -91,7 +91,7 @@ public class OperatorRangePerf {
 
         @Setup
         public void setup(final Blackhole bh) {
-            observable = Observable.create(new OnSubscribeRange(0, size));
+            observable = Observable.unsafeCreate(new OnSubscribeRange(0, size));
             this.bh = bh;
 
         }

--- a/src/perf/java/rx/operators/OperatorSerializePerf.java
+++ b/src/perf/java/rx/operators/OperatorSerializePerf.java
@@ -59,7 +59,7 @@ public class OperatorSerializePerf {
     @Benchmark
     public void serializedTwoStreamsHighlyContended(final Input input) throws InterruptedException {
         LatchedObserver<Integer> o = input.newLatchedObserver();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -101,7 +101,7 @@ public class OperatorSerializePerf {
     @Benchmark
     public void serializedTwoStreamsSlightlyContended(final InputWithInterval input) throws InterruptedException {
         LatchedObserver<Integer> o = input.newLatchedObserver();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -118,7 +118,7 @@ public class OperatorSerializePerf {
     @Benchmark
     public void serializedTwoStreamsOneFastOneSlow(final InputWithInterval input) throws InterruptedException {
         LatchedObserver<Integer> o = input.newLatchedObserver();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> s) {

--- a/src/perf/java/rx/operators/OperatorTakeLastOnePerf.java
+++ b/src/perf/java/rx/operators/OperatorTakeLastOnePerf.java
@@ -46,7 +46,7 @@ public class OperatorTakeLastOnePerf {
 
     @Benchmark
     public void takeLastOneUsingTakeLastOne(Input input) {
-       Observable.create(new OnSubscribeTakeLastOne<Integer>(input.observable)).subscribe(input.observer);
+       Observable.unsafeCreate(new OnSubscribeTakeLastOne<Integer>(input.observable)).subscribe(input.observer);
     }
 
 }

--- a/src/test/java/rx/BackpressureTests.java
+++ b/src/test/java/rx/BackpressureTests.java
@@ -593,7 +593,7 @@ public class BackpressureTests {
     }
 
     private static Observable<Integer> incrementingIntegers(final AtomicInteger counter, final ConcurrentLinkedQueue<Thread> threadsSeen) {
-        return Observable.create(new OnSubscribe<Integer>() {
+        return Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             final AtomicLong requested = new AtomicLong();
 
@@ -637,7 +637,7 @@ public class BackpressureTests {
      * @return
      */
     private static Observable<Integer> firehose(final AtomicInteger counter) {
-        return Observable.create(new OnSubscribe<Integer>() {
+        return Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             int i;
 

--- a/src/test/java/rx/CompletableTest.java
+++ b/src/test/java/rx/CompletableTest.java
@@ -391,7 +391,7 @@ public class CompletableTest {
                     cs.onError(e);
                 }
             })
-            .andThen(Observable.<String>create(new Observable.OnSubscribe<String>() {
+            .andThen(Observable.<String>unsafeCreate(new Observable.OnSubscribe<String>() {
                 @Override
                 public void call(Subscriber<? super String> s) {
                     hasRun.set(true);

--- a/src/test/java/rx/ConcatTests.java
+++ b/src/test/java/rx/ConcatTests.java
@@ -149,7 +149,7 @@ public class ConcatTests {
         Media media = new Media();
         HorrorMovie horrorMovie2 = new HorrorMovie();
 
-        Observable<Movie> o1 = Observable.create(new OnSubscribe<Movie>() {
+        Observable<Movie> o1 = Observable.unsafeCreate(new OnSubscribe<Movie>() {
 
             @Override
             public void call(Subscriber<? super Movie> o) {

--- a/src/test/java/rx/EventStream.java
+++ b/src/test/java/rx/EventStream.java
@@ -32,7 +32,7 @@ public final class EventStream {
         throw new IllegalStateException("No instances!");
     }
     public static Observable<Event> getEventStream(final String type, final int numInstances) {
-        return Observable.create(new OnSubscribe<Event>() {
+        return Observable.unsafeCreate(new OnSubscribe<Event>() {
 
             @Override
             public void call(final Subscriber<? super Event> subscriber) {

--- a/src/test/java/rx/MergeTests.java
+++ b/src/test/java/rx/MergeTests.java
@@ -80,7 +80,7 @@ public class MergeTests {
     @Test
     public void testMergeCovariance4() {
 
-        Observable<Movie> o1 = Observable.create(new OnSubscribe<Movie>() {
+        Observable<Movie> o1 = Observable.unsafeCreate(new OnSubscribe<Movie>() {
 
             @Override
             public void call(Subscriber<? super Movie> o) {

--- a/src/test/java/rx/ObservableTests.java
+++ b/src/test/java/rx/ObservableTests.java
@@ -94,7 +94,7 @@ public class ObservableTests {
     @Test
     public void testCreate() {
 
-        Observable<String> observable = Observable.create(new OnSubscribe<String>() {
+        Observable<String> observable = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> Observer) {
@@ -140,7 +140,7 @@ public class ObservableTests {
 
     @Test
     public void testCountError() {
-        Observable<String> o = Observable.create(new OnSubscribe<String>() {
+        Observable<String> o = Observable.unsafeCreate(new OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> obsv) {
                 obsv.onError(new RuntimeException());
@@ -289,7 +289,7 @@ public class ObservableTests {
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
         final RuntimeException re = new RuntimeException("bad impl");
-        Observable<String> o = Observable.create(new OnSubscribe<String>() {
+        Observable<String> o = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> t1) {
@@ -330,7 +330,7 @@ public class ObservableTests {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
-        Observable.create(new OnSubscribe<String>() {
+        Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(final Subscriber<? super String> observer) {
@@ -395,7 +395,7 @@ public class ObservableTests {
     public void testCustomObservableWithErrorInObserverSynchronous() {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
-        Observable.create(new OnSubscribe<String>() {
+        Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> observer) {
@@ -445,7 +445,7 @@ public class ObservableTests {
     public void testCustomObservableWithErrorInObservableSynchronous() {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
-        Observable.create(new OnSubscribe<String>() {
+        Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> observer) {
@@ -484,7 +484,7 @@ public class ObservableTests {
     @Test
     public void testPublishLast() throws InterruptedException {
         final AtomicInteger count = new AtomicInteger();
-        ConnectableObservable<String> connectable = Observable.create(new OnSubscribe<String>() {
+        ConnectableObservable<String> connectable = Observable.unsafeCreate(new OnSubscribe<String>() {
             @Override
             public void call(final Subscriber<? super String> observer) {
                 count.incrementAndGet();
@@ -522,7 +522,7 @@ public class ObservableTests {
     @Test
     public void testReplay() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        ConnectableObservable<String> o = Observable.create(new OnSubscribe<String>() {
+        ConnectableObservable<String> o = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(final Subscriber<? super String> observer) {
@@ -577,7 +577,7 @@ public class ObservableTests {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Observable<String> o = Observable.create(new OnSubscribe<String>() {
+        Observable<String> o = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(final Subscriber<? super String> observer) {
@@ -625,7 +625,7 @@ public class ObservableTests {
     @Test
     public void testCacheWithCapacity() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Observable<String> o = Observable.create(new OnSubscribe<String>() {
+        Observable<String> o = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(final Subscriber<? super String> observer) {
@@ -711,7 +711,7 @@ public class ObservableTests {
     public void testErrorThrownWithoutErrorHandlerAsynchronous() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
-        Observable.create(new OnSubscribe<String>() {
+        Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(final Subscriber<? super String> observer) {
@@ -1109,7 +1109,7 @@ public class ObservableTests {
 
     @Test
     public void nullOnSubscribe() {
-        Observable<Integer> source = Observable.create((OnSubscribe<Integer>)null);
+        Observable<Integer> source = Observable.unsafeCreate((OnSubscribe<Integer>)null);
 
         try {
             source.subscribe();
@@ -1147,7 +1147,7 @@ public class ObservableTests {
     @Test
     public void testCacheHint() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Observable<String> o = Observable.create(new OnSubscribe<String>() {
+        Observable<String> o = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(final Subscriber<? super String> observer) {

--- a/src/test/java/rx/SubscriberTest.java
+++ b/src/test/java/rx/SubscriberTest.java
@@ -229,7 +229,7 @@ public class SubscriberTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -252,7 +252,7 @@ public class SubscriberTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -282,7 +282,7 @@ public class SubscriberTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -305,7 +305,7 @@ public class SubscriberTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {

--- a/src/test/java/rx/exceptions/ExceptionsTest.java
+++ b/src/test/java/rx/exceptions/ExceptionsTest.java
@@ -254,10 +254,10 @@ public class ExceptionsTest {
 
     @Test(expected = OnErrorFailedException.class)
     public void testOnErrorExceptionIsThrownFromSubscribe() {
-        Observable.create(new Observable.OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
                               @Override
                               public void call(Subscriber<? super Integer> s1) {
-                                  Observable.create(new Observable.OnSubscribe<Integer>() {
+                                  Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
                                       @Override
                                       public void call(Subscriber<? super Integer> s2) {
                                           throw new IllegalArgumentException("original exception");
@@ -270,10 +270,10 @@ public class ExceptionsTest {
 
     @Test(expected = OnErrorFailedException.class)
     public void testOnErrorExceptionIsThrownFromUnsafeSubscribe() {
-        Observable.create(new Observable.OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
                               @Override
                               public void call(Subscriber<? super Integer> s1) {
-                                  Observable.create(new Observable.OnSubscribe<Integer>() {
+                                  Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
                                       @Override
                                       public void call(Subscriber<? super Integer> s2) {
                                           throw new IllegalArgumentException("original exception");

--- a/src/test/java/rx/internal/operators/BlockingOperatorNextTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorNextTest.java
@@ -239,7 +239,7 @@ public class BlockingOperatorNextTest {
         final CountDownLatch timeHasPassed = new CountDownLatch(COUNT);
         final AtomicBoolean running = new AtomicBoolean(true);
         final AtomicInteger count = new AtomicInteger(0);
-        final Observable<Integer> obs = Observable.create(new Observable.OnSubscribe<Integer>() {
+        final Observable<Integer> obs = Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> o) {

--- a/src/test/java/rx/internal/operators/BlockingOperatorToFutureTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorToFutureTest.java
@@ -65,7 +65,7 @@ public class BlockingOperatorToFutureTest {
 
     @Test
     public void testToFutureWithException() {
-        Observable<String> obs = Observable.create(new OnSubscribe<String>() {
+        Observable<String> obs = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> observer) {
@@ -85,7 +85,7 @@ public class BlockingOperatorToFutureTest {
 
     @Test(expected = CancellationException.class)
     public void testGetAfterCancel() throws Exception {
-        Observable<String> obs = Observable.create(new OperationNeverComplete<String>());
+        Observable<String> obs = Observable.unsafeCreate(new OperationNeverComplete<String>());
         Future<String> f = toFuture(obs);
         boolean cancelled = f.cancel(true);
         assertTrue(cancelled);  // because OperationNeverComplete never does
@@ -94,7 +94,7 @@ public class BlockingOperatorToFutureTest {
 
     @Test(expected = CancellationException.class)
     public void testGetWithTimeoutAfterCancel() throws Exception {
-        Observable<String> obs = Observable.create(new OperationNeverComplete<String>());
+        Observable<String> obs = Observable.unsafeCreate(new OperationNeverComplete<String>());
         Future<String> f = toFuture(obs);
         boolean cancelled = f.cancel(true);
         assertTrue(cancelled);  // because OperationNeverComplete never does

--- a/src/test/java/rx/internal/operators/BlockingOperatorToIteratorTest.java
+++ b/src/test/java/rx/internal/operators/BlockingOperatorToIteratorTest.java
@@ -55,7 +55,7 @@ public class BlockingOperatorToIteratorTest {
 
     @Test(expected = TestException.class)
     public void testToIteratorWithException() {
-        Observable<String> obs = Observable.create(new OnSubscribe<String>() {
+        Observable<String> obs = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> observer) {
@@ -75,7 +75,7 @@ public class BlockingOperatorToIteratorTest {
 
     @Test(expected = TestException.class)
     public void testExceptionThrownFromOnSubscribe() {
-        Iterable<String> strings = Observable.create(new Observable.OnSubscribe<String>() {
+        Iterable<String> strings = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> subscriber) {
                 throw new TestException("intentional");

--- a/src/test/java/rx/internal/operators/CachedObservableTest.java
+++ b/src/test/java/rx/internal/operators/CachedObservableTest.java
@@ -85,7 +85,7 @@ public class CachedObservableTest {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Observable<String> o = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> o = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
 
             @Override
             public void call(final Subscriber<? super String> observer) {
@@ -220,7 +220,7 @@ public class CachedObservableTest {
     @Test
     public void testNoMissingBackpressureException() {
         final int m = 4 * 1000 * 1000;
-        Observable<Integer> firehose = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> firehose = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t) {
                 for (int i = 0; i < m; i++) {

--- a/src/test/java/rx/internal/operators/OnSubscribeAmbTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeAmbTest.java
@@ -51,7 +51,7 @@ public class OnSubscribeAmbTest {
 
     private Observable<String> createObservable(final String[] values,
             final long interval, final Throwable e) {
-        return Observable.create(new OnSubscribe<String>() {
+        return Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(final Subscriber<? super String> subscriber) {
@@ -90,7 +90,7 @@ public class OnSubscribeAmbTest {
         Observable<String> observable3 = createObservable(new String[] {
                 "3", "33", "333", "3333" }, 3000, null);
 
-        Observable<String> o = Observable.create(amb(observable1,
+        Observable<String> o = Observable.unsafeCreate(amb(observable1,
                 observable2, observable3));
 
         @SuppressWarnings("unchecked")
@@ -119,7 +119,7 @@ public class OnSubscribeAmbTest {
         Observable<String> observable3 = createObservable(new String[] {},
                 3000, new IOException("fake exception"));
 
-        Observable<String> o = Observable.create(amb(observable1,
+        Observable<String> o = Observable.unsafeCreate(amb(observable1,
                 observable2, observable3));
 
         @SuppressWarnings("unchecked")
@@ -146,7 +146,7 @@ public class OnSubscribeAmbTest {
         Observable<String> observable3 = createObservable(new String[] {
                 "3" }, 3000, null);
 
-        Observable<String> o = Observable.create(amb(observable1,
+        Observable<String> o = Observable.unsafeCreate(amb(observable1,
                 observable2, observable3));
 
         @SuppressWarnings("unchecked")
@@ -165,7 +165,7 @@ public class OnSubscribeAmbTest {
         ts.requestMore(3);
         final AtomicLong requested1 = new AtomicLong();
         final AtomicLong requested2 = new AtomicLong();
-        Observable<Integer> o1 = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> o1 = Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -181,7 +181,7 @@ public class OnSubscribeAmbTest {
             }
 
         });
-        Observable<Integer> o2 = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> o2 = Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {

--- a/src/test/java/rx/internal/operators/OnSubscribeCollectTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCollectTest.java
@@ -130,7 +130,7 @@ public class OnSubscribeCollectTest {
             final RuntimeException e1 = new RuntimeException();
             final RuntimeException e2 = new RuntimeException();
             TestSubscriber<List<Integer>> ts = TestSubscriber.create();
-            Observable.create(new OnSubscribe<Integer>() {
+            Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
                 @Override
                 public void call(final Subscriber<? super Integer> sub) {
@@ -171,7 +171,7 @@ public class OnSubscribeCollectTest {
     public void testCollectorFailureDoesNotResultInErrorAndCompletedEmissions() {
         final RuntimeException e1 = new RuntimeException();
         TestSubscriber<List<Integer>> ts = TestSubscriber.create();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -209,7 +209,7 @@ public class OnSubscribeCollectTest {
         final RuntimeException e1 = new RuntimeException();
         TestSubscriber<List<Integer>> ts = TestSubscriber.create();
         final AtomicBoolean added = new AtomicBoolean();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {

--- a/src/test/java/rx/internal/operators/OnSubscribeCreateTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeCreateTest.java
@@ -32,7 +32,7 @@ import rx.observers.TestSubscriber;
 import rx.plugins.RxJavaHooks;
 import rx.subjects.PublishSubject;
 
-public class OnSubscribeFromEmitterTest {
+public class OnSubscribeCreateTest {
 
     PublishEmitter source;
 
@@ -49,7 +49,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void normalBuffered() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.BUFFER).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -70,7 +70,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void normalDrop() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.DROP).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.DROP).subscribe(ts);
 
         source.onNext(1);
 
@@ -86,7 +86,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void normalLatest() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.LATEST).subscribe(ts);
 
         source.onNext(1);
 
@@ -102,7 +102,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void normalNone() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.NONE).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.NONE).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -115,7 +115,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void normalNoneRequested() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.NONE).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.NONE).subscribe(ts);
         ts.requestMore(2);
 
         source.onNext(1);
@@ -130,7 +130,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void normalError() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.ERROR).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.ERROR).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -140,7 +140,7 @@ public class OnSubscribeFromEmitterTest {
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotCompleted();
 
-        Assert.assertEquals("fromEmitter: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
+        Assert.assertEquals("create: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
     }
 
     @Test
@@ -153,13 +153,13 @@ public class OnSubscribeFromEmitterTest {
                 //don't check for unsubscription
                 emitter.onNext(2);
             }};
-        Observable.fromEmitter(source, Emitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
 
         ts.assertNoValues();
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotCompleted();
 
-        Assert.assertEquals("fromEmitter: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
+        Assert.assertEquals("create: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
     }
 
     @Test
@@ -172,13 +172,13 @@ public class OnSubscribeFromEmitterTest {
                 //don't check for unsubscription
                 emitter.onCompleted();
             }};
-        Observable.fromEmitter(source, Emitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
 
         ts.assertNoValues();
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotCompleted();
 
-        Assert.assertEquals("fromEmitter: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
+        Assert.assertEquals("create: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
     }
 
     @Test
@@ -199,13 +199,13 @@ public class OnSubscribeFromEmitterTest {
                     //don't check for unsubscription
                     emitter.onError(e);
                 }};
-            Observable.fromEmitter(source, Emitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
+            Observable.create(source, Emitter.BackpressureMode.ERROR).unsafeSubscribe(ts);
 
             ts.assertNoValues();
             ts.assertError(MissingBackpressureException.class);
             ts.assertNotCompleted();
 
-            Assert.assertEquals("fromEmitter: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
+            Assert.assertEquals("create: could not emit value due to lack of requests", ts.getOnErrorEvents().get(0).getMessage());
             assertEquals(Arrays.asList(e), list);
         } finally {
             RxJavaHooks.reset();
@@ -214,7 +214,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void errorBuffered() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.BUFFER).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -233,7 +233,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void errorLatest() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.LATEST).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -248,7 +248,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void errorNone() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.NONE).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.NONE).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -263,7 +263,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void unsubscribedBuffer() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.unsubscribe();
 
         source.onNext(1);
@@ -279,7 +279,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void unsubscribedLatest() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.LATEST).subscribe(ts);
         ts.unsubscribe();
 
         source.onNext(1);
@@ -295,7 +295,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void unsubscribedError() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.ERROR).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.ERROR).subscribe(ts);
         ts.unsubscribe();
 
         source.onNext(1);
@@ -311,7 +311,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void unsubscribedDrop() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.DROP).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.DROP).subscribe(ts);
         ts.unsubscribe();
 
         source.onNext(1);
@@ -327,7 +327,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void unsubscribedNone() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.NONE).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.NONE).subscribe(ts);
         ts.unsubscribe();
 
         source.onNext(1);
@@ -343,7 +343,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void unsubscribedNoCancelBuffer() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.unsubscribe();
 
         sourceNoCancel.onNext(1);
@@ -359,7 +359,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void unsubscribedNoCancelLatest() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts);
         ts.unsubscribe();
 
         sourceNoCancel.onNext(1);
@@ -375,7 +375,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void unsubscribedNoCancelError() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.ERROR).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.ERROR).subscribe(ts);
         ts.unsubscribe();
 
         sourceNoCancel.onNext(1);
@@ -391,7 +391,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void unsubscribedNoCancelDrop() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.DROP).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.DROP).subscribe(ts);
         ts.unsubscribe();
 
         sourceNoCancel.onNext(1);
@@ -407,7 +407,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void unsubscribedNoCancelNone() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.NONE).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.NONE).subscribe(ts);
         ts.unsubscribe();
 
         sourceNoCancel.onNext(1);
@@ -423,7 +423,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void deferredRequest() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.BUFFER).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -438,7 +438,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void take() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -453,7 +453,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void takeOne() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
         ts.requestMore(2);
 
         source.onNext(1);
@@ -467,7 +467,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void requestExact() {
-        Observable.fromEmitter(source, Emitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.create(source, Emitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.requestMore(2);
 
         source.onNext(1);
@@ -481,7 +481,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void takeNoCancel() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.BUFFER).take(2).subscribe(ts);
 
         sourceNoCancel.onNext(1);
         sourceNoCancel.onNext(2);
@@ -496,7 +496,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void takeOneNoCancel() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.BUFFER).take(1).subscribe(ts);
         ts.requestMore(2);
 
         sourceNoCancel.onNext(1);
@@ -510,7 +510,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void unsubscribeNoCancel() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts);
         ts.requestMore(2);
 
         sourceNoCancel.onNext(1);
@@ -535,7 +535,7 @@ public class OnSubscribeFromEmitterTest {
             }
         };
 
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts1);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts1);
 
         sourceNoCancel.onNext(1);
 
@@ -546,7 +546,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void completeInline() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts);
 
         sourceNoCancel.onNext(1);
         sourceNoCancel.onCompleted();
@@ -560,7 +560,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void errorInline() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts);
 
         sourceNoCancel.onNext(1);
         sourceNoCancel.onError(new TestException());
@@ -582,7 +582,7 @@ public class OnSubscribeFromEmitterTest {
             }
         };
 
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts1);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.BUFFER).subscribe(ts1);
 
         sourceNoCancel.onNext(1);
         sourceNoCancel.onNext(2);
@@ -602,7 +602,7 @@ public class OnSubscribeFromEmitterTest {
             }
         };
 
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts1);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts1);
 
         sourceNoCancel.onNext(1);
 
@@ -621,7 +621,7 @@ public class OnSubscribeFromEmitterTest {
             }
         };
 
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts1);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts1);
 
         sourceNoCancel.onNext(1);
 
@@ -632,7 +632,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void completeInlineLatest() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts);
 
         sourceNoCancel.onNext(1);
         sourceNoCancel.onCompleted();
@@ -646,7 +646,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void completeInlineExactLatest() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts);
 
         sourceNoCancel.onNext(1);
         sourceNoCancel.onCompleted();
@@ -660,7 +660,7 @@ public class OnSubscribeFromEmitterTest {
 
     @Test
     public void errorInlineLatest() {
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts);
 
         sourceNoCancel.onNext(1);
         sourceNoCancel.onError(new TestException());
@@ -682,7 +682,7 @@ public class OnSubscribeFromEmitterTest {
             }
         };
 
-        Observable.fromEmitter(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts1);
+        Observable.create(sourceNoCancel, Emitter.BackpressureMode.LATEST).subscribe(ts1);
 
         sourceNoCancel.onNext(1);
         sourceNoCancel.onNext(2);

--- a/src/test/java/rx/internal/operators/OnSubscribeDetachTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeDetachTest.java
@@ -138,7 +138,7 @@ public class OnSubscribeDetachTest {
 
         TestSubscriber<Object> ts = new TestSubscriber<Object>(0);
 
-        Observable.create(new OnSubscribe<Object>() {
+        Observable.unsafeCreate(new OnSubscribe<Object>() {
             @Override
             public void call(Subscriber<? super Object> t) {
                 subscriber.set(t);

--- a/src/test/java/rx/internal/operators/OnSubscribeDoOnEachTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeDoOnEachTest.java
@@ -178,7 +178,7 @@ public class OnSubscribeDoOnEachTest {
                     .flatMap(new Func1<Integer, Observable<?>>() {
                         @Override
                         public Observable<?> call(Integer integer) {
-                            return Observable.create(new Observable.OnSubscribe<Object>() {
+                            return Observable.unsafeCreate(new Observable.OnSubscribe<Object>() {
                                 @Override
                                 public void call(Subscriber<Object> o) {
                                     throw new NullPointerException("Test NPE");
@@ -229,7 +229,7 @@ public class OnSubscribeDoOnEachTest {
     public void testIfOnNextActionFailsEmitsErrorAndDoesNotFollowWithCompleted() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
         final RuntimeException e1 = new RuntimeException();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> subscriber) {
@@ -259,7 +259,7 @@ public class OnSubscribeDoOnEachTest {
     public void testIfOnNextActionFailsEmitsErrorAndDoesNotFollowWithOnNext() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
         final RuntimeException e1 = new RuntimeException();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> subscriber) {
@@ -298,7 +298,7 @@ public class OnSubscribeDoOnEachTest {
             TestSubscriber<Integer> ts = TestSubscriber.create();
             final RuntimeException e1 = new RuntimeException();
             final RuntimeException e2 = new RuntimeException();
-            Observable.create(new OnSubscribe<Integer>() {
+            Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
                 @Override
                 public void call(final Subscriber<? super Integer> subscriber) {

--- a/src/test/java/rx/internal/operators/OnSubscribeFromArrayTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromArrayTest.java
@@ -29,7 +29,7 @@ public class OnSubscribeFromArrayTest {
         for (int i = 0; i < n; i++) {
             array[i] = i;
         }
-        return Observable.create(new OnSubscribeFromArray<Integer>(array));
+        return Observable.unsafeCreate(new OnSubscribeFromArray<Integer>(array));
     }
     @Test
     public void simple() {

--- a/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeFromIterableTest.java
@@ -38,12 +38,12 @@ public class OnSubscribeFromIterableTest {
 
     @Test(expected = NullPointerException.class)
     public void testNull() {
-        Observable.create(new OnSubscribeFromIterable<String>(null));
+        Observable.unsafeCreate(new OnSubscribeFromIterable<String>(null));
     }
 
     @Test
     public void testListIterable() {
-        Observable<String> observable = Observable.create(new OnSubscribeFromIterable<String>(Arrays.<String> asList("one", "two", "three")));
+        Observable<String> observable = Observable.unsafeCreate(new OnSubscribeFromIterable<String>(Arrays.<String> asList("one", "two", "three")));
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
@@ -86,7 +86,7 @@ public class OnSubscribeFromIterableTest {
             }
 
         };
-        Observable<String> observable = Observable.create(new OnSubscribeFromIterable<String>(it));
+        Observable<String> observable = Observable.unsafeCreate(new OnSubscribeFromIterable<String>(it));
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);

--- a/src/test/java/rx/internal/operators/OnSubscribeMapTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeMapTest.java
@@ -299,7 +299,7 @@ public class OnSubscribeMapTest {
         };
 
         try {
-            Observable.create(creator).flatMap(manyMapper).map(mapper).subscribe(onNext);
+            Observable.unsafeCreate(creator).flatMap(manyMapper).map(mapper).subscribe(onNext);
         } catch (RuntimeException e) {
             e.printStackTrace();
             throw e;

--- a/src/test/java/rx/internal/operators/OnSubscribeReduceTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeReduceTest.java
@@ -145,7 +145,7 @@ public class OnSubscribeReduceTest {
     @Test
     public void testNoInitialValueDoesNotEmitMultipleTerminalEvents() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -176,7 +176,7 @@ public class OnSubscribeReduceTest {
     @Test
     public void testNoInitialValueUpstreamEmitsMoreOnNextDespiteUnsubscription() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -226,7 +226,7 @@ public class OnSubscribeReduceTest {
             TestSubscriber<Integer> ts = TestSubscriber.create();
             final RuntimeException e1 = new RuntimeException("e1");
             final Throwable e2 = new RuntimeException("e2");
-            Observable.create(new OnSubscribe<Integer>() {
+            Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
                 @Override
                 public void call(final Subscriber<? super Integer> sub) {

--- a/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
@@ -322,7 +322,7 @@ public class OnSubscribeRefCountTest {
     }
 
     private Observable<Long> synchronousInterval() {
-        return Observable.create(new OnSubscribe<Long>() {
+        return Observable.unsafeCreate(new OnSubscribe<Long>() {
 
             @Override
             public void call(Subscriber<? super Long> subscriber) {
@@ -341,7 +341,7 @@ public class OnSubscribeRefCountTest {
     public void onlyFirstShouldSubscribeAndLastUnsubscribe() {
         final AtomicInteger subscriptionCount = new AtomicInteger();
         final AtomicInteger unsubscriptionCount = new AtomicInteger();
-        Observable<Integer> observable = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> observable = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> observer) {
                 subscriptionCount.incrementAndGet();

--- a/src/test/java/rx/internal/operators/OnSubscribeToMapTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeToMapTest.java
@@ -301,7 +301,7 @@ public class OnSubscribeToMapTest {
     public void testFactoryFailureDoesNotAllowErrorAndCompletedEmissions() {
         TestSubscriber<Map<Integer, Integer>> ts = TestSubscriber.create(0);
         final RuntimeException e = new RuntimeException();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -342,7 +342,7 @@ public class OnSubscribeToMapTest {
             TestSubscriber<Map<Integer, Integer>> ts = TestSubscriber.create(0);
             final RuntimeException e1 = new RuntimeException();
             final RuntimeException e2 = new RuntimeException();
-            Observable.create(new OnSubscribe<Integer>() {
+            Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
                 @Override
                 public void call(final Subscriber<? super Integer> sub) {
@@ -377,7 +377,7 @@ public class OnSubscribeToMapTest {
     public void testFactoryFailureDoesNotAllowErrorThenOnNextEmissions() {
         TestSubscriber<Map<Integer, Integer>> ts = TestSubscriber.create(0);
         final RuntimeException e = new RuntimeException();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {

--- a/src/test/java/rx/internal/operators/OnSubscribeToMultimapTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeToMultimapTest.java
@@ -395,7 +395,7 @@ public class OnSubscribeToMultimapTest {
     public void testKeySelectorFailureDoesNotAllowErrorAndCompletedEmissions() {
         TestSubscriber<Map<Integer, Collection<Integer>>> ts = TestSubscriber.create(0);
         final RuntimeException e = new RuntimeException();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -436,7 +436,7 @@ public class OnSubscribeToMultimapTest {
             TestSubscriber<Map<Integer, Collection<Integer>>> ts = TestSubscriber.create(0);
             final RuntimeException e1 = new RuntimeException();
             final RuntimeException e2 = new RuntimeException();
-            Observable.create(new OnSubscribe<Integer>() {
+            Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
                 @Override
                 public void call(final Subscriber<? super Integer> sub) {
@@ -471,7 +471,7 @@ public class OnSubscribeToMultimapTest {
     public void testFactoryFailureDoesNotAllowErrorThenOnNextEmissions() {
         TestSubscriber<Map<Integer, Collection<Integer>>> ts = TestSubscriber.create(0);
         final RuntimeException e = new RuntimeException();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {

--- a/src/test/java/rx/internal/operators/OnSubscribeUsingTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeUsingTest.java
@@ -254,7 +254,7 @@ public class OnSubscribeUsingTest {
         Func1<Subscription, Observable<Integer>> observableFactory = new Func1<Subscription, Observable<Integer>>() {
             @Override
             public Observable<Integer> call(Subscription subscription) {
-                return Observable.create(new OnSubscribe<Integer>() {
+                return Observable.unsafeCreate(new OnSubscribe<Integer>() {
                     @Override
                     public void call(Subscriber<? super Integer> t1) {
                         throw new TestException();

--- a/src/test/java/rx/internal/operators/OperatorAllTest.java
+++ b/src/test/java/rx/internal/operators/OperatorAllTest.java
@@ -186,7 +186,7 @@ public class OperatorAllTest {
     @Test
     public void testDoesNotEmitMultipleTerminalEvents() {
         TestSubscriber<Boolean> ts = TestSubscriber.create();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -216,7 +216,7 @@ public class OperatorAllTest {
     @Test
     public void testUpstreamEmitsOnNextAfterFailureWithoutCheckingSubscription() {
         TestSubscriber<Boolean> ts = TestSubscriber.create();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -263,7 +263,7 @@ public class OperatorAllTest {
             TestSubscriber<Boolean> ts = TestSubscriber.create();
             final RuntimeException e1 = new RuntimeException();
             final Throwable e2 = new RuntimeException();
-            Observable.create(new OnSubscribe<Integer>() {
+            Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
                 @Override
                 public void call(final Subscriber<? super Integer> sub) {

--- a/src/test/java/rx/internal/operators/OperatorAnyTest.java
+++ b/src/test/java/rx/internal/operators/OperatorAnyTest.java
@@ -278,7 +278,7 @@ public class OperatorAnyTest {
     @Test
     public void testUpstreamEmitsOnNextAfterFailureWithoutCheckingSubscription() {
         TestSubscriber<Boolean> ts = TestSubscriber.create();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -314,7 +314,7 @@ public class OperatorAnyTest {
     @Test
     public void testUpstreamEmitsOnNextWithoutCheckingSubscription() {
         TestSubscriber<Boolean> ts = TestSubscriber.create();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -356,7 +356,7 @@ public class OperatorAnyTest {
             TestSubscriber<Boolean> ts = TestSubscriber.create();
             final RuntimeException e1 = new RuntimeException();
             final Throwable e2 = new RuntimeException();
-            Observable.create(new OnSubscribe<Integer>() {
+            Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
                 @Override
                 public void call(final Subscriber<? super Integer> sub) {

--- a/src/test/java/rx/internal/operators/OperatorBufferTest.java
+++ b/src/test/java/rx/internal/operators/OperatorBufferTest.java
@@ -52,7 +52,7 @@ public class OperatorBufferTest {
 
     @Test
     public void testComplete() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 observer.onCompleted();
@@ -69,7 +69,7 @@ public class OperatorBufferTest {
 
     @Test
     public void testSkipAndCountOverlappingBuffers() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 observer.onNext("one");
@@ -94,7 +94,7 @@ public class OperatorBufferTest {
 
     @Test
     public void testSkipAndCountGaplessBuffers() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 observer.onNext("one");
@@ -119,7 +119,7 @@ public class OperatorBufferTest {
 
     @Test
     public void testSkipAndCountBuffersWithGaps() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 observer.onNext("one");
@@ -144,7 +144,7 @@ public class OperatorBufferTest {
 
     @Test
     public void testTimedAndCount() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 push(observer, "one", 10);
@@ -175,7 +175,7 @@ public class OperatorBufferTest {
 
     @Test
     public void testTimed() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 push(observer, "one", 97);
@@ -208,7 +208,7 @@ public class OperatorBufferTest {
 
     @Test
     public void testObservableBasedOpenerAndCloser() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 push(observer, "one", 10);
@@ -220,7 +220,7 @@ public class OperatorBufferTest {
             }
         });
 
-        Observable<Object> openings = Observable.create(new Observable.OnSubscribe<Object>() {
+        Observable<Object> openings = Observable.unsafeCreate(new Observable.OnSubscribe<Object>() {
             @Override
             public void call(Subscriber<Object> observer) {
                 push(observer, new Object(), 50);
@@ -232,7 +232,7 @@ public class OperatorBufferTest {
         Func1<Object, Observable<Object>> closer = new Func1<Object, Observable<Object>>() {
             @Override
             public Observable<Object> call(Object opening) {
-                return Observable.create(new Observable.OnSubscribe<Object>() {
+                return Observable.unsafeCreate(new Observable.OnSubscribe<Object>() {
                     @Override
                     public void call(Subscriber<? super Object> observer) {
                         push(observer, new Object(), 100);
@@ -256,7 +256,7 @@ public class OperatorBufferTest {
 
     @Test
     public void testObservableBasedCloser() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 push(observer, "one", 10);
@@ -271,7 +271,7 @@ public class OperatorBufferTest {
         Func0<Observable<Object>> closer = new Func0<Observable<Object>>() {
             @Override
             public Observable<Object> call() {
-                return Observable.create(new Observable.OnSubscribe<Object>() {
+                return Observable.unsafeCreate(new Observable.OnSubscribe<Object>() {
                     @Override
                     public void call(Subscriber<? super Object> observer) {
                         push(observer, new Object(), 100);
@@ -786,7 +786,7 @@ public class OperatorBufferTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
         ts.requestMore(3);
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new Observable.OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -811,7 +811,7 @@ public class OperatorBufferTest {
     public void testProducerRequestThroughBufferWithSize2() {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new Observable.OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -834,7 +834,7 @@ public class OperatorBufferTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
         ts.requestMore(3);
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new Observable.OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -858,7 +858,7 @@ public class OperatorBufferTest {
     public void testProducerRequestThroughBufferWithSize4() {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new Observable.OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -882,7 +882,7 @@ public class OperatorBufferTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
         ts.requestMore(Long.MAX_VALUE / 2);
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new Observable.OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -905,7 +905,7 @@ public class OperatorBufferTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
         ts.requestMore(Long.MAX_VALUE / 2);
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new Observable.OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -926,7 +926,7 @@ public class OperatorBufferTest {
     @Test
     public void testProducerRequestOverflowThroughBufferWithSize3() {
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new Observable.OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> s) {

--- a/src/test/java/rx/internal/operators/OperatorConcatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorConcatTest.java
@@ -115,7 +115,7 @@ public class OperatorConcatTest {
         final Observable<String> odds = Observable.from(o);
         final Observable<String> even = Observable.from(e);
 
-        Observable<Observable<String>> observableOfObservables = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
 
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
@@ -144,7 +144,7 @@ public class OperatorConcatTest {
         TestObservable<String> o1 = new TestObservable<String>("one", "two", "three");
         TestObservable<String> o2 = new TestObservable<String>("four", "five", "six");
 
-        Observable.concat(Observable.create(o1), Observable.create(o2)).subscribe(observer);
+        Observable.concat(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2)).subscribe(observer);
 
         try {
             // wait for async observables to complete
@@ -179,7 +179,7 @@ public class OperatorConcatTest {
 
         final AtomicReference<Thread> parent = new AtomicReference<Thread>();
         final CountDownLatch parentHasStarted = new CountDownLatch(1);
-        Observable<Observable<String>> observableOfObservables = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
 
             @Override
             public void call(final Subscriber<? super Observable<String>> observer) {
@@ -193,12 +193,12 @@ public class OperatorConcatTest {
                             // emit first
                             if (!s.isUnsubscribed()) {
                                 System.out.println("Emit o1");
-                                observer.onNext(Observable.create(o1));
+                                observer.onNext(Observable.unsafeCreate(o1));
                             }
                             // emit second
                             if (!s.isUnsubscribed()) {
                                 System.out.println("Emit o2");
-                                observer.onNext(Observable.create(o2));
+                                observer.onNext(Observable.unsafeCreate(o2));
                             }
 
                             // wait until sometime later and emit third
@@ -209,7 +209,7 @@ public class OperatorConcatTest {
                             }
                             if (!s.isUnsubscribed()) {
                                 System.out.println("Emit o3");
-                                observer.onNext(Observable.create(o3));
+                                observer.onNext(Observable.unsafeCreate(o3));
                             }
 
                         } catch (Throwable e) {
@@ -285,7 +285,7 @@ public class OperatorConcatTest {
         final CountDownLatch callOnce = new CountDownLatch(1);
         final CountDownLatch okToContinue = new CountDownLatch(1);
         TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(callOnce, okToContinue, odds, even);
-        Observable<String> concatF = Observable.concat(Observable.create(observableOfObservables));
+        Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
         concatF.subscribe(observer);
         try {
             //Block main thread to allow observables to serve up o1.
@@ -323,8 +323,8 @@ public class OperatorConcatTest {
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
         @SuppressWarnings("unchecked")
-        TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(Observable.create(w1), Observable.create(w2));
-        Observable<String> concatF = Observable.concat(Observable.create(observableOfObservables));
+        TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
+        Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
 
         concatF.take(50).subscribe(observer);
 
@@ -357,13 +357,13 @@ public class OperatorConcatTest {
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
-        Observable<Observable<String>> observableOfObservables = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
 
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
                 // simulate what would happen in an observable
-                observer.onNext(Observable.create(w1));
-                observer.onNext(Observable.create(w2));
+                observer.onNext(Observable.unsafeCreate(w1));
+                observer.onNext(Observable.unsafeCreate(w2));
                 observer.onCompleted();
             }
 
@@ -408,7 +408,7 @@ public class OperatorConcatTest {
         @SuppressWarnings("unchecked")
         final Observer<String> observer = mock(Observer.class);
 
-        final Observable<String> concat = Observable.concat(Observable.create(w1), Observable.create(w2));
+        final Observable<String> concat = Observable.concat(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
 
         try {
             // Subscribe
@@ -450,8 +450,8 @@ public class OperatorConcatTest {
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
         @SuppressWarnings("unchecked")
-        TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(Observable.create(w1), Observable.create(w2));
-        Observable<String> concatF = Observable.concat(Observable.create(observableOfObservables));
+        TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
+        Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
 
         Subscription s1 = concatF.subscribe(observer);
 
@@ -618,7 +618,7 @@ public class OperatorConcatTest {
     @Test
     public void concatVeryLongObservableOfObservables() {
         final int n = 10000;
-        Observable<Observable<Integer>> source = Observable.create(new OnSubscribe<Observable<Integer>>() {
+        Observable<Observable<Integer>> source = Observable.unsafeCreate(new OnSubscribe<Observable<Integer>>() {
             @Override
             public void call(Subscriber<? super Observable<Integer>> s) {
                 for (int i = 0; i < n; i++) {
@@ -650,7 +650,7 @@ public class OperatorConcatTest {
     @Test
     public void concatVeryLongObservableOfObservablesTakeHalf() {
         final int n = 10000;
-        Observable<Observable<Integer>> source = Observable.create(new OnSubscribe<Observable<Integer>>() {
+        Observable<Observable<Integer>> source = Observable.unsafeCreate(new OnSubscribe<Observable<Integer>>() {
             @Override
             public void call(Subscriber<? super Observable<Integer>> s) {
                 for (int i = 0; i < n; i++) {
@@ -724,7 +724,7 @@ public class OperatorConcatTest {
     // https://github.com/ReactiveX/RxJava/issues/1818
     @Test
     public void testConcatWithNonCompliantSourceDoubleOnComplete() {
-        Observable<String> o = Observable.create(new OnSubscribe<String>() {
+        Observable<String> o = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> s) {

--- a/src/test/java/rx/internal/operators/OperatorDebounceTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDebounceTest.java
@@ -57,7 +57,7 @@ public class OperatorDebounceTest {
 
     @Test
     public void testDebounceWithCompleted() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 publishNext(observer, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
@@ -82,7 +82,7 @@ public class OperatorDebounceTest {
 
     @Test
     public void testDebounceNeverEmits() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 // all should be skipped since they are happening faster than the 200ms timeout
@@ -111,7 +111,7 @@ public class OperatorDebounceTest {
 
     @Test
     public void testDebounceWithError() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 Exception error = new TestException();

--- a/src/test/java/rx/internal/operators/OperatorDoOnRequestTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDoOnRequestTest.java
@@ -99,7 +99,7 @@ public class OperatorDoOnRequestTest {
 
         final AtomicReference<Producer> producer = new AtomicReference<Producer>();
 
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t) {
                 t.setProducer(new Producer() {

--- a/src/test/java/rx/internal/operators/OperatorDoOnSubscribeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorDoOnSubscribeTest.java
@@ -76,7 +76,7 @@ public class OperatorDoOnSubscribeTest {
         final AtomicInteger countBefore = new AtomicInteger();
         final AtomicInteger countAfter = new AtomicInteger();
         final AtomicReference<Subscriber<? super Integer>> sref = new AtomicReference<Subscriber<? super Integer>>();
-        Observable<Integer> o = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> o = Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {

--- a/src/test/java/rx/internal/operators/OperatorGroupByTest.java
+++ b/src/test/java/rx/internal/operators/OperatorGroupByTest.java
@@ -189,7 +189,7 @@ public class OperatorGroupByTest {
         final int count = 100;
         final int groupCount = 2;
 
-        Observable<Event> es = Observable.create(new Observable.OnSubscribe<Event>() {
+        Observable<Event> es = Observable.unsafeCreate(new Observable.OnSubscribe<Event>() {
 
             @Override
             public void call(final Subscriber<? super Event> observer) {
@@ -602,7 +602,7 @@ public class OperatorGroupByTest {
     public void testFirstGroupsCompleteAndParentSlowToThenEmitFinalGroupsAndThenComplete() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<String>();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> sub) {
@@ -680,7 +680,7 @@ public class OperatorGroupByTest {
         System.err.println("----------------------------------------------------------------------------------------------");
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<String>();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> sub) {
@@ -771,7 +771,7 @@ public class OperatorGroupByTest {
     public void testFirstGroupsCompleteAndParentSlowToThenEmitFinalGroupsWhichThenObservesOnAndDelaysAndThenCompletes() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<String>();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> sub) {
@@ -847,7 +847,7 @@ public class OperatorGroupByTest {
     @Test
     public void testGroupsWithNestedSubscribeOn() throws InterruptedException {
         final ArrayList<String> results = new ArrayList<String>();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> sub) {
@@ -903,7 +903,7 @@ public class OperatorGroupByTest {
     @Test
     public void testGroupsWithNestedObserveOn() throws InterruptedException {
         final ArrayList<String> results = new ArrayList<String>();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> sub) {
@@ -963,7 +963,7 @@ public class OperatorGroupByTest {
     }
 
     Observable<Event> SYNC_INFINITE_OBSERVABLE_OF_EVENT(final int numGroups, final AtomicInteger subscribeCounter, final AtomicInteger sentEventCounter) {
-        return Observable.create(new OnSubscribe<Event>() {
+        return Observable.unsafeCreate(new OnSubscribe<Event>() {
 
             @Override
             public void call(final Subscriber<? super Event> op) {
@@ -1375,7 +1375,7 @@ public class OperatorGroupByTest {
     @Test
     public void testGroupByUnsubscribe() {
         final Subscription s = mock(Subscription.class);
-        Observable<Integer> o = Observable.create(
+        Observable<Integer> o = Observable.unsafeCreate(
                 new OnSubscribe<Integer>() {
                     @Override
                     public void call(Subscriber<? super Integer> subscriber) {
@@ -1419,7 +1419,7 @@ public class OperatorGroupByTest {
                 }
             }
         });
-        Observable.create(
+        Observable.unsafeCreate(
                 new OnSubscribe<Integer>() {
                     @Override
                     public void call(Subscriber<? super Integer> subscriber) {

--- a/src/test/java/rx/internal/operators/OperatorMaterializeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMaterializeTest.java
@@ -43,7 +43,7 @@ public class OperatorMaterializeTest {
                 "three");
 
         TestObserver Observer = new TestObserver();
-        Observable<Notification<String>> m = Observable.create(o1).materialize();
+        Observable<Notification<String>> m = Observable.unsafeCreate(o1).materialize();
         m.subscribe(Observer);
 
         try {
@@ -69,7 +69,7 @@ public class OperatorMaterializeTest {
         final TestAsyncErrorObservable o1 = new TestAsyncErrorObservable("one", "two", "three");
 
         TestObserver Observer = new TestObserver();
-        Observable<Notification<String>> m = Observable.create(o1).materialize();
+        Observable<Notification<String>> m = Observable.unsafeCreate(o1).materialize();
         m.subscribe(Observer);
 
         try {
@@ -94,7 +94,7 @@ public class OperatorMaterializeTest {
     public void testMultipleSubscribes() throws InterruptedException, ExecutionException {
         final TestAsyncErrorObservable o = new TestAsyncErrorObservable("one", "two", null, "three");
 
-        Observable<Notification<String>> m = Observable.create(o).materialize();
+        Observable<Notification<String>> m = Observable.unsafeCreate(o).materialize();
 
         assertEquals(3, m.toList().toBlocking().toFuture().get().size());
         assertEquals(3, m.toList().toBlocking().toFuture().get().size());

--- a/src/test/java/rx/internal/operators/OperatorMergeDelayErrorTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeDelayErrorTest.java
@@ -55,8 +55,8 @@ public class OperatorMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed1() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2);
         m.subscribe(stringObserver);
@@ -76,10 +76,10 @@ public class OperatorMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed2() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight", null));
-        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine"));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight", null));
+        final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine"));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -101,10 +101,10 @@ public class OperatorMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed3() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", "five", "six"));
-        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight", null));
-        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine"));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", "five", "six"));
+        final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight", null));
+        final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine"));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -124,10 +124,10 @@ public class OperatorMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed4() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", "five", "six"));
-        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight"));
-        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine", null));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", "five", "six"));
+        final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight"));
+        final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine", null));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -153,7 +153,7 @@ public class OperatorMergeDelayErrorTest {
         // throw the error at the very end so no onComplete will be called after it
         final TestAsyncErrorObservable o4 = new TestAsyncErrorObservable("nine", null);
 
-        Observable<String> m = Observable.mergeDelayError(Observable.create(o1), Observable.create(o2), Observable.create(o3), Observable.create(o4));
+        Observable<String> m = Observable.mergeDelayError(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2), Observable.unsafeCreate(o3), Observable.unsafeCreate(o4));
         m.subscribe(stringObserver);
 
         try {
@@ -180,8 +180,8 @@ public class OperatorMergeDelayErrorTest {
 
     @Test
     public void testCompositeErrorDelayed1() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", null));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", null));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2);
         m.subscribe(stringObserver);
@@ -200,8 +200,8 @@ public class OperatorMergeDelayErrorTest {
 
     @Test
     public void testCompositeErrorDelayed2() {
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", null));
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", null));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2);
         CaptureObserver w = new CaptureObserver();
@@ -223,10 +223,10 @@ public class OperatorMergeDelayErrorTest {
 
     @Test
     public void testMergeObservableOfObservables() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
 
-        Observable<Observable<String>> observableOfObservables = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
 
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
@@ -247,8 +247,8 @@ public class OperatorMergeDelayErrorTest {
 
     @Test
     public void testMergeArray() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
 
         Observable<String> m = Observable.mergeDelayError(o1, o2);
         m.subscribe(stringObserver);
@@ -260,8 +260,8 @@ public class OperatorMergeDelayErrorTest {
 
     @Test
     public void testMergeList() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
         List<Observable<String>> listOfObservables = new ArrayList<Observable<String>>();
         listOfObservables.add(o1);
         listOfObservables.add(o2);
@@ -277,8 +277,8 @@ public class OperatorMergeDelayErrorTest {
     // This is pretty much a clone of testMergeList but with the overloaded MergeDelayError for Iterables
     @Test
     public void mergeIterable() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
         List<Observable<String>> listOfObservables = new ArrayList<Observable<String>>();
         listOfObservables.add(o1);
         listOfObservables.add(o2);
@@ -296,7 +296,7 @@ public class OperatorMergeDelayErrorTest {
         final TestASynchronousObservable o1 = new TestASynchronousObservable();
         final TestASynchronousObservable o2 = new TestASynchronousObservable();
 
-        Observable<String> m = Observable.mergeDelayError(Observable.create(o1), Observable.create(o2));
+        Observable<String> m = Observable.mergeDelayError(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
         m.subscribe(stringObserver);
 
         try {
@@ -455,7 +455,7 @@ public class OperatorMergeDelayErrorTest {
     }
     @Test
     public void testMergeSourceWhichDoesntPropagateExceptionBack() {
-        Observable<Integer> source = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t1) {
                 try {
@@ -527,11 +527,11 @@ public class OperatorMergeDelayErrorTest {
         for (int i = 0; i < 50; i++) {
             final TestASynchronous1sDelayedObservable o1 = new TestASynchronous1sDelayedObservable();
             final TestASynchronous1sDelayedObservable o2 = new TestASynchronous1sDelayedObservable();
-            Observable<Observable<String>> parentObservable = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+            Observable<Observable<String>> parentObservable = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
                 @Override
                 public void call(Subscriber<? super Observable<String>> op) {
-                    op.onNext(Observable.create(o1));
-                    op.onNext(Observable.create(o2));
+                    op.onNext(Observable.unsafeCreate(o1));
+                    op.onNext(Observable.unsafeCreate(o2));
                     op.onError(new NullPointerException("throwing exception in parent"));
                 }
             });

--- a/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeMaxConcurrentTest.java
@@ -72,7 +72,7 @@ public class OperatorMergeMaxConcurrentTest {
             for (int i = 0; i < observableCount; i++) {
                 SubscriptionCheckObservable sco = new SubscriptionCheckObservable(subscriptionCount, maxConcurrent);
                 scos.add(sco);
-                os.add(Observable.create(sco));
+                os.add(Observable.unsafeCreate(sco));
             }
 
             Iterator<String> iter = Observable.merge(os, maxConcurrent).toBlocking().toIterable().iterator();

--- a/src/test/java/rx/internal/operators/OperatorMergeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorMergeTest.java
@@ -53,10 +53,10 @@ public class OperatorMergeTest {
 
     @Test
     public void testMergeObservableOfObservables() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
 
-        Observable<Observable<String>> observableOfObservables = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
 
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
@@ -77,8 +77,8 @@ public class OperatorMergeTest {
 
     @Test
     public void testMergeArray() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
 
         Observable<String> m = Observable.merge(o1, o2);
         m.subscribe(stringObserver);
@@ -90,8 +90,8 @@ public class OperatorMergeTest {
 
     @Test
     public void testMergeList() {
-        final Observable<String> o1 = Observable.create(new TestSynchronousObservable());
-        final Observable<String> o2 = Observable.create(new TestSynchronousObservable());
+        final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
+        final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
         List<Observable<String>> listOfObservables = new ArrayList<Observable<String>>();
         listOfObservables.add(o1);
         listOfObservables.add(o2);
@@ -110,7 +110,7 @@ public class OperatorMergeTest {
         final AtomicBoolean unsubscribed = new AtomicBoolean();
         final CountDownLatch latch = new CountDownLatch(1);
 
-        Observable<Observable<Long>> source = Observable.create(new Observable.OnSubscribe<Observable<Long>>() {
+        Observable<Observable<Long>> source = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<Long>>() {
 
             @Override
             public void call(final Subscriber<? super Observable<Long>> observer) {
@@ -172,7 +172,7 @@ public class OperatorMergeTest {
         final TestASynchronousObservable o1 = new TestASynchronousObservable();
         final TestASynchronousObservable o2 = new TestASynchronousObservable();
 
-        Observable<String> m = Observable.merge(Observable.create(o1), Observable.create(o2));
+        Observable<String> m = Observable.merge(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
         TestSubscriber<String> ts = new TestSubscriber<String>(stringObserver);
         m.subscribe(ts);
 
@@ -195,7 +195,7 @@ public class OperatorMergeTest {
         final AtomicInteger concurrentCounter = new AtomicInteger();
         final AtomicInteger totalCounter = new AtomicInteger();
 
-        Observable<String> m = Observable.merge(Observable.create(o1), Observable.create(o2));
+        Observable<String> m = Observable.merge(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
         m.subscribe(new Subscriber<String>() {
 
             @Override
@@ -262,8 +262,8 @@ public class OperatorMergeTest {
     @Test
     public void testError1() {
         // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("one", "two", "three")); // we expect to lose all of these since o1 is done first and fails
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three")); // we expect to lose all of these since o1 is done first and fails
 
         Observable<String> m = Observable.merge(o1, o2);
         m.subscribe(stringObserver);
@@ -284,10 +284,10 @@ public class OperatorMergeTest {
     @Test
     public void testError2() {
         // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
-        final Observable<String> o1 = Observable.create(new TestErrorObservable("one", "two", "three"));
-        final Observable<String> o2 = Observable.create(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
-        final Observable<String> o3 = Observable.create(new TestErrorObservable("seven", "eight", null));// we expect to lose all of these since o2 is done first and fails
-        final Observable<String> o4 = Observable.create(new TestErrorObservable("nine"));// we expect to lose all of these since o2 is done first and fails
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
+        final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight", null));// we expect to lose all of these since o2 is done first and fails
+        final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine"));// we expect to lose all of these since o2 is done first and fails
 
         Observable<String> m = Observable.merge(o1, o2, o3, o4);
         m.subscribe(stringObserver);
@@ -308,7 +308,7 @@ public class OperatorMergeTest {
     @Test
     public void testThrownErrorHandling() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Observable<String> o1 = Observable.create(new OnSubscribe<String>() {
+        Observable<String> o1 = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> s) {
@@ -460,7 +460,7 @@ public class OperatorMergeTest {
     }
 
     private Observable<Long> createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(final Scheduler scheduler, final AtomicBoolean unsubscribed) {
-        return Observable.create(new OnSubscribe<Long>() {
+        return Observable.unsafeCreate(new OnSubscribe<Long>() {
 
             @Override
             public void call(Subscriber<? super Long> s) {
@@ -499,7 +499,7 @@ public class OperatorMergeTest {
     @Test
     public void testConcurrencyWithSleeping() {
 
-        Observable<Integer> o = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> o = Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> s) {
@@ -543,7 +543,7 @@ public class OperatorMergeTest {
 
     @Test
     public void testConcurrencyWithBrokenOnCompleteContract() {
-        Observable<Integer> o = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> o = Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> s) {
@@ -807,7 +807,7 @@ public class OperatorMergeTest {
     public void mergeWithTerminalEventAfterUnsubscribe() {
         System.out.println("mergeWithTerminalEventAfterUnsubscribe");
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Observable<String> bad = Observable.create(new OnSubscribe<String>() {
+        Observable<String> bad = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> s) {
@@ -984,7 +984,7 @@ public class OperatorMergeTest {
 
             @Override
             public Observable<Integer> call(final Integer i) {
-                return Observable.create(new OnSubscribe<Integer>() {
+                return Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
                     @Override
                     public void call(Subscriber<? super Integer> s) {

--- a/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorObserveOnTest.java
@@ -526,7 +526,7 @@ public class OperatorObserveOnTest {
     @Test
     public void testQueueFullEmitsError() {
         final CountDownLatch latch = new CountDownLatch(1);
-        Observable<Integer> observable = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> observable = Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> o) {

--- a/src/test/java/rx/internal/operators/OperatorOnBackpressureBufferTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnBackpressureBufferTest.java
@@ -227,7 +227,7 @@ public class OperatorOnBackpressureBufferTest {
         });
     }
 
-    static final Observable<Long> infinite = Observable.create(new OnSubscribe<Long>() {
+    static final Observable<Long> infinite = Observable.unsafeCreate(new OnSubscribe<Long>() {
 
         @Override
         public void call(Subscriber<? super Long> s) {

--- a/src/test/java/rx/internal/operators/OperatorOnBackpressureDropTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnBackpressureDropTest.java
@@ -151,7 +151,7 @@ public class OperatorOnBackpressureDropTest {
         final List<Integer> list = new ArrayList<Integer>();
         // request 0
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -180,7 +180,7 @@ public class OperatorOnBackpressureDropTest {
     public void testUpstreamEmitsOnCompletedAfterFailureWithoutCheckingSubscription() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
         final RuntimeException e = new RuntimeException();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -221,7 +221,7 @@ public class OperatorOnBackpressureDropTest {
             TestSubscriber<Integer> ts = TestSubscriber.create(0);
             final RuntimeException e1 = new RuntimeException();
             final RuntimeException e2 = new RuntimeException();
-            Observable.create(new OnSubscribe<Integer>() {
+            Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
                 @Override
                 public void call(final Subscriber<? super Integer> sub) {
@@ -255,7 +255,7 @@ public class OperatorOnBackpressureDropTest {
     public void testUpstreamEmitsOnNextAfterFailureWithoutCheckingSubscription() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
         final RuntimeException e = new RuntimeException();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> sub) {
@@ -291,7 +291,7 @@ public class OperatorOnBackpressureDropTest {
         }
     };
 
-    static final Observable<Long> infinite = Observable.create(new OnSubscribe<Long>() {
+    static final Observable<Long> infinite = Observable.unsafeCreate(new OnSubscribe<Long>() {
 
         @Override
         public void call(Subscriber<? super Long> s) {
@@ -304,7 +304,7 @@ public class OperatorOnBackpressureDropTest {
     });
 
     private static final Observable<Long> range(final long n) {
-        return Observable.create(new OnSubscribe<Long>() {
+        return Observable.unsafeCreate(new OnSubscribe<Long>() {
 
             @Override
             public void call(Subscriber<? super Long> s) {

--- a/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaFunctionTest.java
@@ -44,7 +44,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
     @Test
     public void testResumeNextWithSynchronousExecution() {
         final AtomicReference<Throwable> receivedException = new AtomicReference<Throwable>();
-        Observable<String> w = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> w = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> observer) {
@@ -94,7 +94,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
             }
 
         };
-        Observable<String> observable = Observable.create(w).onErrorResumeNext(resume);
+        Observable<String> observable = Observable.unsafeCreate(w).onErrorResumeNext(resume);
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
@@ -131,7 +131,7 @@ public class OperatorOnErrorResumeNextViaFunctionTest {
             }
 
         };
-        Observable<String> observable = Observable.create(w).onErrorResumeNext(resume);
+        Observable<String> observable = Observable.unsafeCreate(w).onErrorResumeNext(resume);
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);

--- a/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnErrorResumeNextViaObservableTest.java
@@ -42,7 +42,7 @@ public class OperatorOnErrorResumeNextViaObservableTest {
         Subscription s = mock(Subscription.class);
         // Trigger failure on second element
         TestObservable f = new TestObservable(s, "one", "fail", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> observable = w.onErrorResumeNext(resume);
 
@@ -72,7 +72,7 @@ public class OperatorOnErrorResumeNextViaObservableTest {
         Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
         // Resume Observable is async
         TestObservable f = new TestObservable(sr, "twoResume", "threeResume");
-        Observable<String> resume = Observable.create(f);
+        Observable<String> resume = Observable.unsafeCreate(f);
 
         // Introduce map function that fails intermittently (Map does not prevent this when the observer is a
         //  rx.operator incl onErrorResumeNextViaObservable)
@@ -110,7 +110,7 @@ public class OperatorOnErrorResumeNextViaObservableTest {
 
     @Test
     public void testResumeNextWithFailedOnSubscribe() {
-        Observable<String> testObservable = Observable.create(new OnSubscribe<String>() {
+        Observable<String> testObservable = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> t1) {
@@ -132,7 +132,7 @@ public class OperatorOnErrorResumeNextViaObservableTest {
 
     @Test
     public void testResumeNextWithFailedOnSubscribeAsync() {
-        Observable<String> testObservable = Observable.create(new OnSubscribe<String>() {
+        Observable<String> testObservable = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> t1) {

--- a/src/test/java/rx/internal/operators/OperatorOnErrorReturnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnErrorReturnTest.java
@@ -41,7 +41,7 @@ public class OperatorOnErrorReturnTest {
     @Test
     public void testResumeNext() {
         TestObservable f = new TestObservable("one");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
 
         Observable<String> observable = w.onErrorReturn(new Func1<Throwable, String>() {
@@ -77,7 +77,7 @@ public class OperatorOnErrorReturnTest {
     @Test
     public void testFunctionThrowsError() {
         TestObservable f = new TestObservable("one");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
 
         Observable<String> observable = w.onErrorReturn(new Func1<Throwable, String>() {

--- a/src/test/java/rx/internal/operators/OperatorOnExceptionResumeNextViaObservableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorOnExceptionResumeNextViaObservableTest.java
@@ -35,7 +35,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
     public void testResumeNextWithException() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "EXCEPTION", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> observable = w.onExceptionResumeNext(resume);
 
@@ -63,7 +63,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
     public void testResumeNextWithRuntimeException() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "RUNTIMEEXCEPTION", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> observable = w.onExceptionResumeNext(resume);
 
@@ -91,7 +91,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
     public void testThrowablePassesThru() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "THROWABLE", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> observable = w.onExceptionResumeNext(resume);
 
@@ -119,7 +119,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
     public void testErrorPassesThru() {
         // Trigger failure on second element
         TestObservable f = new TestObservable("one", "ON_OVERFLOW_ERROR", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
         Observable<String> observable = w.onExceptionResumeNext(resume);
 
@@ -149,7 +149,7 @@ public class OperatorOnExceptionResumeNextViaObservableTest {
         Observable<String> w = Observable.just("one", "fail", "two", "three", "fail");
         // Resume Observable is async
         TestObservable f = new TestObservable("twoResume", "threeResume");
-        Observable<String> resume = Observable.create(f);
+        Observable<String> resume = Observable.unsafeCreate(f);
 
         // Introduce map function that fails intermittently (Map does not prevent this when the observer is a
         //  rx.operator incl onErrorResumeNextViaObservable)

--- a/src/test/java/rx/internal/operators/OperatorPublishTest.java
+++ b/src/test/java/rx/internal/operators/OperatorPublishTest.java
@@ -37,7 +37,7 @@ public class OperatorPublishTest {
     @Test
     public void testPublish() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        ConnectableObservable<String> o = Observable.create(new OnSubscribe<String>() {
+        ConnectableObservable<String> o = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(final Subscriber<? super String> observer) {
@@ -368,7 +368,7 @@ public class OperatorPublishTest {
     @Test
     public void testConnectIsIdempotent() {
         final AtomicInteger calls = new AtomicInteger();
-        Observable<Integer> source = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t) {
                 calls.getAndIncrement();

--- a/src/test/java/rx/internal/operators/OperatorRepeatTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRepeatTest.java
@@ -40,7 +40,7 @@ public class OperatorRepeatTest {
     public void testRepetition() {
         int NUM = 10;
         final AtomicInteger count = new AtomicInteger();
-        int value = Observable.create(new OnSubscribe<Integer>() {
+        int value = Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> o) {
@@ -68,7 +68,7 @@ public class OperatorRepeatTest {
     public void testRepeatTakeWithSubscribeOn() throws InterruptedException {
 
         final AtomicInteger counter = new AtomicInteger();
-        Observable<Integer> oi = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> oi = Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> sub) {

--- a/src/test/java/rx/internal/operators/OperatorReplayTest.java
+++ b/src/test/java/rx/internal/operators/OperatorReplayTest.java
@@ -915,7 +915,7 @@ public class OperatorReplayTest {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Observable<String> o = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> o = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
 
             @Override
             public void call(final Subscriber<? super String> observer) {
@@ -1055,7 +1055,7 @@ public class OperatorReplayTest {
             m = 4 * 1000 * 1000;
         }
 
-        Observable<Integer> firehose = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> firehose = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t) {
                 for (int i = 0; i < m; i++) {

--- a/src/test/java/rx/internal/operators/OperatorRetryTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRetryTest.java
@@ -45,7 +45,7 @@ public class OperatorRetryTest {
     public void iterativeBackoff() {
         @SuppressWarnings("unchecked")
         Observer<String> consumer = mock(Observer.class);
-        Observable<String> producer = Observable.create(new OnSubscribe<String>() {
+        Observable<String> producer = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             private AtomicInteger count = new AtomicInteger(4);
             long last = System.currentTimeMillis();
@@ -116,7 +116,7 @@ public class OperatorRetryTest {
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
         int NUM_RETRIES = 20;
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
         origin.retry().unsafeSubscribe(new TestSubscriber<String>(observer));
 
         InOrder inOrder = inOrder(observer);
@@ -136,7 +136,7 @@ public class OperatorRetryTest {
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
         int NUM_RETRIES = 2;
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
         TestSubscriber<String> subscriber = new TestSubscriber<String>(observer);
         origin.retryWhen(new Func1<Observable<? extends Throwable>, Observable<?>>() {
             @Override
@@ -168,7 +168,7 @@ public class OperatorRetryTest {
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
         int NUM_RETRIES = 2;
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
         origin.retryWhen(new Func1<Observable<? extends Throwable>, Observable<?>>() {
             @Override
             public Observable<?> call(Observable<? extends Throwable> t1) {
@@ -198,7 +198,7 @@ public class OperatorRetryTest {
     public void testOnCompletedFromNotificationHandler() {
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
-        Observable<String> origin = Observable.create(new FuncWithErrors(1));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(1));
         TestSubscriber<String> subscriber = new TestSubscriber<String>(observer);
         origin.retryWhen(new Func1<Observable<? extends Throwable>, Observable<?>>() {
             @Override
@@ -219,7 +219,7 @@ public class OperatorRetryTest {
     public void testOnErrorFromNotificationHandler() {
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
-        Observable<String> origin = Observable.create(new FuncWithErrors(2));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(2));
         origin.retryWhen(new Func1<Observable<? extends Throwable>, Observable<?>>() {
             @Override
             public Observable<?> call(Observable<? extends Throwable> t1) {
@@ -247,7 +247,7 @@ public class OperatorRetryTest {
             }
         };
 
-        int first = Observable.create(onSubscribe)
+        int first = Observable.unsafeCreate(onSubscribe)
                 .retryWhen(new Func1<Observable<? extends Throwable>, Observable<?>>() {
                     @Override
                     public Observable<?> call(Observable<? extends Throwable> attempt) {
@@ -270,7 +270,7 @@ public class OperatorRetryTest {
     public void testOriginFails() {
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
-        Observable<String> origin = Observable.create(new FuncWithErrors(1));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(1));
         origin.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -286,7 +286,7 @@ public class OperatorRetryTest {
         int NUM_FAILURES = 2;
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_FAILURES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
         origin.retry(NUM_RETRIES).subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -305,7 +305,7 @@ public class OperatorRetryTest {
         int NUM_FAILURES = 1;
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_FAILURES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
         origin.retry(3).subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -325,7 +325,7 @@ public class OperatorRetryTest {
         int NUM_FAILURES = 20;
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
-        Observable<String> origin = Observable.create(new FuncWithErrors(NUM_FAILURES));
+        Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_FAILURES));
         origin.retry().subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
@@ -478,7 +478,7 @@ public class OperatorRetryTest {
                 });
             }
         };
-        Observable<String> stream = Observable.create(onSubscribe);
+        Observable<String> stream = Observable.unsafeCreate(onSubscribe);
         Observable<String> streamWithRetry = stream.retry();
         Subscription sub = streamWithRetry.subscribe();
         assertEquals(1, subsCount.get());
@@ -512,7 +512,7 @@ public class OperatorRetryTest {
             }
         };
 
-        Observable.create(onSubscribe).retry(3).subscribe(ts);
+        Observable.unsafeCreate(onSubscribe).retry(3).subscribe(ts);
         assertEquals(4, subsCount.get()); // 1 + 3 retries
     }
 
@@ -530,7 +530,7 @@ public class OperatorRetryTest {
             }
         };
 
-        Observable.create(onSubscribe).retry(1).subscribe(ts);
+        Observable.unsafeCreate(onSubscribe).retry(1).subscribe(ts);
         assertEquals(2, subsCount.get());
     }
 
@@ -548,7 +548,7 @@ public class OperatorRetryTest {
             }
         };
 
-        Observable.create(onSubscribe).retry(0).subscribe(ts);
+        Observable.unsafeCreate(onSubscribe).retry(0).subscribe(ts);
         assertEquals(1, subsCount.get());
     }
 
@@ -651,7 +651,7 @@ public class OperatorRetryTest {
 
         // Observable that always fails after 100ms
         SlowObservable so = new SlowObservable(100, 0);
-        Observable<Long> o = Observable.create(so).retry(5);
+        Observable<Long> o = Observable.unsafeCreate(so).retry(5);
 
         AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
 
@@ -676,7 +676,7 @@ public class OperatorRetryTest {
 
         // Observable that sends every 100ms (timeout fails instead)
         SlowObservable so = new SlowObservable(100, 10);
-        Observable<Long> o = Observable.create(so).timeout(80, TimeUnit.MILLISECONDS).retry(5);
+        Observable<Long> o = Observable.unsafeCreate(so).timeout(80, TimeUnit.MILLISECONDS).retry(5);
 
         AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
 
@@ -700,7 +700,7 @@ public class OperatorRetryTest {
             for (int i = 0; i < 400; i++) {
                 @SuppressWarnings("unchecked")
                 Observer<String> observer = mock(Observer.class);
-                Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+                Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
                 TestSubscriber<String> ts = new TestSubscriber<String>(observer);
                 origin.retry().observeOn(Schedulers.computation()).unsafeSubscribe(ts);
                 ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
@@ -743,7 +743,7 @@ public class OperatorRetryTest {
                         public void run() {
                             final AtomicInteger nexts = new AtomicInteger();
                             try {
-                                Observable<String> origin = Observable.create(new FuncWithErrors(NUM_RETRIES));
+                                Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
                                 TestSubscriber<String> ts = new TestSubscriber<String>();
                                 origin.retry()
                                 .observeOn(Schedulers.computation()).unsafeSubscribe(ts);
@@ -866,7 +866,7 @@ public class OperatorRetryTest {
         final int NUM_MSG = 1034;
         final AtomicInteger count = new AtomicInteger();
 
-        Observable<String> origin = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> origin = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> o) {

--- a/src/test/java/rx/internal/operators/OperatorRetryWithPredicateTest.java
+++ b/src/test/java/rx/internal/operators/OperatorRetryWithPredicateTest.java
@@ -81,7 +81,7 @@ public class OperatorRetryWithPredicateTest {
     }
     @Test
     public void testRetryTwice() {
-        Observable<Integer> source = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             int count;
             @Override
             public void call(Subscriber<? super Integer> t1) {
@@ -116,7 +116,7 @@ public class OperatorRetryWithPredicateTest {
     }
     @Test
     public void testRetryTwiceAndGiveUp() {
-        Observable<Integer> source = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t1) {
                 t1.onNext(0);
@@ -143,7 +143,7 @@ public class OperatorRetryWithPredicateTest {
     }
     @Test
     public void testRetryOnSpecificException() {
-        Observable<Integer> source = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             int count;
             @Override
             public void call(Subscriber<? super Integer> t1) {
@@ -179,7 +179,7 @@ public class OperatorRetryWithPredicateTest {
     public void testRetryOnSpecificExceptionAndNotOther() {
         final IOException ioe = new IOException();
         final TestException te = new TestException();
-        Observable<Integer> source = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             int count;
             @Override
             public void call(Subscriber<? super Integer> t1) {
@@ -238,7 +238,7 @@ public class OperatorRetryWithPredicateTest {
         // Observable that always fails after 100ms
         OperatorRetryTest.SlowObservable so = new OperatorRetryTest.SlowObservable(100, 0);
         Observable<Long> o = Observable
-                .create(so)
+                .unsafeCreate(so)
                 .retry(retry5);
 
         OperatorRetryTest.AsyncObserver<Long> async = new OperatorRetryTest.AsyncObserver<Long>(observer);
@@ -265,7 +265,7 @@ public class OperatorRetryWithPredicateTest {
         // Observable that sends every 100ms (timeout fails instead)
         OperatorRetryTest.SlowObservable so = new OperatorRetryTest.SlowObservable(100, 10);
         Observable<Long> o = Observable
-                .create(so)
+                .unsafeCreate(so)
                 .timeout(80, TimeUnit.MILLISECONDS)
                 .retry(retry5);
 

--- a/src/test/java/rx/internal/operators/OperatorSampleTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSampleTest.java
@@ -50,7 +50,7 @@ public class OperatorSampleTest {
 
     @Test
     public void testSample() {
-        Observable<Long> source = Observable.create(new OnSubscribe<Long>() {
+        Observable<Long> source = Observable.unsafeCreate(new OnSubscribe<Long>() {
             @Override
             public void call(final Subscriber<? super Long> observer1) {
                 innerScheduler.schedule(new Action0() {
@@ -111,7 +111,7 @@ public class OperatorSampleTest {
 
     @Test
     public void sampleWithTimeEmitAndTerminate() {
-        Observable<Long> source = Observable.create(new OnSubscribe<Long>() {
+        Observable<Long> source = Observable.unsafeCreate(new OnSubscribe<Long>() {
             @Override
             public void call(final Subscriber<? super Long> observer1) {
                 innerScheduler.schedule(new Action0() {
@@ -303,7 +303,7 @@ public class OperatorSampleTest {
     @Test
     public void testSampleUnsubscribe() {
         final Subscription s = mock(Subscription.class);
-        Observable<Integer> o = Observable.create(
+        Observable<Integer> o = Observable.unsafeCreate(
                 new OnSubscribe<Integer>() {
                     @Override
                     public void call(Subscriber<? super Integer> subscriber) {
@@ -387,7 +387,7 @@ public class OperatorSampleTest {
 
     @Test
     public void neverSetProducer() {
-        Observable<Integer> neverBackpressure = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> neverBackpressure = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t) {
                 t.setProducer(new Producer() {
@@ -430,7 +430,7 @@ public class OperatorSampleTest {
     public void unsubscribeMainAfterCompleted() {
         final AtomicBoolean unsubscribed = new AtomicBoolean();
 
-        Observable<Integer> source = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t) {
                 t.add(Subscriptions.create(new Action0() {
@@ -467,7 +467,7 @@ public class OperatorSampleTest {
     public void unsubscribeSamplerAfterCompleted() {
         final AtomicBoolean unsubscribed = new AtomicBoolean();
 
-        Observable<Integer> source = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t) {
                 t.add(Subscriptions.create(new Action0() {

--- a/src/test/java/rx/internal/operators/OperatorScanTest.java
+++ b/src/test/java/rx/internal/operators/OperatorScanTest.java
@@ -306,7 +306,7 @@ public class OperatorScanTest {
     @Test
     public void testScanShouldNotRequestZero() {
         final AtomicReference<Producer> producer = new AtomicReference<Producer>();
-        Observable<Integer> o = Observable.create(new Observable.OnSubscribe<Integer>() {
+        Observable<Integer> o = Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
             @Override
             public void call(final Subscriber<? super Integer> subscriber) {
                 Producer p = spy(new Producer() {
@@ -371,7 +371,7 @@ public class OperatorScanTest {
 
     @Test
     public void testInitialValueEmittedWithProducer() {
-        Observable<Integer> source = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> t) {
                 t.setProducer(new Producer() {

--- a/src/test/java/rx/internal/operators/OperatorSerializeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSerializeTest.java
@@ -51,7 +51,7 @@ public class OperatorSerializeTest {
     @Test
     public void testSingleThreadedBasic() {
         TestSingleThreadedObservable onSubscribe = new TestSingleThreadedObservable("one", "two", "three");
-        Observable<String> w = Observable.create(onSubscribe);
+        Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
         w.serialize().subscribe(observer);
         onSubscribe.waitToFinish();
@@ -69,7 +69,7 @@ public class OperatorSerializeTest {
     @Test
     public void testMultiThreadedBasic() {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three");
-        Observable<String> w = Observable.create(onSubscribe);
+        Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
         BusyObserver busyobserver = new BusyObserver();
 
@@ -92,7 +92,7 @@ public class OperatorSerializeTest {
     @Test
     public void testMultiThreadedWithNPE() {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null);
-        Observable<String> w = Observable.create(onSubscribe);
+        Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
         BusyObserver busyobserver = new BusyObserver();
 
@@ -123,7 +123,7 @@ public class OperatorSerializeTest {
         boolean lessThan9 = false;
         for (int i = 0; i < 3; i++) {
             TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null, "four", "five", "six", "seven", "eight", "nine");
-            Observable<String> w = Observable.create(onSubscribe);
+            Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
             BusyObserver busyobserver = new BusyObserver();
 

--- a/src/test/java/rx/internal/operators/OperatorSubscribeOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSubscribeOnTest.java
@@ -50,7 +50,7 @@ public class OperatorSubscribeOnTest {
         TestSubscriber<Integer> observer = new TestSubscriber<Integer>();
 
         final Subscription subscription = Observable
-                .create(new Observable.OnSubscribe<Integer>() {
+                .unsafeCreate(new Observable.OnSubscribe<Integer>() {
                     @Override
                     public void call(
                             final Subscriber<? super Integer> subscriber) {
@@ -85,7 +85,7 @@ public class OperatorSubscribeOnTest {
     @Test
     public void testThrownErrorHandling() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Observable.create(new OnSubscribe<String>() {
+        Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> s) {
@@ -100,7 +100,7 @@ public class OperatorSubscribeOnTest {
     @Test
     public void testOnError() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Observable.create(new OnSubscribe<String>() {
+        Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> s) {
@@ -170,7 +170,7 @@ public class OperatorSubscribeOnTest {
     public void testUnsubscribeInfiniteStream() throws InterruptedException {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         final AtomicInteger count = new AtomicInteger();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> sub) {

--- a/src/test/java/rx/internal/operators/OperatorSwitchIfEmptyTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSwitchIfEmptyTest.java
@@ -58,7 +58,7 @@ public class OperatorSwitchIfEmptyTest {
     @Test
     public void testSwitchWithProducer() throws Exception {
         final AtomicBoolean emitted = new AtomicBoolean(false);
-        Observable<Long> withProducer = Observable.create(new Observable.OnSubscribe<Long>() {
+        Observable<Long> withProducer = Observable.unsafeCreate(new Observable.OnSubscribe<Long>() {
             @Override
             public void call(final Subscriber<? super Long> subscriber) {
                 subscriber.setProducer(new Producer() {
@@ -82,7 +82,7 @@ public class OperatorSwitchIfEmptyTest {
     public void testSwitchTriggerUnsubscribe() throws Exception {
         final Subscription empty = Subscriptions.empty();
 
-        Observable<Long> withProducer = Observable.create(new Observable.OnSubscribe<Long>() {
+        Observable<Long> withProducer = Observable.unsafeCreate(new Observable.OnSubscribe<Long>() {
             @Override
             public void call(final Subscriber<? super Long> subscriber) {
                 subscriber.add(empty);
@@ -121,7 +121,7 @@ public class OperatorSwitchIfEmptyTest {
     public void testSwitchShouldTriggerUnsubscribe() {
         final Subscription s = Subscriptions.empty();
 
-        Observable.create(new Observable.OnSubscribe<Long>() {
+        Observable.unsafeCreate(new Observable.OnSubscribe<Long>() {
             @Override
             public void call(final Subscriber<? super Long> subscriber) {
                 subscriber.add(s);
@@ -176,7 +176,7 @@ public class OperatorSwitchIfEmptyTest {
     @Test(timeout = 10000)
     public void testRequestsNotLost() throws InterruptedException {
         final TestSubscriber<Long> ts = new TestSubscriber<Long>(0);
-        Observable.create(new OnSubscribe<Long>() {
+        Observable.unsafeCreate(new OnSubscribe<Long>() {
 
             @Override
             public void call(final Subscriber<? super Long> subscriber) {

--- a/src/test/java/rx/internal/operators/OperatorSwitchTest.java
+++ b/src/test/java/rx/internal/operators/OperatorSwitchTest.java
@@ -53,10 +53,10 @@ public class OperatorSwitchTest {
 
     @Test
     public void testSwitchWhenOuterCompleteBeforeInner() {
-        Observable<Observable<String>> source = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
-                publishNext(observer, 50, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 50, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishNext(observer, 70, "one");
@@ -80,10 +80,10 @@ public class OperatorSwitchTest {
 
     @Test
     public void testSwitchWhenInnerCompleteBeforeOuter() {
-        Observable<Observable<String>> source = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
-                publishNext(observer, 10, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 10, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishNext(observer, 0, "one");
@@ -92,7 +92,7 @@ public class OperatorSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 100, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 100, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishNext(observer, 0, "three");
@@ -123,10 +123,10 @@ public class OperatorSwitchTest {
 
     @Test
     public void testSwitchWithComplete() {
-        Observable<Observable<String>> source = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
-                publishNext(observer, 50, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 50, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(final Subscriber<? super String> observer) {
                         publishNext(observer, 60, "one");
@@ -134,7 +134,7 @@ public class OperatorSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 200, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 200, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(final Subscriber<? super String> observer) {
                         publishNext(observer, 0, "three");
@@ -179,10 +179,10 @@ public class OperatorSwitchTest {
 
     @Test
     public void testSwitchWithError() {
-        Observable<Observable<String>> source = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
-                publishNext(observer, 50, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 50, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(final Subscriber<? super String> observer) {
                         publishNext(observer, 50, "one");
@@ -190,7 +190,7 @@ public class OperatorSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 200, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 200, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishNext(observer, 0, "three");
@@ -235,10 +235,10 @@ public class OperatorSwitchTest {
 
     @Test
     public void testSwitchWithSubsequenceComplete() {
-        Observable<Observable<String>> source = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
-                publishNext(observer, 50, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 50, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishNext(observer, 50, "one");
@@ -246,14 +246,14 @@ public class OperatorSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 130, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 130, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishCompleted(observer, 0);
                     }
                 }));
 
-                publishNext(observer, 150, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 150, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishNext(observer, 50, "three");
@@ -285,10 +285,10 @@ public class OperatorSwitchTest {
 
     @Test
     public void testSwitchWithSubsequenceError() {
-        Observable<Observable<String>> source = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
-                publishNext(observer, 50, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 50, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishNext(observer, 50, "one");
@@ -296,14 +296,14 @@ public class OperatorSwitchTest {
                     }
                 }));
 
-                publishNext(observer, 130, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 130, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishError(observer, 0, new TestException());
                     }
                 }));
 
-                publishNext(observer, 150, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 150, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishNext(observer, 50, "three");
@@ -364,10 +364,10 @@ public class OperatorSwitchTest {
     @Test
     public void testSwitchIssue737() {
         // https://github.com/ReactiveX/RxJava/issues/737
-        Observable<Observable<String>> source = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> source = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
-                publishNext(observer, 0, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 0, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishNext(observer, 10, "1-one");
@@ -377,7 +377,7 @@ public class OperatorSwitchTest {
                         publishCompleted(observer, 40);
                     }
                 }));
-                publishNext(observer, 25, Observable.create(new Observable.OnSubscribe<String>() {
+                publishNext(observer, 25, Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
                     @Override
                     public void call(Subscriber<? super String> observer) {
                         publishNext(observer, 10, "2-one");
@@ -407,7 +407,7 @@ public class OperatorSwitchTest {
 
     @Test
     public void testBackpressure() {
-        final Observable<String> o1 = Observable.create(new Observable.OnSubscribe<String>() {
+        final Observable<String> o1 = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(final Subscriber<? super String> observer) {
                 observer.setProducer(new Producer() {
@@ -428,7 +428,7 @@ public class OperatorSwitchTest {
                 });
             }
         });
-        final Observable<String> o2 = Observable.create(new Observable.OnSubscribe<String>() {
+        final Observable<String> o2 = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(final Subscriber<? super String> observer) {
                 observer.setProducer(new Producer() {
@@ -449,7 +449,7 @@ public class OperatorSwitchTest {
                 });
             }
         });
-        final Observable<String> o3 = Observable.create(new Observable.OnSubscribe<String>() {
+        final Observable<String> o3 = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(final Subscriber<? super String> observer) {
                 observer.setProducer(new Producer() {
@@ -469,7 +469,7 @@ public class OperatorSwitchTest {
                 });
             }
         });
-        Observable<Observable<String>> o = Observable.create(new Observable.OnSubscribe<Observable<String>>() {
+        Observable<Observable<String>> o = Observable.unsafeCreate(new Observable.OnSubscribe<Observable<String>>() {
             @Override
             public void call(Subscriber<? super Observable<String>> observer) {
                 publishNext(observer, 10, o1);
@@ -519,7 +519,7 @@ public class OperatorSwitchTest {
     public void testUnsubscribe() {
         final AtomicBoolean isUnsubscribed = new AtomicBoolean();
         Observable.switchOnNext(
-                Observable.create(new Observable.OnSubscribe<Observable<Integer>>() {
+                Observable.unsafeCreate(new Observable.OnSubscribe<Observable<Integer>>() {
                     @Override
                     public void call(final Subscriber<? super Observable<Integer>> subscriber) {
                         subscriber.onNext(Observable.just(1));

--- a/src/test/java/rx/internal/operators/OperatorTakeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeTest.java
@@ -112,7 +112,7 @@ public class OperatorTakeTest {
 
     @Test
     public void testTakeDoesntLeakErrors() {
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 observer.onNext("one");
@@ -136,7 +136,7 @@ public class OperatorTakeTest {
     public void testTakeZeroDoesntLeakError() {
         final AtomicBoolean subscribed = new AtomicBoolean(false);
         final AtomicBoolean unSubscribed = new AtomicBoolean(false);
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 subscribed.set(true);
@@ -173,7 +173,7 @@ public class OperatorTakeTest {
     public void testUnsubscribeAfterTake() {
         final Subscription s = mock(Subscription.class);
         TestObservableFunc f = new TestObservableFunc("one", "two", "three");
-        Observable<String> w = Observable.create(f);
+        Observable<String> w = Observable.unsafeCreate(f);
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
@@ -218,7 +218,7 @@ public class OperatorTakeTest {
     @Test(timeout = 2000)
     public void testMultiTake() {
         final AtomicInteger count = new AtomicInteger();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -277,7 +277,7 @@ public class OperatorTakeTest {
         }
     }
 
-    private static Observable<Long> INFINITE_OBSERVABLE = Observable.create(new OnSubscribe<Long>() {
+    private static Observable<Long> INFINITE_OBSERVABLE = Observable.unsafeCreate(new OnSubscribe<Long>() {
 
         @Override
         public void call(Subscriber<? super Long> op) {
@@ -311,7 +311,7 @@ public class OperatorTakeTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.requestMore(3);
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {
@@ -334,7 +334,7 @@ public class OperatorTakeTest {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ts.requestMore(3);
         final AtomicLong requested = new AtomicLong();
-        Observable.create(new OnSubscribe<Integer>() {
+        Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(Subscriber<? super Integer> s) {

--- a/src/test/java/rx/internal/operators/OperatorTakeUntilTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeUntilTest.java
@@ -40,7 +40,7 @@ public class OperatorTakeUntilTest {
         TestObservable other = new TestObservable(sOther);
 
         Observer<String> result = mock(Observer.class);
-        Observable<String> stringObservable = Observable.create(source).takeUntil(Observable.create(other));
+        Observable<String> stringObservable = Observable.unsafeCreate(source).takeUntil(Observable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -67,7 +67,7 @@ public class OperatorTakeUntilTest {
         TestObservable other = new TestObservable(sOther);
 
         Observer<String> result = mock(Observer.class);
-        Observable<String> stringObservable = Observable.create(source).takeUntil(Observable.create(other));
+        Observable<String> stringObservable = Observable.unsafeCreate(source).takeUntil(Observable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -90,7 +90,7 @@ public class OperatorTakeUntilTest {
         Throwable error = new Throwable();
 
         Observer<String> result = mock(Observer.class);
-        Observable<String> stringObservable = Observable.create(source).takeUntil(Observable.create(other));
+        Observable<String> stringObservable = Observable.unsafeCreate(source).takeUntil(Observable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -116,7 +116,7 @@ public class OperatorTakeUntilTest {
         Throwable error = new Throwable();
 
         Observer<String> result = mock(Observer.class);
-        Observable<String> stringObservable = Observable.create(source).takeUntil(Observable.create(other));
+        Observable<String> stringObservable = Observable.unsafeCreate(source).takeUntil(Observable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");
@@ -145,7 +145,7 @@ public class OperatorTakeUntilTest {
         TestObservable other = new TestObservable(sOther);
 
         Observer<String> result = mock(Observer.class);
-        Observable<String> stringObservable = Observable.create(source).takeUntil(Observable.create(other));
+        Observable<String> stringObservable = Observable.unsafeCreate(source).takeUntil(Observable.unsafeCreate(other));
         stringObservable.subscribe(result);
         source.sendOnNext("one");
         source.sendOnNext("two");

--- a/src/test/java/rx/internal/operators/OperatorTakeWhileTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTakeWhileTest.java
@@ -107,7 +107,7 @@ public class OperatorTakeWhileTest {
 
     @Test
     public void testTakeWhileDoesntLeakErrors() {
-        Observable<String> source = Observable.create(new OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 observer.onNext("one");
@@ -130,7 +130,7 @@ public class OperatorTakeWhileTest {
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
-        Observable<String> take = Observable.create(source).takeWhile(new Func1<String, Boolean>() {
+        Observable<String> take = Observable.unsafeCreate(source).takeWhile(new Func1<String, Boolean>() {
             @Override
             public Boolean call(String s) {
                 throw testException;
@@ -157,7 +157,7 @@ public class OperatorTakeWhileTest {
 
         @SuppressWarnings("unchecked")
         Observer<String> observer = mock(Observer.class);
-        Observable<String> take = Observable.create(w).takeWhile(new Func1<String, Boolean>() {
+        Observable<String> take = Observable.unsafeCreate(w).takeWhile(new Func1<String, Boolean>() {
             int index;
 
             @Override

--- a/src/test/java/rx/internal/operators/OperatorThrottleFirstTest.java
+++ b/src/test/java/rx/internal/operators/OperatorThrottleFirstTest.java
@@ -55,7 +55,7 @@ public class OperatorThrottleFirstTest {
 
     @Test
     public void testThrottlingWithCompleted() {
-        Observable<String> source = Observable.create(new OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 publishNext(observer, 100, "one");    // publish as it's first
@@ -82,7 +82,7 @@ public class OperatorThrottleFirstTest {
 
     @Test
     public void testThrottlingWithError() {
-        Observable<String> source = Observable.create(new OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 Exception error = new TestException();

--- a/src/test/java/rx/internal/operators/OperatorTimeoutTests.java
+++ b/src/test/java/rx/internal/operators/OperatorTimeoutTests.java
@@ -234,7 +234,7 @@ public class OperatorTimeoutTests {
 
             @Override
             public void run() {
-                Observable.create(new OnSubscribe<String>() {
+                Observable.unsafeCreate(new OnSubscribe<String>() {
 
                     @Override
                     public void call(Subscriber<? super String> subscriber) {
@@ -268,7 +268,7 @@ public class OperatorTimeoutTests {
         // From https://github.com/ReactiveX/RxJava/pull/951
         final Subscription s = mock(Subscription.class);
 
-        Observable<String> never = Observable.create(new OnSubscribe<String>() {
+        Observable<String> never = Observable.unsafeCreate(new OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> subscriber) {
                 subscriber.add(s);
@@ -296,7 +296,7 @@ public class OperatorTimeoutTests {
         // From https://github.com/ReactiveX/RxJava/pull/951
         final Subscription s = mock(Subscription.class);
 
-        Observable<String> immediatelyComplete = Observable.create(new OnSubscribe<String>() {
+        Observable<String> immediatelyComplete = Observable.unsafeCreate(new OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> subscriber) {
                 subscriber.add(s);
@@ -326,7 +326,7 @@ public class OperatorTimeoutTests {
         // From https://github.com/ReactiveX/RxJava/pull/951
         final Subscription s = mock(Subscription.class);
 
-        Observable<String> immediatelyError = Observable.create(new OnSubscribe<String>() {
+        Observable<String> immediatelyError = Observable.unsafeCreate(new OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> subscriber) {
                 subscriber.add(s);

--- a/src/test/java/rx/internal/operators/OperatorTimeoutWithSelectorTest.java
+++ b/src/test/java/rx/internal/operators/OperatorTimeoutWithSelectorTest.java
@@ -334,7 +334,7 @@ public class OperatorTimeoutWithSelectorTest {
             public Observable<Integer> call(Integer t1) {
                 if (t1 == 1) {
                     // Force "unsubscribe" run on another thread
-                    return Observable.create(new OnSubscribe<Integer>() {
+                    return Observable.unsafeCreate(new OnSubscribe<Integer>() {
                         @Override
                         public void call(Subscriber<? super Integer> subscriber) {
                             enteredTimeoutOne.countDown();

--- a/src/test/java/rx/internal/operators/OperatorUnsubscribeOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorUnsubscribeOnTest.java
@@ -39,7 +39,7 @@ public class OperatorUnsubscribeOnTest {
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
             final AtomicReference<Thread> subscribeThread = new AtomicReference<Thread>();
-            Observable<Integer> w = Observable.create(new OnSubscribe<Integer>() {
+            Observable<Integer> w = Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
                 @Override
                 public void call(Subscriber<? super Integer> t1) {
@@ -84,7 +84,7 @@ public class OperatorUnsubscribeOnTest {
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
             final AtomicReference<Thread> subscribeThread = new AtomicReference<Thread>();
-            Observable<Integer> w = Observable.create(new OnSubscribe<Integer>() {
+            Observable<Integer> w = Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
                 @Override
                 public void call(Subscriber<? super Integer> t1) {

--- a/src/test/java/rx/internal/operators/OperatorWindowWithSizeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWindowWithSizeTest.java
@@ -249,7 +249,7 @@ public class OperatorWindowWithSizeTest {
     }
 
     public static Observable<Integer> hotStream() {
-        return Observable.create(new OnSubscribe<Integer>() {
+        return Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> s) {
                 while (!s.isUnsubscribed()) {

--- a/src/test/java/rx/internal/operators/OperatorWindowWithStartEndObservableTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWindowWithStartEndObservableTest.java
@@ -46,7 +46,7 @@ public class OperatorWindowWithStartEndObservableTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 push(observer, "one", 10);
@@ -58,7 +58,7 @@ public class OperatorWindowWithStartEndObservableTest {
             }
         });
 
-        Observable<Object> openings = Observable.create(new Observable.OnSubscribe<Object>() {
+        Observable<Object> openings = Observable.unsafeCreate(new Observable.OnSubscribe<Object>() {
             @Override
             public void call(Subscriber<? super Object> observer) {
                 push(observer, new Object(), 50);
@@ -70,7 +70,7 @@ public class OperatorWindowWithStartEndObservableTest {
         Func1<Object, Observable<Object>> closer = new Func1<Object, Observable<Object>>() {
             @Override
             public Observable<Object> call(Object opening) {
-                return Observable.create(new Observable.OnSubscribe<Object>() {
+                return Observable.unsafeCreate(new Observable.OnSubscribe<Object>() {
                     @Override
                     public void call(Subscriber<? super Object> observer) {
                         push(observer, new Object(), 100);
@@ -94,7 +94,7 @@ public class OperatorWindowWithStartEndObservableTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 push(observer, "one", 10);
@@ -110,7 +110,7 @@ public class OperatorWindowWithStartEndObservableTest {
             int calls;
             @Override
             public Observable<Object> call() {
-                return Observable.create(new Observable.OnSubscribe<Object>() {
+                return Observable.unsafeCreate(new Observable.OnSubscribe<Object>() {
                     @Override
                     public void call(Subscriber<? super Object> observer) {
                         int c = calls++;

--- a/src/test/java/rx/internal/operators/OperatorWindowWithTimeTest.java
+++ b/src/test/java/rx/internal/operators/OperatorWindowWithTimeTest.java
@@ -45,7 +45,7 @@ public class OperatorWindowWithTimeTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 push(observer, "one", 10);
@@ -78,7 +78,7 @@ public class OperatorWindowWithTimeTest {
         final List<String> list = new ArrayList<String>();
         final List<List<String>> lists = new ArrayList<List<String>>();
 
-        Observable<String> source = Observable.create(new Observable.OnSubscribe<String>() {
+        Observable<String> source = Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
             @Override
             public void call(Subscriber<? super String> observer) {
                 push(observer, "one", 98);

--- a/src/test/java/rx/internal/operators/OperatorZipTest.java
+++ b/src/test/java/rx/internal/operators/OperatorZipTest.java
@@ -94,7 +94,7 @@ public class OperatorZipTest {
         TestObservable w2 = new TestObservable();
         TestObservable w3 = new TestObservable();
 
-        Observable<String> zipW = Observable.zip(Observable.create(w1), Observable.create(w2), Observable.create(w3), getConcat3StringsZipr());
+        Observable<String> zipW = Observable.zip(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2), Observable.unsafeCreate(w3), getConcat3StringsZipr());
         zipW.subscribe(w);
 
         /* simulate sending data */
@@ -128,7 +128,7 @@ public class OperatorZipTest {
         TestObservable w2 = new TestObservable();
         TestObservable w3 = new TestObservable();
 
-        Observable<String> zipW = Observable.zip(Observable.create(w1), Observable.create(w2), Observable.create(w3), getConcat3StringsZipr());
+        Observable<String> zipW = Observable.zip(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2), Observable.unsafeCreate(w3), getConcat3StringsZipr());
         zipW.subscribe(w);
 
         /* simulate sending data */
@@ -1212,7 +1212,7 @@ public class OperatorZipTest {
     Observable<Integer> OBSERVABLE_OF_5_INTEGERS = OBSERVABLE_OF_5_INTEGERS(new AtomicInteger());
 
     Observable<Integer> OBSERVABLE_OF_5_INTEGERS(final AtomicInteger numEmitted) {
-        return Observable.create(new OnSubscribe<Integer>() {
+        return Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> o) {
@@ -1231,7 +1231,7 @@ public class OperatorZipTest {
     }
 
     Observable<Integer> ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(final CountDownLatch latch) {
-        return Observable.create(new OnSubscribe<Integer>() {
+        return Observable.unsafeCreate(new OnSubscribe<Integer>() {
 
             @Override
             public void call(final Subscriber<? super Integer> o) {

--- a/src/test/java/rx/internal/operators/SafeSubscriberTest.java
+++ b/src/test/java/rx/internal/operators/SafeSubscriberTest.java
@@ -38,7 +38,7 @@ public class SafeSubscriberTest {
     @Test
     public void testOnNextAfterOnError() {
         TestObservable t = new TestObservable();
-        Observable<String> st = Observable.create(t);
+        Observable<String> st = Observable.unsafeCreate(t);
 
         @SuppressWarnings("unchecked")
         Observer<String> w = mock(Observer.class);
@@ -60,7 +60,7 @@ public class SafeSubscriberTest {
     @Test
     public void testOnCompletedAfterOnError() {
         TestObservable t = new TestObservable();
-        Observable<String> st = Observable.create(t);
+        Observable<String> st = Observable.unsafeCreate(t);
 
         @SuppressWarnings("unchecked")
         Observer<String> w = mock(Observer.class);
@@ -82,7 +82,7 @@ public class SafeSubscriberTest {
     @Test
     public void testOnNextAfterOnCompleted() {
         TestObservable t = new TestObservable();
-        Observable<String> st = Observable.create(t);
+        Observable<String> st = Observable.unsafeCreate(t);
 
         @SuppressWarnings("unchecked")
         Observer<String> w = mock(Observer.class);
@@ -105,7 +105,7 @@ public class SafeSubscriberTest {
     @Test
     public void testOnErrorAfterOnCompleted() {
         TestObservable t = new TestObservable();
-        Observable<String> st = Observable.create(t);
+        Observable<String> st = Observable.unsafeCreate(t);
 
         @SuppressWarnings("unchecked")
         Observer<String> w = mock(Observer.class);

--- a/src/test/java/rx/internal/producers/ProducersTest.java
+++ b/src/test/java/rx/internal/producers/ProducersTest.java
@@ -365,7 +365,7 @@ public class ProducersTest {
                 .map(plus(40))
         );
 
-        Observable<Long> source = Observable.create(
+        Observable<Long> source = Observable.unsafeCreate(
             new SwitchTimer<Long>(timers, 550,
             TimeUnit.MILLISECONDS, test));
 

--- a/src/test/java/rx/observables/AsyncOnSubscribeTest.java
+++ b/src/test/java/rx/observables/AsyncOnSubscribeTest.java
@@ -110,7 +110,7 @@ public class AsyncOnSubscribeTest {
             public void call(Long requested, Observer<Observable<? extends Integer>> observer) {
                 observer.onNext(Observable.range(1, requested.intValue()));
             }});
-        Observable.create(os).observeOn(scheduler).subscribe(subscriber);
+        Observable.unsafeCreate(os).observeOn(scheduler).subscribe(subscriber);
         subscriber.requestMore(RxRingBuffer.SIZE);
         scheduler.advanceTimeBy(10, TimeUnit.DAYS);
         subscriber.assertNoErrors();
@@ -141,7 +141,7 @@ public class AsyncOnSubscribeTest {
             public void call(Integer t) {
                 lastState.set(t);
             }});
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
         subscriber.requestMore(1); // [[1]], state = 1
         subscriber.requestMore(2); // [[1]], state = 2
         subscriber.requestMore(3); // onComplete, state = 3
@@ -158,7 +158,7 @@ public class AsyncOnSubscribeTest {
             public void call(Long requested, Observer<Observable<? extends Integer>> observer) {
                 observer.onCompleted();
             }});
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
         subscriber.requestMore(1);
         subscriber.assertNoErrors();
         subscriber.assertCompleted();
@@ -174,7 +174,7 @@ public class AsyncOnSubscribeTest {
                 observer.onNext(Observable.just(2));
             }
         });
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
         subscriber.requestMore(1);
         subscriber.assertError(IllegalStateException.class);
         subscriber.assertNotCompleted();
@@ -189,7 +189,7 @@ public class AsyncOnSubscribeTest {
             public void call(Long requested, Observer<Observable<? extends Integer>> observer) {
                 throw new TestException();
             }});
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
         subscriber.requestMore(1);
         subscriber.assertError(TestException.class);
         subscriber.assertNotCompleted();
@@ -209,7 +209,7 @@ public class AsyncOnSubscribeTest {
                 observer.onCompleted();
                 throw new TestException();
             }});
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
         subscriber.requestMore(1);
         subscriber.assertNoErrors();
         subscriber.assertCompleted();
@@ -230,7 +230,7 @@ public class AsyncOnSubscribeTest {
                 observer.onNext(Observable.just(1));
                 return 1;
             }});
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
         subscriber.requestMore(1);
         subscriber.assertNoErrors();
         subscriber.assertCompleted();
@@ -251,7 +251,7 @@ public class AsyncOnSubscribeTest {
                 observer.onNext(Observable.just(1));
                 return 1;
             }});
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
         subscriber.requestMore(1);
         subscriber.assertError(TestException.class);
         subscriber.assertNotCompleted();
@@ -272,7 +272,7 @@ public class AsyncOnSubscribeTest {
                 observer.onCompleted();
                 return state;
             }});
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
         subscriber.requestMore(1);
         subscriber.assertNoErrors();
         subscriber.assertCompleted();
@@ -293,7 +293,7 @@ public class AsyncOnSubscribeTest {
                 return state;
             }
         });
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
         subscriber.requestMore(1);
         subscriber.assertError(TestException.class);
         subscriber.assertNotCompleted();
@@ -315,7 +315,7 @@ public class AsyncOnSubscribeTest {
                 return state;
             }
         });
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
         subscriber.requestMore(1);
         subscriber.assertCompleted();
         subscriber.assertNoErrors();
@@ -359,7 +359,7 @@ public class AsyncOnSubscribeTest {
                 observer.onNext(o1);
                 return state + 1;
             }});
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
         subscriber.requestMore(1); // [[1]]
         subscriber.requestMore(2); // [[2]]
         subscriber.requestMore(2); // onCompleted
@@ -413,7 +413,7 @@ public class AsyncOnSubscribeTest {
                     }
                     return state + 1;
                 }});
-        Subscription subscription = Observable.create(os)
+        Subscription subscription = Observable.unsafeCreate(os)
             .observeOn(scheduler, 1)
             .subscribe(subscriber);
         sub.set(subscription);
@@ -465,7 +465,7 @@ public class AsyncOnSubscribeTest {
                 }
                 return state + 1;
             }});
-        Observable.create(os).subscribe(subscriber);
+        Observable.unsafeCreate(os).subscribe(subscriber);
 
         subscriber.assertNoErrors();
         subscriber.assertNotCompleted();

--- a/src/test/java/rx/observables/BlockingObservableTest.java
+++ b/src/test/java/rx/observables/BlockingObservableTest.java
@@ -259,7 +259,7 @@ public class BlockingObservableTest {
 
     @Test(expected = TestException.class)
     public void testToIterableWithException() {
-        BlockingObservable<String> obs = BlockingObservable.from(Observable.create(new Observable.OnSubscribe<String>() {
+        BlockingObservable<String> obs = BlockingObservable.from(Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> observer) {
@@ -281,7 +281,7 @@ public class BlockingObservableTest {
     @Test
     public void testForEachWithError() {
         try {
-            BlockingObservable.from(Observable.create(new Observable.OnSubscribe<String>() {
+            BlockingObservable.from(Observable.unsafeCreate(new Observable.OnSubscribe<String>() {
 
                 @Override
                 public void call(final Subscriber<? super String> observer) {
@@ -382,7 +382,7 @@ public class BlockingObservableTest {
     @Test
     public void testSingleOrDefaultUnsubscribe() throws InterruptedException {
         final CountDownLatch unsubscribe = new CountDownLatch(1);
-        Observable<Integer> o = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> o = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> subscriber) {
                 subscriber.add(Subscriptions.create(new Action0() {

--- a/src/test/java/rx/observables/SyncOnSubscribeTest.java
+++ b/src/test/java/rx/observables/SyncOnSubscribeTest.java
@@ -52,7 +52,7 @@ public class SyncOnSubscribeTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        Observable.create(os).subscribe(ts);
+        Observable.unsafeCreate(os).subscribe(ts);
 
         ts.assertNoErrors();
         ts.assertTerminalEvent();
@@ -82,7 +82,7 @@ public class SyncOnSubscribeTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        Observable.create(os).subscribe(ts);
+        Observable.unsafeCreate(os).subscribe(ts);
 
         ts.assertNoErrors();
         ts.assertTerminalEvent();
@@ -103,7 +103,7 @@ public class SyncOnSubscribeTest {
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);
 
-        Observable.create(os).subscribe(o);
+        Observable.unsafeCreate(os).subscribe(o);
 
         verify(o, times(1)).onNext(1);
         verify(o, never()).onNext(2);
@@ -124,7 +124,7 @@ public class SyncOnSubscribeTest {
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);
 
-        Observable.create(os).subscribe(o);
+        Observable.unsafeCreate(os).subscribe(o);
 
         verify(o, times(1)).onNext(1);
         verify(o, times(1)).onCompleted();
@@ -144,7 +144,7 @@ public class SyncOnSubscribeTest {
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);
 
-        Observable.create(os).subscribe(o);
+        Observable.unsafeCreate(os).subscribe(o);
 
         verify(o, times(1)).onNext(1);
         verify(o, times(1)).onCompleted();
@@ -171,7 +171,7 @@ public class SyncOnSubscribeTest {
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);
 
-        Observable.create(os).subscribe(o);
+        Observable.unsafeCreate(os).subscribe(o);
 
         verify(o, times(1)).onNext(1);
         verify(o, never()).onCompleted();
@@ -190,7 +190,7 @@ public class SyncOnSubscribeTest {
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);
 
-        Observable.create(os).subscribe(o);
+        Observable.unsafeCreate(os).subscribe(o);
 
         verify(o, never()).onNext(any(Integer.class));
         verify(o, never()).onError(any(Throwable.class));
@@ -206,7 +206,7 @@ public class SyncOnSubscribeTest {
             }});
 
 
-        Observable<Integer> neverObservable = Observable.create(os).subscribeOn(Schedulers.newThread());
+        Observable<Integer> neverObservable = Observable.unsafeCreate(os).subscribeOn(Schedulers.newThread());
         Observable<? extends Number> merged = Observable.amb(neverObservable, Observable.timer(100, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.newThread()));
         Iterator<? extends Number> values = merged.toBlocking().toIterable().iterator();
 
@@ -225,7 +225,7 @@ public class SyncOnSubscribeTest {
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);
 
-        Observable.create(os).subscribe(o);
+        Observable.unsafeCreate(os).subscribe(o);
 
         verify(o, never()).onNext(any(Integer.class));
         verify(o, never()).onCompleted();
@@ -243,7 +243,7 @@ public class SyncOnSubscribeTest {
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);
 
-        Observable.create(os).subscribe(o);
+        Observable.unsafeCreate(os).subscribe(o);
 
         verify(o, never()).onNext(any(Integer.class));
         verify(o, times(1)).onCompleted();
@@ -268,7 +268,7 @@ public class SyncOnSubscribeTest {
             }
         };
 
-        Observable.create(os).subscribe(ts);
+        Observable.unsafeCreate(os).subscribe(ts);
 
         ts.requestMore(1);
 
@@ -288,7 +288,7 @@ public class SyncOnSubscribeTest {
         @SuppressWarnings("unchecked")
         Observer<Object> o = mock(Observer.class);
 
-        Observable.create(os).subscribe(o);
+        Observable.unsafeCreate(os).subscribe(o);
 
         verify(o, never()).onNext(any(Integer.class));
         verify(o).onError(any(TestException.class));
@@ -319,7 +319,7 @@ public class SyncOnSubscribeTest {
         Observer<Object> o = mock(Observer.class);
         InOrder inOrder = inOrder(o);
 
-        Observable.create(os).subscribe(o);
+        Observable.unsafeCreate(os).subscribe(o);
 
         verify(o, never()).onError(any(TestException.class));
         inOrder.verify(o, times(count)).onNext(any(Integer.class));
@@ -357,7 +357,7 @@ public class SyncOnSubscribeTest {
         Observer<Object> o = mock(Observer.class);
         InOrder inOrder = inOrder(o);
 
-        Observable.create(os).subscribe(o);
+        Observable.unsafeCreate(os).subscribe(o);
 
         verify(o, never()).onError(any(TestException.class));
         inOrder.verify(o, times(n)).onNext(any());
@@ -385,7 +385,7 @@ public class SyncOnSubscribeTest {
         Observer<Object> o = mock(Observer.class);
         InOrder inOrder = inOrder(o);
 
-        Observable.create(os).take(finalCount).subscribe(o);
+        Observable.unsafeCreate(os).take(finalCount).subscribe(o);
 
         verify(o, never()).onError(any(Throwable.class));
         inOrder.verify(o, times(finalCount)).onNext(any());
@@ -416,7 +416,7 @@ public class SyncOnSubscribeTest {
                 onUnSubscribe);
 
         TestSubscriber<Object> ts = new TestSubscriber<Object>(0);
-        Observable.create(os).subscribe(ts);
+        Observable.unsafeCreate(os).subscribe(ts);
 
         ts.requestMore(finalCount);
 
@@ -451,7 +451,7 @@ public class SyncOnSubscribeTest {
 
         TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
 
-        Observable.create(os).take(1).subscribe(ts);
+        Observable.unsafeCreate(os).take(1).subscribe(ts);
 
         verify(o, never()).onError(any(Throwable.class));
         verify(onUnSubscribe, times(1)).call(any(Integer.class));
@@ -521,7 +521,7 @@ public class SyncOnSubscribeTest {
         InOrder inOrder = inOrder(o);
 
         final TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
-        Observable.create(os).subscribeOn(Schedulers.newThread()).subscribe(ts);
+        Observable.unsafeCreate(os).subscribeOn(Schedulers.newThread()).subscribe(ts);
 
         // wait until the first request has started processing
         if (!l2.await(2, TimeUnit.SECONDS)) {
@@ -569,7 +569,7 @@ public class SyncOnSubscribeTest {
 
         final CountDownLatch latch = new CountDownLatch(1);
         final TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
-        Observable.create(os).lift(new Operator<Void, Void>() {
+        Observable.unsafeCreate(os).lift(new Operator<Void, Void>() {
             @Override
             public Subscriber<? super Void> call(final Subscriber<? super Void> subscriber) {
                 return new Subscriber<Void>(subscriber) {
@@ -634,7 +634,7 @@ public class SyncOnSubscribeTest {
                 }},
             onUnSubscribe);
 
-        Observable<Integer> source = Observable.create(os);
+        Observable<Integer> source = Observable.unsafeCreate(os);
         for (int i = 0; i < count; i++) {
             source.subscribe();
         }
@@ -678,7 +678,7 @@ public class SyncOnSubscribeTest {
             subs.add(ts);
         }
         TestScheduler scheduler = new TestScheduler();
-        Observable<Integer> o2 = Observable.create(os).subscribeOn(scheduler);
+        Observable<Integer> o2 = Observable.unsafeCreate(os).subscribeOn(scheduler);
         for (Subscriber<Object> ts : subs) {
             o2.subscribe(ts);
         }
@@ -719,7 +719,7 @@ public class SyncOnSubscribeTest {
         TestSubscriber<Object> ts = new TestSubscriber<Object>();
 
         TestScheduler scheduler = new TestScheduler();
-        Observable.create(os).observeOn(scheduler).subscribe(ts);
+        Observable.unsafeCreate(os).observeOn(scheduler).subscribe(ts);
 
         scheduler.triggerActions();
         ts.awaitTerminalEvent();
@@ -748,7 +748,7 @@ public class SyncOnSubscribeTest {
                     }},
                 onUnSubscribe);
         final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
-        Observable.create(os).subscribe(new Subscriber<Integer>() {
+        Observable.unsafeCreate(os).subscribe(new Subscriber<Integer>() {
             @Override
             public void onCompleted() {
 

--- a/src/test/java/rx/observers/SerializedObserverTest.java
+++ b/src/test/java/rx/observers/SerializedObserverTest.java
@@ -50,7 +50,7 @@ public class SerializedObserverTest {
     @Test
     public void testSingleThreadedBasic() {
         TestSingleThreadedObservable onSubscribe = new TestSingleThreadedObservable("one", "two", "three");
-        Observable<String> w = Observable.create(onSubscribe);
+        Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
         Observer<String> aw = serializedObserver(observer);
 
@@ -70,7 +70,7 @@ public class SerializedObserverTest {
     @Test
     public void testMultiThreadedBasic() {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three");
-        Observable<String> w = Observable.create(onSubscribe);
+        Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
         BusyObserver busyObserver = new BusyObserver();
         Observer<String> aw = serializedObserver(busyObserver);
@@ -94,7 +94,7 @@ public class SerializedObserverTest {
     @Test(timeout = 1000)
     public void testMultiThreadedWithNPE() throws InterruptedException {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null);
-        Observable<String> w = Observable.create(onSubscribe);
+        Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
         BusyObserver busyObserver = new BusyObserver();
         Observer<String> aw = serializedObserver(busyObserver);
@@ -128,7 +128,7 @@ public class SerializedObserverTest {
         for (int i = 0; i < n; i++) {
             TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null,
                     "four", "five", "six", "seven", "eight", "nine");
-            Observable<String> w = Observable.create(onSubscribe);
+            Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
             BusyObserver busyObserver = new BusyObserver();
             Observer<String> aw = serializedObserver(busyObserver);
@@ -391,7 +391,7 @@ public class SerializedObserverTest {
     }
 
     private static Observable<String> infinite(final AtomicInteger produced) {
-        return Observable.create(new OnSubscribe<String>() {
+        return Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(Subscriber<? super String> s) {

--- a/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/rx/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -297,7 +297,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch completionLatch = new CountDownLatch(1);
         final Worker inner = getScheduler().createWorker();
         try {
-            Observable<Integer> obs = Observable.create(new OnSubscribe<Integer>() {
+            Observable<Integer> obs = Observable.unsafeCreate(new OnSubscribe<Integer>() {
                 @Override
                 public void call(final Subscriber<? super Integer> observer) {
                     inner.schedule(new Action0() {

--- a/src/test/java/rx/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/rx/schedulers/AbstractSchedulerTests.java
@@ -322,7 +322,7 @@ public abstract class AbstractSchedulerTests {
 
     @Test
     public final void testRecursiveSchedulerInObservable() {
-        Observable<Integer> obs = Observable.create(new OnSubscribe<Integer>() {
+        Observable<Integer> obs = Observable.unsafeCreate(new OnSubscribe<Integer>() {
             @Override
             public void call(final Subscriber<? super Integer> observer) {
                 final Scheduler.Worker inner = getScheduler().createWorker();
@@ -362,7 +362,7 @@ public abstract class AbstractSchedulerTests {
     public final void testConcurrentOnNextFailsValidation() throws InterruptedException {
         final int count = 10;
         final CountDownLatch latch = new CountDownLatch(count);
-        Observable<String> o = Observable.create(new OnSubscribe<String>() {
+        Observable<String> o = Observable.unsafeCreate(new OnSubscribe<String>() {
 
             @Override
             public void call(final Subscriber<? super String> observer) {
@@ -423,7 +423,7 @@ public abstract class AbstractSchedulerTests {
 
                     @Override
                     public Observable<String> call(final String v) {
-                        return Observable.create(new OnSubscribe<String>() {
+                        return Observable.unsafeCreate(new OnSubscribe<String>() {
 
                             @Override
                             public void call(Subscriber<? super String> observer) {

--- a/src/test/java/rx/schedulers/TestSchedulerTest.java
+++ b/src/test/java/rx/schedulers/TestSchedulerTest.java
@@ -181,7 +181,7 @@ public class TestSchedulerTest {
             final Action0 calledOp = mock(Action0.class);
 
             Observable<Object> poller;
-            poller = Observable.create(new OnSubscribe<Object>() {
+            poller = Observable.unsafeCreate(new OnSubscribe<Object>() {
                 @Override
                 public void call(final Subscriber<? super Object> aSubscriber) {
                     inner.schedule(new Action0() {

--- a/src/test/java/rx/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/rx/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -52,7 +52,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
 
             @Override
             public void run() {
-                Observable.create(new OnSubscribe<Long>() {
+                Observable.unsafeCreate(new OnSubscribe<Long>() {
 
                     @Override
                     public void call(Subscriber<? super Long> o) {

--- a/src/test/java/rx/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/rx/subjects/ReplaySubjectConcurrencyTest.java
@@ -52,7 +52,7 @@ public class ReplaySubjectConcurrencyTest {
 
             @Override
             public void run() {
-                Observable.create(new OnSubscribe<Long>() {
+                Observable.unsafeCreate(new OnSubscribe<Long>() {
 
                     @Override
                     public void call(Subscriber<? super Long> o) {
@@ -174,7 +174,7 @@ public class ReplaySubjectConcurrencyTest {
 
             @Override
             public void run() {
-                Observable.create(new OnSubscribe<Long>() {
+                Observable.unsafeCreate(new OnSubscribe<Long>() {
 
                     @Override
                     public void call(Subscriber<? super Long> o) {


### PR DESCRIPTION
Looks like `create()` won't go away unless we get the IDE mark it someway, such as being deprecated.

This PR deprecates `create()` and adds `unsafeCreate` for internal use and deprecate-renames `fromEmitter` to `create(Action1, BackpressureMode)`.

There was an earlier attempt at deprecating `create`, #4253, but it was not followed up. This PR executes what I suggested in one of the [comments](https://github.com/ReactiveX/RxJava/pull/4253#issuecomment-235913860).