### PR TITLE
2.x: Observable.first* with predicate

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -7197,6 +7197,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         the {@code predicate}, or a default item if the source Observable completes without emitting any items.
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX operators documentation: First</a>
      */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> first(T defaultItem, Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
         return filter(predicate).first(defaultItem);
@@ -7237,6 +7239,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         the {@code predicate}, or raises an {@code NoSuchElementException} if no such items are emitted.
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX operators documentation: First</a>
      */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> firstOrError(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
         return filter(predicate).firstOrError();

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -7136,6 +7136,29 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
+     * Returns a Maybe that emits only the very first item emitted by the source ObservableSource that satisfies
+     * a specified condition, or completes if the source ObservableSource is empty.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstElement.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code firstElement} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param predicate
+     *            the condition that an item emitted by the source Observable has to satisfy
+     * @return the new Maybe that emits only the very first item emitted by the source ObservableSource that satisfies
+     *            the {@code predicate}, or completes if the source ObservableSource is empty.
+     * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX operators documentation: First</a>
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> firstElement(Predicate<? super T> predicate) {
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
+        return filter(predicate).firstElement();
+    }
+
+    /**
      * Returns a Single that emits only the very first item emitted by the source ObservableSource, or a default item
      * if the source ObservableSource completes without emitting any items.
      * <p>
@@ -7157,6 +7180,29 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
+     * Returns a Single that emits only the very first item emitted by the source ObservableSource that satisfies
+     * a specified condition, or a default item if the source ObservableSource completes without emitting any items.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/first.2.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code first} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param defaultItem
+     *            the default item to emit if nothing passed through the predicate
+     * @param predicate
+     *            the condition that an item emitted by the source Observable has to satisfy
+     * @return an Single that emits only the very first item emitted by the source Observable that satisfies
+     *         the {@code predicate}, or a default item if the source Observable completes without emitting any items.
+     * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX operators documentation: First</a>
+     */
+    public final Single<T> first(T defaultItem, Predicate<? super T> predicate) {
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
+        return filter(predicate).first(defaultItem);
+    }
+
+    /**
      * Returns a Single that emits only the very first item emitted by this Observable or
      * signals a {@link NoSuchElementException} if this Observable is empty.
      * <p>
@@ -7173,6 +7219,27 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> firstOrError() {
         return elementAtOrError(0L);
+    }
+
+    /**
+     * Returns a Single that emits only the very first item emitted by the source Observable that satisfies
+     * a specified condition, or signals a {@link NoSuchElementException} if this Observable is empty.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstN.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code first} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param predicate
+     *            the condition that an item emitted by the source Observable has to satisfy
+     * @return an Single that emits only the very first item emitted by the source Observable that satisfies
+     *         the {@code predicate}, or raises an {@code NoSuchElementException} if no such items are emitted.
+     * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX operators documentation: First</a>
+     */
+    public final Single<T> firstOrError(Predicate<? super T> predicate) {
+        ObjectHelper.requireNonNull(predicate, "predicate is null");
+        return filter(predicate).firstOrError();
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -7193,7 +7193,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the default item to emit if nothing passed through the predicate
      * @param predicate
      *            the condition that an item emitted by the source Observable has to satisfy
-     * @return an Single that emits only the very first item emitted by the source Observable that satisfies
+     * @return a Single that emits only the very first item emitted by the source Observable that satisfies
      *         the {@code predicate}, or a default item if the source Observable completes without emitting any items.
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX operators documentation: First</a>
      */
@@ -7230,12 +7230,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstN.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code first} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code firstOrError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param predicate
      *            the condition that an item emitted by the source Observable has to satisfy
-     * @return an Single that emits only the very first item emitted by the source Observable that satisfies
+     * @return a Single that emits only the very first item emitted by the source Observable that satisfies
      *         the {@code predicate}, or raises an {@code NoSuchElementException} if no such items are emitted.
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX operators documentation: First</a>
      */

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -183,62 +183,6 @@ public class ObservableTest {
     }
 
     @Test
-    public void testTakeFirstWithPredicateOfSome() {
-        Observable<Integer> o = Observable.just(1, 3, 5, 4, 6, 3);
-        o.filter(IS_EVEN).take(1).subscribe(w);
-        verify(w, times(1)).onNext(anyInt());
-        verify(w).onNext(4);
-        verify(w, times(1)).onComplete();
-        verify(w, never()).onError(any(Throwable.class));
-    }
-
-    @Test
-    public void testTakeFirstWithPredicateOfNoneMatchingThePredicate() {
-        Observable<Integer> o = Observable.just(1, 3, 5, 7, 9, 7, 5, 3, 1);
-        o.filter(IS_EVEN).take(1).subscribe(w);
-        verify(w, never()).onNext(anyInt());
-        verify(w, times(1)).onComplete();
-        verify(w, never()).onError(any(Throwable.class));
-    }
-
-    @Test
-    public void testTakeFirstOfSome() {
-        Observable<Integer> o = Observable.just(1, 2, 3);
-        o.take(1).subscribe(w);
-        verify(w, times(1)).onNext(anyInt());
-        verify(w).onNext(1);
-        verify(w, times(1)).onComplete();
-        verify(w, never()).onError(any(Throwable.class));
-    }
-
-    @Test
-    public void testTakeFirstOfNone() {
-        Observable<Integer> o = Observable.empty();
-        o.take(1).subscribe(w);
-        verify(w, never()).onNext(anyInt());
-        verify(w, times(1)).onComplete();
-        verify(w, never()).onError(any(Throwable.class));
-    }
-
-    @Test
-    public void testFirstOfNone() {
-        Observable<Integer> o = Observable.empty();
-        o.firstElement().subscribe(wm);
-        verify(wm, never()).onSuccess(anyInt());
-        verify(wm).onComplete();
-        verify(wm, never()).onError(any(Throwable.class));
-    }
-
-    @Test
-    public void testFirstWithPredicateOfNoneMatchingThePredicate() {
-        Observable<Integer> o = Observable.just(1, 3, 5, 7, 9, 7, 5, 3, 1);
-        o.filter(IS_EVEN).firstElement().subscribe(wm);
-        verify(wm, never()).onSuccess(anyInt());
-        verify(wm).onComplete();
-        verify(wm, never()).onError(any(Throwable.class));
-    }
-
-    @Test
     public void testReduce() {
         Observable<Integer> o = Observable.just(1, 2, 3, 4);
         o.reduce(new BiFunction<Integer, Integer, Integer>() {

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -183,6 +183,131 @@ public class ObservableTest {
     }
 
     @Test
+    public void testFirstElementOfSome() {
+        Observable<Integer> o = Observable.just(1, 2, 3);
+        o.firstElement().subscribe(wm);
+        verify(wm, times(1)).onSuccess(anyInt());
+        verify(wm, never()).onComplete();
+        verify(wm, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstElementOfNone() {
+        Observable<Integer> o = Observable.empty();
+        o.firstElement().subscribe(wm);
+        verify(wm, never()).onSuccess(anyInt());
+        verify(wm, times(1)).onComplete();
+        verify(wm, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstElementWithPredicateOfSomeMatchingThePredicate() {
+        Observable<Integer> o = Observable.just(1, 2, 3);
+        o.firstElement(IS_EVEN).subscribe(wm);
+        verify(wm, times(1)).onSuccess(anyInt());
+        verify(wm, never()).onComplete();
+        verify(wm, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstElementWithPredicateOfNoneMatchingThePredicate() {
+        Observable<Integer> o = Observable.just(1, 3, 5);
+        o.firstElement(IS_EVEN).subscribe(wm);
+        verify(wm, never()).onSuccess(anyInt());
+        verify(wm, times(1)).onComplete();
+        verify(wm, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstElementWithPredicateOfNone() {
+        Observable<Integer> o = Observable.empty();
+        o.firstElement(IS_EVEN).subscribe(wm);
+        verify(wm, never()).onSuccess(anyInt());
+        verify(wm, times(1)).onComplete();
+        verify(wm, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstOfSome() {
+        Observable<Integer> o = Observable.just(1, 2, 3);
+        o.first(0).subscribe(wo);
+        verify(wo, times(1)).onSuccess(1);
+        verify(wo, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstOfNone() {
+        Observable<Integer> o = Observable.empty();
+        o.first(0).subscribe(wo);
+        verify(wo, times(1)).onSuccess(anyInt());
+        verify(wo, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstWithPredicateOfSomeMatchingThePredicate() {
+        Observable<Integer> o = Observable.just(1, 2, 3);
+        o.first(0, IS_EVEN).subscribe(wo);
+        verify(wo, times(1)).onSuccess(2);
+        verify(wo, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstWithPredicateOfNoneMatchingThePredicate() {
+        Observable<Integer> o = Observable.just(1, 3, 5);
+        o.first(0, IS_EVEN).subscribe(wo);
+        verify(wo, times(1)).onSuccess(0);
+        verify(wo, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstWithPredicateOfNone() {
+        Observable<Integer> o = Observable.empty();
+        o.first(0, IS_EVEN).subscribe(wo);
+        verify(wo, times(1)).onSuccess(0);
+        verify(wo, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstOrErrorOfSome() {
+        Observable<Integer> o = Observable.just(1, 2, 3);
+        o.firstOrError().subscribe(wo);
+        verify(wo, times(1)).onSuccess(anyInt());
+        verify(wo, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstOrErrorOfNone() {
+        Observable<Integer> o = Observable.empty();
+        o.firstOrError().subscribe(wo);
+        verify(wo, never()).onSuccess(anyInt());
+        verify(wo, times(1)).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstOrErrorWithPredicateOfSomeMatchingThePredicate() {
+        Observable<Integer> o = Observable.just(1, 2, 3);
+        o.firstOrError(IS_EVEN).subscribe(wo);
+        verify(wo, times(1)).onSuccess(anyInt());
+        verify(wo, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstOrErrorWithPredicateOfNoneMatchingThePredicate() {
+        Observable<Integer> o = Observable.just(1, 3, 5);
+        o.firstOrError(IS_EVEN).subscribe(wo);
+        verify(wo, never()).onSuccess(anyInt());
+        verify(wo, times(1)).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testFirstOrErrorWithPredicateOfNone() {
+        Observable<Integer> o = Observable.empty();
+        o.firstOrError(IS_EVEN).subscribe(wo);
+        verify(wo, never()).onSuccess(anyInt());
+        verify(wo, times(1)).onError(any(Throwable.class));
+    }
+
+    @Test
     public void testReduce() {
         Observable<Integer> o = Observable.just(1, 2, 3, 4);
         o.reduce(new BiFunction<Integer, Integer, Integer>() {


### PR DESCRIPTION
Recently I discovered that there is no first-with-predicate operator in `2.x.` So I've implemented `Observable.firstElement(predicate)`, `Observable.first(defaultItem, predicate)` and `Observable.firstOrError(predicate)` overloads using simple constructs like `filter(predicate).firstElement()`.

Also, I've rewritten all first* tests because seems it was just copied from 1.x with do-it-later intention.