### PR TITLE
2.x: Flowable as a Publisher to be fully RS compliant

### DIFF
--- a/src/main/java/io/reactivex/FlowableSubscriber.java
+++ b/src/main/java/io/reactivex/FlowableSubscriber.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import org.reactivestreams.*;
+
+import io.reactivex.annotations.Experimental;
+
+/**
+ * Represents a Reactive-Streams inspired Subscriber that is RxJava 2 only
+ * and weakens rules §1.3 and §3.9 of the specification for gaining performance.
+ *
+ * @param <T> the value type
+ * @since 2.0.7 - experimental
+ */
+@Experimental
+public interface FlowableSubscriber<T> extends Subscriber<T> {
+
+    /**
+     * Implementors of this method should make sure everything that needs
+     * to be visible in {@link #onNext(Object)} is established before
+     * calling {@link Subscription#request(long)}. In practice this means
+     * no initialization should happen after the {@code request()} call and
+     * additional behavior is thread safe in respect to {@code onNext}.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    void onSubscribe(Subscription s);
+}

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -254,7 +254,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     public static <T> Flowable<T> concat(Publisher<? extends MaybeSource<? extends T>> sources, int prefetch) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMap(sources, MaybeToPublisher.instance(), prefetch, ErrorMode.IMMEDIATE));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapPublisher(sources, MaybeToPublisher.instance(), prefetch, ErrorMode.IMMEDIATE));
     }
 
     /**
@@ -827,7 +827,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Flowable<T> merge(Publisher<? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
-        return RxJavaPlugins.onAssembly(new FlowableFlatMap(sources, MaybeToPublisher.instance(), false, maxConcurrency, Flowable.bufferSize()));
+        return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, MaybeToPublisher.instance(), false, maxConcurrency, Flowable.bufferSize()));
     }
 
     /**

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -188,8 +188,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Flowable<T> concat(Publisher<? extends SingleSource<? extends T>> sources, int prefetch) {
+        ObjectHelper.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMap(sources, SingleInternalHelper.toFlowable(), prefetch, ErrorMode.IMMEDIATE));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapPublisher(sources, SingleInternalHelper.toFlowable(), prefetch, ErrorMode.IMMEDIATE));
     }
 
     /**
@@ -684,7 +685,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Flowable<T> merge(Publisher<? extends SingleSource<? extends T>> sources) {
-        return RxJavaPlugins.onAssembly(new FlowableFlatMap(sources, SingleInternalHelper.toFlowable(), false, Integer.MAX_VALUE, Flowable.bufferSize()));
+        return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, SingleInternalHelper.toFlowable(), false, Integer.MAX_VALUE, Flowable.bufferSize()));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/fuseable/ConditionalSubscriber.java
+++ b/src/main/java/io/reactivex/internal/fuseable/ConditionalSubscriber.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.fuseable;
 
-import org.reactivestreams.Subscriber;
+import io.reactivex.FlowableSubscriber;
 
 /**
  * A Subscriber with an additional onNextIf(T) method that
@@ -25,7 +25,7 @@ import org.reactivestreams.Subscriber;
  *
  * @param <T> the value type
  */
-public interface ConditionalSubscriber<T> extends Subscriber<T> {
+public interface ConditionalSubscriber<T> extends FlowableSubscriber<T> {
     /**
      * Conditionally takes the value.
      * @param t the value to deliver

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcat.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcat.java
@@ -42,7 +42,7 @@ public final class CompletableConcat extends Completable {
 
     static final class CompletableConcatSubscriber
     extends AtomicInteger
-    implements Subscriber<CompletableSource>, Disposable {
+    implements FlowableSubscriber<CompletableSource>, Disposable {
         private static final long serialVersionUID = 9032184911934499404L;
 
         final CompletableObserver actual;

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromPublisher.java
@@ -32,7 +32,7 @@ public final class CompletableFromPublisher<T> extends Completable {
         flowable.subscribe(new FromPublisherSubscriber<T>(cs));
     }
 
-    static final class FromPublisherSubscriber<T> implements Subscriber<T>, Disposable {
+    static final class FromPublisherSubscriber<T> implements FlowableSubscriber<T>, Disposable {
 
         final CompletableObserver cs;
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMerge.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMerge.java
@@ -43,7 +43,7 @@ public final class CompletableMerge extends Completable {
 
     static final class CompletableMergeSubscriber
     extends AtomicInteger
-    implements Subscriber<CompletableSource>, Disposable {
+    implements FlowableSubscriber<CompletableSource>, Disposable {
 
         private static final long serialVersionUID = -2108443387387077490L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/AbstractFlowableWithUpstream.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/AbstractFlowableWithUpstream.java
@@ -31,14 +31,14 @@ abstract class AbstractFlowableWithUpstream<T, R> extends Flowable<R> implements
     /**
      * The upstream source Publisher.
      */
-    protected final Publisher<T> source;
+    protected final Flowable<T> source;
 
     /**
      * Constructs a FlowableSource wrapping the given non-null (verified)
      * source Publisher.
      * @param source the source (upstream) Publisher instance, not null (verified)
      */
-    AbstractFlowableWithUpstream(Publisher<T> source) {
+    AbstractFlowableWithUpstream(Flowable<T> source) {
         this.source = ObjectHelper.requireNonNull(source, "source is null");
     }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableIterable.java
@@ -17,8 +17,9 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.*;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.queue.SpscArrayQueue;
@@ -26,11 +27,11 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 
 public final class BlockingFlowableIterable<T> implements Iterable<T> {
-    final Publisher<? extends T> source;
+    final Flowable<? extends T> source;
 
     final int bufferSize;
 
-    public BlockingFlowableIterable(Publisher<? extends T> source, int bufferSize) {
+    public BlockingFlowableIterable(Flowable<? extends T> source, int bufferSize) {
         this.source = source;
         this.bufferSize = bufferSize;
     }
@@ -44,7 +45,7 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
 
     static final class BlockingFlowableIterator<T>
     extends AtomicReference<Subscription>
-    implements Subscriber<T>, Iterator<T>, Runnable, Disposable {
+    implements FlowableSubscriber<T>, Iterator<T>, Runnable, Disposable {
 
         private static final long serialVersionUID = 6695226475494099826L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecent.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecent.java
@@ -15,8 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.*;
 
-import org.reactivestreams.Publisher;
-
+import io.reactivex.Flowable;
 import io.reactivex.internal.util.*;
 import io.reactivex.subscribers.DefaultSubscriber;
 
@@ -30,11 +29,11 @@ import io.reactivex.subscribers.DefaultSubscriber;
  */
 public final class BlockingFlowableMostRecent<T> implements Iterable<T> {
 
-    final Publisher<? extends T> source;
+    final Flowable<? extends T> source;
 
     final T initialValue;
 
-    public BlockingFlowableMostRecent(Publisher<? extends T> source, T initialValue) {
+    public BlockingFlowableMostRecent(Flowable<? extends T> source, T initialValue) {
         this.source = source;
         this.initialValue = initialValue;
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAll.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAll.java
@@ -14,6 +14,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.*;
@@ -23,7 +24,7 @@ public final class FlowableAll<T> extends AbstractFlowableWithUpstream<T, Boolea
 
     final Predicate<? super T> predicate;
 
-    public FlowableAll(Publisher<T> source, Predicate<? super T> predicate) {
+    public FlowableAll(Flowable<T> source, Predicate<? super T> predicate) {
         super(source);
         this.predicate = predicate;
     }
@@ -33,7 +34,7 @@ public final class FlowableAll<T> extends AbstractFlowableWithUpstream<T, Boolea
         source.subscribe(new AllSubscriber<T>(s, predicate));
     }
 
-    static final class AllSubscriber<T> extends DeferredScalarSubscription<Boolean> implements Subscriber<T> {
+    static final class AllSubscriber<T> extends DeferredScalarSubscription<Boolean> implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -3521127104134758517L;
         final Predicate<? super T> predicate;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAllSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAllSingle.java
@@ -24,11 +24,11 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableAllSingle<T> extends Single<Boolean> implements FuseToFlowable<Boolean> {
 
-    final Publisher<T> source;
+    final Flowable<T> source;
 
     final Predicate<? super T> predicate;
 
-    public FlowableAllSingle(Publisher<T> source, Predicate<? super T> predicate) {
+    public FlowableAllSingle(Flowable<T> source, Predicate<? super T> predicate) {
         this.source = source;
         this.predicate = predicate;
     }
@@ -43,7 +43,7 @@ public final class FlowableAllSingle<T> extends Single<Boolean> implements FuseT
         return RxJavaPlugins.onAssembly(new FlowableAll<T>(source, predicate));
     }
 
-    static final class AllSubscriber<T> implements Subscriber<T>, Disposable {
+    static final class AllSubscriber<T> implements FlowableSubscriber<T>, Disposable {
 
         final SingleObserver<? super Boolean> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAmb.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -147,7 +147,7 @@ public final class FlowableAmb<T> extends Flowable<T> {
         }
     }
 
-    static final class AmbInnerSubscriber<T> extends AtomicReference<Subscription> implements Subscriber<T>, Subscription {
+    static final class AmbInnerSubscriber<T> extends AtomicReference<Subscription> implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -1185974347409665484L;
         final AmbCoordinator<T> parent;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAny.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAny.java
@@ -12,16 +12,17 @@
  */
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.plugins.RxJavaPlugins;
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.*;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableAny<T> extends AbstractFlowableWithUpstream<T, Boolean> {
     final Predicate<? super T> predicate;
-    public FlowableAny(Publisher<T> source, Predicate<? super T> predicate) {
+    public FlowableAny(Flowable<T> source, Predicate<? super T> predicate) {
         super(source);
         this.predicate = predicate;
     }
@@ -31,7 +32,7 @@ public final class FlowableAny<T> extends AbstractFlowableWithUpstream<T, Boolea
         source.subscribe(new AnySubscriber<T>(s, predicate));
     }
 
-    static final class AnySubscriber<T> extends DeferredScalarSubscription<Boolean> implements Subscriber<T> {
+    static final class AnySubscriber<T> extends DeferredScalarSubscription<Boolean> implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -2311252482644620661L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAnySingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAnySingle.java
@@ -23,11 +23,11 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableAnySingle<T> extends Single<Boolean> implements FuseToFlowable<Boolean> {
-    final Publisher<T> source;
+    final Flowable<T> source;
 
     final Predicate<? super T> predicate;
 
-    public FlowableAnySingle(Publisher<T> source, Predicate<? super T> predicate) {
+    public FlowableAnySingle(Flowable<T> source, Predicate<? super T> predicate) {
         this.source = source;
         this.predicate = predicate;
     }
@@ -42,7 +42,7 @@ public final class FlowableAnySingle<T> extends Single<Boolean> implements FuseT
         return RxJavaPlugins.onAssembly(new FlowableAny<T>(source, predicate));
     }
 
-    static final class AnySubscriber<T> implements Subscriber<T>, Disposable {
+    static final class AnySubscriber<T> implements FlowableSubscriber<T>, Disposable {
 
         final SingleObserver<? super Boolean> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAutoConnect.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAutoConnect.java
@@ -13,9 +13,9 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import org.reactivestreams.Subscriber;
-
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
@@ -13,15 +13,16 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -33,7 +34,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
     final Callable<C> bufferSupplier;
 
-    public FlowableBuffer(Publisher<T> source, int size, int skip, Callable<C> bufferSupplier) {
+    public FlowableBuffer(Flowable<T> source, int size, int skip, Callable<C> bufferSupplier) {
         super(source);
         this.size = size;
         this.skip = skip;
@@ -52,7 +53,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
     }
 
     static final class PublisherBufferExactSubscriber<T, C extends Collection<? super T>>
-      implements Subscriber<T>, Subscription {
+      implements FlowableSubscriber<T>, Subscription {
 
         final Subscriber<? super C> actual;
 
@@ -156,7 +157,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
     static final class PublisherBufferSkipSubscriber<T, C extends Collection<? super T>>
     extends AtomicInteger
-    implements Subscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
 
 
         private static final long serialVersionUID = -5616169793639412593L;
@@ -288,7 +289,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
     static final class PublisherBufferOverlappingSubscriber<T, C extends Collection<? super T>>
     extends AtomicLong
-    implements Subscriber<T>, Subscription, BooleanSupplier {
+    implements FlowableSubscriber<T>, Subscription, BooleanSupplier {
 
         private static final long serialVersionUID = -7370244972039324525L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
@@ -13,16 +13,17 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.reactivestreams.*;
 
+import io.reactivex.Flowable;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.SimpleQueue;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.QueueDrainSubscriber;
@@ -37,7 +38,7 @@ extends AbstractFlowableWithUpstream<T, U> {
     final Publisher<? extends Open> bufferOpen;
     final Function<? super Open, ? extends Publisher<? extends Close>> bufferClose;
 
-    public FlowableBufferBoundary(Publisher<T> source, Publisher<? extends Open> bufferOpen,
+    public FlowableBufferBoundary(Flowable<T> source, Publisher<? extends Open> bufferOpen,
             Function<? super Open, ? extends Publisher<? extends Close>> bufferClose, Callable<U> bufferSupplier) {
         super(source);
         this.bufferOpen = bufferOpen;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundarySupplier.java
@@ -13,16 +13,17 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.QueueDrainSubscriber;
 import io.reactivex.internal.subscriptions.*;
@@ -35,7 +36,7 @@ extends AbstractFlowableWithUpstream<T, U> {
     final Callable<? extends Publisher<B>> boundarySupplier;
     final Callable<U> bufferSupplier;
 
-    public FlowableBufferBoundarySupplier(Publisher<T> source, Callable<? extends Publisher<B>> boundarySupplier, Callable<U> bufferSupplier) {
+    public FlowableBufferBoundarySupplier(Flowable<T> source, Callable<? extends Publisher<B>> boundarySupplier, Callable<U> bufferSupplier) {
         super(source);
         this.boundarySupplier = boundarySupplier;
         this.bufferSupplier = bufferSupplier;
@@ -47,7 +48,7 @@ extends AbstractFlowableWithUpstream<T, U> {
     }
 
     static final class BufferBoundarySupplierSubscriber<T, U extends Collection<? super T>, B>
-    extends QueueDrainSubscriber<T, U, U> implements Subscriber<T>, Subscription, Disposable {
+    extends QueueDrainSubscriber<T, U, U> implements FlowableSubscriber<T>, Subscription, Disposable {
 
         final Callable<U> bufferSupplier;
         final Callable<? extends Publisher<B>> boundarySupplier;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
@@ -13,14 +13,15 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.QueueDrainSubscriber;
 import io.reactivex.internal.subscriptions.*;
@@ -32,7 +33,7 @@ extends AbstractFlowableWithUpstream<T, U> {
     final Publisher<B> boundary;
     final Callable<U> bufferSupplier;
 
-    public FlowableBufferExactBoundary(Publisher<T> source, Publisher<B> boundary, Callable<U> bufferSupplier) {
+    public FlowableBufferExactBoundary(Flowable<T> source, Publisher<B> boundary, Callable<U> bufferSupplier) {
         super(source);
         this.boundary = boundary;
         this.bufferSupplier = bufferSupplier;
@@ -44,7 +45,7 @@ extends AbstractFlowableWithUpstream<T, U> {
     }
 
     static final class BufferExactBoundarySubscriber<T, U extends Collection<? super T>, B>
-    extends QueueDrainSubscriber<T, U, U> implements Subscriber<T>, Subscription, Disposable {
+    extends QueueDrainSubscriber<T, U, U> implements FlowableSubscriber<T>, Subscription, Disposable {
 
         final Callable<U> bufferSupplier;
         final Publisher<B> boundary;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -13,18 +13,18 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Scheduler;
+import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.QueueDrainSubscriber;
 import io.reactivex.internal.subscriptions.*;
@@ -41,7 +41,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
     final int maxSize;
     final boolean restartTimerOnMaxSize;
 
-    public FlowableBufferTimed(Publisher<T> source, long timespan, long timeskip, TimeUnit unit, Scheduler scheduler, Callable<U> bufferSupplier, int maxSize,
+    public FlowableBufferTimed(Flowable<T> source, long timespan, long timeskip, TimeUnit unit, Scheduler scheduler, Callable<U> bufferSupplier, int maxSize,
             boolean restartTimerOnMaxSize) {
         super(source);
         this.timespan = timespan;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -91,7 +91,7 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
      *
      * @param <T> the value type of the cached items
      */
-    static final class CacheState<T> extends LinkedArrayList implements Subscriber<T> {
+    static final class CacheState<T> extends LinkedArrayList implements FlowableSubscriber<T> {
         /** The source observable to connect to. */
         final Flowable<? extends T> source;
         /** Holds onto the subscriber connected to source. */

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollect.java
@@ -12,13 +12,14 @@
  */
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiConsumer;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -27,7 +28,7 @@ public final class FlowableCollect<T, U> extends AbstractFlowableWithUpstream<T,
     final Callable<? extends U> initialSupplier;
     final BiConsumer<? super U, ? super T> collector;
 
-    public FlowableCollect(Publisher<T> source, Callable<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
+    public FlowableCollect(Flowable<T> source, Callable<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
         super(source);
         this.initialSupplier = initialSupplier;
         this.collector = collector;
@@ -46,7 +47,7 @@ public final class FlowableCollect<T, U> extends AbstractFlowableWithUpstream<T,
         source.subscribe(new CollectSubscriber<T, U>(s, u, collector));
     }
 
-    static final class CollectSubscriber<T, U> extends DeferredScalarSubscription<U> implements Subscriber<T> {
+    static final class CollectSubscriber<T, U> extends DeferredScalarSubscription<U> implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -3589550218733891694L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollectSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollectSingle.java
@@ -28,12 +28,12 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableCollectSingle<T, U> extends Single<U> implements FuseToFlowable<U> {
 
-    final Publisher<T> source;
+    final Flowable<T> source;
 
     final Callable<? extends U> initialSupplier;
     final BiConsumer<? super U, ? super T> collector;
 
-    public FlowableCollectSingle(Publisher<T> source, Callable<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
+    public FlowableCollectSingle(Flowable<T> source, Callable<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
         this.source = source;
         this.initialSupplier = initialSupplier;
         this.collector = collector;
@@ -57,7 +57,7 @@ public final class FlowableCollectSingle<T, U> extends Single<U> implements Fuse
         return RxJavaPlugins.onAssembly(new FlowableCollect<T, U>(source, initialSupplier, collector));
     }
 
-    static final class CollectSubscriber<T, U> implements Subscriber<T>, Disposable {
+    static final class CollectSubscriber<T, U> implements FlowableSubscriber<T>, Disposable {
 
         final SingleObserver<? super U> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -16,14 +16,14 @@ package io.reactivex.internal.operators.flowable;
 import java.util.Iterator;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.annotations.NonNull;
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
+import io.reactivex.annotations.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.operators.flowable.FlowableMap.MapSubscriber;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.*;
@@ -132,12 +132,12 @@ extends Flowable<R> {
             return;
         }
         if (n == 1) {
-            new FlowableMap<T, R>((Publisher<T>)a[0], new Function<T, R>() {
+            ((Publisher<T>)a[0]).subscribe(new MapSubscriber<T, R>(s, new Function<T, R>() {
                 @Override
                 public R apply(T t) throws Exception {
                     return combiner.apply(new Object[] { t });
                 }
-            }).subscribe(s);
+            }));
             return;
         }
 
@@ -497,7 +497,7 @@ extends Flowable<R> {
 
     static final class CombineLatestInnerSubscriber<T>
     extends AtomicReference<Subscription>
-            implements Subscriber<T> {
+            implements FlowableSubscriber<T> {
 
 
         private static final long serialVersionUID = -8730235182291002949L;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatArray.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatArray.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
@@ -40,7 +40,7 @@ public final class FlowableConcatArray<T> extends Flowable<T> {
         parent.onComplete();
     }
 
-    static final class ConcatArraySubscriber<T> extends SubscriptionArbiter implements Subscriber<T> {
+    static final class ConcatArraySubscriber<T> extends SubscriptionArbiter implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -8158322871608889516L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
@@ -12,14 +12,15 @@
  */
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscArrayQueue;
 import io.reactivex.internal.subscriptions.*;
@@ -34,7 +35,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
 
     final ErrorMode errorMode;
 
-    public FlowableConcatMap(Publisher<T> source,
+    public FlowableConcatMap(Flowable<T> source,
             Function<? super T, ? extends Publisher<? extends R>> mapper,
             int prefetch, ErrorMode errorMode) {
         super(source);
@@ -67,7 +68,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
 
     abstract static class BaseConcatMapSubscriber<T, R>
     extends AtomicInteger
-    implements Subscriber<T>, ConcatMapSupport<R>, Subscription {
+    implements FlowableSubscriber<T>, ConcatMapSupport<R>, Subscription {
 
         private static final long serialVersionUID = -3511336836796789179L;
 
@@ -567,7 +568,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
 
     static final class ConcatMapInner<R>
     extends SubscriptionArbiter
-    implements Subscriber<R> {
+    implements FlowableSubscriber<R> {
 
 
         private static final long serialVersionUID = 897683679971470653L;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -37,12 +38,11 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
 
     final ErrorMode errorMode;
 
-    public FlowableConcatMapEager(Publisher<T> source,
+    public FlowableConcatMapEager(Flowable<T> source,
             Function<? super T, ? extends Publisher<? extends R>> mapper,
             int maxConcurrency,
             int prefetch,
-            ErrorMode errorMode
-                    ) {
+            ErrorMode errorMode) {
         super(source);
         this.mapper = mapper;
         this.maxConcurrency = maxConcurrency;
@@ -58,7 +58,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
 
     static final class ConcatMapEagerDelayErrorSubscriber<T, R>
     extends AtomicInteger
-    implements Subscriber<T>, Subscription, InnerQueuedSubscriberSupport<R> {
+    implements FlowableSubscriber<T>, Subscription, InnerQueuedSubscriberSupport<R> {
 
         private static final long serialVersionUID = -4255299542215038287L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerPublisher.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.operators.flowable.FlowableConcatMapEager.ConcatMapEagerDelayErrorSubscriber;
+import io.reactivex.internal.util.ErrorMode;
+
+/**
+ * ConcatMapEager which works with an arbitrary Publisher source.
+ * @param <T> the input value type
+ * @param <R> the output type
+ * @since 2.0.7 - experimental
+ */
+public final class FlowableConcatMapEagerPublisher<T, R> extends Flowable<R> {
+
+    final Publisher<T> source;
+
+    final Function<? super T, ? extends Publisher<? extends R>> mapper;
+
+    final int maxConcurrency;
+
+    final int prefetch;
+
+    final ErrorMode errorMode;
+
+    public FlowableConcatMapEagerPublisher(Publisher<T> source,
+            Function<? super T, ? extends Publisher<? extends R>> mapper,
+            int maxConcurrency,
+            int prefetch,
+            ErrorMode errorMode) {
+        this.source = source;
+        this.mapper = mapper;
+        this.maxConcurrency = maxConcurrency;
+        this.prefetch = prefetch;
+        this.errorMode = errorMode;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+        source.subscribe(new ConcatMapEagerDelayErrorSubscriber<T, R>(
+                s, mapper, maxConcurrency, prefetch, errorMode));
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapPublisher.java
@@ -1,0 +1,622 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.internal.subscriptions.*;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class FlowableConcatMapPublisher<T, R> extends Flowable<R> {
+
+    final Publisher<T> source;
+
+    final Function<? super T, ? extends Publisher<? extends R>> mapper;
+
+    final int prefetch;
+
+    final ErrorMode errorMode;
+
+    public FlowableConcatMapPublisher(Publisher<T> source,
+            Function<? super T, ? extends Publisher<? extends R>> mapper,
+            int prefetch, ErrorMode errorMode) {
+        this.source = source;
+        this.mapper = mapper;
+        this.prefetch = prefetch;
+        this.errorMode = errorMode;
+    }
+
+    public static <T, R> Subscriber<T> subscribe(Subscriber<? super R> s, Function<? super T, ? extends Publisher<? extends R>> mapper,
+            int prefetch, ErrorMode errorMode) {
+        switch (errorMode) {
+        case BOUNDARY:
+            return new ConcatMapDelayed<T, R>(s, mapper, prefetch, false);
+        case END:
+            return new ConcatMapDelayed<T, R>(s, mapper, prefetch, true);
+        default:
+            return new ConcatMapImmediate<T, R>(s, mapper, prefetch);
+        }
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+
+        if (FlowableScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
+            return;
+        }
+
+        source.subscribe(subscribe(s, mapper, prefetch, errorMode));
+    }
+
+    abstract static class BaseConcatMapSubscriber<T, R>
+    extends AtomicInteger
+    implements FlowableSubscriber<T>, ConcatMapSupport<R>, Subscription {
+
+        private static final long serialVersionUID = -3511336836796789179L;
+
+        final ConcatMapInner<R> inner;
+
+        final Function<? super T, ? extends Publisher<? extends R>> mapper;
+
+        final int prefetch;
+
+        final int limit;
+
+        Subscription s;
+
+        int consumed;
+
+        SimpleQueue<T> queue;
+
+        volatile boolean done;
+
+        volatile boolean cancelled;
+
+        final AtomicThrowable errors;
+
+        volatile boolean active;
+
+        int sourceMode;
+
+        BaseConcatMapSubscriber(
+                Function<? super T, ? extends Publisher<? extends R>> mapper,
+                int prefetch) {
+            this.mapper = mapper;
+            this.prefetch = prefetch;
+            this.limit = prefetch - (prefetch >> 2);
+            this.inner = new ConcatMapInner<R>(this);
+            this.errors = new AtomicThrowable();
+        }
+
+        @Override
+        public final void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s))  {
+                this.s = s;
+
+                if (s instanceof QueueSubscription) {
+                    @SuppressWarnings("unchecked") QueueSubscription<T> f = (QueueSubscription<T>)s;
+                    int m = f.requestFusion(QueueSubscription.ANY);
+                    if (m == QueueSubscription.SYNC) {
+                        sourceMode = m;
+                        queue = f;
+                        done = true;
+
+                        subscribeActual();
+
+                        drain();
+                        return;
+                    }
+                    if (m == QueueSubscription.ASYNC) {
+                        sourceMode = m;
+                        queue = f;
+
+                        subscribeActual();
+
+                        s.request(prefetch);
+                        return;
+                    }
+                }
+
+                queue = new SpscArrayQueue<T>(prefetch);
+
+                subscribeActual();
+
+                s.request(prefetch);
+            }
+        }
+
+        abstract void drain();
+
+        abstract void subscribeActual();
+
+        @Override
+        public final void onNext(T t) {
+            if (sourceMode != QueueSubscription.ASYNC) {
+                if (!queue.offer(t)) {
+                    s.cancel();
+                    onError(new IllegalStateException("Queue full?!"));
+                    return;
+                }
+            }
+            drain();
+        }
+
+        @Override
+        public final void onComplete() {
+            done = true;
+            drain();
+        }
+
+        @Override
+        public final void innerComplete() {
+            active = false;
+            drain();
+        }
+
+    }
+
+
+    static final class ConcatMapImmediate<T, R>
+    extends BaseConcatMapSubscriber<T, R> {
+
+
+        private static final long serialVersionUID = 7898995095634264146L;
+
+        final Subscriber<? super R> actual;
+
+        final AtomicInteger wip;
+
+        ConcatMapImmediate(Subscriber<? super R> actual,
+                Function<? super T, ? extends Publisher<? extends R>> mapper,
+                int prefetch) {
+            super(mapper, prefetch);
+            this.actual = actual;
+            this.wip = new AtomicInteger();
+        }
+
+        @Override
+        void subscribeActual() {
+            actual.onSubscribe(this);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (errors.addThrowable(t)) {
+                inner.cancel();
+
+                if (getAndIncrement() == 0) {
+                    actual.onError(errors.terminate());
+                }
+            } else {
+                RxJavaPlugins.onError(t);
+            }
+        }
+
+        @Override
+        public void innerNext(R value) {
+            if (get() == 0 && compareAndSet(0, 1)) {
+                actual.onNext(value);
+                if (compareAndSet(1, 0)) {
+                    return;
+                }
+                actual.onError(errors.terminate());
+            }
+        }
+
+        @Override
+        public void innerError(Throwable e) {
+            if (errors.addThrowable(e)) {
+                s.cancel();
+
+                if (getAndIncrement() == 0) {
+                    actual.onError(errors.terminate());
+                }
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            inner.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+
+                inner.cancel();
+                s.cancel();
+            }
+        }
+
+        @Override
+        void drain() {
+            if (wip.getAndIncrement() == 0) {
+                for (;;) {
+                    if (cancelled) {
+                        return;
+                    }
+
+                    if (!active) {
+                        boolean d = done;
+
+                        T v;
+
+                        try {
+                            v = queue.poll();
+                        } catch (Throwable e) {
+                            Exceptions.throwIfFatal(e);
+                            s.cancel();
+                            errors.addThrowable(e);
+                            actual.onError(errors.terminate());
+                            return;
+                        }
+
+                        boolean empty = v == null;
+
+                        if (d && empty) {
+                            actual.onComplete();
+                            return;
+                        }
+
+                        if (!empty) {
+                            Publisher<? extends R> p;
+
+                            try {
+                                p = ObjectHelper.requireNonNull(mapper.apply(v), "The mapper returned a null Publisher");
+                            } catch (Throwable e) {
+                                Exceptions.throwIfFatal(e);
+
+                                s.cancel();
+                                errors.addThrowable(e);
+                                actual.onError(errors.terminate());
+                                return;
+                            }
+
+                            if (sourceMode != QueueSubscription.SYNC) {
+                                int c = consumed + 1;
+                                if (c == limit) {
+                                    consumed = 0;
+                                    s.request(c);
+                                } else {
+                                    consumed = c;
+                                }
+                            }
+
+
+                            if (p instanceof Callable) {
+                                @SuppressWarnings("unchecked")
+                                Callable<R> callable = (Callable<R>) p;
+
+                                R vr;
+
+                                try {
+                                    vr = callable.call();
+                                } catch (Throwable e) {
+                                    Exceptions.throwIfFatal(e);
+                                    s.cancel();
+                                    errors.addThrowable(e);
+                                    actual.onError(errors.terminate());
+                                    return;
+                                }
+
+
+                                if (vr == null) {
+                                    continue;
+                                }
+
+                                if (inner.isUnbounded()) {
+                                    if (get() == 0 && compareAndSet(0, 1)) {
+                                        actual.onNext(vr);
+                                        if (!compareAndSet(1, 0)) {
+                                            actual.onError(errors.terminate());
+                                            return;
+                                        }
+                                    }
+                                    continue;
+                                } else {
+                                    active = true;
+                                    inner.setSubscription(new WeakScalarSubscription<R>(vr, inner));
+                                }
+
+                            } else {
+                                active = true;
+                                p.subscribe(inner);
+                            }
+                        }
+                    }
+                    if (wip.decrementAndGet() == 0) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    static final class WeakScalarSubscription<T> implements Subscription {
+        final Subscriber<? super T> actual;
+        final T value;
+        boolean once;
+
+        WeakScalarSubscription(T value, Subscriber<? super T> actual) {
+            this.value = value;
+            this.actual = actual;
+        }
+
+        @Override
+        public void request(long n) {
+            if (n > 0 && !once) {
+                once = true;
+                Subscriber<? super T> a = actual;
+                a.onNext(value);
+                a.onComplete();
+            }
+        }
+
+        @Override
+        public void cancel() {
+
+        }
+    }
+
+    static final class ConcatMapDelayed<T, R>
+    extends BaseConcatMapSubscriber<T, R> {
+
+
+        private static final long serialVersionUID = -2945777694260521066L;
+
+        final Subscriber<? super R> actual;
+
+        final boolean veryEnd;
+
+        ConcatMapDelayed(Subscriber<? super R> actual,
+                Function<? super T, ? extends Publisher<? extends R>> mapper,
+                int prefetch, boolean veryEnd) {
+            super(mapper, prefetch);
+            this.actual = actual;
+            this.veryEnd = veryEnd;
+        }
+
+        @Override
+        void subscribeActual() {
+            actual.onSubscribe(this);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (errors.addThrowable(t)) {
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(t);
+            }
+        }
+
+        @Override
+        public void innerNext(R value) {
+            actual.onNext(value);
+        }
+
+
+        @Override
+        public void innerError(Throwable e) {
+            if (errors.addThrowable(e)) {
+                if (!veryEnd) {
+                    s.cancel();
+                    done = true;
+                }
+                active = false;
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            inner.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+
+                inner.cancel();
+                s.cancel();
+            }
+        }
+
+        @Override
+        void drain() {
+            if (getAndIncrement() == 0) {
+
+                for (;;) {
+                    if (cancelled) {
+                        return;
+                    }
+
+                    if (!active) {
+
+                        boolean d = done;
+
+                        if (d && !veryEnd) {
+                            Throwable ex = errors.get();
+                            if (ex != null) {
+                                actual.onError(errors.terminate());
+                                return;
+                            }
+                        }
+
+                        T v;
+
+                        try {
+                            v = queue.poll();
+                        } catch (Throwable e) {
+                            Exceptions.throwIfFatal(e);
+                            s.cancel();
+                            errors.addThrowable(e);
+                            actual.onError(errors.terminate());
+                            return;
+                        }
+
+                        boolean empty = v == null;
+
+                        if (d && empty) {
+                            Throwable ex = errors.terminate();
+                            if (ex != null) {
+                                actual.onError(ex);
+                            } else {
+                                actual.onComplete();
+                            }
+                            return;
+                        }
+
+                        if (!empty) {
+                            Publisher<? extends R> p;
+
+                            try {
+                                p = ObjectHelper.requireNonNull(mapper.apply(v), "The mapper returned a null Publisher");
+                            } catch (Throwable e) {
+                                Exceptions.throwIfFatal(e);
+
+                                s.cancel();
+                                errors.addThrowable(e);
+                                actual.onError(errors.terminate());
+                                return;
+                            }
+
+                            if (sourceMode != QueueSubscription.SYNC) {
+                                int c = consumed + 1;
+                                if (c == limit) {
+                                    consumed = 0;
+                                    s.request(c);
+                                } else {
+                                    consumed = c;
+                                }
+                            }
+
+                            if (p instanceof Callable) {
+                                @SuppressWarnings("unchecked")
+                                Callable<R> supplier = (Callable<R>) p;
+
+                                R vr;
+
+                                try {
+                                    vr = supplier.call();
+                                } catch (Throwable e) {
+                                    Exceptions.throwIfFatal(e);
+                                    s.cancel();
+                                    errors.addThrowable(e);
+                                    actual.onError(errors.terminate());
+                                    return;
+                                }
+
+                                if (vr == null) {
+                                    continue;
+                                }
+
+                                if (inner.isUnbounded()) {
+                                    actual.onNext(vr);
+                                    continue;
+                                } else {
+                                    active = true;
+                                    inner.setSubscription(new WeakScalarSubscription<R>(vr, inner));
+                                }
+                            } else {
+                                active = true;
+                                p.subscribe(inner);
+                            }
+                        }
+                    }
+                    if (decrementAndGet() == 0) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    interface ConcatMapSupport<T> {
+
+        void innerNext(T value);
+
+        void innerComplete();
+
+        void innerError(Throwable e);
+    }
+
+    static final class ConcatMapInner<R>
+    extends SubscriptionArbiter
+    implements FlowableSubscriber<R> {
+
+
+        private static final long serialVersionUID = 897683679971470653L;
+
+        final ConcatMapSupport<R> parent;
+
+        long produced;
+
+        ConcatMapInner(ConcatMapSupport<R> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            setSubscription(s);
+        }
+
+        @Override
+        public void onNext(R t) {
+            produced++;
+
+            parent.innerNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            long p = produced;
+
+            if (p != 0L) {
+                produced = 0L;
+                produced(p);
+            }
+
+            parent.innerError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            long p = produced;
+
+            if (p != 0L) {
+                produced = 0L;
+                produced(p);
+            }
+
+            parent.innerComplete();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCount.java
@@ -15,11 +15,12 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.*;
 
 public final class FlowableCount<T> extends AbstractFlowableWithUpstream<T, Long> {
 
-    public FlowableCount(Publisher<T> source) {
+    public FlowableCount(Flowable<T> source) {
         super(source);
     }
 
@@ -29,7 +30,7 @@ public final class FlowableCount<T> extends AbstractFlowableWithUpstream<T, Long
     }
 
     static final class CountSubscriber extends DeferredScalarSubscription<Long>
-    implements Subscriber<Object> {
+    implements FlowableSubscriber<Object> {
 
 
         private static final long serialVersionUID = 4973004223787171406L;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCountSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCountSingle.java
@@ -23,9 +23,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableCountSingle<T> extends Single<Long> implements FuseToFlowable<Long> {
 
-    final Publisher<T> source;
+    final Flowable<T> source;
 
-    public FlowableCountSingle(Publisher<T> source) {
+    public FlowableCountSingle(Flowable<T> source) {
         this.source = source;
     }
 
@@ -39,7 +39,7 @@ public final class FlowableCountSingle<T> extends Single<Long> implements FuseTo
         return RxJavaPlugins.onAssembly(new FlowableCount<T>(source));
     }
 
-    static final class CountSubscriber implements Subscriber<Object>, Disposable {
+    static final class CountSubscriber implements FlowableSubscriber<Object>, Disposable {
 
         final SingleObserver<? super Long> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
@@ -30,7 +31,7 @@ import io.reactivex.subscribers.*;
 public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T, T> {
     final Function<? super T, ? extends Publisher<U>> debounceSelector;
 
-    public FlowableDebounce(Publisher<T> source, Function<? super T, ? extends Publisher<U>> debounceSelector) {
+    public FlowableDebounce(Flowable<T> source, Function<? super T, ? extends Publisher<U>> debounceSelector) {
         super(source);
         this.debounceSelector = debounceSelector;
     }
@@ -41,7 +42,7 @@ public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T
     }
 
     static final class DebounceSubscriber<T, U> extends AtomicLong
-    implements Subscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = 6725975399620862591L;
         final Subscriber<? super T> actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Scheduler;
+import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.MissingBackpressureException;
@@ -33,7 +33,7 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
     final TimeUnit unit;
     final Scheduler scheduler;
 
-    public FlowableDebounceTimed(Publisher<T> source, long timeout, TimeUnit unit, Scheduler scheduler) {
+    public FlowableDebounceTimed(Flowable<T> source, long timeout, TimeUnit unit, Scheduler scheduler) {
         super(source);
         this.timeout = timeout;
         this.unit = unit;
@@ -48,7 +48,7 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
     }
 
     static final class DebounceTimedSubscriber<T> extends AtomicLong
-    implements Subscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -9102637559663639004L;
         final Subscriber<? super T> actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDefer.java
@@ -13,13 +13,13 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 
 public final class FlowableDefer<T> extends Flowable<T> {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
@@ -28,7 +28,7 @@ public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
     final Scheduler scheduler;
     final boolean delayError;
 
-    public FlowableDelay(Publisher<T> source, long delay, TimeUnit unit, Scheduler scheduler, boolean delayError) {
+    public FlowableDelay(Flowable<T> source, long delay, TimeUnit unit, Scheduler scheduler, boolean delayError) {
         super(source);
         this.delay = delay;
         this.unit = unit;
@@ -50,7 +50,7 @@ public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
         source.subscribe(new DelaySubscriber<T>(s, delay, unit, w, delayError));
     }
 
-    static final class DelaySubscriber<T> implements Subscriber<T>, Subscription {
+    static final class DelaySubscriber<T> implements FlowableSubscriber<T>, Subscription {
         final Subscriber<? super T> actual;
         final long delay;
         final TimeUnit unit;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
@@ -14,7 +14,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -38,7 +38,7 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
         final SubscriptionArbiter serial = new SubscriptionArbiter();
         child.onSubscribe(serial);
 
-        Subscriber<U> otherSubscriber = new Subscriber<U>() {
+        FlowableSubscriber<U> otherSubscriber = new FlowableSubscriber<U>() {
             boolean done;
 
             @Override
@@ -79,7 +79,7 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
                 }
                 done = true;
 
-                main.subscribe(new Subscriber<T>() {
+                main.subscribe(new FlowableSubscriber<T>() {
                     @Override
                     public void onSubscribe(Subscription s) {
                         serial.setSubscription(s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDematerialize.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDematerialize.java
@@ -21,7 +21,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableDematerialize<T> extends AbstractFlowableWithUpstream<Notification<T>, T> {
 
-    public FlowableDematerialize(Publisher<Notification<T>> source) {
+    public FlowableDematerialize(Flowable<Notification<T>> source) {
         super(source);
     }
 
@@ -30,7 +30,7 @@ public final class FlowableDematerialize<T> extends AbstractFlowableWithUpstream
         source.subscribe(new DematerializeSubscriber<T>(s));
     }
 
-    static final class DematerializeSubscriber<T> implements Subscriber<Notification<T>>, Subscription {
+    static final class DematerializeSubscriber<T> implements FlowableSubscriber<Notification<T>>, Subscription {
         final Subscriber<? super T> actual;
 
         boolean done;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDetach.java
@@ -15,12 +15,13 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.EmptyComponent;
 
 public final class FlowableDetach<T> extends AbstractFlowableWithUpstream<T, T> {
 
-    public FlowableDetach(Publisher<T> source) {
+    public FlowableDetach(Flowable<T> source) {
         super(source);
     }
 
@@ -29,7 +30,7 @@ public final class FlowableDetach<T> extends AbstractFlowableWithUpstream<T, T> 
         source.subscribe(new DetachSubscriber<T>(s));
     }
 
-    static final class DetachSubscriber<T> implements Subscriber<T>, Subscription {
+    static final class DetachSubscriber<T> implements FlowableSubscriber<T>, Subscription {
 
         Subscriber<? super T> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -16,9 +16,10 @@ package io.reactivex.internal.operators.flowable;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
-import io.reactivex.annotations.Nullable;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
 
+import io.reactivex.Flowable;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -33,7 +34,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
 
     final Callable<? extends Collection<? super K>> collectionSupplier;
 
-    public FlowableDistinct(Publisher<T> source, Function<? super T, K> keySelector, Callable<? extends Collection<? super K>> collectionSupplier) {
+    public FlowableDistinct(Flowable<T> source, Function<? super T, K> keySelector, Callable<? extends Collection<? super K>> collectionSupplier) {
         super(source);
         this.keySelector = keySelector;
         this.collectionSupplier = collectionSupplier;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
@@ -13,9 +13,10 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.annotations.Nullable;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
 
+import io.reactivex.Flowable;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscribers.*;
@@ -26,7 +27,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
 
     final BiPredicate<? super K, ? super K> comparer;
 
-    public FlowableDistinctUntilChanged(Publisher<T> source, Function<? super T, K> keySelector, BiPredicate<? super K, ? super K> comparer) {
+    public FlowableDistinctUntilChanged(Flowable<T> source, Function<? super T, K> keySelector, BiPredicate<? super K, ? super K> comparer) {
         super(source);
         this.keySelector = keySelector;
         this.comparer = comparer;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
@@ -13,10 +13,10 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.annotations.Nullable;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
 
-import io.reactivex.annotations.Experimental;
+import io.reactivex.Flowable;
+import io.reactivex.annotations.*;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscribers.*;
@@ -31,7 +31,7 @@ public final class FlowableDoAfterNext<T> extends AbstractFlowableWithUpstream<T
 
     final Consumer<? super T> onAfterNext;
 
-    public FlowableDoAfterNext(Publisher<T> source, Consumer<? super T> onAfterNext) {
+    public FlowableDoAfterNext(Flowable<T> source, Consumer<? super T> onAfterNext) {
         super(source);
         this.onAfterNext = onAfterNext;
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoFinally.java
@@ -13,10 +13,10 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
-import io.reactivex.annotations.Experimental;
+import io.reactivex.*;
+import io.reactivex.annotations.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;
 import io.reactivex.internal.fuseable.*;
@@ -34,7 +34,7 @@ public final class FlowableDoFinally<T> extends AbstractFlowableWithUpstream<T, 
 
     final Action onFinally;
 
-    public FlowableDoFinally(Publisher<T> source, Action onFinally) {
+    public FlowableDoFinally(Flowable<T> source, Action onFinally) {
         super(source);
         this.onFinally = onFinally;
     }
@@ -48,7 +48,7 @@ public final class FlowableDoFinally<T> extends AbstractFlowableWithUpstream<T, 
         }
     }
 
-    static final class DoFinallySubscriber<T> extends BasicIntQueueSubscription<T> implements Subscriber<T> {
+    static final class DoFinallySubscriber<T> extends BasicIntQueueSubscription<T> implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = 4109457741734051389L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
@@ -13,9 +13,10 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.annotations.Nullable;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
 
+import io.reactivex.Flowable;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
@@ -28,7 +29,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
     final Action onComplete;
     final Action onAfterTerminate;
 
-    public FlowableDoOnEach(Publisher<T> source, Consumer<? super T> onNext,
+    public FlowableDoOnEach(Flowable<T> source, Consumer<? super T> onNext,
             Consumer<? super Throwable> onError,
             Action onComplete,
             Action onAfterTerminate) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
@@ -14,7 +14,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.*;
@@ -38,7 +38,7 @@ public final class FlowableDoOnLifecycle<T> extends AbstractFlowableWithUpstream
         source.subscribe(new SubscriptionLambdaSubscriber<T>(s, onSubscribe, onRequest, onCancel));
     }
 
-    static final class SubscriptionLambdaSubscriber<T> implements Subscriber<T>, Subscription {
+    static final class SubscriptionLambdaSubscriber<T> implements FlowableSubscriber<T>, Subscription {
         final Subscriber<? super T> actual;
         final Consumer<? super Subscription> onSubscribe;
         final LongConsumer onRequest;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAt.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAt.java
@@ -17,6 +17,7 @@ import java.util.NoSuchElementException;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -25,7 +26,7 @@ public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, 
     final T defaultValue;
     final boolean errorOnFewer;
 
-    public FlowableElementAt(Publisher<T> source, long index, T defaultValue, boolean errorOnFewer) {
+    public FlowableElementAt(Flowable<T> source, long index, T defaultValue, boolean errorOnFewer) {
         super(source);
         this.index = index;
         this.defaultValue = defaultValue;
@@ -37,7 +38,7 @@ public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, 
         source.subscribe(new ElementAtSubscriber<T>(s, index, defaultValue, errorOnFewer));
     }
 
-    static final class ElementAtSubscriber<T> extends DeferredScalarSubscription<T> implements Subscriber<T> {
+    static final class ElementAtSubscriber<T> extends DeferredScalarSubscription<T> implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = 4066607327284737757L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtMaybe.java
@@ -22,11 +22,11 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableElementAtMaybe<T> extends Maybe<T> implements FuseToFlowable<T> {
-    final Publisher<T> source;
+    final Flowable<T> source;
 
     final long index;
 
-    public FlowableElementAtMaybe(Publisher<T> source, long index) {
+    public FlowableElementAtMaybe(Flowable<T> source, long index) {
         this.source = source;
         this.index = index;
     }
@@ -41,7 +41,7 @@ public final class FlowableElementAtMaybe<T> extends Maybe<T> implements FuseToF
         return RxJavaPlugins.onAssembly(new FlowableElementAt<T>(source, index, null, false));
     }
 
-    static final class ElementAtSubscriber<T> implements Subscriber<T>, Disposable {
+    static final class ElementAtSubscriber<T> implements FlowableSubscriber<T>, Disposable {
 
         final MaybeObserver<? super T> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtSingle.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.NoSuchElementException;
+
 import org.reactivestreams.*;
 
 import io.reactivex.*;
@@ -23,13 +24,13 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableElementAtSingle<T> extends Single<T> implements FuseToFlowable<T> {
-    final Publisher<T> source;
+    final Flowable<T> source;
 
     final long index;
 
     final T defaultValue;
 
-    public FlowableElementAtSingle(Publisher<T> source, long index, T defaultValue) {
+    public FlowableElementAtSingle(Flowable<T> source, long index, T defaultValue) {
         this.source = source;
         this.index = index;
         this.defaultValue = defaultValue;
@@ -45,7 +46,7 @@ public final class FlowableElementAtSingle<T> extends Single<T> implements FuseT
         return RxJavaPlugins.onAssembly(new FlowableElementAt<T>(source, index, defaultValue, true));
     }
 
-    static final class ElementAtSubscriber<T> implements Subscriber<T>, Disposable {
+    static final class ElementAtSubscriber<T> implements FlowableSubscriber<T>, Disposable {
 
         final SingleObserver<? super T> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableError.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableError.java
@@ -13,13 +13,13 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.concurrent.Callable;
 
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 
 public final class FlowableError<T> extends Flowable<T> {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
@@ -13,16 +13,17 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.annotations.Nullable;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
 
+import io.reactivex.Flowable;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscribers.*;
 
 public final class FlowableFilter<T> extends AbstractFlowableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
-    public FlowableFilter(Publisher<T> source, Predicate<? super T> predicate) {
+    public FlowableFilter(Flowable<T> source, Predicate<? super T> predicate) {
         super(source);
         this.predicate = predicate;
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
@@ -34,7 +35,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
     final int maxConcurrency;
     final int bufferSize;
 
-    public FlowableFlatMap(Publisher<T> source,
+    public FlowableFlatMap(Flowable<T> source,
             Function<? super T, ? extends Publisher<? extends U>> mapper,
             boolean delayErrors, int maxConcurrency, int bufferSize) {
         super(source);
@@ -52,13 +53,13 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
         source.subscribe(subscribe(s, mapper, delayErrors, maxConcurrency, bufferSize));
     }
 
-    public static <T, U> Subscriber<T> subscribe(Subscriber<? super U> s,
+    public static <T, U> FlowableSubscriber<T> subscribe(Subscriber<? super U> s,
             Function<? super T, ? extends Publisher<? extends U>> mapper,
             boolean delayErrors, int maxConcurrency, int bufferSize) {
         return new MergeSubscriber<T, U>(s, mapper, delayErrors, maxConcurrency, bufferSize);
     }
 
-    static final class MergeSubscriber<T, U> extends AtomicInteger implements Subscription, Subscriber<T> {
+    static final class MergeSubscriber<T, U> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -2117620485640801370L;
 
@@ -581,7 +582,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
     }
 
     static final class InnerSubscriber<T, U> extends AtomicReference<Subscription>
-    implements Subscriber<U>, Disposable {
+    implements FlowableSubscriber<U>, Disposable {
 
         private static final long serialVersionUID = -4606175640614850599L;
         final long id;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
@@ -15,10 +15,10 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -40,7 +40,7 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
 
     final boolean delayErrors;
 
-    public FlowableFlatMapCompletable(Publisher<T> source,
+    public FlowableFlatMapCompletable(Flowable<T> source,
             Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors,
             int maxConcurrency) {
         super(source);
@@ -55,7 +55,7 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
     }
 
     static final class FlatMapCompletableMainSubscriber<T> extends BasicIntQueueSubscription<T>
-    implements Subscriber<T> {
+    implements FlowableSubscriber<T> {
         private static final long serialVersionUID = 8443155186132538303L;
 
         final Subscriber<? super T> actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
@@ -34,7 +34,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  */
 public final class FlowableFlatMapCompletableCompletable<T> extends Completable implements FuseToFlowable<T> {
 
-    final Publisher<T> source;
+    final Flowable<T> source;
 
     final Function<? super T, ? extends CompletableSource> mapper;
 
@@ -42,7 +42,7 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
 
     final boolean delayErrors;
 
-    public FlowableFlatMapCompletableCompletable(Publisher<T> source,
+    public FlowableFlatMapCompletableCompletable(Flowable<T> source,
             Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors,
             int maxConcurrency) {
         this.source = source;
@@ -62,7 +62,7 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
     }
 
     static final class FlatMapCompletableMainSubscriber<T> extends AtomicInteger
-    implements Subscriber<T>, Disposable {
+    implements FlowableSubscriber<T>, Disposable {
         private static final long serialVersionUID = 8443155186132538303L;
 
         final CompletableObserver actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -41,7 +41,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
 
     final int maxConcurrency;
 
-    public FlowableFlatMapMaybe(Publisher<T> source, Function<? super T, ? extends MaybeSource<? extends R>> mapper,
+    public FlowableFlatMapMaybe(Flowable<T> source, Function<? super T, ? extends MaybeSource<? extends R>> mapper,
             boolean delayError, int maxConcurrency) {
         super(source);
         this.mapper = mapper;
@@ -56,7 +56,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
 
     static final class FlatMapMaybeSubscriber<T, R>
     extends AtomicInteger
-    implements Subscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = 8600231336733376951L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapPublisher.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+
+public final class FlowableFlatMapPublisher<T, U> extends Flowable<U> {
+    final Publisher<T> source;
+    final Function<? super T, ? extends Publisher<? extends U>> mapper;
+    final boolean delayErrors;
+    final int maxConcurrency;
+    final int bufferSize;
+
+    public FlowableFlatMapPublisher(Publisher<T> source,
+            Function<? super T, ? extends Publisher<? extends U>> mapper,
+            boolean delayErrors, int maxConcurrency, int bufferSize) {
+        this.source = source;
+        this.mapper = mapper;
+        this.delayErrors = delayErrors;
+        this.maxConcurrency = maxConcurrency;
+        this.bufferSize = bufferSize;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super U> s) {
+        if (FlowableScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
+            return;
+        }
+        source.subscribe(FlowableFlatMap.subscribe(s, mapper, delayErrors, maxConcurrency, bufferSize));
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -41,7 +41,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
 
     final int maxConcurrency;
 
-    public FlowableFlatMapSingle(Publisher<T> source, Function<? super T, ? extends SingleSource<? extends R>> mapper,
+    public FlowableFlatMapSingle(Flowable<T> source, Function<? super T, ? extends SingleSource<? extends R>> mapper,
             boolean delayError, int maxConcurrency) {
         super(source);
         this.mapper = mapper;
@@ -56,7 +56,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
 
     static final class FlatMapSingleSubscriber<T, R>
     extends AtomicInteger
-    implements Subscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = 8600231336733376951L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
@@ -17,9 +17,10 @@ import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
+import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.fuseable.*;
@@ -34,7 +35,7 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
 
     final int prefetch;
 
-    public FlowableFlattenIterable(Publisher<T> source,
+    public FlowableFlattenIterable(Flowable<T> source,
             Function<? super T, ? extends Iterable<? extends R>> mapper, int prefetch) {
         super(source);
         this.mapper = mapper;
@@ -81,7 +82,7 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
 
     static final class FlattenIterableSubscriber<T, R>
     extends BasicIntQueueSubscription<R>
-    implements Subscriber<T> {
+    implements FlowableSubscriber<T> {
 
 
         private static final long serialVersionUID = -3096000382929934955L;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
@@ -13,10 +13,10 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.*;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
@@ -15,10 +15,10 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.Iterator;
 
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromObservable.java
@@ -12,12 +12,10 @@
  */
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.Flowable;
-import io.reactivex.Observable;
-import io.reactivex.Observer;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 
 public final class FlowableFromObservable<T> extends Flowable<T> {
     private final Observable<T> upstream;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
@@ -17,9 +17,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
+import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.flowables.GroupedFlowable;
 import io.reactivex.functions.Function;
@@ -35,7 +36,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
     final int bufferSize;
     final boolean delayError;
 
-    public FlowableGroupBy(Publisher<T> source, Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError) {
+    public FlowableGroupBy(Flowable<T> source, Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError) {
         super(source);
         this.keySelector = keySelector;
         this.valueSelector = valueSelector;
@@ -50,7 +51,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
 
     public static final class GroupBySubscriber<T, K, V>
     extends BasicIntQueueSubscription<GroupedFlowable<K, V>>
-    implements Subscriber<T> {
+    implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -3688291656102519502L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupJoin.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
@@ -44,7 +44,7 @@ public final class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> exte
     final BiFunction<? super TLeft, ? super Flowable<TRight>, ? extends R> resultSelector;
 
     public FlowableGroupJoin(
-            Publisher<TLeft> source,
+            Flowable<TLeft> source,
             Publisher<? extends TRight> other,
             Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd,
             Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
@@ -392,7 +392,7 @@ public final class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> exte
 
     static final class LeftRightSubscriber
     extends AtomicReference<Subscription>
-    implements Subscriber<Object>, Disposable {
+    implements FlowableSubscriber<Object>, Disposable {
 
         private static final long serialVersionUID = 1883890389173668373L;
 
@@ -441,7 +441,7 @@ public final class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> exte
 
     static final class LeftRightEndSubscriber
     extends AtomicReference<Subscription>
-    implements Subscriber<Object>, Disposable {
+    implements FlowableSubscriber<Object>, Disposable {
 
         private static final long serialVersionUID = 1883890389173668373L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableHide.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableHide.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 /**
@@ -25,7 +26,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
  */
 public final class FlowableHide<T> extends AbstractFlowableWithUpstream<T, T> {
 
-    public FlowableHide(Publisher<T> source) {
+    public FlowableHide(Flowable<T> source) {
         super(source);
     }
 
@@ -34,7 +35,7 @@ public final class FlowableHide<T> extends AbstractFlowableWithUpstream<T, T> {
         source.subscribe(new HideSubscriber<T>(s));
     }
 
-    static final class HideSubscriber<T> implements Subscriber<T>, Subscription {
+    static final class HideSubscriber<T> implements FlowableSubscriber<T>, Subscription {
 
         final Subscriber<? super T> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElements.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElements.java
@@ -13,15 +13,16 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
+import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 public final class FlowableIgnoreElements<T> extends AbstractFlowableWithUpstream<T, T> {
 
-    public FlowableIgnoreElements(Publisher<T> source) {
+    public FlowableIgnoreElements(Flowable<T> source) {
         super(source);
     }
 
@@ -30,7 +31,7 @@ public final class FlowableIgnoreElements<T> extends AbstractFlowableWithUpstrea
         source.subscribe(new IgnoreElementsSubscriber<T>(t));
     }
 
-    static final class IgnoreElementsSubscriber<T> implements QueueSubscription<T>, Subscriber<T> {
+    static final class IgnoreElementsSubscriber<T> implements FlowableSubscriber<T>, QueueSubscription<T> {
         final Subscriber<? super T> actual;
 
         Subscription s;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsCompletable.java
@@ -23,9 +23,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableIgnoreElementsCompletable<T> extends Completable implements FuseToFlowable<T> {
 
-    final Publisher<T> source;
+    final Flowable<T> source;
 
-    public FlowableIgnoreElementsCompletable(Publisher<T> source) {
+    public FlowableIgnoreElementsCompletable(Flowable<T> source) {
         this.source = source;
     }
 
@@ -39,7 +39,7 @@ public final class FlowableIgnoreElementsCompletable<T> extends Completable impl
         return RxJavaPlugins.onAssembly(new FlowableIgnoreElements<T>(source));
     }
 
-    static final class IgnoreElementsSubscriber<T> implements Subscriber<T>, Disposable {
+    static final class IgnoreElementsSubscriber<T> implements FlowableSubscriber<T>, Disposable {
         final CompletableObserver actual;
 
         Subscription s;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableInternalHelper.java
@@ -77,7 +77,7 @@ public final class FlowableInternalHelper {
 
         @Override
         public Publisher<T> apply(final T v) throws Exception {
-            return new FlowableTake<U>(itemDelay.apply(v), 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
+            return new FlowableTakePublisher<U>(itemDelay.apply(v), 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
         }
     }
 
@@ -165,7 +165,7 @@ public final class FlowableInternalHelper {
         public Publisher<R> apply(final T t) throws Exception {
             @SuppressWarnings("unchecked")
             Publisher<U> u = (Publisher<U>)mapper.apply(t);
-            return new FlowableMap<U, R>(u, new FlatMapWithCombinerInner<U, R, T>(combiner, t));
+            return new FlowableMapPublisher<U, R>(u, new FlatMapWithCombinerInner<U, R, T>(combiner, t));
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableInterval.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.MissingBackpressureException;
-import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableJoin.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.Flowable;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
@@ -40,7 +41,7 @@ public final class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends A
     final BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector;
 
     public FlowableJoin(
-            Publisher<TLeft> source,
+            Flowable<TLeft> source,
             Publisher<? extends TRight> other,
             Function<? super TLeft, ? extends Publisher<TLeftEnd>> leftEnd,
             Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastMaybe.java
@@ -39,7 +39,7 @@ public final class FlowableLastMaybe<T> extends Maybe<T> {
         source.subscribe(new LastSubscriber<T>(observer));
     }
 
-    static final class LastSubscriber<T> implements Subscriber<T>, Disposable {
+    static final class LastSubscriber<T> implements FlowableSubscriber<T>, Disposable {
 
         final MaybeObserver<? super T> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableLastSingle.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.NoSuchElementException;
+
 import org.reactivestreams.*;
 
 import io.reactivex.*;
@@ -44,7 +45,7 @@ public final class FlowableLastSingle<T> extends Single<T> {
         source.subscribe(new LastSubscriber<T>(observer, defaultItem));
     }
 
-    static final class LastSubscriber<T> implements Subscriber<T>, Disposable {
+    static final class LastSubscriber<T> implements FlowableSubscriber<T>, Disposable {
 
         final SingleObserver<? super T> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableLift.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableLift.java
@@ -13,9 +13,9 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
 
-import io.reactivex.FlowableOperator;
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -32,7 +32,7 @@ public final class FlowableLift<R, T> extends AbstractFlowableWithUpstream<T, R>
     /** The actual operator. */
     final FlowableOperator<? extends R, ? super T> operator;
 
-    public FlowableLift(Publisher<T> source, FlowableOperator<? extends R, ? super T> operator) {
+    public FlowableLift(Flowable<T> source, FlowableOperator<? extends R, ? super T> operator) {
         super(source);
         this.operator = operator;
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
@@ -14,9 +14,10 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.annotations.Nullable;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
 
+import io.reactivex.Flowable;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
@@ -24,7 +25,7 @@ import io.reactivex.internal.subscribers.*;
 
 public final class FlowableMap<T, U> extends AbstractFlowableWithUpstream<T, U> {
     final Function<? super T, ? extends U> mapper;
-    public FlowableMap(Publisher<T> source, Function<? super T, ? extends U> mapper) {
+    public FlowableMap(Flowable<T> source, Function<? super T, ? extends U> mapper) {
         super(source);
         this.mapper = mapper;
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
@@ -15,8 +15,9 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.concurrent.Callable;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
 
+import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -29,7 +30,7 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
     final Callable<? extends R> onCompleteSupplier;
 
     public FlowableMapNotification(
-            Publisher<T> source,
+            Flowable<T> source,
             Function<? super T, ? extends R> onNextMapper,
             Function<? super Throwable, ? extends R> onErrorMapper,
             Callable<? extends R> onCompleteSupplier) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapPublisher.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.internal.operators.flowable.FlowableMap.*;
+
+/**
+ * Map working with an arbitrary Publisher source.
+ *
+ * @param <T> the input value type
+ * @param <U> the output value type
+ * @since 2.0.7 - experimental
+ */
+public final class FlowableMapPublisher<T, U> extends Flowable<U> {
+
+    final Publisher<T> source;
+
+    final Function<? super T, ? extends U> mapper;
+    public FlowableMapPublisher(Publisher<T> source, Function<? super T, ? extends U> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super U> s) {
+        if (s instanceof ConditionalSubscriber) {
+            source.subscribe(new MapConditionalSubscriber<T, U>((ConditionalSubscriber<? super U>)s, mapper));
+        } else {
+            source.subscribe(new MapSubscriber<T, U>(s, mapper));
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMaterialize.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMaterialize.java
@@ -13,15 +13,15 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
 
-import io.reactivex.Notification;
+import io.reactivex.*;
 import io.reactivex.internal.subscribers.SinglePostCompleteSubscriber;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableMaterialize<T> extends AbstractFlowableWithUpstream<T, Notification<T>> {
 
-    public FlowableMaterialize(Publisher<T> source) {
+    public FlowableMaterialize(Flowable<T> source) {
         super(source);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableNever.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableNever.java
@@ -12,9 +12,10 @@
  */
 package io.reactivex.internal.operators.flowable;
 
+import org.reactivestreams.Subscriber;
+
 import io.reactivex.Flowable;
 import io.reactivex.internal.subscriptions.EmptySubscription;
-import org.reactivestreams.Subscriber;
 
 public final class FlowableNever extends Flowable<Object> {
     public static final Flowable<Object> INSTANCE = new FlowableNever();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
@@ -15,11 +15,11 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
-import io.reactivex.Scheduler;
+import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.*;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscArrayQueue;
@@ -35,7 +35,7 @@ final Scheduler scheduler;
     final int prefetch;
 
     public FlowableObserveOn(
-            Publisher<T> source,
+            Flowable<T> source,
             Scheduler scheduler,
             boolean delayError,
             int prefetch) {
@@ -59,7 +59,7 @@ final Scheduler scheduler;
 
     abstract static class BaseObserveOnSubscriber<T>
     extends BasicIntQueueSubscription<T>
-    implements Runnable, Subscriber<T> {
+    implements FlowableSubscriber<T>, Runnable {
         private static final long serialVersionUID = -8241002408341274697L;
 
         final Worker worker;
@@ -240,7 +240,7 @@ final Scheduler scheduler;
     }
 
     static final class ObserveOnSubscriber<T> extends BaseObserveOnSubscriber<T>
-    implements Subscriber<T> {
+    implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -4547113800637756442L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -15,12 +15,13 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
+import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Action;
-import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
 import io.reactivex.internal.queue.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -31,7 +32,7 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
     final boolean delayError;
     final Action onOverflow;
 
-    public FlowableOnBackpressureBuffer(Publisher<T> source, int bufferSize, boolean unbounded,
+    public FlowableOnBackpressureBuffer(Flowable<T> source, int bufferSize, boolean unbounded,
             boolean delayError, Action onOverflow) {
         super(source);
         this.bufferSize = bufferSize;
@@ -45,7 +46,7 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
         source.subscribe(new BackpressureBufferSubscriber<T>(s, bufferSize, unbounded, delayError, onOverflow));
     }
 
-    static final class BackpressureBufferSubscriber<T> extends BasicIntQueueSubscription<T> implements Subscriber<T> {
+    static final class BackpressureBufferSubscriber<T> extends BasicIntQueueSubscription<T> implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -2514538129242366402L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.BackpressureOverflowStrategy;
+import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Action;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -38,7 +38,7 @@ public final class FlowableOnBackpressureBufferStrategy<T> extends AbstractFlowa
 
     final BackpressureOverflowStrategy strategy;
 
-    public FlowableOnBackpressureBufferStrategy(Publisher<T> source,
+    public FlowableOnBackpressureBufferStrategy(Flowable<T> source,
             long bufferSize, Action onOverflow, BackpressureOverflowStrategy strategy) {
         super(source);
         this.bufferSize = bufferSize;
@@ -53,7 +53,7 @@ public final class FlowableOnBackpressureBufferStrategy<T> extends AbstractFlowa
 
     static final class OnBackpressureBufferStrategySubscriber<T>
     extends AtomicInteger
-    implements Subscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = 3240706908776709697L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDrop.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDrop.java
@@ -13,26 +13,27 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.plugins.RxJavaPlugins;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableOnBackpressureDrop<T> extends AbstractFlowableWithUpstream<T, T> implements Consumer<T> {
 
     final Consumer<? super T> onDrop;
 
-    public FlowableOnBackpressureDrop(Publisher<T> source) {
+    public FlowableOnBackpressureDrop(Flowable<T> source) {
         super(source);
         this.onDrop = this;
     }
 
-    public FlowableOnBackpressureDrop(Publisher<T> source, Consumer<? super T> onDrop) {
+    public FlowableOnBackpressureDrop(Flowable<T> source, Consumer<? super T> onDrop) {
         super(source);
         this.onDrop = onDrop;
     }
@@ -48,7 +49,7 @@ public final class FlowableOnBackpressureDrop<T> extends AbstractFlowableWithUps
     }
 
     static final class BackpressureDropSubscriber<T>
-    extends AtomicLong implements Subscriber<T>, Subscription {
+    extends AtomicLong implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -6246093802440953054L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureError.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureError.java
@@ -13,20 +13,20 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-
-import java.util.concurrent.atomic.AtomicLong;
 
 public final class FlowableOnBackpressureError<T> extends AbstractFlowableWithUpstream<T, T> {
 
 
-    public FlowableOnBackpressureError(Publisher<T> source) {
+    public FlowableOnBackpressureError(Flowable<T> source) {
         super(source);
     }
 
@@ -37,7 +37,7 @@ public final class FlowableOnBackpressureError<T> extends AbstractFlowableWithUp
     }
 
     static final class BackpressureErrorSubscriber<T>
-            extends AtomicLong implements Subscriber<T>, Subscription {
+            extends AtomicLong implements FlowableSubscriber<T>, Subscription {
         private static final long serialVersionUID = -3176480756392482682L;
 
         final Subscriber<? super T> actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatest.java
@@ -17,12 +17,13 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
 public final class FlowableOnBackpressureLatest<T> extends AbstractFlowableWithUpstream<T, T> {
 
-    public FlowableOnBackpressureLatest(Publisher<T> source) {
+    public FlowableOnBackpressureLatest(Flowable<T> source) {
         super(source);
     }
 
@@ -31,7 +32,7 @@ public final class FlowableOnBackpressureLatest<T> extends AbstractFlowableWithU
         source.subscribe(new BackpressureLatestSubscriber<T>(s));
     }
 
-    static final class BackpressureLatestSubscriber<T> extends AtomicInteger implements Subscriber<T>, Subscription {
+    static final class BackpressureLatestSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = 163080509307634843L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorNext.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
@@ -24,7 +25,7 @@ public final class FlowableOnErrorNext<T> extends AbstractFlowableWithUpstream<T
     final Function<? super Throwable, ? extends Publisher<? extends T>> nextSupplier;
     final boolean allowFatal;
 
-    public FlowableOnErrorNext(Publisher<T> source,
+    public FlowableOnErrorNext(Flowable<T> source,
             Function<? super Throwable, ? extends Publisher<? extends T>> nextSupplier, boolean allowFatal) {
         super(source);
         this.nextSupplier = nextSupplier;
@@ -38,7 +39,7 @@ public final class FlowableOnErrorNext<T> extends AbstractFlowableWithUpstream<T
         source.subscribe(parent);
     }
 
-    static final class OnErrorNextSubscriber<T> implements Subscriber<T> {
+    static final class OnErrorNextSubscriber<T> implements FlowableSubscriber<T> {
         final Subscriber<? super T> actual;
         final Function<? super Throwable, ? extends Publisher<? extends T>> nextSupplier;
         final boolean allowFatal;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturn.java
@@ -13,8 +13,9 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscriber;
 
+import io.reactivex.Flowable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -22,7 +23,7 @@ import io.reactivex.internal.subscribers.SinglePostCompleteSubscriber;
 
 public final class FlowableOnErrorReturn<T> extends AbstractFlowableWithUpstream<T, T> {
     final Function<? super Throwable, ? extends T> valueSupplier;
-    public FlowableOnErrorReturn(Publisher<T> source, Function<? super Throwable, ? extends T> valueSupplier) {
+    public FlowableOnErrorReturn(Flowable<T> source, Function<? super Throwable, ? extends T> valueSupplier) {
         super(source);
         this.valueSupplier = valueSupplier;
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublish.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublish.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.flowables.ConnectableFlowable;
@@ -41,7 +41,7 @@ public final class FlowablePublish<T> extends ConnectableFlowable<T> implements 
     static final long CANCELLED = Long.MIN_VALUE;
 
     /** The source observable. */
-    final Publisher<T> source;
+    final Flowable<T> source;
     /** Holds the current subscriber that is, will be or just was subscribed to the source observable. */
     final AtomicReference<PublishSubscriber<T>> current;
 
@@ -128,7 +128,7 @@ public final class FlowablePublish<T> extends ConnectableFlowable<T> implements 
         return RxJavaPlugins.onAssembly(new FlowablePublish<T>(onSubscribe, source, curr, bufferSize));
     }
 
-    private FlowablePublish(Publisher<T> onSubscribe, Publisher<T> source,
+    private FlowablePublish(Publisher<T> onSubscribe, Flowable<T> source,
             final AtomicReference<PublishSubscriber<T>> current, int bufferSize) {
         this.onSubscribe = onSubscribe;
         this.source = source;
@@ -198,7 +198,7 @@ public final class FlowablePublish<T> extends ConnectableFlowable<T> implements 
     @SuppressWarnings("rawtypes")
     static final class PublishSubscriber<T>
     extends AtomicInteger
-    implements Subscriber<T>, Disposable {
+    implements FlowableSubscriber<T>, Disposable {
         private static final long serialVersionUID = -202316842419149694L;
 
         /** Indicates an empty array of inner subscribers. */

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticast.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticast.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
@@ -44,7 +44,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
 
     final boolean delayError;
 
-    public FlowablePublishMulticast(Publisher<T> source,
+    public FlowablePublishMulticast(Flowable<T> source,
             Function<? super Flowable<T>, ? extends Publisher<? extends R>> selector, int prefetch,
             boolean delayError) {
         super(source);
@@ -74,7 +74,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
         source.subscribe(mp);
     }
 
-    static final class OutputCanceller<R> implements Subscriber<R>, Subscription {
+    static final class OutputCanceller<R> implements FlowableSubscriber<R>, Subscription {
         final Subscriber<? super R> actual;
 
         final MulticastProcessor<?> processor;
@@ -124,7 +124,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
         }
     }
 
-    static final class MulticastProcessor<T> extends Flowable<T> implements Subscriber<T>, Disposable {
+    static final class MulticastProcessor<T> extends Flowable<T> implements FlowableSubscriber<T>, Disposable {
 
         @SuppressWarnings("rawtypes")
         static final MulticastSubscription[] EMPTY = new MulticastSubscription[0];

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
@@ -13,10 +13,10 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRangeLong.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRangeLong.java
@@ -13,13 +13,13 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import org.reactivestreams.Subscriber;
+
 import io.reactivex.Flowable;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
-import io.reactivex.internal.subscriptions.BasicQueueSubscription;
-import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;
-import org.reactivestreams.Subscriber;
 
 /**
  * Emits a range of long values.

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduce.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduce.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -31,7 +32,7 @@ public final class FlowableReduce<T> extends AbstractFlowableWithUpstream<T, T> 
 
     final BiFunction<T, T, T> reducer;
 
-    public FlowableReduce(Publisher<T> source, BiFunction<T, T, T> reducer) {
+    public FlowableReduce(Flowable<T> source, BiFunction<T, T, T> reducer) {
         super(source);
         this.reducer = reducer;
     }
@@ -41,7 +42,7 @@ public final class FlowableReduce<T> extends AbstractFlowableWithUpstream<T, T> 
         source.subscribe(new ReduceSubscriber<T>(s, reducer));
     }
 
-    static final class ReduceSubscriber<T> extends DeferredScalarSubscription<T> implements Subscriber<T> {
+    static final class ReduceSubscriber<T> extends DeferredScalarSubscription<T> implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -4663883003264602070L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceMaybe.java
@@ -57,7 +57,7 @@ implements HasUpstreamPublisher<T>, FuseToFlowable<T> {
         source.subscribe(new ReduceSubscriber<T>(observer, reducer));
     }
 
-    static final class ReduceSubscriber<T> implements Subscriber<T>, Disposable {
+    static final class ReduceSubscriber<T> implements FlowableSubscriber<T>, Disposable {
         final MaybeObserver<? super T> actual;
 
         final BiFunction<T, T, T> reducer;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceSeedSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceSeedSingle.java
@@ -49,7 +49,7 @@ public final class FlowableReduceSeedSingle<T, R> extends Single<R> {
         source.subscribe(new ReduceSeedObserver<T, R>(observer, reducer, seed));
     }
 
-    static final class ReduceSeedObserver<T, R> implements Subscriber<T>, Disposable {
+    static final class ReduceSeedObserver<T, R> implements FlowableSubscriber<T>, Disposable {
 
         final SingleObserver<? super R> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
@@ -18,6 +18,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.reactivestreams.*;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.disposables.*;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.Consumer;
@@ -42,7 +43,7 @@ public final class FlowableRefCount<T> extends AbstractFlowableWithUpstream<T, T
 
     final class ConnectionSubscriber
     extends AtomicReference<Subscription>
-    implements Subscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = 152064694420235350L;
         final Subscriber<? super T> subscriber;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeat.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeat.java
@@ -17,11 +17,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
 public final class FlowableRepeat<T> extends AbstractFlowableWithUpstream<T, T> {
     final long count;
-    public FlowableRepeat(Publisher<T> source, long count) {
+    public FlowableRepeat(Flowable<T> source, long count) {
         super(source);
         this.count = count;
     }
@@ -36,7 +37,7 @@ public final class FlowableRepeat<T> extends AbstractFlowableWithUpstream<T, T> 
     }
 
     // FIXME update to a fresh Rsc algorithm
-    static final class RepeatSubscriber<T> extends AtomicInteger implements Subscriber<T> {
+    static final class RepeatSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -7098360935104053232L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatUntil.java
@@ -17,13 +17,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BooleanSupplier;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
 public final class FlowableRepeatUntil<T> extends AbstractFlowableWithUpstream<T, T> {
     final BooleanSupplier until;
-    public FlowableRepeatUntil(Publisher<T> source, BooleanSupplier until) {
+    public FlowableRepeatUntil(Flowable<T> source, BooleanSupplier until) {
         super(source);
         this.until = until;
     }
@@ -38,7 +39,7 @@ public final class FlowableRepeatUntil<T> extends AbstractFlowableWithUpstream<T
     }
 
     // FIXME update to a fresh Rsc algorithm
-    static final class RepeatSubscriber<T> extends AtomicInteger implements Subscriber<T> {
+    static final class RepeatSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -7098360935104053232L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -28,7 +28,7 @@ import io.reactivex.subscribers.SerializedSubscriber;
 public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T, T> {
     final Function<? super Flowable<Object>, ? extends Publisher<?>> handler;
 
-    public FlowableRepeatWhen(Publisher<T> source,
+    public FlowableRepeatWhen(Flowable<T> source,
             Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
         super(source);
         this.handler = handler;
@@ -66,7 +66,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
 
     static final class WhenReceiver<T, U>
     extends AtomicInteger
-    implements Subscriber<Object>, Subscription {
+    implements FlowableSubscriber<Object>, Subscription {
 
 
         private static final long serialVersionUID = 2827772011130406689L;
@@ -130,7 +130,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
         }
     }
 
-    abstract static class WhenSourceSubscriber<T, U> extends SubscriptionArbiter implements Subscriber<T> {
+    abstract static class WhenSourceSubscriber<T, U> extends SubscriptionArbiter implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -5604623027276966720L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -25,6 +24,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.HasUpstreamPublisher;
 import io.reactivex.internal.subscribers.SubscriberResourceWrapper;
 import io.reactivex.internal.subscriptions.*;
@@ -34,7 +34,7 @@ import io.reactivex.schedulers.Timed;
 
 public final class FlowableReplay<T> extends ConnectableFlowable<T> implements HasUpstreamPublisher<T> {
     /** The source observable. */
-    final Publisher<T> source;
+    final Flowable<T> source;
     /** Holds the current subscriber that is, will be or just was subscribed to the source observable. */
     final AtomicReference<ReplaySubscriber<T>> current;
     /** A factory that creates the appropriate buffer for the ReplaySubscriber. */
@@ -127,7 +127,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      * @return the new ConnectableObservable instance
      */
     @SuppressWarnings("unchecked")
-    public static <T> ConnectableFlowable<T> createFrom(Publisher<? extends T> source) {
+    public static <T> ConnectableFlowable<T> createFrom(Flowable<? extends T> source) {
         return create(source, DEFAULT_UNBOUNDED_FACTORY);
     }
 
@@ -138,7 +138,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      * @param bufferSize the maximum number of elements to hold
      * @return the new ConnectableObservable instance
      */
-    public static <T> ConnectableFlowable<T> create(Publisher<T> source,
+    public static <T> ConnectableFlowable<T> create(Flowable<T> source,
             final int bufferSize) {
         if (bufferSize == Integer.MAX_VALUE) {
             return createFrom(source);
@@ -160,7 +160,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      * @param scheduler the target scheduler providing the current time
      * @return the new ConnectableObservable instance
      */
-    public static <T> ConnectableFlowable<T> create(Publisher<T> source,
+    public static <T> ConnectableFlowable<T> create(Flowable<T> source,
             long maxAge, TimeUnit unit, Scheduler scheduler) {
         return create(source, maxAge, unit, scheduler, Integer.MAX_VALUE);
     }
@@ -175,7 +175,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      * @param bufferSize the maximum number of elements to hold
      * @return the new ConnectableFlowable instance
      */
-    public static <T> ConnectableFlowable<T> create(Publisher<T> source,
+    public static <T> ConnectableFlowable<T> create(Flowable<T> source,
             final long maxAge, final TimeUnit unit, final Scheduler scheduler, final int bufferSize) {
         return create(source, new Callable<ReplayBuffer<T>>() {
             @Override
@@ -191,7 +191,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      * @param bufferFactory the factory to instantiate the appropriate buffer when the observable becomes active
      * @return the connectable observable
      */
-    static <T> ConnectableFlowable<T> create(Publisher<T> source,
+    static <T> ConnectableFlowable<T> create(Flowable<T> source,
             final Callable<? extends ReplayBuffer<T>> bufferFactory) {
         // the current connection to source needs to be shared between the operator and its onSubscribe call
         final AtomicReference<ReplaySubscriber<T>> curr = new AtomicReference<ReplaySubscriber<T>>();
@@ -254,7 +254,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
         return RxJavaPlugins.onAssembly(new FlowableReplay<T>(onSubscribe, source, curr, bufferFactory));
     }
 
-    private FlowableReplay(Publisher<T> onSubscribe, Publisher<T> source,
+    private FlowableReplay(Publisher<T> onSubscribe, Flowable<T> source,
             final AtomicReference<ReplaySubscriber<T>> current,
             final Callable<? extends ReplayBuffer<T>> bufferFactory) {
         this.onSubscribe = onSubscribe;
@@ -338,7 +338,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
     @SuppressWarnings("rawtypes")
     static final class ReplaySubscriber<T>
     extends AtomicReference<Subscription>
-    implements Subscriber<T>, Disposable {
+    implements FlowableSubscriber<T>, Disposable {
         private static final long serialVersionUID = 7224554242710036740L;
         /** Holds notifications from upstream. */
         final ReplayBuffer<T> buffer;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryBiPredicate.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.BiPredicate;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
@@ -24,7 +25,7 @@ import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 public final class FlowableRetryBiPredicate<T> extends AbstractFlowableWithUpstream<T, T> {
     final BiPredicate<? super Integer, ? super Throwable> predicate;
     public FlowableRetryBiPredicate(
-            Publisher<T> source,
+            Flowable<T> source,
             BiPredicate<? super Integer, ? super Throwable> predicate) {
         super(source);
         this.predicate = predicate;
@@ -40,7 +41,7 @@ public final class FlowableRetryBiPredicate<T> extends AbstractFlowableWithUpstr
     }
 
     // FIXME update to a fresh Rsc algorithm
-    static final class RetryBiSubscriber<T> extends AtomicInteger implements Subscriber<T> {
+    static final class RetryBiSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -7098360935104053232L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryPredicate.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
@@ -24,7 +25,7 @@ import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 public final class FlowableRetryPredicate<T> extends AbstractFlowableWithUpstream<T, T> {
     final Predicate<? super Throwable> predicate;
     final long count;
-    public FlowableRetryPredicate(Publisher<T> source,
+    public FlowableRetryPredicate(Flowable<T> source,
             long count,
             Predicate<? super Throwable> predicate) {
         super(source);
@@ -42,7 +43,7 @@ public final class FlowableRetryPredicate<T> extends AbstractFlowableWithUpstrea
     }
 
     // FIXME update to a fresh Rsc algorithm
-    static final class RepeatSubscriber<T> extends AtomicInteger implements Subscriber<T> {
+    static final class RepeatSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -7098360935104053232L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryWhen.java
@@ -27,7 +27,7 @@ import io.reactivex.subscribers.SerializedSubscriber;
 public final class FlowableRetryWhen<T> extends AbstractFlowableWithUpstream<T, T> {
     final Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler;
 
-    public FlowableRetryWhen(Publisher<T> source,
+    public FlowableRetryWhen(Flowable<T> source,
             Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
         super(source);
         this.handler = handler;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSamplePublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSamplePublisher.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -45,7 +45,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
         }
     }
 
-    abstract static class SamplePublisherSubscriber<T> extends AtomicReference<T> implements Subscriber<T>, Subscription {
+    abstract static class SamplePublisherSubscriber<T> extends AtomicReference<T> implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -3517602651313910099L;
 
@@ -141,7 +141,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
         abstract void run();
     }
 
-    static final class SamplerSubscriber<T> implements Subscriber<Object> {
+    static final class SamplerSubscriber<T> implements FlowableSubscriber<Object> {
         final SamplePublisherSubscriber<T> parent;
         SamplerSubscriber(SamplePublisherSubscriber<T> parent) {
             this.parent = parent;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSampleTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSampleTimed.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Scheduler;
+import io.reactivex.*;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -32,7 +32,7 @@ public final class FlowableSampleTimed<T> extends AbstractFlowableWithUpstream<T
 
     final boolean emitLast;
 
-    public FlowableSampleTimed(Publisher<T> source, long period, TimeUnit unit, Scheduler scheduler, boolean emitLast) {
+    public FlowableSampleTimed(Flowable<T> source, long period, TimeUnit unit, Scheduler scheduler, boolean emitLast) {
         super(source);
         this.period = period;
         this.unit = unit;
@@ -50,7 +50,7 @@ public final class FlowableSampleTimed<T> extends AbstractFlowableWithUpstream<T
         }
     }
 
-    abstract static class SampleTimedSubscriber<T> extends AtomicReference<T> implements Subscriber<T>, Subscription, Runnable {
+    abstract static class SampleTimedSubscriber<T> extends AtomicReference<T> implements FlowableSubscriber<T>, Subscription, Runnable {
 
         private static final long serialVersionUID = -3517602651313910099L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScan.java
@@ -13,17 +13,18 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableScan<T> extends AbstractFlowableWithUpstream<T, T> {
     final BiFunction<T, T, T> accumulator;
-    public FlowableScan(Publisher<T> source, BiFunction<T, T, T> accumulator) {
+    public FlowableScan(Flowable<T> source, BiFunction<T, T, T> accumulator) {
         super(source);
         this.accumulator = accumulator;
     }
@@ -33,7 +34,7 @@ public final class FlowableScan<T> extends AbstractFlowableWithUpstream<T, T> {
         source.subscribe(new ScanSubscriber<T>(s, accumulator));
     }
 
-    static final class ScanSubscriber<T> implements Subscriber<T>, Subscription {
+    static final class ScanSubscriber<T> implements FlowableSubscriber<T>, Subscription {
         final Subscriber<? super T> actual;
         final BiFunction<T, T, T> accumulator;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -30,7 +31,7 @@ public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T
     final BiFunction<R, ? super T, R> accumulator;
     final Callable<R> seedSupplier;
 
-    public FlowableScanSeed(Publisher<T> source, Callable<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
+    public FlowableScanSeed(Flowable<T> source, Callable<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
         super(source);
         this.accumulator = accumulator;
         this.seedSupplier = seedSupplier;
@@ -53,7 +54,7 @@ public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T
 
     static final class ScanSeedSubscriber<T, R>
     extends AtomicInteger
-    implements Subscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
         private static final long serialVersionUID = -1776795561228106469L;
 
         final Subscriber<? super R> actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqual.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqual.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.BiPredicate;
 import io.reactivex.internal.fuseable.*;
@@ -244,7 +244,7 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
 
     static final class EqualSubscriber<T>
     extends AtomicReference<Subscription>
-    implements Subscriber<T> {
+    implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = 4804128302091633067L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSerialized.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSerialized.java
@@ -12,9 +12,10 @@
  */
 package io.reactivex.internal.operators.flowable;
 
+import org.reactivestreams.Subscriber;
+
 import io.reactivex.Flowable;
 import io.reactivex.subscribers.SerializedSubscriber;
-import org.reactivestreams.Subscriber;
 
 public final class FlowableSerialized<T> extends AbstractFlowableWithUpstream<T, T> {
     public FlowableSerialized(Flowable<T> source) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingle.java
@@ -13,16 +13,17 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.plugins.RxJavaPlugins;
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.*;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableSingle<T> extends AbstractFlowableWithUpstream<T, T> {
 
     final T defaultValue;
 
-    public FlowableSingle(Publisher<T> source, T defaultValue) {
+    public FlowableSingle(Flowable<T> source, T defaultValue) {
         super(source);
         this.defaultValue = defaultValue;
     }
@@ -33,7 +34,7 @@ public final class FlowableSingle<T> extends AbstractFlowableWithUpstream<T, T> 
     }
 
     static final class SingleElementSubscriber<T> extends DeferredScalarSubscription<T>
-    implements Subscriber<T> {
+    implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -5526049321428043809L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleMaybe.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
@@ -23,9 +23,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableSingleMaybe<T> extends Maybe<T> implements FuseToFlowable<T> {
 
-    final Publisher<T> source;
+    final Flowable<T> source;
 
-    public FlowableSingleMaybe(Publisher<T> source) {
+    public FlowableSingleMaybe(Flowable<T> source) {
         this.source = source;
     }
 
@@ -40,7 +40,7 @@ public final class FlowableSingleMaybe<T> extends Maybe<T> implements FuseToFlow
     }
 
     static final class SingleElementSubscriber<T>
-    implements Subscriber<T>, Disposable {
+    implements FlowableSubscriber<T>, Disposable {
 
         final MaybeObserver<? super T> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleSingle.java
@@ -14,7 +14,8 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.NoSuchElementException;
-import org.reactivestreams.*;
+
+import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
@@ -24,11 +25,11 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableSingleSingle<T> extends Single<T> implements FuseToFlowable<T> {
 
-    final Publisher<T> source;
+    final Flowable<T> source;
 
     final T defaultValue;
 
-    public FlowableSingleSingle(Publisher<T> source, T defaultValue) {
+    public FlowableSingleSingle(Flowable<T> source, T defaultValue) {
         this.source = source;
         this.defaultValue = defaultValue;
     }
@@ -44,7 +45,7 @@ public final class FlowableSingleSingle<T> extends Single<T> implements FuseToFl
     }
 
     static final class SingleElementSubscriber<T>
-    implements Subscriber<T>, Disposable {
+    implements FlowableSubscriber<T>, Disposable {
 
         final SingleObserver<? super T> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkip.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkip.java
@@ -15,11 +15,12 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 public final class FlowableSkip<T> extends AbstractFlowableWithUpstream<T, T> {
     final long n;
-    public FlowableSkip(Publisher<T> source, long n) {
+    public FlowableSkip(Flowable<T> source, long n) {
         super(source);
         this.n = n;
     }
@@ -29,7 +30,7 @@ public final class FlowableSkip<T> extends AbstractFlowableWithUpstream<T, T> {
         source.subscribe(new SkipSubscriber<T>(s, n));
     }
 
-    static final class SkipSubscriber<T> implements Subscriber<T>, Subscription {
+    static final class SkipSubscriber<T> implements FlowableSubscriber<T>, Subscription {
         final Subscriber<? super T> actual;
         long remaining;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLast.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLast.java
@@ -17,12 +17,13 @@ import java.util.ArrayDeque;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 public final class FlowableSkipLast<T> extends AbstractFlowableWithUpstream<T, T> {
     final int skip;
 
-    public FlowableSkipLast(Publisher<T> source, int skip) {
+    public FlowableSkipLast(Flowable<T> source, int skip) {
         super(source);
         this.skip = skip;
     }
@@ -32,7 +33,7 @@ public final class FlowableSkipLast<T> extends AbstractFlowableWithUpstream<T, T
         source.subscribe(new SkipLastSubscriber<T>(s, skip));
     }
 
-    static final class SkipLastSubscriber<T> extends ArrayDeque<T> implements Subscriber<T>, Subscription {
+    static final class SkipLastSubscriber<T> extends ArrayDeque<T> implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -3807491841935125653L;
         final Subscriber<? super T> actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimed.java
@@ -30,7 +30,7 @@ public final class FlowableSkipLastTimed<T> extends AbstractFlowableWithUpstream
     final int bufferSize;
     final boolean delayError;
 
-    public FlowableSkipLastTimed(Publisher<T> source, long time, TimeUnit unit, Scheduler scheduler, int bufferSize, boolean delayError) {
+    public FlowableSkipLastTimed(Flowable<T> source, long time, TimeUnit unit, Scheduler scheduler, int bufferSize, boolean delayError) {
         super(source);
         this.time = time;
         this.unit = unit;
@@ -44,7 +44,7 @@ public final class FlowableSkipLastTimed<T> extends AbstractFlowableWithUpstream
         source.subscribe(new SkipLastTimedSubscriber<T>(s, time, unit, scheduler, bufferSize, delayError));
     }
 
-    static final class SkipLastTimedSubscriber<T> extends AtomicInteger implements Subscriber<T>, Subscription {
+    static final class SkipLastTimedSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -5677354903406201275L;
         final Subscriber<? super T> actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipUntil.java
@@ -17,13 +17,14 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 
 public final class FlowableSkipUntil<T, U> extends AbstractFlowableWithUpstream<T, T> {
     final Publisher<U> other;
-    public FlowableSkipUntil(Publisher<T> source, Publisher<U> other) {
+    public FlowableSkipUntil(Flowable<T> source, Publisher<U> other) {
         super(source);
         this.other = other;
     }
@@ -107,7 +108,7 @@ public final class FlowableSkipUntil<T, U> extends AbstractFlowableWithUpstream<
         }
 
         final class OtherSubscriber extends AtomicReference<Subscription>
-        implements Subscriber<Object> {
+        implements FlowableSubscriber<Object> {
 
             private static final long serialVersionUID = -5592042965931999169L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSkipWhile.java
@@ -15,13 +15,14 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 public final class FlowableSkipWhile<T> extends AbstractFlowableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
-    public FlowableSkipWhile(Publisher<T> source, Predicate<? super T> predicate) {
+    public FlowableSkipWhile(Flowable<T> source, Predicate<? super T> predicate) {
         super(source);
         this.predicate = predicate;
     }
@@ -31,7 +32,7 @@ public final class FlowableSkipWhile<T> extends AbstractFlowableWithUpstream<T, 
         source.subscribe(new SkipWhileSubscriber<T>(s, predicate));
     }
 
-    static final class SkipWhileSubscriber<T> implements Subscriber<T>, Subscription {
+    static final class SkipWhileSubscriber<T> implements FlowableSubscriber<T>, Subscription {
         final Subscriber<? super T> actual;
         final Predicate<? super T> predicate;
         Subscription s;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableStrict.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableStrict.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 
@@ -35,7 +36,7 @@ import io.reactivex.internal.util.*;
  */
 public final class FlowableStrict<T> extends AbstractFlowableWithUpstream<T, T> {
 
-    public FlowableStrict(Publisher<T> source) {
+    public FlowableStrict(Flowable<T> source) {
         super(source);
     }
 
@@ -44,9 +45,9 @@ public final class FlowableStrict<T> extends AbstractFlowableWithUpstream<T, T> 
         source.subscribe(new StrictSubscriber<T>(s));
     }
 
-    static final class StrictSubscriber<T>
+    public static final class StrictSubscriber<T>
     extends AtomicInteger
-    implements Subscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -4945028590049415624L;
 
@@ -62,7 +63,7 @@ public final class FlowableStrict<T> extends AbstractFlowableWithUpstream<T, T> 
 
         volatile boolean done;
 
-        StrictSubscriber(Subscriber<? super T> actual) {
+        public StrictSubscriber(Subscriber<? super T> actual) {
             this.actual = actual;
             this.error = new AtomicThrowable();
             this.requested = new AtomicLong();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
@@ -33,7 +33,7 @@ public final class FlowableSubscribeOn<T> extends AbstractFlowableWithUpstream<T
 
     final boolean nonScheduledRequests;
 
-    public FlowableSubscribeOn(Publisher<T> source, Scheduler scheduler, boolean nonScheduledRequests) {
+    public FlowableSubscribeOn(Flowable<T> source, Scheduler scheduler, boolean nonScheduledRequests) {
         super(source);
         this.scheduler = scheduler;
         this.nonScheduledRequests = nonScheduledRequests;
@@ -49,7 +49,7 @@ public final class FlowableSubscribeOn<T> extends AbstractFlowableWithUpstream<T
     }
 
     static final class SubscribeOnSubscriber<T> extends AtomicReference<Thread>
-    implements Subscriber<T>, Subscription, Runnable {
+    implements FlowableSubscriber<T>, Subscription, Runnable {
 
         private static final long serialVersionUID = 8094547886072529208L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmpty.java
@@ -15,11 +15,12 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionArbiter;
 
 public final class FlowableSwitchIfEmpty<T> extends AbstractFlowableWithUpstream<T, T> {
     final Publisher<? extends T> other;
-    public FlowableSwitchIfEmpty(Publisher<T> source, Publisher<? extends T> other) {
+    public FlowableSwitchIfEmpty(Flowable<T> source, Publisher<? extends T> other) {
         super(source);
         this.other = other;
     }
@@ -31,7 +32,7 @@ public final class FlowableSwitchIfEmpty<T> extends AbstractFlowableWithUpstream
         source.subscribe(parent);
     }
 
-    static final class SwitchIfEmptySubscriber<T> implements Subscriber<T> {
+    static final class SwitchIfEmptySubscriber<T> implements FlowableSubscriber<T> {
         final Subscriber<? super T> actual;
         final Publisher<? extends T> other;
         final SubscriptionArbiter arbiter;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -31,7 +32,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
     final int bufferSize;
     final boolean delayErrors;
 
-    public FlowableSwitchMap(Publisher<T> source,
+    public FlowableSwitchMap(Flowable<T> source,
             Function<? super T, ? extends Publisher<? extends R>> mapper, int bufferSize,
                     boolean delayErrors) {
         super(source);
@@ -48,7 +49,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
         source.subscribe(new SwitchMapSubscriber<T, R>(s, mapper, bufferSize, delayErrors));
     }
 
-    static final class SwitchMapSubscriber<T, R> extends AtomicInteger implements Subscriber<T>, Subscription {
+    static final class SwitchMapSubscriber<T, R> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -3491074160481096299L;
         final Subscriber<? super R> actual;
@@ -332,7 +333,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
     }
 
     static final class SwitchMapInnerSubscriber<T, R>
-    extends AtomicReference<Subscription> implements Subscriber<R> {
+    extends AtomicReference<Subscription> implements FlowableSubscriber<R> {
 
         private static final long serialVersionUID = 3837284832786408377L;
         final SwitchMapSubscriber<T, R> parent;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTake.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTake.java
@@ -17,11 +17,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.*;
 
 public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
     final long limit;
-    public FlowableTake(Publisher<T> source, long limit) {
+    public FlowableTake(Flowable<T> source, long limit) {
         super(source);
         this.limit = limit;
     }
@@ -31,7 +32,7 @@ public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
         source.subscribe(new TakeSubscriber<T>(s, limit));
     }
 
-    static final class TakeSubscriber<T> extends AtomicBoolean implements Subscriber<T>, Subscription {
+    static final class TakeSubscriber<T> extends AtomicBoolean implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -5636543848937116287L;
         boolean done;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLast.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLast.java
@@ -18,13 +18,14 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
 public final class FlowableTakeLast<T> extends AbstractFlowableWithUpstream<T, T> {
     final int count;
 
-    public FlowableTakeLast(Publisher<T> source, int count) {
+    public FlowableTakeLast(Flowable<T> source, int count) {
         super(source);
         this.count = count;
     }
@@ -34,7 +35,7 @@ public final class FlowableTakeLast<T> extends AbstractFlowableWithUpstream<T, T
         source.subscribe(new TakeLastSubscriber<T>(s, count));
     }
 
-    static final class TakeLastSubscriber<T> extends ArrayDeque<T> implements Subscriber<T>, Subscription {
+    static final class TakeLastSubscriber<T> extends ArrayDeque<T> implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = 7240042530241604978L;
         final Subscriber<? super T> actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOne.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOne.java
@@ -14,11 +14,12 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.*;
 
 public final class FlowableTakeLastOne<T> extends AbstractFlowableWithUpstream<T, T> {
 
-    public FlowableTakeLastOne(Publisher<T> source) {
+    public FlowableTakeLastOne(Flowable<T> source) {
         super(source);
     }
 
@@ -28,7 +29,7 @@ public final class FlowableTakeLastOne<T> extends AbstractFlowableWithUpstream<T
     }
 
     static final class TakeLastOneSubscriber<T> extends DeferredScalarSubscription<T>
-    implements Subscriber<T> {
+    implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -5467847744262967226L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimed.java
@@ -31,7 +31,7 @@ public final class FlowableTakeLastTimed<T> extends AbstractFlowableWithUpstream
     final int bufferSize;
     final boolean delayError;
 
-    public FlowableTakeLastTimed(Publisher<T> source,
+    public FlowableTakeLastTimed(Flowable<T> source,
             long count, long time, TimeUnit unit, Scheduler scheduler,
             int bufferSize, boolean delayError) {
         super(source);
@@ -48,7 +48,7 @@ public final class FlowableTakeLastTimed<T> extends AbstractFlowableWithUpstream
         source.subscribe(new TakeLastTimedSubscriber<T>(s, count, time, unit, scheduler, bufferSize, delayError));
     }
 
-    static final class TakeLastTimedSubscriber<T> extends AtomicInteger implements Subscriber<T>, Subscription {
+    static final class TakeLastTimedSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -5677354903406201275L;
         final Subscriber<? super T> actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakePublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakePublisher.java
@@ -11,23 +11,30 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.tck;
+package io.reactivex.internal.operators.flowable;
+
+import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
+import io.reactivex.internal.operators.flowable.FlowableTake.TakeSubscriber;
 
-public final class FlowableTck {
-    /** Utility class (remnant).*/
-    private FlowableTck() {
-        throw new IllegalStateException("No instances!");
+/**
+ * Take with a generic Publisher source.
+ *
+ * @param <T> the value type
+ * @since 2.0.7 - experimental
+ */
+public final class FlowableTakePublisher<T> extends Flowable<T> {
+
+    final Publisher<T> source;
+    final long limit;
+    public FlowableTakePublisher(Publisher<T> source, long limit) {
+        this.source = source;
+        this.limit = limit;
     }
 
-    /**
-     * Enable strict mode.
-     * @param <T> the value type
-     * @param f the input Flowable
-     * @return the output Flowable
-     */
-    public static <T> Flowable<T> wrap(Flowable<T> f) {
-        return f.strict();
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        source.subscribe(new TakeSubscriber<T>(s, limit));
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntil.java
@@ -17,12 +17,13 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 
 public final class FlowableTakeUntil<T, U> extends AbstractFlowableWithUpstream<T, T> {
     final Publisher<? extends U> other;
-    public FlowableTakeUntil(Publisher<T> source, Publisher<? extends U> other) {
+    public FlowableTakeUntil(Flowable<T> source, Publisher<? extends U> other) {
         super(source);
         this.other = other;
     }
@@ -37,7 +38,7 @@ public final class FlowableTakeUntil<T, U> extends AbstractFlowableWithUpstream<
         source.subscribe(parent);
     }
 
-    static final class TakeUntilMainSubscriber<T> extends AtomicInteger implements Subscriber<T>, Subscription {
+    static final class TakeUntilMainSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -4945480365982832967L;
 
@@ -92,7 +93,7 @@ public final class FlowableTakeUntil<T, U> extends AbstractFlowableWithUpstream<
             SubscriptionHelper.cancel(other);
         }
 
-        final class OtherSubscriber extends AtomicReference<Subscription> implements Subscriber<Object> {
+        final class OtherSubscriber extends AtomicReference<Subscription> implements FlowableSubscriber<Object> {
 
             private static final long serialVersionUID = -3592821756711087922L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicate.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -22,7 +23,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableTakeUntilPredicate<T> extends AbstractFlowableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
-    public FlowableTakeUntilPredicate(Publisher<T> source, Predicate<? super T> predicate) {
+    public FlowableTakeUntilPredicate(Flowable<T> source, Predicate<? super T> predicate) {
         super(source);
         this.predicate = predicate;
     }
@@ -32,7 +33,7 @@ public final class FlowableTakeUntilPredicate<T> extends AbstractFlowableWithUps
         source.subscribe(new InnerSubscriber<T>(s, predicate));
     }
 
-    static final class InnerSubscriber<T> implements Subscriber<T>, Subscription {
+    static final class InnerSubscriber<T> implements FlowableSubscriber<T>, Subscription {
         final Subscriber<? super T> actual;
         final Predicate<? super T> predicate;
         Subscription s;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakeWhile.java
@@ -13,16 +13,17 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.plugins.RxJavaPlugins;
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableTakeWhile<T> extends AbstractFlowableWithUpstream<T, T> {
     final Predicate<? super T> predicate;
-    public FlowableTakeWhile(Publisher<T> source, Predicate<? super T> predicate) {
+    public FlowableTakeWhile(Flowable<T> source, Predicate<? super T> predicate) {
         super(source);
         this.predicate = predicate;
     }
@@ -32,7 +33,7 @@ public final class FlowableTakeWhile<T> extends AbstractFlowableWithUpstream<T, 
         source.subscribe(new TakeWhileSubscriber<T>(s, predicate));
     }
 
-    static final class TakeWhileSubscriber<T> implements Subscriber<T>, Subscription {
+    static final class TakeWhileSubscriber<T> implements FlowableSubscriber<T>, Subscription {
         final Subscriber<? super T> actual;
         final Predicate<? super T> predicate;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTimed.java
@@ -18,11 +18,11 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Scheduler;
+import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.MissingBackpressureException;
-import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.disposables.SequentialDisposable;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -33,7 +33,7 @@ public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUps
     final TimeUnit unit;
     final Scheduler scheduler;
 
-    public FlowableThrottleFirstTimed(Publisher<T> source, long timeout, TimeUnit unit, Scheduler scheduler) {
+    public FlowableThrottleFirstTimed(Flowable<T> source, long timeout, TimeUnit unit, Scheduler scheduler) {
         super(source);
         this.timeout = timeout;
         this.unit = unit;
@@ -49,7 +49,7 @@ public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUps
 
     static final class DebounceTimedSubscriber<T>
     extends AtomicLong
-    implements Subscriber<T>, Subscription, Runnable {
+    implements FlowableSubscriber<T>, Subscription, Runnable {
 
         private static final long serialVersionUID = -9102637559663639004L;
         final Subscriber<? super T> actual;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeInterval.java
@@ -25,7 +25,7 @@ public final class FlowableTimeInterval<T> extends AbstractFlowableWithUpstream<
     final Scheduler scheduler;
     final TimeUnit unit;
 
-    public FlowableTimeInterval(Publisher<T> source, TimeUnit unit, Scheduler scheduler) {
+    public FlowableTimeInterval(Flowable<T> source, TimeUnit unit, Scheduler scheduler) {
         super(source);
         this.scheduler = scheduler;
         this.unit = unit;
@@ -37,7 +37,7 @@ public final class FlowableTimeInterval<T> extends AbstractFlowableWithUpstream<
         source.subscribe(new TimeIntervalSubscriber<T>(s, unit, scheduler));
     }
 
-    static final class TimeIntervalSubscriber<T> implements Subscriber<T>, Subscription {
+    static final class TimeIntervalSubscriber<T> implements FlowableSubscriber<T>, Subscription {
         final Subscriber<? super Timed<T>> actual;
         final TimeUnit unit;
         final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
@@ -13,16 +13,17 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
-import java.util.concurrent.*;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscribers.FullArbiterSubscriber;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -34,7 +35,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
     final Publisher<? extends T> other;
 
     public FlowableTimeout(
-            Publisher<T> source,
+            Flowable<T> source,
             Publisher<U> firstTimeoutIndicator,
             Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator,
             Publisher<? extends T> other) {
@@ -56,7 +57,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
         }
     }
 
-    static final class TimeoutSubscriber<T, U, V> implements Subscriber<T>, Subscription, OnTimeout {
+    static final class TimeoutSubscriber<T, U, V> implements FlowableSubscriber<T>, Subscription, OnTimeout {
         final Subscriber<? super T> actual;
         final Publisher<U> firstTimeoutIndicator;
         final Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator;
@@ -214,7 +215,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
         }
     }
 
-    static final class TimeoutOtherSubscriber<T, U, V> implements Subscriber<T>, Disposable, OnTimeout {
+    static final class TimeoutOtherSubscriber<T, U, V> implements FlowableSubscriber<T>, Disposable, OnTimeout {
         final Subscriber<? super T> actual;
         final Publisher<U> firstTimeoutIndicator;
         final Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -43,7 +43,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
         }
     };
 
-    public FlowableTimeoutTimed(Publisher<T> source,
+    public FlowableTimeoutTimed(Flowable<T> source,
             long timeout, TimeUnit unit, Scheduler scheduler, Publisher<? extends T> other) {
         super(source);
         this.timeout = timeout;
@@ -65,7 +65,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
         }
     }
 
-    static final class TimeoutTimedOtherSubscriber<T> implements Subscriber<T>, Disposable {
+    static final class TimeoutTimedOtherSubscriber<T> implements FlowableSubscriber<T>, Disposable {
         final Subscriber<? super T> actual;
         final long timeout;
         final TimeUnit unit;
@@ -180,7 +180,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
         }
     }
 
-    static final class TimeoutTimedSubscriber<T> implements Subscriber<T>, Disposable, Subscription {
+    static final class TimeoutTimedSubscriber<T> implements FlowableSubscriber<T>, Disposable, Subscription {
         final Subscriber<? super T> actual;
         final long timeout;
         final TimeUnit unit;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableToList.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableToList.java
@@ -13,19 +13,20 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.*;
 
 public final class FlowableToList<T, U extends Collection<? super T>> extends AbstractFlowableWithUpstream<T, U> {
     final Callable<U> collectionSupplier;
 
-    public FlowableToList(Publisher<T> source, Callable<U> collectionSupplier) {
+    public FlowableToList(Flowable<T> source, Callable<U> collectionSupplier) {
         super(source);
         this.collectionSupplier = collectionSupplier;
     }
@@ -46,7 +47,7 @@ public final class FlowableToList<T, U extends Collection<? super T>> extends Ab
 
     static final class ToListSubscriber<T, U extends Collection<? super T>>
     extends DeferredScalarSubscription<U>
-    implements Subscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
 
 
         private static final long serialVersionUID = -8134157938864266736L;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableToListSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableToListSingle.java
@@ -13,16 +13,16 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.FuseToFlowable;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.ArrayListSupplier;
@@ -30,16 +30,16 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableToListSingle<T, U extends Collection<? super T>> extends Single<U> implements FuseToFlowable<U> {
 
-    final Publisher<T> source;
+    final Flowable<T> source;
 
     final Callable<U> collectionSupplier;
 
     @SuppressWarnings("unchecked")
-    public FlowableToListSingle(Publisher<T> source) {
+    public FlowableToListSingle(Flowable<T> source) {
         this(source, (Callable<U>)ArrayListSupplier.asCallable());
     }
 
-    public FlowableToListSingle(Publisher<T> source, Callable<U> collectionSupplier) {
+    public FlowableToListSingle(Flowable<T> source, Callable<U> collectionSupplier) {
         this.source = source;
         this.collectionSupplier = collectionSupplier;
     }
@@ -63,7 +63,7 @@ public final class FlowableToListSingle<T, U extends Collection<? super T>> exte
     }
 
     static final class ToListSubscriber<T, U extends Collection<? super T>>
-    implements Subscriber<T>, Disposable {
+    implements FlowableSubscriber<T>, Disposable {
 
         final SingleObserver<? super U> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
@@ -17,13 +17,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Scheduler;
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableUnsubscribeOn<T> extends AbstractFlowableWithUpstream<T, T> {
     final Scheduler scheduler;
-    public FlowableUnsubscribeOn(Publisher<T> source, Scheduler scheduler) {
+    public FlowableUnsubscribeOn(Flowable<T> source, Scheduler scheduler) {
         super(source);
         this.scheduler = scheduler;
     }
@@ -33,7 +33,7 @@ public final class FlowableUnsubscribeOn<T> extends AbstractFlowableWithUpstream
         source.subscribe(new UnsubscribeSubscriber<T>(s, scheduler));
     }
 
-    static final class UnsubscribeSubscriber<T> extends AtomicBoolean implements Subscriber<T>, Subscription {
+    static final class UnsubscribeSubscriber<T> extends AtomicBoolean implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = 1015244841293359600L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableUsing.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.*;
@@ -73,7 +73,7 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
         source.subscribe(us);
     }
 
-    static final class UsingSubscriber<T, D> extends AtomicBoolean implements Subscriber<T>, Subscription {
+    static final class UsingSubscriber<T, D> extends AtomicBoolean implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = 5904473792286235046L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindow.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindow.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -32,7 +32,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
     final int bufferSize;
 
-    public FlowableWindow(Publisher<T> source, long size, long skip,  int bufferSize) {
+    public FlowableWindow(Flowable<T> source, long size, long skip,  int bufferSize) {
         super(source);
         this.size = size;
         this.skip = skip;
@@ -53,7 +53,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
     static final class WindowExactSubscriber<T>
     extends AtomicInteger
-    implements Subscriber<T>, Subscription, Runnable {
+    implements FlowableSubscriber<T>, Subscription, Runnable {
 
 
         private static final long serialVersionUID = -2365647875069161133L;
@@ -176,7 +176,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
     static final class WindowSkipSubscriber<T>
     extends AtomicInteger
-    implements Subscriber<T>, Subscription, Runnable {
+    implements FlowableSubscriber<T>, Subscription, Runnable {
 
 
         private static final long serialVersionUID = -8792836352386833856L;
@@ -318,7 +318,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
     static final class WindowOverlapSubscriber<T>
     extends AtomicInteger
-    implements Subscriber<T>, Subscription, Runnable {
+    implements FlowableSubscriber<T>, Subscription, Runnable {
 
 
         private static final long serialVersionUID = 2428527070996323976L;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
@@ -34,7 +34,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
     final Publisher<B> other;
     final int bufferSize;
 
-    public FlowableWindowBoundary(Publisher<T> source, Publisher<B> other, int bufferSize) {
+    public FlowableWindowBoundary(Flowable<T> source, Publisher<B> other, int bufferSize) {
         super(source);
         this.other = other;
         this.bufferSize = bufferSize;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -39,7 +39,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
     final int bufferSize;
 
     public FlowableWindowBoundarySelector(
-            Publisher<T> source,
+            Flowable<T> source,
             Publisher<B> open, Function<? super B, ? extends Publisher<V>> close,
             int bufferSize) {
         super(source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
@@ -36,7 +36,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
     final Callable<? extends Publisher<B>> other;
     final int bufferSize;
 
-    public FlowableWindowBoundarySupplier(Publisher<T> source,
+    public FlowableWindowBoundarySupplier(Flowable<T> source,
             Callable<? extends Publisher<B>> other, int bufferSize) {
         super(source);
         this.other = other;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -40,7 +40,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
     final int bufferSize;
     final boolean restartTimerOnMaxSize;
 
-    public FlowableWindowTimed(Publisher<T> source,
+    public FlowableWindowTimed(Flowable<T> source,
             long timespan, long timeskip, TimeUnit unit, Scheduler scheduler, long maxSize,
             int bufferSize, boolean restartTimerOnMaxSize) {
         super(source);
@@ -76,7 +76,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
     static final class WindowExactUnboundedSubscriber<T>
             extends QueueDrainSubscriber<T, Object, Flowable<T>>
-            implements Subscriber<T>, Subscription, Runnable {
+            implements FlowableSubscriber<T>, Subscription, Runnable {
         final long timespan;
         final TimeUnit unit;
         final Scheduler scheduler;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -26,7 +27,7 @@ import io.reactivex.subscribers.SerializedSubscriber;
 public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithUpstream<T, R> {
     final BiFunction<? super T, ? super U, ? extends R> combiner;
     final Publisher<? extends U> other;
-    public FlowableWithLatestFrom(Publisher<T> source, BiFunction<? super T, ? super U, ? extends R> combiner, Publisher<? extends U> other) {
+    public FlowableWithLatestFrom(Flowable<T> source, BiFunction<? super T, ? super U, ? extends R> combiner, Publisher<? extends U> other) {
         super(source);
         this.combiner = combiner;
         this.other = other;
@@ -39,7 +40,7 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
 
         serial.onSubscribe(wlf);
 
-        other.subscribe(new Subscriber<U>() {
+        other.subscribe(new FlowableSubscriber<U>() {
             @Override
             public void onSubscribe(Subscription s) {
                 if (wlf.setOther(s)) {
@@ -66,7 +67,7 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
         source.subscribe(wlf);
     }
 
-    static final class WithLatestFromSubscriber<T, U, R> extends AtomicReference<U> implements Subscriber<T>, Subscription {
+    static final class WithLatestFromSubscriber<T, U, R> extends AtomicReference<U> implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -312246233408980075L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -15,10 +15,10 @@ package io.reactivex.internal.operators.flowable;
 import java.util.Arrays;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.annotations.NonNull;
-import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
+import io.reactivex.*;
+import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -43,14 +43,14 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
 
     final Function<? super Object[], R> combiner;
 
-    public FlowableWithLatestFromMany(@NonNull Publisher<T> source, @NonNull Publisher<?>[] otherArray, Function<? super Object[], R> combiner) {
+    public FlowableWithLatestFromMany(@NonNull Flowable<T> source, @NonNull Publisher<?>[] otherArray, Function<? super Object[], R> combiner) {
         super(source);
         this.otherArray = otherArray;
         this.otherIterable = null;
         this.combiner = combiner;
     }
 
-    public FlowableWithLatestFromMany(@NonNull Publisher<T> source, @NonNull Iterable<? extends Publisher<?>> otherIterable, @NonNull Function<? super Object[], R> combiner) {
+    public FlowableWithLatestFromMany(@NonNull Flowable<T> source, @NonNull Iterable<? extends Publisher<?>> otherIterable, @NonNull Function<? super Object[], R> combiner) {
         super(source);
         this.otherArray = null;
         this.otherIterable = otherIterable;
@@ -100,7 +100,7 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
 
     static final class WithLatestFromSubscriber<T, R>
     extends AtomicInteger
-    implements Subscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = 1577321883966341961L;
 
@@ -248,7 +248,7 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
 
     static final class WithLatestInnerSubscriber
     extends AtomicReference<Subscription>
-    implements Subscriber<Object>, Disposable {
+    implements FlowableSubscriber<Object>, Disposable {
 
         private static final long serialVersionUID = 3256684027868224024L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableZip.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableZip.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -323,7 +323,7 @@ public final class FlowableZip<T, R> extends Flowable<R> {
     }
 
 
-    static final class ZipSubscriber<T, R> extends AtomicReference<Subscription> implements Subscriber<T>, Subscription {
+    static final class ZipSubscriber<T, R> extends AtomicReference<Subscription> implements FlowableSubscriber<T>, Subscription {
 
         private static final long serialVersionUID = -4627193790118206028L;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableZipIterable.java
@@ -13,26 +13,25 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Iterator;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class FlowableZipIterable<T, U, V> extends Flowable<V> {
-    final Publisher<? extends T> source;
+public final class FlowableZipIterable<T, U, V> extends AbstractFlowableWithUpstream<T, V> {
     final Iterable<U> other;
     final BiFunction<? super T, ? super U, ? extends V> zipper;
 
     public FlowableZipIterable(
-            Publisher<? extends T> source,
+            Flowable<T> source,
             Iterable<U> other, BiFunction<? super T, ? super U, ? extends V> zipper) {
-        this.source = source;
+        super(source);
         this.other = other;
         this.zipper = zipper;
     }
@@ -67,7 +66,7 @@ public final class FlowableZipIterable<T, U, V> extends Flowable<V> {
         source.subscribe(new ZipIterableSubscriber<T, U, V>(t, it, zipper));
     }
 
-    static final class ZipIterableSubscriber<T, U, V> implements Subscriber<T>, Subscription {
+    static final class ZipIterableSubscriber<T, U, V> implements FlowableSubscriber<T>, Subscription {
         final Subscriber<? super V> actual;
         final Iterator<U> iterator;
         final BiFunction<? super T, ? super U, ? extends V> zipper;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherPublisher.java
@@ -104,7 +104,7 @@ public final class MaybeDelayOtherPublisher<T, U> extends AbstractMaybeWithUpstr
 
     static final class OtherSubscriber<T> extends
     AtomicReference<Subscription>
-    implements Subscriber<Object> {
+    implements FlowableSubscriber<Object> {
 
         private static final long serialVersionUID = -1215060610805418006L;
 

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionOtherPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionOtherPublisher.java
@@ -43,7 +43,7 @@ public final class MaybeDelaySubscriptionOtherPublisher<T, U> extends AbstractMa
         other.subscribe(new OtherSubscriber<T>(observer, source));
     }
 
-    static final class OtherSubscriber<T> implements Subscriber<Object>, Disposable {
+    static final class OtherSubscriber<T> implements FlowableSubscriber<Object>, Disposable {
         final DelayMaybeObserver<T> main;
 
         MaybeSource<T> source;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisher.java
@@ -120,7 +120,7 @@ public final class MaybeTakeUntilPublisher<T, U> extends AbstractMaybeWithUpstre
         }
 
         static final class TakeUntilOtherMaybeObserver<U>
-        extends AtomicReference<Subscription> implements Subscriber<U> {
+        extends AtomicReference<Subscription> implements FlowableSubscriber<U> {
 
             private static final long serialVersionUID = -1266041316834525931L;
 

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimeoutPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeTimeoutPublisher.java
@@ -142,7 +142,7 @@ public final class MaybeTimeoutPublisher<T, U> extends AbstractMaybeWithUpstream
 
     static final class TimeoutOtherMaybeObserver<T, U>
     extends AtomicReference<Subscription>
-    implements Subscriber<Object> {
+    implements FlowableSubscriber<Object> {
 
 
         private static final long serialVersionUID = 8663801314800248617L;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromPublisher.java
@@ -32,7 +32,7 @@ public final class ObservableFromPublisher<T> extends Observable<T> {
     }
 
     static final class PublisherSubscriber<T>
-    implements Subscriber<T>, Disposable {
+    implements FlowableSubscriber<T>, Disposable {
 
         final Observer<? super T> actual;
         Subscription s;

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFlatMap.java
@@ -13,10 +13,9 @@
 
 package io.reactivex.internal.operators.parallel;
 
-import io.reactivex.functions.Function;
-
 import org.reactivestreams.*;
 
+import io.reactivex.functions.Function;
 import io.reactivex.internal.operators.flowable.FlowableFlatMap;
 import io.reactivex.parallel.ParallelFlowable;
 

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromArray.java
@@ -13,8 +13,7 @@
 
 package io.reactivex.internal.operators.parallel;
 
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
+import org.reactivestreams.*;
 
 import io.reactivex.parallel.ParallelFlowable;
 

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromPublisher.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.exceptions.*;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscArrayQueue;
@@ -59,7 +60,7 @@ public final class ParallelFromPublisher<T> extends ParallelFlowable<T> {
 
     static final class ParallelDispatcher<T>
     extends AtomicInteger
-    implements Subscriber<T> {
+    implements FlowableSubscriber<T> {
 
 
         private static final long serialVersionUID = -4470634016609963609L;

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelJoin.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscArrayQueue;
@@ -290,7 +290,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
     static final class JoinInnerSubscriber<T>
     extends AtomicReference<Subscription>
-    implements Subscriber<T> {
+    implements FlowableSubscriber<T> {
 
 
         private static final long serialVersionUID = 8410034718427740355L;

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelMap.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelMap.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.parallel;
 
 import org.reactivestreams.*;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -67,7 +68,7 @@ public final class ParallelMap<T, R> extends ParallelFlowable<R> {
         return source.parallelism();
     }
 
-    static final class ParallelMapSubscriber<T, R> implements Subscriber<T>, Subscription {
+    static final class ParallelMapSubscriber<T, R> implements FlowableSubscriber<T>, Subscription {
 
         final Subscriber<? super R> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelPeek.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelPeek.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.parallel;
 
 import org.reactivestreams.*;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -84,7 +85,7 @@ public final class ParallelPeek<T> extends ParallelFlowable<T> {
         return source.parallelism();
     }
 
-    static final class ParallelPeekSubscriber<T> implements Subscriber<T>, Subscription {
+    static final class ParallelPeekSubscriber<T> implements FlowableSubscriber<T>, Subscription {
 
         final Subscriber<? super T> actual;
 

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelReduceFull.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelReduceFull.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -161,7 +161,7 @@ public final class ParallelReduceFull<T> extends Flowable<T> {
 
     static final class ParallelReduceFullInnerSubscriber<T>
     extends AtomicReference<Subscription>
-    implements Subscriber<T> {
+    implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -7954444275102466525L;
 

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelRunOn.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelRunOn.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Scheduler;
+import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
@@ -82,7 +82,7 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
     }
 
     abstract static class BaseRunOnSubscriber<T> extends AtomicInteger
-    implements  Subscriber<T>, Subscription, Runnable {
+    implements FlowableSubscriber<T>, Subscription, Runnable {
 
         private static final long serialVersionUID = 9222303586456402150L;
 

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelSortedJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelSortedJoin.java
@@ -18,10 +18,10 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.internal.util.*;
+import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -264,7 +264,7 @@ public final class ParallelSortedJoin<T> extends Flowable<T> {
 
     static final class SortedJoinInnerSubscriber<T>
     extends AtomicReference<Subscription>
-    implements Subscriber<List<T>> {
+    implements FlowableSubscriber<List<T>> {
 
 
         private static final long serialVersionUID = 6751017204873808094L;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithPublisher.java
@@ -42,7 +42,7 @@ public final class SingleDelayWithPublisher<T, U> extends Single<T> {
 
     static final class OtherSubscriber<T, U>
     extends AtomicReference<Disposable>
-    implements Subscriber<U>, Disposable {
+    implements FlowableSubscriber<U>, Disposable {
 
 
         private static final long serialVersionUID = -8565274649390031272L;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFromPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFromPublisher.java
@@ -35,7 +35,7 @@ public final class SingleFromPublisher<T> extends Single<T> {
         publisher.subscribe(new ToSingleObserver<T>(s));
     }
 
-    static final class ToSingleObserver<T> implements Subscriber<T>, Disposable {
+    static final class ToSingleObserver<T> implements FlowableSubscriber<T>, Disposable {
         final SingleObserver<? super T> actual;
 
         Subscription s;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTakeUntil.java
@@ -127,7 +127,7 @@ public final class SingleTakeUntil<T, U> extends Single<T> {
 
     static final class TakeUntilOtherSubscriber
     extends AtomicReference<Subscription>
-    implements Subscriber<Object> {
+    implements FlowableSubscriber<Object> {
 
         private static final long serialVersionUID = 5170026210238877381L;
 

--- a/src/main/java/io/reactivex/internal/subscribers/BasicFuseableSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/BasicFuseableSubscriber.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.subscribers;
 
 import org.reactivestreams.*;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -25,7 +26,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * @param <T> the upstream value type
  * @param <R> the downstream value type
  */
-public abstract class BasicFuseableSubscriber<T, R> implements Subscriber<T>, QueueSubscription<R> {
+public abstract class BasicFuseableSubscriber<T, R> implements FlowableSubscriber<T>, QueueSubscription<R> {
 
     /** The downstream subscriber. */
     protected final Subscriber<? super R> actual;

--- a/src/main/java/io/reactivex/internal/subscribers/BlockingBaseSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/BlockingBaseSubscriber.java
@@ -14,13 +14,14 @@ package io.reactivex.internal.subscribers;
 
 import java.util.concurrent.CountDownLatch;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 
 public abstract class BlockingBaseSubscriber<T> extends CountDownLatch
-implements Subscriber<T> {
+implements FlowableSubscriber<T> {
 
     T value;
     Throwable error;

--- a/src/main/java/io/reactivex/internal/subscribers/BlockingSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/BlockingSubscriber.java
@@ -16,12 +16,13 @@ package io.reactivex.internal.subscribers;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.NotificationLite;
 
-public final class BlockingSubscriber<T> extends AtomicReference<Subscription> implements Subscriber<T>, Subscription {
+public final class BlockingSubscriber<T> extends AtomicReference<Subscription> implements FlowableSubscriber<T>, Subscription {
 
     private static final long serialVersionUID = -4875965440900746268L;
 

--- a/src/main/java/io/reactivex/internal/subscribers/DeferredScalarSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/DeferredScalarSubscriber.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.subscribers;
 
 import org.reactivestreams.*;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.internal.subscriptions.*;
 
 /**
@@ -24,7 +25,7 @@ import io.reactivex.internal.subscriptions.*;
  * @param <R> the output value type
  */
 public abstract class DeferredScalarSubscriber<T, R> extends DeferredScalarSubscription<R>
-implements Subscriber<T> {
+implements FlowableSubscriber<T> {
 
     private static final long serialVersionUID = 2984505488220891551L;
 

--- a/src/main/java/io/reactivex/internal/subscribers/ForEachWhileSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/ForEachWhileSubscriber.java
@@ -15,8 +15,9 @@ package io.reactivex.internal.subscribers;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
@@ -25,7 +26,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ForEachWhileSubscriber<T>
 extends AtomicReference<Subscription>
-implements Subscriber<T>, Disposable {
+implements FlowableSubscriber<T>, Disposable {
 
 
     private static final long serialVersionUID = -4403180040475402120L;

--- a/src/main/java/io/reactivex/internal/subscribers/FullArbiterSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/FullArbiterSubscriber.java
@@ -13,8 +13,9 @@
 
 package io.reactivex.internal.subscribers;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.internal.subscriptions.*;
 
 /**
@@ -22,7 +23,7 @@ import io.reactivex.internal.subscriptions.*;
  *
  * @param <T> the value type
  */
-public final class FullArbiterSubscriber<T> implements Subscriber<T> {
+public final class FullArbiterSubscriber<T> implements FlowableSubscriber<T> {
     final FullArbiter<T> arbiter;
 
     Subscription s;

--- a/src/main/java/io/reactivex/internal/subscribers/FutureSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/FutureSubscriber.java
@@ -17,8 +17,9 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BlockingHelper;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -30,7 +31,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * @param <T> the value type
  */
 public final class FutureSubscriber<T> extends CountDownLatch
-implements Subscriber<T>, Future<T>, Subscription {
+implements FlowableSubscriber<T>, Future<T>, Subscription {
 
     T value;
     Throwable error;

--- a/src/main/java/io/reactivex/internal/subscribers/InnerQueuedSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/InnerQueuedSubscriber.java
@@ -15,8 +15,9 @@ package io.reactivex.internal.subscribers;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.QueueDrainHelper;
@@ -29,7 +30,7 @@ import io.reactivex.internal.util.QueueDrainHelper;
  */
 public final class InnerQueuedSubscriber<T>
 extends AtomicReference<Subscription>
-implements Subscriber<T>, Subscription {
+implements FlowableSubscriber<T>, Subscription {
 
 
     private static final long serialVersionUID = 22876611072430776L;

--- a/src/main/java/io/reactivex/internal/subscribers/LambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/LambdaSubscriber.java
@@ -15,15 +15,16 @@ package io.reactivex.internal.subscribers;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class LambdaSubscriber<T> extends AtomicReference<Subscription> implements Subscriber<T>, Subscription, Disposable {
+public final class LambdaSubscriber<T> extends AtomicReference<Subscription> implements FlowableSubscriber<T>, Subscription, Disposable {
 
     private static final long serialVersionUID = -7251123623727029452L;
     final Consumer<? super T> onNext;

--- a/src/main/java/io/reactivex/internal/subscribers/QueueDrainSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/QueueDrainSubscriber.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.Subscriber;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.fuseable.*;
@@ -31,7 +32,7 @@ import io.reactivex.internal.util.*;
  * @param <U> the value type in the queue
  * @param <V> the value type the child subscriber accepts
  */
-public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriberPad4 implements Subscriber<T>, QueueDrain<U, V> {
+public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriberPad4 implements FlowableSubscriber<T>, QueueDrain<U, V> {
     protected final Subscriber<? super V> actual;
     protected final SimplePlainQueue<U> queue;
 

--- a/src/main/java/io/reactivex/internal/subscribers/SinglePostCompleteSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/SinglePostCompleteSubscriber.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.reactivestreams.*;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
@@ -27,7 +28,7 @@ import io.reactivex.internal.util.BackpressureHelper;
  * @param <T> the input value type
  * @param <R> the output value type
  */
-public abstract class SinglePostCompleteSubscriber<T, R> extends AtomicLong implements Subscriber<T>, Subscription {
+public abstract class SinglePostCompleteSubscriber<T, R> extends AtomicLong implements FlowableSubscriber<T>, Subscription {
     private static final long serialVersionUID = 7917814472626990048L;
 
     /** The downstream consumer. */

--- a/src/main/java/io/reactivex/internal/subscribers/SubscriberResourceWrapper.java
+++ b/src/main/java/io/reactivex/internal/subscribers/SubscriberResourceWrapper.java
@@ -17,11 +17,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.*;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
-public final class SubscriberResourceWrapper<T> extends AtomicReference<Disposable> implements Subscriber<T>, Disposable, Subscription {
+public final class SubscriberResourceWrapper<T> extends AtomicReference<Disposable> implements FlowableSubscriber<T>, Disposable, Subscription {
 
     private static final long serialVersionUID = -8612022020200669122L;
 

--- a/src/main/java/io/reactivex/internal/util/EmptyComponent.java
+++ b/src/main/java/io/reactivex/internal/util/EmptyComponent.java
@@ -22,7 +22,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Singleton implementing many interfaces as empty.
  */
-public enum EmptyComponent implements Subscriber<Object>, Observer<Object>, MaybeObserver<Object>,
+public enum EmptyComponent implements FlowableSubscriber<Object>, Observer<Object>, MaybeObserver<Object>,
 SingleObserver<Object>, CompletableObserver, Subscription, Disposable {
     INSTANCE;
 

--- a/src/main/java/io/reactivex/processors/FlowableProcessor.java
+++ b/src/main/java/io/reactivex/processors/FlowableProcessor.java
@@ -15,7 +15,7 @@ package io.reactivex.processors;
 
 import org.reactivestreams.Processor;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 
 /**
  * Represents a Subscriber and a Flowable (Publisher) at the same time, allowing
@@ -25,7 +25,7 @@ import io.reactivex.Flowable;
  *
  * @param <T> the item value type
  */
-public abstract class FlowableProcessor<T> extends Flowable<T> implements Processor<T, T> {
+public abstract class FlowableProcessor<T> extends Flowable<T> implements Processor<T, T>, FlowableSubscriber<T> {
 
     /**
      * Returns true if the subject has subscribers.

--- a/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
@@ -13,8 +13,9 @@
 
 package io.reactivex.subscribers;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 /**
@@ -25,7 +26,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
  *
  * @param <T> the value type
  */
-public abstract class DefaultSubscriber<T> implements Subscriber<T> {
+public abstract class DefaultSubscriber<T> implements FlowableSubscriber<T> {
     private Subscription s;
     @Override
     public final void onSubscribe(Subscription s) {

--- a/src/main/java/io/reactivex/subscribers/DisposableSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/DisposableSubscriber.java
@@ -15,8 +15,9 @@ package io.reactivex.subscribers;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
@@ -25,7 +26,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
  *
  * @param <T> the received value type.
  */
-public abstract class DisposableSubscriber<T> implements Subscriber<T>, Disposable {
+public abstract class DisposableSubscriber<T> implements FlowableSubscriber<T>, Disposable {
     final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
 
     @Override

--- a/src/main/java/io/reactivex/subscribers/ResourceSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/ResourceSubscriber.java
@@ -13,12 +13,11 @@
 
 package io.reactivex.subscribers;
 
-import org.reactivestreams.Subscriber;
+import java.util.concurrent.atomic.*;
+
 import org.reactivestreams.Subscription;
 
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.ListCompositeDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -34,7 +33,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
  *
  * @param <T> the value type
  */
-public abstract class ResourceSubscriber<T> implements Subscriber<T>, Disposable {
+public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Disposable {
     /** The active subscription. */
     private final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
 

--- a/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/SafeSubscriber.java
@@ -14,6 +14,7 @@ package io.reactivex.subscribers;
 
 import org.reactivestreams.*;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.exceptions.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -24,7 +25,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the value type
  */
-public final class SafeSubscriber<T> implements Subscriber<T>, Subscription {
+public final class SafeSubscriber<T> implements FlowableSubscriber<T>, Subscription {
     /** The actual Subscriber. */
     final Subscriber<? super T> actual;
     /** The subscription. */

--- a/src/main/java/io/reactivex/subscribers/SerializedSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/SerializedSubscriber.java
@@ -14,6 +14,7 @@ package io.reactivex.subscribers;
 
 import org.reactivestreams.*;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -28,7 +29,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the value type
  */
-public final class SerializedSubscriber<T> implements Subscriber<T>, Subscription {
+public final class SerializedSubscriber<T> implements FlowableSubscriber<T>, Subscription {
     final Subscriber<? super T> actual;
     final boolean delayError;
 

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
@@ -39,7 +40,7 @@ import io.reactivex.observers.BaseTestConsumer;
  */
 public class TestSubscriber<T>
 extends BaseTestConsumer<T, TestSubscriber<T>>
-implements Subscriber<T>, Subscription, Disposable {
+implements FlowableSubscriber<T>, Subscription, Disposable {
     /** The actual subscriber to forward events to. */
     private final Subscriber<? super T> actual;
 
@@ -419,7 +420,7 @@ implements Subscriber<T>, Subscription, Disposable {
     /**
      * A subscriber that ignores all events and does not report errors.
      */
-    enum EmptySubscriber implements Subscriber<Object> {
+    enum EmptySubscriber implements FlowableSubscriber<Object> {
         INSTANCE;
 
         @Override

--- a/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
+++ b/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
@@ -82,7 +82,7 @@ public abstract class InputWithIncrementingInteger {
         return new PerfSubscriber(bh);
     }
 
-    public Subscriber<Integer> newSubscriber() {
+    public FlowableSubscriber<Integer> newSubscriber() {
         return new DefaultSubscriber<Integer>() {
 
             @Override

--- a/src/perf/java/io/reactivex/PerfAsyncConsumer.java
+++ b/src/perf/java/io/reactivex/PerfAsyncConsumer.java
@@ -23,7 +23,7 @@ import io.reactivex.disposables.Disposable;
 /**
  * A multi-type asynchronous consumer.
  */
-public final class PerfAsyncConsumer extends CountDownLatch implements Subscriber<Object>, Observer<Object>,
+public final class PerfAsyncConsumer extends CountDownLatch implements FlowableSubscriber<Object>, Observer<Object>,
 SingleObserver<Object>, CompletableObserver, MaybeObserver<Object> {
 
     final Blackhole bh;

--- a/src/perf/java/io/reactivex/PerfConsumer.java
+++ b/src/perf/java/io/reactivex/PerfConsumer.java
@@ -14,14 +14,14 @@
 package io.reactivex;
 
 import org.openjdk.jmh.infra.Blackhole;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
 import io.reactivex.disposables.Disposable;
 
 /**
  * A multi-type synchronous consumer.
  */
-public final class PerfConsumer implements Subscriber<Object>, Observer<Object>,
+public final class PerfConsumer implements FlowableSubscriber<Object>, Observer<Object>,
 SingleObserver<Object>, CompletableObserver, MaybeObserver<Object> {
 
     final Blackhole bh;

--- a/src/perf/java/io/reactivex/PerfSubscriber.java
+++ b/src/perf/java/io/reactivex/PerfSubscriber.java
@@ -16,9 +16,9 @@ package io.reactivex;
 import java.util.concurrent.CountDownLatch;
 
 import org.openjdk.jmh.infra.Blackhole;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
-public class PerfSubscriber implements Subscriber<Object> {
+public class PerfSubscriber implements FlowableSubscriber<Object> {
 
     public CountDownLatch latch = new CountDownLatch(1);
     private final Blackhole bh;

--- a/src/test/java/io/reactivex/InternalWrongNaming.java
+++ b/src/test/java/io/reactivex/InternalWrongNaming.java
@@ -123,7 +123,7 @@ public class InternalWrongNaming {
 
     @Test
     public void observableNoFlowable() throws Exception {
-        checkInternalOperatorNaming("Observable", "Flowable");
+        checkInternalOperatorNaming("Observable", "Flowable", "ObservableFromPublisher");
     }
 
     @Test

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -55,8 +55,8 @@ public enum TestHelper {
      * @return the mocked subscriber
      */
     @SuppressWarnings("unchecked")
-    public static <T> Subscriber<T> mockSubscriber() {
-        Subscriber<T> w = mock(Subscriber.class);
+    public static <T> FlowableSubscriber<T> mockSubscriber() {
+        FlowableSubscriber<T> w = mock(FlowableSubscriber.class);
 
         Mockito.doAnswer(new Answer<Object>() {
             @Override
@@ -295,7 +295,7 @@ public enum TestHelper {
         try {
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            source.subscribe(new Subscriber<Object>() {
+            source.subscribe(new FlowableSubscriber<Object>() {
 
                 @Override
                 public void onSubscribe(Subscription s) {
@@ -646,7 +646,7 @@ public enum TestHelper {
      */
     public static void checkDisposed(Flowable<?> source) {
         final TestSubscriber<Object> ts = new TestSubscriber<Object>(0L);
-        source.subscribe(new Subscriber<Object>() {
+        source.subscribe(new FlowableSubscriber<Object>() {
             @Override
             public void onSubscribe(Subscription s) {
                 ts.onSubscribe(new BooleanSubscription());
@@ -870,7 +870,7 @@ public enum TestHelper {
     /**
      * Consumer for all base reactive types.
      */
-    enum NoOpConsumer implements Subscriber<Object>, Observer<Object>, MaybeObserver<Object>, SingleObserver<Object>, CompletableObserver {
+    enum NoOpConsumer implements FlowableSubscriber<Object>, Observer<Object>, MaybeObserver<Object>, SingleObserver<Object>, CompletableObserver {
         INSTANCE;
 
         @Override
@@ -2237,7 +2237,7 @@ public enum TestHelper {
 
         final Boolean[] state = { null, null, null, null };
 
-        source.subscribe(new Subscriber<T>() {
+        source.subscribe(new FlowableSubscriber<T>() {
             @Override
             public void onSubscribe(Subscription d) {
                 try {

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -4291,7 +4291,7 @@ public class CompletableTest {
     public void safeOnCompleteThrowsRegularSubscriber() {
         /*
         try {
-            normal.completable.subscribe(new Subscriber<Object>() {
+            normal.completable.subscribe(new FlowableSubscriber<Object>() {
 
                 @Override
                 public void onComplete() {
@@ -4323,7 +4323,7 @@ public class CompletableTest {
     public void safeOnErrorThrowsRegularSubscriber() {
         /*
         try {
-            error.completable.subscribe(new Subscriber<Object>() {
+            error.completable.subscribe(new FlowableSubscriber<Object>() {
 
                 @Override
                 public void onComplete() {

--- a/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
+++ b/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
@@ -388,7 +388,7 @@ public class ExceptionsTest {
                                   public void subscribe(SingleObserver<? super Integer> s2) {
                                       throw new IllegalArgumentException("original exception");
                                   }
-                              }).toFlowable().subscribe(new Subscriber<Integer>() {
+                              }).toFlowable().subscribe(new FlowableSubscriber<Integer>() {
 
                                   @Override
                                   public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
@@ -76,11 +76,11 @@ public class FlowableConversionTest {
         }
 
         public final CylonDetectorObservable<T> beep(Predicate<? super T> predicate) {
-            return new CylonDetectorObservable<T>(new FlowableFilter<T>(onSubscribe, predicate));
+            return new CylonDetectorObservable<T>(new FlowableFilter<T>(Flowable.fromPublisher(onSubscribe), predicate));
         }
 
         public final <R> CylonDetectorObservable<R> boop(Function<? super T, ? extends R> func) {
-            return new CylonDetectorObservable<R>(new FlowableMap<T, R>(onSubscribe, func));
+            return new CylonDetectorObservable<R>(new FlowableMap<T, R>(Flowable.fromPublisher(onSubscribe), func));
         }
 
         public CylonDetectorObservable<String> DESTROY() {

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -2156,6 +2156,11 @@ public class FlowableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
+    public void subscribeNull2() {
+        just1.subscribe((FlowableSubscriber<Integer>)null);
+    }
+
+    @Test(expected = NullPointerException.class)
     public void subscribeOnNull() {
         just1.subscribeOn(null);
     }
@@ -2820,7 +2825,7 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void unsafeSubscribeNull() {
-        just1.subscribe((Subscriber<Object>)null);
+        just1.subscribe((FlowableSubscriber<Object>)null);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
@@ -88,7 +88,7 @@ public class FlowableSubscriberTest {
         FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
             @Override
             public Subscriber<? super String> apply(final Subscriber<? super String> s1) {
-                return new Subscriber<String>() {
+                return new FlowableSubscriber<String>() {
 
                     @Override
                     public void onSubscribe(Subscription a) {
@@ -140,7 +140,7 @@ public class FlowableSubscriberTest {
         FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
             @Override
             public Subscriber<? super String> apply(final Subscriber<? super String> s1) {
-                return new Subscriber<String>() {
+                return new FlowableSubscriber<String>() {
 
                     @Override
                     public void onSubscribe(Subscription a) {

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -808,7 +808,7 @@ public class FlowableTests {
     public void testContainsFlowable() {
         Flowable<Boolean> observable = Flowable.just("a", "b", "c").contains("b").toFlowable();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        FlowableSubscriber<Boolean> observer = TestHelper.mockSubscriber();
 
         observable.subscribe(observer);
 
@@ -854,7 +854,7 @@ public class FlowableTests {
     public void testContainsWithEmptyObservableFlowable() {
         Flowable<Boolean> observable = Flowable.<String> empty().contains("a").toFlowable();
 
-        Subscriber<Object> observer = TestHelper.mockSubscriber();
+        FlowableSubscriber<Object> observer = TestHelper.mockSubscriber();
 
         observable.subscribe(observer);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
@@ -127,7 +127,7 @@ public class FlowableBlockingTest {
 
         Flowable.range(1, 5)
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(new Subscriber<Object>() {
+        .blockingSubscribe(new FlowableSubscriber<Object>() {
 
             @Override
             public void onSubscribe(Subscription d) {
@@ -162,7 +162,7 @@ public class FlowableBlockingTest {
 
         Flowable.range(1, 5).concatWith(Flowable.<Integer>error(ex))
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(new Subscriber<Object>() {
+        .blockingSubscribe(new FlowableSubscriber<Object>() {
 
             @Override
             public void onSubscribe(Subscription d) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -673,7 +673,7 @@ public class FlowableCreateTest {
                     assertTrue(d.isDisposed());
                 }
             }, m)
-            .subscribe(new Subscriber<Object>() {
+            .subscribe(new FlowableSubscriber<Object>() {
                 @Override
                 public void onSubscribe(Subscription d) {
                 }
@@ -711,7 +711,7 @@ public class FlowableCreateTest {
                     assertTrue(d.isDisposed());
                 }
             }, m)
-            .subscribe(new Subscriber<Object>() {
+            .subscribe(new FlowableSubscriber<Object>() {
                 @Override
                 public void onSubscribe(Subscription d) {
                 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
@@ -173,7 +173,7 @@ public class FlowableDistinctTest {
     public void fusedClear() {
         Flowable.just(1, 1, 2, 1, 3, 2, 4, 5, 4)
         .distinct()
-        .subscribe(new Subscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() {
             @Override
             public void onSubscribe(Subscription d) {
                 QueueSubscription<?> qd = (QueueSubscription<?>)d;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoFinallyTest.java
@@ -350,7 +350,7 @@ public class FlowableDoFinallyTest implements Action {
     public void clearIsEmpty() {
         Flowable.range(1, 5)
         .doFinally(this)
-        .subscribe(new Subscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -397,7 +397,7 @@ public class FlowableDoFinallyTest implements Action {
         Flowable.range(1, 5)
         .doFinally(this)
         .filter(Functions.alwaysTrue())
-        .subscribe(new Subscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() {
 
             @Override
             public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnRequestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnRequestTest.java
@@ -105,7 +105,7 @@ public class FlowableDoOnRequestTest {
 //                    }
 //                });
 //            }
-//        }).doOnRequest(empty).subscribe(new Subscriber<Object>() {
+//        }).doOnRequest(empty).subscribe(new FlowableSubscriber<Object>() {
 //            @Override
 //            public void onNext(Object t) {
 //

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
@@ -419,7 +419,7 @@ public class FlowableFlatMapCompletableTest {
             }
         })
         .toFlowable()
-        .subscribe(new Subscriber<Object>() {
+        .subscribe(new FlowableSubscriber<Object>() {
             @Override
             public void onSubscribe(Subscription d) {
                 QueueSubscription<?> qd = (QueueSubscription<?>)d;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -609,7 +609,7 @@ public class FlowableFlattenIterableTest {
     public void fusionMethods() {
         Flowable.just(1, 2)
         .flatMapIterable(Functions.justFunction(Arrays.asList(1, 2, 3)))
-        .subscribe(new Subscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() {
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")
@@ -737,7 +737,7 @@ public class FlowableFlattenIterableTest {
                 return Arrays.asList(v);
             }
         })
-        .subscribe(new Subscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() {
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
@@ -569,7 +569,7 @@ public class FlowableFromIterableTest {
     @Test
     public void fusedAPICalls() {
         Flowable.fromIterable(Arrays.asList(1, 2, 3))
-        .subscribe(new Subscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -880,7 +880,7 @@ public class FlowableFromIterableTest {
     @Test
     public void fusionClear() {
         Flowable.fromIterable(Arrays.asList(1, 2, 3))
-        .subscribe(new Subscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() {
             @Override
             public void onSubscribe(Subscription d) {
                 @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
@@ -620,7 +620,7 @@ public class FlowableFromSourceTest {
         ts1.assertNotComplete();
     }
 
-    static final class PublishAsyncEmitter implements FlowableOnSubscribe<Integer>, Subscriber<Integer> {
+    static final class PublishAsyncEmitter implements FlowableOnSubscribe<Integer>, FlowableSubscriber<Integer> {
 
         final PublishProcessor<Integer> subject;
 
@@ -689,7 +689,7 @@ public class FlowableFromSourceTest {
         }
     }
 
-    static final class PublishAsyncEmitterNoCancel implements FlowableOnSubscribe<Integer>, Subscriber<Integer> {
+    static final class PublishAsyncEmitterNoCancel implements FlowableOnSubscribe<Integer>, FlowableSubscriber<Integer> {
 
         final PublishProcessor<Integer> subject;
 
@@ -700,7 +700,7 @@ public class FlowableFromSourceTest {
         @Override
         public void subscribe(final FlowableEmitter<Integer> t) {
 
-            subject.subscribe(new Subscriber<Integer>() {
+            subject.subscribe(new FlowableSubscriber<Integer>() {
 
                 @Override
                 public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -172,7 +172,7 @@ public class FlowableGroupJoinTest {
                 });
 
         q.subscribe(
-                new Subscriber<PPF>() {
+                new FlowableSubscriber<PPF>() {
                     @Override
                     public void onNext(final PPF ppf) {
                         ppf.fruits.filter(new Predicate<PersonFruit>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -273,7 +273,7 @@ public class FlowableIgnoreElementsTest {
     @Test
     public void fusedAPICalls() {
         Flowable.just(1).hide().ignoreElements().<Integer>toFlowable()
-        .subscribe(new Subscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() {
 
             @Override
             public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -516,7 +516,7 @@ public class FlowableMergeTest {
             public void subscribe(final Subscriber<? super Long> child) {
                 Flowable.interval(1, TimeUnit.SECONDS, scheduler)
                 .take(5)
-                .subscribe(new Subscriber<Long>() {
+                .subscribe(new FlowableSubscriber<Long>() {
                     @Override
                     public void onSubscribe(final Subscription s) {
                         child.onSubscribe(new Subscription() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -1306,7 +1306,7 @@ public class FlowableObserveOnTest {
         final CountDownLatch cdl = new CountDownLatch(1);
 
         us.observeOn(Schedulers.single())
-        .subscribe(new Subscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() {
             Subscription d;
             int count;
             @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
@@ -190,7 +190,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
 
             @Override
             public Subscriber<? super Integer> apply(final Subscriber<? super String> t1) {
-                return new Subscriber<Integer>() {
+                return new FlowableSubscriber<Integer>() {
 
                     @Override
                     public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -577,7 +577,7 @@ public class FlowableRefCountTest {
         assertEquals(6, intervalSubscribed.get());
     }
 
-    private enum CancelledSubscriber implements Subscriber<Integer> {
+    private enum CancelledSubscriber implements FlowableSubscriber<Integer> {
         INSTANCE;
 
         @Override public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
@@ -298,7 +298,7 @@ public class MaybeFlatMapIterableFlowableTest {
                     public Iterable<Integer> apply(Object v) throws Exception {
                         return Arrays.asList(1, 2, 3);
                     }
-        }).subscribe(new Subscriber<Integer>() {
+        }).subscribe(new FlowableSubscriber<Integer>() {
             QueueSubscription<Integer> qd;
             @SuppressWarnings("unchecked")
             @Override

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeArrayTest.java
@@ -62,7 +62,7 @@ public class MaybeMergeArrayTest {
     @Test
     public void fusedEmptyCheck() {
         Maybe.mergeArray(Maybe.just(1), Maybe.<Integer>empty(), Maybe.just(2))
-        .subscribe(new Subscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() {
             QueueSubscription<Integer> qd;
             @Override
             public void onSubscribe(Subscription d) {
@@ -192,7 +192,7 @@ public class MaybeMergeArrayTest {
     @Test
     public void smallOffer2Throws() {
         Maybe.mergeArray(Maybe.never(), Maybe.never())
-        .subscribe(new Subscriber<Object>() {
+        .subscribe(new FlowableSubscriber<Object>() {
 
             @SuppressWarnings("rawtypes")
             @Override
@@ -227,7 +227,7 @@ public class MaybeMergeArrayTest {
         Maybe<Integer>[] a = new Maybe[1024];
         Arrays.fill(a, Maybe.never());
         Maybe.mergeArray(a)
-        .subscribe(new Subscriber<Object>() {
+        .subscribe(new FlowableSubscriber<Object>() {
 
             @SuppressWarnings("rawtypes")
             @Override

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowableTest.java
@@ -285,7 +285,7 @@ public class SingleFlatMapIterableFlowableTest {
                     public Iterable<Integer> apply(Object v) throws Exception {
                         return Arrays.asList(1, 2, 3);
                     }
-        }).subscribe(new Subscriber<Integer>() {
+        }).subscribe(new FlowableSubscriber<Integer>() {
             QueueSubscription<Integer> qd;
             @SuppressWarnings("unchecked")
             @Override

--- a/src/test/java/io/reactivex/internal/util/HalfSerializerSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/util/HalfSerializerSubscriberTest.java
@@ -12,7 +12,7 @@
  */
 package io.reactivex.internal.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.reactivestreams.*;
 
-import io.reactivex.TestHelper;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
@@ -43,7 +43,7 @@ public class HalfSerializerSubscriberTest {
 
         final TestSubscriber ts = new TestSubscriber();
 
-        Subscriber s = new Subscriber() {
+        FlowableSubscriber s = new FlowableSubscriber() {
             @Override
             public void onSubscribe(Subscription s) {
                 ts.onSubscribe(s);
@@ -87,7 +87,7 @@ public class HalfSerializerSubscriberTest {
 
         final TestSubscriber ts = new TestSubscriber();
 
-        Subscriber s = new Subscriber() {
+        FlowableSubscriber s = new FlowableSubscriber() {
             @Override
             public void onSubscribe(Subscription s) {
                 ts.onSubscribe(s);
@@ -131,7 +131,7 @@ public class HalfSerializerSubscriberTest {
 
         final TestSubscriber ts = new TestSubscriber();
 
-        Subscriber s = new Subscriber() {
+        FlowableSubscriber s = new FlowableSubscriber() {
             @Override
             public void onSubscribe(Subscription s) {
                 ts.onSubscribe(s);
@@ -175,7 +175,7 @@ public class HalfSerializerSubscriberTest {
 
         final TestSubscriber ts = new TestSubscriber();
 
-        Subscriber s = new Subscriber() {
+        FlowableSubscriber s = new FlowableSubscriber() {
             @Override
             public void onSubscribe(Subscription s) {
                 ts.onSubscribe(s);

--- a/src/test/java/io/reactivex/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/PublishProcessorTest.java
@@ -13,27 +13,23 @@
 
 package io.reactivex.processors;
 
-import io.reactivex.Flowable;
-import io.reactivex.TestHelper;
-import io.reactivex.exceptions.MissingBackpressureException;
-import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Function;
-import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultSubscriber;
-import io.reactivex.subscribers.TestSubscriber;
-import org.junit.Test;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import org.junit.Test;
+import org.mockito.*;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.*;
 
 public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 
@@ -548,7 +544,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 
         TestSubscriber<Integer> ts = pp.test();
 
-        pp.subscribe(new Subscriber<Integer>() {
+        pp.subscribe(new FlowableSubscriber<Integer>() {
 
             @Override
             public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
@@ -720,7 +720,7 @@ public class SafeSubscriberTest {
         ts.assertResult(1);
     }
 
-    static final class CrashDummy implements Subscriber<Object>, Subscription {
+    static final class CrashDummy implements FlowableSubscriber<Object>, Subscription {
         final boolean crashOnSubscribe;
 
         int crashOnNext;

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -1539,7 +1539,7 @@ public class TestSubscriberTest {
 
     @Test
     public void completeDelegateThrows() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(new Subscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(new FlowableSubscriber<Integer>() {
 
             @Override
             public void onSubscribe(Subscription d) {
@@ -1575,7 +1575,7 @@ public class TestSubscriberTest {
 
     @Test
     public void errorDelegateThrows() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(new Subscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(new FlowableSubscriber<Integer>() {
 
             @Override
             public void onSubscribe(Subscription d) {

--- a/src/test/java/io/reactivex/tck/AllTckTest.java
+++ b/src/test/java/io/reactivex/tck/AllTckTest.java
@@ -24,14 +24,14 @@ public class AllTckTest extends BaseTck<Boolean> {
 
     @Override
     public Publisher<Boolean> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 1000).all(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer e) throws Exception {
                         return e < 800;
                     }
                 }).toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/AmbArrayTckTest.java
+++ b/src/test/java/io/reactivex/tck/AmbArrayTckTest.java
@@ -24,11 +24,11 @@ public class AmbArrayTckTest extends BaseTck<Long> {
     @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.ambArray(
                         Flowable.fromIterable(iterate(elements)),
                         Flowable.<Long>never()
                 )
-            );
+            ;
     }
 }

--- a/src/test/java/io/reactivex/tck/AmbTckTest.java
+++ b/src/test/java/io/reactivex/tck/AmbTckTest.java
@@ -26,12 +26,12 @@ public class AmbTckTest extends BaseTck<Long> {
     @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.amb(Arrays.asList(
                     Flowable.fromIterable(iterate(elements)),
                     Flowable.<Long>never()
                 )
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/AnyTckTest.java
+++ b/src/test/java/io/reactivex/tck/AnyTckTest.java
@@ -24,14 +24,14 @@ public class AnyTckTest extends BaseTck<Boolean> {
 
     @Override
     public Publisher<Boolean> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 1000).any(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer e) throws Exception {
                         return e == 500;
                     }
                 }).toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/BufferBoundaryTckTest.java
+++ b/src/test/java/io/reactivex/tck/BufferBoundaryTckTest.java
@@ -25,11 +25,11 @@ public class BufferBoundaryTckTest extends BaseTck<List<Long>> {
 
     @Override
     public Publisher<List<Long>> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.fromIterable(iterate(elements))
             .buffer(Flowable.just(1).concatWith(Flowable.<Integer>never()))
             .onBackpressureLatest()
-        );
+        ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/BufferExactSizeTckTest.java
+++ b/src/test/java/io/reactivex/tck/BufferExactSizeTckTest.java
@@ -25,9 +25,9 @@ public class BufferExactSizeTckTest extends BaseTck<List<Long>> {
 
     @Override
     public Publisher<List<Long>> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.fromIterable(iterate(elements * 2))
             .buffer(2)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/CacheTckTest.java
+++ b/src/test/java/io/reactivex/tck/CacheTckTest.java
@@ -23,8 +23,8 @@ public class CacheTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.fromIterable(iterate(elements)).cache()
-            );
+            ;
     }
 }

--- a/src/test/java/io/reactivex/tck/CollectTckTest.java
+++ b/src/test/java/io/reactivex/tck/CollectTckTest.java
@@ -27,14 +27,14 @@ public class CollectTckTest extends BaseTck<List<Integer>> {
 
     @Override
     public Publisher<List<Integer>> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 1000).collect(Functions.<Integer>createArrayList(128), new BiConsumer<List<Integer>, Integer>() {
                     @Override
                     public void accept(List<Integer> a, Integer b) throws Exception {
                         a.add(b);
                     }
                 }).toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/CombineLatestArrayDelayErrorTckTest.java
+++ b/src/test/java/io/reactivex/tck/CombineLatestArrayDelayErrorTckTest.java
@@ -25,7 +25,7 @@ public class CombineLatestArrayDelayErrorTckTest extends BaseTck<Long> {
     @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.combineLatestDelayError(
                 new Function<Object[], Long>() {
                     @Override
@@ -36,6 +36,6 @@ public class CombineLatestArrayDelayErrorTckTest extends BaseTck<Long> {
                 Flowable.just(1L),
                 Flowable.fromIterable(iterate(elements))
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/CombineLatestArrayTckTest.java
+++ b/src/test/java/io/reactivex/tck/CombineLatestArrayTckTest.java
@@ -25,7 +25,7 @@ public class CombineLatestArrayTckTest extends BaseTck<Long> {
     @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.combineLatest(
                 new Function<Object[], Long>() {
                     @Override
@@ -36,6 +36,6 @@ public class CombineLatestArrayTckTest extends BaseTck<Long> {
                 Flowable.just(1L),
                 Flowable.fromIterable(iterate(elements))
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/CombineLatestIterableDelayErrorTckTest.java
+++ b/src/test/java/io/reactivex/tck/CombineLatestIterableDelayErrorTckTest.java
@@ -27,7 +27,7 @@ public class CombineLatestIterableDelayErrorTckTest extends BaseTck<Long> {
     @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.combineLatestDelayError(Arrays.asList(
                     Flowable.just(1L),
                     Flowable.fromIterable(iterate(elements))
@@ -39,6 +39,6 @@ public class CombineLatestIterableDelayErrorTckTest extends BaseTck<Long> {
                     }
                 }
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/CombineLatestIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/CombineLatestIterableTckTest.java
@@ -27,7 +27,7 @@ public class CombineLatestIterableTckTest extends BaseTck<Long> {
     @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.combineLatest(Arrays.asList(
                     Flowable.just(1L),
                     Flowable.fromIterable(iterate(elements))
@@ -39,6 +39,6 @@ public class CombineLatestIterableTckTest extends BaseTck<Long> {
                     }
                 }
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatArrayEagerTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatArrayEagerTckTest.java
@@ -26,12 +26,12 @@ public class ConcatArrayEagerTckTest extends BaseTck<Long> {
     @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.concatEager(Arrays.asList(
                     Flowable.fromIterable(iterate(elements / 2)),
                     Flowable.fromIterable(iterate(elements - elements / 2))
                 )
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatIterableEagerTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatIterableEagerTckTest.java
@@ -24,11 +24,11 @@ public class ConcatIterableEagerTckTest extends BaseTck<Long> {
     @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.concatArrayEager(
                 Flowable.fromIterable(iterate(elements / 2)),
                 Flowable.fromIterable(iterate(elements - elements / 2))
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatMapIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatMapIterableTckTest.java
@@ -26,7 +26,7 @@ public class ConcatMapIterableTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements)
                 .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
                     @Override
@@ -34,6 +34,6 @@ public class ConcatMapIterableTckTest extends BaseTck<Integer> {
                         return Collections.singletonList(v);
                     }
                 })
-            );
+            ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatMapTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatMapTckTest.java
@@ -24,7 +24,7 @@ public class ConcatMapTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements)
                 .concatMap(new Function<Integer, Publisher<Integer>>() {
                     @Override
@@ -32,6 +32,6 @@ public class ConcatMapTckTest extends BaseTck<Integer> {
                         return Flowable.just(v);
                     }
                 })
-            );
+            ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatPublisherEagerTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatPublisherEagerTckTest.java
@@ -23,12 +23,12 @@ public class ConcatPublisherEagerTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.concatEager(Flowable.just(
                     Flowable.fromIterable(iterate(elements / 2)),
                     Flowable.fromIterable(iterate(elements - elements / 2))
                 )
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatPublisherTckTest.java
@@ -23,12 +23,12 @@ public class ConcatPublisherTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.concat(Flowable.just(
                     Flowable.fromIterable(iterate(elements / 2)),
                     Flowable.fromIterable(iterate(elements - elements / 2))
                 )
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ConcatTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatTckTest.java
@@ -23,11 +23,11 @@ public class ConcatTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.concat(
                     Flowable.fromIterable(iterate(elements / 2)),
                     Flowable.fromIterable(iterate(elements - elements / 2))
                 )
-            );
+            ;
     }
 }

--- a/src/test/java/io/reactivex/tck/CreateTckTest.java
+++ b/src/test/java/io/reactivex/tck/CreateTckTest.java
@@ -23,7 +23,7 @@ public class CreateTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.create(new FlowableOnSubscribe<Long>() {
                 @Override
                 public void subscribe(FlowableEmitter<Long> e) throws Exception {
@@ -33,6 +33,6 @@ public class CreateTckTest extends BaseTck<Long> {
                     e.onComplete();
                 }
             }, BackpressureStrategy.BUFFER)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/DefaultIfEmptyTckTest.java
+++ b/src/test/java/io/reactivex/tck/DefaultIfEmptyTckTest.java
@@ -23,8 +23,8 @@ public class DefaultIfEmptyTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, (int)elements).defaultIfEmpty(0)
-            );
+            ;
     }
 }

--- a/src/test/java/io/reactivex/tck/DeferTckTest.java
+++ b/src/test/java/io/reactivex/tck/DeferTckTest.java
@@ -25,7 +25,7 @@ public class DeferTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.defer(new Callable<Publisher<Long>>() {
                     @Override
                     public Publisher<Long> call() throws Exception {
@@ -33,6 +33,6 @@ public class DeferTckTest extends BaseTck<Long> {
                     }
                 }
                 )
-            );
+            ;
     }
 }

--- a/src/test/java/io/reactivex/tck/DelaySubscriptionTckTest.java
+++ b/src/test/java/io/reactivex/tck/DelaySubscriptionTckTest.java
@@ -29,8 +29,8 @@ public class DelaySubscriptionTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).delaySubscription(1, TimeUnit.MILLISECONDS)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/DelayTckTest.java
+++ b/src/test/java/io/reactivex/tck/DelayTckTest.java
@@ -23,10 +23,14 @@ import io.reactivex.Flowable;
 @Test
 public class DelayTckTest extends BaseTck<Integer> {
 
+    public DelayTckTest() {
+        super(100L);
+    }
+
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.range(0, (int)elements).delay(1, TimeUnit.MILLISECONDS)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/DistinctTckTest.java
+++ b/src/test/java/io/reactivex/tck/DistinctTckTest.java
@@ -23,10 +23,10 @@ public class DistinctTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements)
                 .concatWith(Flowable.range(0, (int)elements))
                 .distinct()
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/DistinctUntilChangedTckTest.java
+++ b/src/test/java/io/reactivex/tck/DistinctUntilChangedTckTest.java
@@ -23,9 +23,9 @@ public class DistinctUntilChangedTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements)
                 .distinctUntilChanged()
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/DoAfterNextTckTest.java
+++ b/src/test/java/io/reactivex/tck/DoAfterNextTckTest.java
@@ -24,8 +24,8 @@ public class DoAfterNextTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).doAfterNext(Functions.emptyConsumer())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/DoFinallyTckTest.java
+++ b/src/test/java/io/reactivex/tck/DoFinallyTckTest.java
@@ -24,8 +24,8 @@ public class DoFinallyTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).doFinally(Functions.EMPTY_ACTION)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/DoOnNextTckTest.java
+++ b/src/test/java/io/reactivex/tck/DoOnNextTckTest.java
@@ -24,8 +24,8 @@ public class DoOnNextTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).doOnNext(Functions.emptyConsumer())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ElementAtTckTest.java
+++ b/src/test/java/io/reactivex/tck/ElementAtTckTest.java
@@ -23,9 +23,9 @@ public class ElementAtTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 10).elementAt(5).toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/EmptyTckTest.java
+++ b/src/test/java/io/reactivex/tck/EmptyTckTest.java
@@ -23,8 +23,7 @@ public class EmptyTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(final long elements) {
-        return FlowableTck.wrap(
-                Flowable.<Long>empty());
+        return Flowable.<Long>empty();
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/FilterTckTest.java
+++ b/src/test/java/io/reactivex/tck/FilterTckTest.java
@@ -24,13 +24,13 @@ public class FilterTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements * 2).filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer v) throws Exception {
                         return (v & 1) == 0;
                     }
                 })
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/FirstTckTest.java
+++ b/src/test/java/io/reactivex/tck/FirstTckTest.java
@@ -23,9 +23,9 @@ public class FirstTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 10).firstElement().toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/FlatMapTckTest.java
+++ b/src/test/java/io/reactivex/tck/FlatMapTckTest.java
@@ -24,7 +24,7 @@ public class FlatMapTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements)
                 .flatMap(new Function<Integer, Publisher<Integer>>() {
                     @Override
@@ -32,6 +32,6 @@ public class FlatMapTckTest extends BaseTck<Integer> {
                         return Flowable.just(v);
                     }
                 })
-            );
+            ;
     }
 }

--- a/src/test/java/io/reactivex/tck/FromArrayTckTest.java
+++ b/src/test/java/io/reactivex/tck/FromArrayTckTest.java
@@ -23,9 +23,9 @@ public class FromArrayTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.fromArray(array(elements))
-        );
+        ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/FromCallableTckTest.java
+++ b/src/test/java/io/reactivex/tck/FromCallableTckTest.java
@@ -25,7 +25,7 @@ public class FromCallableTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.fromCallable(new Callable<Long>() {
                     @Override
                     public Long call() throws Exception {
@@ -33,7 +33,7 @@ public class FromCallableTckTest extends BaseTck<Long> {
                     }
                 }
                 )
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/FromFutureTckTest.java
+++ b/src/test/java/io/reactivex/tck/FromFutureTckTest.java
@@ -33,9 +33,7 @@ public class FromFutureTckTest extends BaseTck<Long> {
         });
 
         ft.run();
-        return FlowableTck.wrap(
-                Flowable.fromFuture(ft)
-            );
+        return Flowable.fromFuture(ft);
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/FromIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/FromIterableTckTest.java
@@ -23,8 +23,6 @@ public class FromIterableTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
-                Flowable.fromIterable(iterate(elements))
-        );
+        return Flowable.fromIterable(iterate(elements));
     }
 }

--- a/src/test/java/io/reactivex/tck/GenerateTckTest.java
+++ b/src/test/java/io/reactivex/tck/GenerateTckTest.java
@@ -25,7 +25,7 @@ public class GenerateTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.generate(Functions.justCallable(0L),
             new BiFunction<Long, Emitter<Long>, Long>() {
                 @Override
@@ -37,6 +37,6 @@ public class GenerateTckTest extends BaseTck<Long> {
                     return s;
                 }
             }, Functions.<Long>emptyConsumer())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/GroupByTckTest.java
+++ b/src/test/java/io/reactivex/tck/GroupByTckTest.java
@@ -26,7 +26,7 @@ public class GroupByTckTest extends BaseTck<Integer> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).groupBy(new Function<Integer, Integer>() {
                     @Override
                     public Integer apply(Integer v) throws Exception {
@@ -34,6 +34,6 @@ public class GroupByTckTest extends BaseTck<Integer> {
                     }
                 })
                 .flatMap((Function)Functions.identity())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/HideTckTest.java
+++ b/src/test/java/io/reactivex/tck/HideTckTest.java
@@ -23,8 +23,6 @@ public class HideTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
-                Flowable.range(0, (int)elements).hide()
-        );
+        return Flowable.range(0, (int)elements).hide();
     }
 }

--- a/src/test/java/io/reactivex/tck/IgnoreElementsTckTest.java
+++ b/src/test/java/io/reactivex/tck/IgnoreElementsTckTest.java
@@ -23,9 +23,9 @@ public class IgnoreElementsTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 1000).ignoreElements().<Integer>toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/IntervalRangeTckTest.java
+++ b/src/test/java/io/reactivex/tck/IntervalRangeTckTest.java
@@ -25,9 +25,9 @@ public class IntervalRangeTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.intervalRange(0, elements, 0, 1, TimeUnit.MILLISECONDS)
             .onBackpressureBuffer()
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/IntervalTckTest.java
+++ b/src/test/java/io/reactivex/tck/IntervalTckTest.java
@@ -25,9 +25,9 @@ public class IntervalTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.interval(0, 1, TimeUnit.MILLISECONDS).take(elements)
             .onBackpressureBuffer()
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/IsEmptyTckTest.java
+++ b/src/test/java/io/reactivex/tck/IsEmptyTckTest.java
@@ -23,9 +23,9 @@ public class IsEmptyTckTest extends BaseTck<Boolean> {
 
     @Override
     public Publisher<Boolean> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 10).isEmpty().toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/JustTckTest.java
+++ b/src/test/java/io/reactivex/tck/JustTckTest.java
@@ -23,9 +23,9 @@ public class JustTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.just(0L)
-        );
+        ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/LastTckTest.java
+++ b/src/test/java/io/reactivex/tck/LastTckTest.java
@@ -23,9 +23,9 @@ public class LastTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 10).lastElement().toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/MapTckTest.java
+++ b/src/test/java/io/reactivex/tck/MapTckTest.java
@@ -24,8 +24,8 @@ public class MapTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).map(Functions.<Integer>identity())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/MergeIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/MergeIterableTckTest.java
@@ -26,12 +26,12 @@ public class MergeIterableTckTest extends BaseTck<Long> {
     @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.merge(Arrays.asList(
                     Flowable.fromIterable(iterate(elements / 2)),
                     Flowable.fromIterable(iterate(elements - elements / 2))
                 )
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/MergePublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/MergePublisherTckTest.java
@@ -23,12 +23,12 @@ public class MergePublisherTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.merge(Flowable.just(
                     Flowable.fromIterable(iterate(elements / 2)),
                     Flowable.fromIterable(iterate(elements - elements / 2))
                 )
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/MergeTckTest.java
+++ b/src/test/java/io/reactivex/tck/MergeTckTest.java
@@ -23,11 +23,11 @@ public class MergeTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.merge(
                 Flowable.fromIterable(iterate(elements / 2)),
                 Flowable.fromIterable(iterate(elements - elements / 2))
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ObserveOnTckTest.java
+++ b/src/test/java/io/reactivex/tck/ObserveOnTckTest.java
@@ -28,8 +28,8 @@ public class ObserveOnTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).observeOn(Schedulers.single())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/OnBackpressureBufferTckTest.java
+++ b/src/test/java/io/reactivex/tck/OnBackpressureBufferTckTest.java
@@ -23,8 +23,8 @@ public class OnBackpressureBufferTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).onBackpressureBuffer()
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/OnErrorResumeNextTckTest.java
+++ b/src/test/java/io/reactivex/tck/OnErrorResumeNextTckTest.java
@@ -23,8 +23,8 @@ public class OnErrorResumeNextTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).onErrorResumeNext(Flowable.<Integer>never())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/OnErrorReturnItemTckTest.java
+++ b/src/test/java/io/reactivex/tck/OnErrorReturnItemTckTest.java
@@ -23,8 +23,8 @@ public class OnErrorReturnItemTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).onErrorReturnItem(0)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/PublishSelectorTckTest.java
+++ b/src/test/java/io/reactivex/tck/PublishSelectorTckTest.java
@@ -26,8 +26,8 @@ public class PublishSelectorTckTest extends BaseTck<Integer> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).publish((Function)Functions.identity())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/PublishTckTest.java
+++ b/src/test/java/io/reactivex/tck/PublishTckTest.java
@@ -23,8 +23,8 @@ public class PublishTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).publish().autoConnect()
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/RangeTckTest.java
+++ b/src/test/java/io/reactivex/tck/RangeTckTest.java
@@ -23,8 +23,8 @@ public class RangeTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/RebatchRequestsTckTest.java
+++ b/src/test/java/io/reactivex/tck/RebatchRequestsTckTest.java
@@ -23,8 +23,8 @@ public class RebatchRequestsTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).rebatchRequests(2)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ReduceTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReduceTckTest.java
@@ -24,14 +24,14 @@ public class ReduceTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 1000).reduce(new BiFunction<Integer, Integer, Integer>() {
                     @Override
                     public Integer apply(Integer a, Integer b) throws Exception {
                         return a + b;
                     }
                 }).toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/ReduceWithTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReduceWithTckTest.java
@@ -25,7 +25,7 @@ public class ReduceWithTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 1000).reduceWith(Functions.justCallable(0),
                 new BiFunction<Integer, Integer, Integer>() {
                     @Override
@@ -33,7 +33,7 @@ public class ReduceWithTckTest extends BaseTck<Integer> {
                         return a + b;
                     }
                 }).toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/RepeatTckTest.java
+++ b/src/test/java/io/reactivex/tck/RepeatTckTest.java
@@ -23,8 +23,6 @@ public class RepeatTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
-                Flowable.just(1).repeat(elements)
-        );
+        return Flowable.just(1).repeat(elements);
     }
 }

--- a/src/test/java/io/reactivex/tck/ReplaySelectorTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReplaySelectorTckTest.java
@@ -26,8 +26,8 @@ public class ReplaySelectorTckTest extends BaseTck<Integer> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).replay((Function)Functions.identity())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ReplayTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReplayTckTest.java
@@ -23,8 +23,8 @@ public class ReplayTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).replay().autoConnect()
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/RetryTckTest.java
+++ b/src/test/java/io/reactivex/tck/RetryTckTest.java
@@ -23,8 +23,8 @@ public class RetryTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).retry(1)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ScanTckTest.java
+++ b/src/test/java/io/reactivex/tck/ScanTckTest.java
@@ -24,13 +24,13 @@ public class ScanTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).scan(new BiFunction<Integer, Integer, Integer>() {
                     @Override
                     public Integer apply(Integer a, Integer b) throws Exception {
                         return a + b;
                     }
                 })
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/SequenceEqualTckTest.java
+++ b/src/test/java/io/reactivex/tck/SequenceEqualTckTest.java
@@ -23,12 +23,12 @@ public class SequenceEqualTckTest extends BaseTck<Boolean> {
 
     @Override
     public Publisher<Boolean> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.sequenceEqual(
                         Flowable.range(1, 1000),
                         Flowable.range(1, 1001))
                 .toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/ShareTckTest.java
+++ b/src/test/java/io/reactivex/tck/ShareTckTest.java
@@ -23,8 +23,8 @@ public class ShareTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).share()
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/SingleTckTest.java
+++ b/src/test/java/io/reactivex/tck/SingleTckTest.java
@@ -23,9 +23,9 @@ public class SingleTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.just(1).singleElement().toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/SkipLastTckTest.java
+++ b/src/test/java/io/reactivex/tck/SkipLastTckTest.java
@@ -23,8 +23,8 @@ public class SkipLastTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements * 2).skipLast((int)elements)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/SkipTckTest.java
+++ b/src/test/java/io/reactivex/tck/SkipTckTest.java
@@ -23,8 +23,8 @@ public class SkipTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements * 2).skip(elements)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/SkipUntilTckTest.java
+++ b/src/test/java/io/reactivex/tck/SkipUntilTckTest.java
@@ -23,8 +23,8 @@ public class SkipUntilTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).skipUntil(Flowable.just(1))
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/SkipWhileTckTest.java
+++ b/src/test/java/io/reactivex/tck/SkipWhileTckTest.java
@@ -24,8 +24,8 @@ public class SkipWhileTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).skipWhile(Functions.alwaysFalse())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/SortedTckTest.java
+++ b/src/test/java/io/reactivex/tck/SortedTckTest.java
@@ -23,8 +23,8 @@ public class SortedTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).sorted()
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/SubscribeOnTckTest.java
+++ b/src/test/java/io/reactivex/tck/SubscribeOnTckTest.java
@@ -24,8 +24,8 @@ public class SubscribeOnTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).subscribeOn(Schedulers.single())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/SwitchIfEmptyTckTest.java
+++ b/src/test/java/io/reactivex/tck/SwitchIfEmptyTckTest.java
@@ -23,8 +23,8 @@ public class SwitchIfEmptyTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.<Integer>empty().switchIfEmpty(Flowable.range(1, (int)elements))
-            );
+            ;
     }
 }

--- a/src/test/java/io/reactivex/tck/SwitchMapDelayErrorTckTest.java
+++ b/src/test/java/io/reactivex/tck/SwitchMapDelayErrorTckTest.java
@@ -24,10 +24,10 @@ public class SwitchMapDelayErrorTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.just(1).switchMapDelayError(Functions.justFunction(
                     Flowable.fromIterable(iterate(elements)))
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/SwitchMapTckTest.java
+++ b/src/test/java/io/reactivex/tck/SwitchMapTckTest.java
@@ -24,10 +24,10 @@ public class SwitchMapTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.just(1).switchMap(Functions.justFunction(
                     Flowable.fromIterable(iterate(elements)))
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/SwitchOnNextTckTest.java
+++ b/src/test/java/io/reactivex/tck/SwitchOnNextTckTest.java
@@ -23,10 +23,10 @@ public class SwitchOnNextTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.switchOnNext(Flowable.just(
                     Flowable.fromIterable(iterate(elements)))
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/TakeLastTckTest.java
+++ b/src/test/java/io/reactivex/tck/TakeLastTckTest.java
@@ -23,8 +23,8 @@ public class TakeLastTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements * 2).takeLast((int)elements)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/TakeTckTest.java
+++ b/src/test/java/io/reactivex/tck/TakeTckTest.java
@@ -23,8 +23,8 @@ public class TakeTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements * 2).take(elements)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/TakeUntilTckTest.java
+++ b/src/test/java/io/reactivex/tck/TakeUntilTckTest.java
@@ -23,8 +23,8 @@ public class TakeUntilTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).takeUntil(Flowable.never())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/TakeWhileTckTest.java
+++ b/src/test/java/io/reactivex/tck/TakeWhileTckTest.java
@@ -24,8 +24,8 @@ public class TakeWhileTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).takeWhile(Functions.alwaysTrue())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/TimeIntervalTckTest.java
+++ b/src/test/java/io/reactivex/tck/TimeIntervalTckTest.java
@@ -24,8 +24,8 @@ public class TimeIntervalTckTest extends BaseTck<Timed<Integer>> {
 
     @Override
     public Publisher<Timed<Integer>> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).timeInterval()
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/TimeoutTckTest.java
+++ b/src/test/java/io/reactivex/tck/TimeoutTckTest.java
@@ -25,8 +25,8 @@ public class TimeoutTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).timeout(1, TimeUnit.DAYS)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/TimerTckTest.java
+++ b/src/test/java/io/reactivex/tck/TimerTckTest.java
@@ -25,10 +25,10 @@ public class TimerTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.timer(1, TimeUnit.MILLISECONDS)
                 .onBackpressureLatest()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/TimestampTckTest.java
+++ b/src/test/java/io/reactivex/tck/TimestampTckTest.java
@@ -24,8 +24,8 @@ public class TimestampTckTest extends BaseTck<Timed<Integer>> {
 
     @Override
     public Publisher<Timed<Integer>> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements).timestamp()
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ToListTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToListTckTest.java
@@ -25,9 +25,9 @@ public class ToListTckTest extends BaseTck<List<Integer>> {
 
     @Override
     public Publisher<List<Integer>> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 1000).toList().toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/ToMapTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToMapTckTest.java
@@ -26,9 +26,9 @@ public class ToMapTckTest extends BaseTck<Map<Integer, Integer>> {
 
     @Override
     public Publisher<Map<Integer, Integer>> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 1000).toMap(Functions.<Integer>identity()).toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/ToMultimapTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToMultimapTckTest.java
@@ -26,9 +26,9 @@ public class ToMultimapTckTest extends BaseTck<Map<Integer, Collection<Integer>>
 
     @Override
     public Publisher<Map<Integer, Collection<Integer>>> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 1000).toMultimap(Functions.<Integer>identity()).toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/ToSortedListTckTest.java
+++ b/src/test/java/io/reactivex/tck/ToSortedListTckTest.java
@@ -25,9 +25,9 @@ public class ToSortedListTckTest extends BaseTck<List<Integer>> {
 
     @Override
     public Publisher<List<Integer>> createPublisher(final long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(1, 1000).toSortedList().toFlowable()
-            );
+            ;
     }
 
     @Override

--- a/src/test/java/io/reactivex/tck/UnsubscribeOnTckTest.java
+++ b/src/test/java/io/reactivex/tck/UnsubscribeOnTckTest.java
@@ -24,10 +24,10 @@ public class UnsubscribeOnTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements * 2)
                 .unsubscribeOn(Schedulers.single())
                 .take(elements)
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/UsingTckTest.java
+++ b/src/test/java/io/reactivex/tck/UsingTckTest.java
@@ -24,11 +24,11 @@ public class UsingTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.using(Functions.justCallable(1),
                     Functions.justFunction(Flowable.fromIterable(iterate(elements))),
                     Functions.emptyConsumer()
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/WindowBoundaryTckTest.java
+++ b/src/test/java/io/reactivex/tck/WindowBoundaryTckTest.java
@@ -28,11 +28,11 @@ public class WindowBoundaryTckTest extends BaseTck<List<Long>> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public Publisher<List<Long>> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.fromIterable(iterate(elements))
             .window(Flowable.just(1).concatWith(Flowable.<Integer>never()))
             .onBackpressureBuffer()
             .flatMap((Function)Functions.identity())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/WindowExactSizeTckTest.java
+++ b/src/test/java/io/reactivex/tck/WindowExactSizeTckTest.java
@@ -28,10 +28,10 @@ public class WindowExactSizeTckTest extends BaseTck<List<Long>> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public Publisher<List<Long>> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.fromIterable(iterate(elements))
             .window(2)
             .flatMap((Function)Functions.identity())
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/WithLatestFromTckTest.java
+++ b/src/test/java/io/reactivex/tck/WithLatestFromTckTest.java
@@ -24,7 +24,7 @@ public class WithLatestFromTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements)
                 .withLatestFrom(Flowable.just(1), new BiFunction<Integer, Integer, Integer>() {
                     @Override
@@ -32,6 +32,6 @@ public class WithLatestFromTckTest extends BaseTck<Integer> {
                         return a + b;
                     }
                 })
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ZipIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/ZipIterableTckTest.java
@@ -27,7 +27,7 @@ public class ZipIterableTckTest extends BaseTck<Long> {
     @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.zip(Arrays.asList(
                     Flowable.fromIterable(iterate(elements)),
                     Flowable.fromIterable(iterate(elements))
@@ -39,6 +39,6 @@ public class ZipIterableTckTest extends BaseTck<Long> {
                     }
                 }
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ZipTckTest.java
+++ b/src/test/java/io/reactivex/tck/ZipTckTest.java
@@ -24,7 +24,7 @@ public class ZipTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
             Flowable.zip(
                     Flowable.fromIterable(iterate(elements)),
                     Flowable.fromIterable(iterate(elements)),
@@ -35,6 +35,6 @@ public class ZipTckTest extends BaseTck<Long> {
                         }
                     }
             )
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ZipWithIterableTckTest.java
+++ b/src/test/java/io/reactivex/tck/ZipWithIterableTckTest.java
@@ -24,7 +24,7 @@ public class ZipWithIterableTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements)
                 .zipWith(iterate(elements), new BiFunction<Integer, Long, Integer>() {
                     @Override
@@ -32,6 +32,6 @@ public class ZipWithIterableTckTest extends BaseTck<Integer> {
                         return a + b.intValue();
                     }
                 })
-        );
+        ;
     }
 }

--- a/src/test/java/io/reactivex/tck/ZipWithTckTest.java
+++ b/src/test/java/io/reactivex/tck/ZipWithTckTest.java
@@ -24,7 +24,7 @@ public class ZipWithTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
-        return FlowableTck.wrap(
+        return
                 Flowable.range(0, (int)elements)
                 .zipWith(Flowable.range((int)elements, (int)elements), new BiFunction<Integer, Integer, Integer>() {
                     @Override
@@ -32,6 +32,6 @@ public class ZipWithTckTest extends BaseTck<Integer> {
                         return a + b;
                     }
                 })
-        );
+        ;
     }
 }


### PR DESCRIPTION
This PR performs the changes suggested in #5110.

 - Introduce `FlowableSubscriber` with extra textual specification on its relaxed nature
 - `Flowable.subscribe(Subscriber)` checks for `FlowableSubscriber` and if not found, it wraps the incoming RS `Subscriber` into a `StrictSubscriber` that follows the RS spec to the letter at any cost.
 - Introduce `Flowable.subscribe(FlowableSubscribe)` that most internal operators will use
 - Change `AbstractFlowableWithUpstream` to accept `Flowable` as a source, update operators
 - Some operators were useful with raw `Publisher` input, these were duplicated on their outer containing type but use the same internal `FlowableSubscriber`
 - Removed "cheat" from the TCK tests, adjusted timeout on `delay`
 - Replaced most `implements Subscriber` with `implements FlowableSubscriber`
 - Replaced most `new Subscriber` with `new FlowableSubscriber` in tests, the rest is required for testing the strictness itself.
 - `strict()` is now an identity operator with suggested scheduled removal.

Performance impact estimation

- Most primary use of a `Flowable` should go through `subscribe(FlowableSubscribe)` and thus no overhead change.
- Where the API mandated `Publisher` as input, providing a `Flowable` will have an `instanceof` check at subscription time and routed to `subscribe(FlowableSubscriber) if the consumer is part of RxJava 2 itself.