### PR TITLE
1.x: create+subscribeOn avoid same-pool deadlock

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorSubscribeOn.java
+++ b/src/main/java/rx/internal/operators/OperatorSubscribeOn.java
@@ -31,68 +31,92 @@ public final class OperatorSubscribeOn<T> implements OnSubscribe<T> {
 
     final Scheduler scheduler;
     final Observable<T> source;
+    final boolean requestOn;
 
-    public OperatorSubscribeOn(Observable<T> source, Scheduler scheduler) {
+    public OperatorSubscribeOn(Observable<T> source, Scheduler scheduler, boolean requestOn) {
         this.scheduler = scheduler;
         this.source = source;
+        this.requestOn = requestOn;
     }
 
     @Override
     public void call(final Subscriber<? super T> subscriber) {
         final Worker inner = scheduler.createWorker();
+
+        SubscribeOnSubscriber<T> parent = new SubscribeOnSubscriber<T>(subscriber, requestOn, inner, source);
+        subscriber.add(parent);
         subscriber.add(inner);
 
-        inner.schedule(new Action0() {
-            @Override
-            public void call() {
-                final Thread t = Thread.currentThread();
+        inner.schedule(parent);
+    }
 
-                Subscriber<T> s = new Subscriber<T>(subscriber) {
-                    @Override
-                    public void onNext(T t) {
-                        subscriber.onNext(t);
-                    }
+    static final class SubscribeOnSubscriber<T> extends Subscriber<T> implements Action0 {
 
-                    @Override
-                    public void onError(Throwable e) {
-                        try {
-                            subscriber.onError(e);
-                        } finally {
-                            inner.unsubscribe();
-                        }
-                    }
+        final Subscriber<? super T> actual;
 
-                    @Override
-                    public void onCompleted() {
-                        try {
-                            subscriber.onCompleted();
-                        } finally {
-                            inner.unsubscribe();
-                        }
-                    }
+        final boolean requestOn;
 
-                    @Override
-                    public void setProducer(final Producer p) {
-                        subscriber.setProducer(new Producer() {
+        final Worker worker;
+
+        Observable<T> source;
+
+        Thread t;
+
+        SubscribeOnSubscriber(Subscriber<? super T> actual, boolean requestOn, Worker worker, Observable<T> source) {
+            this.actual = actual;
+            this.requestOn = requestOn;
+            this.worker = worker;
+            this.source = source;
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            try {
+                actual.onError(e);
+            } finally {
+                worker.unsubscribe();
+            }
+        }
+
+        @Override
+        public void onCompleted() {
+            try {
+                actual.onCompleted();
+            } finally {
+                worker.unsubscribe();
+            }
+        }
+
+        @Override
+        public void call() {
+            Observable<T> src = source;
+            source = null;
+            t = Thread.currentThread();
+            src.unsafeSubscribe(this);
+        }
+
+        @Override
+        public void setProducer(final Producer p) {
+            actual.setProducer(new Producer() {
+                @Override
+                public void request(final long n) {
+                    if (t == Thread.currentThread() || !requestOn) {
+                        p.request(n);
+                    } else {
+                        worker.schedule(new Action0() {
                             @Override
-                            public void request(final long n) {
-                                if (t == Thread.currentThread()) {
-                                    p.request(n);
-                                } else {
-                                    inner.schedule(new Action0() {
-                                        @Override
-                                        public void call() {
-                                            p.request(n);
-                                        }
-                                    });
-                                }
+                            public void call() {
+                                p.request(n);
                             }
                         });
                     }
-                };
-
-                source.unsafeSubscribe(s);
-            }
-        });
+                }
+            });
+        }
     }
 }

--- a/src/test/java/rx/internal/operators/OperatorGroupByTest.java
+++ b/src/test/java/rx/internal/operators/OperatorGroupByTest.java
@@ -2017,11 +2017,11 @@ public class OperatorGroupByTest {
                 throw exception;
             }};
     }
-    
+
     @Test
     public void outerConsumedInABoundedManner() {
         final int[] counter = { 0 };
-        
+
         Observable.range(1, 10000)
         .doOnRequest(new Action1<Long>() {
             @Override


### PR DESCRIPTION
This PR allows to fix the same-pool deadlock that may happen with `create()` (formerly `fromEmitter`) and `subscribeOn` as `subscribeOn` by default schedules the requests behind a running emitter and thus the internal request amount may not get updated, leading to unnecessary dataloss.

See #4735.

In the update, if `subscribeOn` detects its upstream is `OnSubscribeCreate`, it no longer reschedules requests for it. For other, non-immediate cases, a new overload allows specifying the `requestOn` parameter that should be `false` if there is a `create(Action1, BackpressureStrategy)` in the sequence upstream.