### PR TITLE
2.x: fix Observable.combineLatest to dispose eagerly

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
@@ -124,9 +124,9 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
         public void dispose() {
             if (!cancelled) {
                 cancelled = true;
-
+                cancelSources();
                 if (getAndIncrement() == 0) {
-                    cancel(queue);
+                    clear(queue);
                 }
             }
         }
@@ -138,6 +138,10 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
 
         void cancel(SpscLinkedArrayQueue<?> q) {
             clear(q);
+            cancelSources();
+        }
+
+        void cancelSources() {
             for (CombinerObserver<T, R> s : observers) {
                 s.dispose();
             }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
@@ -1165,4 +1165,37 @@ public class ObservableCombineLatestTest {
         }
     }
 
+    @Test
+    public void eagerDispose() {
+        final PublishSubject<Integer> ps1 = PublishSubject.create();
+        final PublishSubject<Integer> ps2 = PublishSubject.create();
+
+        TestObserver<Integer> ts = new TestObserver<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                cancel();
+                if (ps1.hasObservers()) {
+                    onError(new IllegalStateException("ps1 not disposed"));
+                } else
+                if (ps2.hasObservers()) {
+                    onError(new IllegalStateException("ps2 not disposed"));
+                } else {
+                    onComplete();
+                }
+            }
+        };
+
+        Observable.combineLatest(ps1, ps2, new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t1, Integer t2) throws Exception {
+                return t1 + t2;
+            }
+        })
+        .subscribe(ts);
+
+        ps1.onNext(1);
+        ps2.onNext(2);
+        ts.assertResult(3);
+    }
 }


### PR DESCRIPTION
This PR fixes `Observable.combineLatest` to dispose the sources outside the serialization loop, just like `Flowable.combineLatest` does. This allows cancellation even if the serialization loop is busy/blocking inside an `onNext` emission.

In addition, a unit test was added to `Flowable.combineLatest` as well.

Reported in #5111.