### PR TITLE
2.x: fix Maybe.concat() subscribe-after-cancel, verify others

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeConcatArray.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeConcatArray.java
@@ -114,9 +114,10 @@ public final class MaybeConcatArray<T> extends Flowable<T> {
 
             AtomicReference<Object> c = current;
             Subscriber<? super T> a = actual;
+            Disposable cancelled = disposables;
 
             for (;;) {
-                if (disposables.isDisposed()) {
+                if (cancelled.isDisposed()) {
                     c.lazySet(null);
                     return;
                 }
@@ -141,7 +142,7 @@ public final class MaybeConcatArray<T> extends Flowable<T> {
                         c.lazySet(null);
                     }
 
-                    if (goNextSource) {
+                    if (goNextSource && !cancelled.isDisposed()) {
                         int i = index;
                         if (i == sources.length) {
                             a.onComplete();

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayDelayError.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayDelayError.java
@@ -124,9 +124,10 @@ public final class MaybeConcatArrayDelayError<T> extends Flowable<T> {
 
             AtomicReference<Object> c = current;
             Subscriber<? super T> a = actual;
+            Disposable cancelled = disposables;
 
             for (;;) {
-                if (disposables.isDisposed()) {
+                if (cancelled.isDisposed()) {
                     c.lazySet(null);
                     return;
                 }
@@ -151,7 +152,7 @@ public final class MaybeConcatArrayDelayError<T> extends Flowable<T> {
                         c.lazySet(null);
                     }
 
-                    if (goNextSource) {
+                    if (goNextSource && !cancelled.isDisposed()) {
                         int i = index;
                         if (i == sources.length) {
                             Throwable ex = errors.get();

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeConcatIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeConcatIterable.java
@@ -126,9 +126,10 @@ public final class MaybeConcatIterable<T> extends Flowable<T> {
 
             AtomicReference<Object> c = current;
             Subscriber<? super T> a = actual;
+            Disposable cancelled = disposables;
 
             for (;;) {
-                if (disposables.isDisposed()) {
+                if (cancelled.isDisposed()) {
                     c.lazySet(null);
                     return;
                 }
@@ -153,7 +154,7 @@ public final class MaybeConcatIterable<T> extends Flowable<T> {
                         c.lazySet(null);
                     }
 
-                    if (goNextSource) {
+                    if (goNextSource && !cancelled.isDisposed()) {
                         boolean b;
 
                         try {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -1542,4 +1542,88 @@ public class FlowableConcatTest {
         .test()
         .assertFailure(TestException.class);
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscription() {
+        final int[] calls = { 0 };
+
+        Flowable<Integer> source = Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onNext(1);
+                s.onComplete();
+            }
+        }, BackpressureStrategy.MISSING);
+
+        Flowable.concatArray(source, source).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscriptionDelayError() {
+        final int[] calls = { 0 };
+
+        Flowable<Integer> source = Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onNext(1);
+                s.onComplete();
+            }
+        }, BackpressureStrategy.MISSING);
+
+        Flowable.concatArrayDelayError(source, source).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscriptionIterable() {
+        final int[] calls = { 0 };
+
+        Flowable<Integer> source = Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onNext(1);
+                s.onComplete();
+            }
+        }, BackpressureStrategy.MISSING);
+
+        Flowable.concat(Arrays.asList(source, source)).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscriptionDelayErrorIterable() {
+        final int[] calls = { 0 };
+
+        Flowable<Integer> source = Flowable.create(new FlowableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(FlowableEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onNext(1);
+                s.onComplete();
+            }
+        }, BackpressureStrategy.MISSING);
+
+        Flowable.concatDelayError(Arrays.asList(source, source)).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayTest.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.maybe;
 import java.io.IOException;
 import java.util.List;
 
+import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.*;
@@ -155,5 +156,45 @@ public class MaybeConcatArrayTest {
         } finally {
             RxJavaPlugins.reset();
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscription() {
+        final int[] calls = { 0 };
+
+        Maybe<Integer> source = Maybe.create(new MaybeOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(MaybeEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onSuccess(1);
+            }
+        });
+
+        Maybe.concatArray(source, source).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscriptionDelayError() {
+        final int[] calls = { 0 };
+
+        Maybe<Integer> source = Maybe.create(new MaybeOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(MaybeEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onSuccess(1);
+            }
+        });
+
+        Maybe.concatArrayDelayError(source, source).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatIterableTest.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.internal.operators.maybe;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.*;
 
 import org.junit.Test;
@@ -120,5 +122,45 @@ public class MaybeConcatIterableTest {
         }))
         .test()
         .assertFailure(NullPointerException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscription() {
+        final int[] calls = { 0 };
+
+        Maybe<Integer> source = Maybe.create(new MaybeOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(MaybeEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onSuccess(1);
+            }
+        });
+
+        Maybe.concat(Arrays.asList(source, source)).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscriptionDelayError() {
+        final int[] calls = { 0 };
+
+        Maybe<Integer> source = Maybe.create(new MaybeOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(MaybeEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onSuccess(1);
+            }
+        });
+
+        Maybe.concatDelayError(Arrays.asList(source, source)).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
@@ -958,4 +958,87 @@ public class ObservableConcatTest {
 
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscription() {
+        final int[] calls = { 0 };
+
+        Observable<Integer> source = Observable.create(new ObservableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(ObservableEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onNext(1);
+                s.onComplete();
+            }
+        });
+
+        Observable.concatArray(source, source).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscriptionDelayError() {
+        final int[] calls = { 0 };
+
+        Observable<Integer> source = Observable.create(new ObservableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(ObservableEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onNext(1);
+                s.onComplete();
+            }
+        });
+
+        Observable.concatArrayDelayError(source, source).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscriptionIterable() {
+        final int[] calls = { 0 };
+
+        Observable<Integer> source = Observable.create(new ObservableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(ObservableEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onNext(1);
+                s.onComplete();
+            }
+        });
+
+        Observable.concat(Arrays.asList(source, source)).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscriptionDelayErrorIterable() {
+        final int[] calls = { 0 };
+
+        Observable<Integer> source = Observable.create(new ObservableOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(ObservableEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onNext(1);
+                s.onComplete();
+            }
+        });
+
+        Observable.concatDelayError(Arrays.asList(source, source)).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.internal.operators.single;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -80,5 +82,46 @@ public class SingleConcatTest {
             .assertNoErrors()
             .assertComplete();
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscription() {
+        final int[] calls = { 0 };
+
+        Single<Integer> source = Single.create(new SingleOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(SingleEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onSuccess(1);
+            }
+        });
+
+        Single.concatArray(source, source).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noSubsequentSubscriptionIterable() {
+        final int[] calls = { 0 };
+
+        Single<Integer> source = Single.create(new SingleOnSubscribe<Integer>() {
+            @Override
+            public void subscribe(SingleEmitter<Integer> s) throws Exception {
+                calls[0]++;
+                s.onSuccess(1);
+            }
+        });
+
+        Single.concat(Arrays.asList(source, source)).firstElement()
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls[0]);
     }
 }


### PR DESCRIPTION
This PR fixes `Maybe.concatX` subscribing to the next source when the downstream cancelled the `Flowable` sequence from its `onNext`. This resulted in executing the subscription side-effects of the source to be immediately cancelled when it called `onSubscribe` on concat's `MaybeObserver`.

In addition, tests were added to verify the other types don't have this kind of a problem.

Related #5100.