### PR TITLE
2.x: fix doOnSubscribe signalling Undeliv.Exception instead of just onError

### DIFF
--- a/src/main/java/io/reactivex/internal/observers/DisposableLambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/DisposableLambdaObserver.java
@@ -43,8 +43,7 @@ public final class DisposableLambdaObserver<T> implements Observer<T>, Disposabl
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             s.dispose();
-            RxJavaPlugins.onError(e);
-
+            this.s = DisposableHelper.DISPOSED;
             EmptyDisposable.error(e, actual);
             return;
         }
@@ -61,12 +60,18 @@ public final class DisposableLambdaObserver<T> implements Observer<T>, Disposabl
 
     @Override
     public void onError(Throwable t) {
-        actual.onError(t);
+        if (s != DisposableHelper.DISPOSED) {
+            actual.onError(t);
+        } else {
+            RxJavaPlugins.onError(t);
+        }
     }
 
     @Override
     public void onComplete() {
-        actual.onComplete();
+        if (s != DisposableHelper.DISPOSED) {
+            actual.onComplete();
+        }
     }
 
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
@@ -64,7 +64,7 @@ public final class FlowableDoOnLifecycle<T> extends AbstractFlowableWithUpstream
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 s.cancel();
-                RxJavaPlugins.onError(e);
+                this.s = SubscriptionHelper.CANCELLED;
                 EmptySubscription.error(e, actual);
                 return;
             }
@@ -81,12 +81,18 @@ public final class FlowableDoOnLifecycle<T> extends AbstractFlowableWithUpstream
 
         @Override
         public void onError(Throwable t) {
-            actual.onError(t);
+            if (s != SubscriptionHelper.CANCELLED) {
+                actual.onError(t);
+            } else {
+                RxJavaPlugins.onError(t);
+            }
         }
 
         @Override
         public void onComplete() {
-            actual.onComplete();
+            if (s != SubscriptionHelper.CANCELLED) {
+                actual.onComplete();
+            }
         }
 
         @Override

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDoOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDoOnTest.java
@@ -20,9 +20,11 @@ import static org.junit.Assert.*;
 import org.junit.*;
 
 import io.reactivex.*;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public class CompletableDoOnTest {
 
@@ -73,5 +75,36 @@ public class CompletableDoOnTest {
             .dispose();
 
         assertTrue(atomicBoolean.get());
+    }
+
+    @Test
+    public void onSubscribeCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable bs = Disposables.empty();
+
+            new Completable() {
+                @Override
+                protected void subscribeActual(CompletableObserver s) {
+                    s.onSubscribe(bs);
+                    s.onError(new TestException("Second"));
+                    s.onComplete();
+                }
+            }
+            .doOnSubscribe(new Consumer<Disposable>() {
+                @Override
+                public void accept(Disposable s) throws Exception {
+                    throw new TestException("First");
+                }
+            })
+            .test()
+            .assertFailureAndMessage(TestException.class, "First");
+
+            assertTrue(bs.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
@@ -13,9 +13,10 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import static org.junit.Assert.*;
+
 import java.util.List;
 
-import static org.junit.Assert.*;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -23,6 +24,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public class FlowableDoOnLifecycleTest {
@@ -128,6 +130,37 @@ public class FlowableDoOnLifecycleTest {
             .assertResult(1);
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onSubscribeCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final BooleanSubscription bs = new BooleanSubscription();
+
+            new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(bs);
+                    s.onError(new TestException("Second"));
+                    s.onComplete();
+                }
+            }
+            .doOnSubscribe(new Consumer<Subscription>() {
+                @Override
+                public void accept(Subscription s) throws Exception {
+                    throw new TestException("First");
+                }
+            })
+            .test()
+            .assertFailureAndMessage(TestException.class, "First");
+
+            assertTrue(bs.isCancelled());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoOnEventTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoOnEventTest.java
@@ -13,10 +13,17 @@
 
 package io.reactivex.internal.operators.maybe;
 
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
 import org.junit.Test;
 
 import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
 
 public class MaybeDoOnEventTest {
@@ -44,5 +51,37 @@ public class MaybeDoOnEventTest {
                 });
             }
         });
+    }
+
+    @Test
+    public void onSubscribeCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable bs = Disposables.empty();
+
+            new Maybe<Integer>() {
+                @Override
+                protected void subscribeActual(MaybeObserver<? super Integer> s) {
+                    s.onSubscribe(bs);
+                    s.onError(new TestException("Second"));
+                    s.onComplete();
+                    s.onSuccess(1);
+                }
+            }
+            .doOnSubscribe(new Consumer<Disposable>() {
+                @Override
+                public void accept(Disposable s) throws Exception {
+                    throw new TestException("First");
+                }
+            })
+            .test()
+            .assertFailureAndMessage(TestException.class, "First");
+
+            assertTrue(bs.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the issue reported on [StackOverflow](http://stackoverflow.com/questions/42279543/exception-is-not-propagated-to-onerror-when-thrown-from-doonsubscribe) where crashing the lambda in `Flowable.doOnSubscribe` calls the `RxJavaPlugins.onError`, which crashes the app and prevents calling the `EmptySubscription.error` on Android. (Desktop prints to the console and delivers the error normally.)

The bug was present in the `Flowable`, `Observable` and `Completable`. All 5 base types received the respective unit test to ensure correct behavior.