### PR TITLE
2.x: fix CI load sensitive BlockingNextTests, XFlatMapTest

### DIFF
--- a/src/test/java/io/reactivex/XFlatMapTest.java
+++ b/src/test/java/io/reactivex/XFlatMapTest.java
@@ -37,7 +37,7 @@ public class XFlatMapTest {
     void sleep() throws Exception {
         cb.await();
         try {
-            Thread.sleep(1000);
+            Thread.sleep(5000);
         } catch (InterruptedException ex) {
             // ignored here
         }


### PR DESCRIPTION
This PR updates `testNoBufferingOrBlockingOfSequence` with

  - retry up to 3 times with an exponential backoff as the test is time sensitive and Travis CI load sensitive,
  - uses `Schedulers.single()` as the helper thread and manages resource cleanup properly,
  - both `Flowable` and `Observable` variants.

Update: Looks like `XFlatMapTest` is still flaky, added changes here to try fixing it as well.