### PR TITLE
1.x: throttleFirst detecting clock-drift backwards to open the gate

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorThrottleFirst.java
+++ b/src/main/java/rx/internal/operators/OperatorThrottleFirst.java
@@ -48,7 +48,7 @@ public final class OperatorThrottleFirst<T> implements Operator<T, T> {
             @Override
             public void onNext(T v) {
                 long now = scheduler.now();
-                if (lastOnNext == -1 || now - lastOnNext >= timeInMilliseconds) {
+                if (lastOnNext == -1 || now < lastOnNext || now - lastOnNext >= timeInMilliseconds) {
                     lastOnNext = now;
                     subscriber.onNext(v);
                 }


### PR DESCRIPTION
If the current time moves backwards before the time the gate was closed, the opening of the gate would happen way later. Since we don't know how much relative time has passed, this fix opens the gate when the drift is detected during `onNext`.

Reported in #5120.

/cc @davidmoten as you've been experimenting with time-only (that is non-scheduled) gating.