### PR TITLE
2.x: benchmark the new strict/interop mode

### DIFF
--- a/src/perf/java/io/reactivex/PerfInteropConsumer.java
+++ b/src/perf/java/io/reactivex/PerfInteropConsumer.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.*;
+
+import io.reactivex.disposables.Disposable;
+
+/**
+ * A multi-type synchronous consumer that doesn't implement FlowableSubscriber and
+ * thus should be treated by Flowable as a candidate for strict interop.
+ */
+public final class PerfInteropConsumer implements Subscriber<Object>, Observer<Object>,
+SingleObserver<Object>, CompletableObserver, MaybeObserver<Object> {
+
+    final Blackhole bh;
+
+    public PerfInteropConsumer(Blackhole bh) {
+        this.bh = bh;
+    }
+
+    @Override
+    public void onSuccess(Object value) {
+        bh.consume(value);
+    }
+
+    @Override
+    public void onSubscribe(Disposable d) {
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        s.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(Object t) {
+        bh.consume(t);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        t.printStackTrace();
+    }
+
+    @Override
+    public void onComplete() {
+        bh.consume(true);
+    }
+}

--- a/src/perf/java/io/reactivex/StrictPerf.java
+++ b/src/perf/java/io/reactivex/StrictPerf.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class StrictPerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> source;
+
+    @Setup
+    public void setup() {
+        Integer[] array = new Integer[count];
+        Arrays.fill(array, 777);
+
+        source = Flowable.fromArray(array);
+    }
+
+    @Benchmark
+    public void internal(Blackhole bh) {
+        source.subscribe(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public void external(Blackhole bh) {
+        source.subscribe(new PerfInteropConsumer(bh));
+    }
+}


### PR DESCRIPTION
Benchmark the overhead of the strict/interop mode.

i5 6440HQ, Windows 10 x64, Java 8u121

![image](https://cloud.githubusercontent.com/assets/1269832/23092637/ce9f343c-f5cf-11e6-868b-e24ff6fc2b43.png)

The numbers are consistent with my expectations; this mobile processor is roughly equivalent to i7 4770 desktop where the cost model is: 1 atomic increment per item equals to roughly 130 Mops/s upper limit, 2 atomic increment per item is roughly 60 Mops/s upper limit. Since the interop mode requires at minimum two atomic increments, 54 Mops/s is a reasonable value to get.