### PR TITLE
1.x: reduce stack depth with switchIfEmpty

### DIFF
--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -5481,7 +5481,7 @@ public class Observable<T> {
         if (alternate == null) {
             throw new NullPointerException("alternate is null");
         }
-        return lift(new OperatorSwitchIfEmpty<T>(alternate));
+        return unsafeCreate(new OnSubscribeSwitchIfEmpty<T>(this, alternate));
     }
 
     /**

--- a/src/main/java/rx/internal/operators/OnSubscribeSwitchIfEmpty.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeSwitchIfEmpty.java
@@ -16,6 +16,8 @@
 package rx.internal.operators;
 
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import rx.*;
 import rx.internal.producers.ProducerArbiter;
 import rx.subscriptions.SerialSubscription;
@@ -26,22 +28,28 @@ import rx.subscriptions.SerialSubscription;
  * empty, the results of the given Observable will be emitted.
  * @param <T> the value type
  */
-public final class OperatorSwitchIfEmpty<T> implements Observable.Operator<T, T> {
-    private final Observable<? extends T> alternate;
+public final class OnSubscribeSwitchIfEmpty<T> implements Observable.OnSubscribe<T> {
 
-    public OperatorSwitchIfEmpty(Observable<? extends T> alternate) {
+    final Observable<? extends T> source;
+
+    final Observable<? extends T> alternate;
+
+    public OnSubscribeSwitchIfEmpty(Observable<? extends T> source, Observable<? extends T> alternate) {
+        this.source = source;
         this.alternate = alternate;
     }
 
     @Override
-    public Subscriber<? super T> call(Subscriber<? super T> child) {
+    public void call(Subscriber<? super T> child) {
         final SerialSubscription serial = new SerialSubscription();
         ProducerArbiter arbiter = new ProducerArbiter();
         final ParentSubscriber<T> parent = new ParentSubscriber<T>(child, serial, arbiter, alternate);
+
         serial.set(parent);
         child.add(serial);
         child.setProducer(arbiter);
-        return parent;
+
+        parent.subscribe(source);
     }
 
     static final class ParentSubscriber<T> extends Subscriber<T> {
@@ -52,11 +60,16 @@ public final class OperatorSwitchIfEmpty<T> implements Observable.Operator<T, T>
         private final ProducerArbiter arbiter;
         private final Observable<? extends T> alternate;
 
+        final AtomicInteger wip;
+        volatile boolean active;
+        boolean secondary;
+
         ParentSubscriber(Subscriber<? super T> child, final SerialSubscription serial, ProducerArbiter arbiter, Observable<? extends T> alternate) {
             this.child = child;
             this.serial = serial;
             this.arbiter = arbiter;
             this.alternate = alternate;
+            this.wip = new AtomicInteger();
         }
 
         @Override
@@ -69,14 +82,33 @@ public final class OperatorSwitchIfEmpty<T> implements Observable.Operator<T, T>
             if (!empty) {
                 child.onCompleted();
             } else if (!child.isUnsubscribed()) {
-                subscribeToAlternate();
+                active = false;
+                subscribe(null);
             }
         }
 
-        private void subscribeToAlternate() {
-            AlternateSubscriber<T> as = new AlternateSubscriber<T>(child, arbiter);
-            serial.set(as);
-            alternate.unsafeSubscribe(as);
+        void subscribe(Observable<? extends T> source) {
+            if (wip.getAndIncrement() == 0) {
+                do {
+                    if (child.isUnsubscribed()) {
+                        break;
+                    }
+
+                    if (!active) {
+                        if (secondary) {
+                            AlternateSubscriber<T> as = new AlternateSubscriber<T>(child, arbiter);
+                            serial.set(as);
+                            active = true;
+                            alternate.unsafeSubscribe(as);
+                        } else {
+                            secondary = true;
+                            active = true;
+                            source.unsafeSubscribe(this);
+                        }
+                    }
+
+                } while (wip.decrementAndGet() != 0);
+            }
         }
 
         @Override

--- a/src/main/java/rx/internal/operators/OnSubscribeSwitchIfEmpty.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeSwitchIfEmpty.java
@@ -62,7 +62,6 @@ public final class OnSubscribeSwitchIfEmpty<T> implements Observable.OnSubscribe
 
         final AtomicInteger wip;
         volatile boolean active;
-        boolean secondary;
 
         ParentSubscriber(Subscriber<? super T> child, final SerialSubscription serial, ProducerArbiter arbiter, Observable<? extends T> alternate) {
             this.child = child;
@@ -95,15 +94,15 @@ public final class OnSubscribeSwitchIfEmpty<T> implements Observable.OnSubscribe
                     }
 
                     if (!active) {
-                        if (secondary) {
+                        if (source == null) {
                             AlternateSubscriber<T> as = new AlternateSubscriber<T>(child, arbiter);
                             serial.set(as);
                             active = true;
                             alternate.unsafeSubscribe(as);
                         } else {
-                            secondary = true;
                             active = true;
                             source.unsafeSubscribe(this);
+                            source = null;
                         }
                     }
 


### PR DESCRIPTION
Stack depths may get deep if `switchIfEmpty` has to switch to the alternative source at the end of an already long chain leading to the `onCompleted`. Using multiple `switchIfEmpty` amplifies the impact on the stack depth. 

This PR introduces trampolined subscribing to both sources (similar to how `concat` works), thus given synchronous sources, the stack depth rewinds to the level it was when the `switchIfEmpty` was subscribed to. In addition, to reduce the depth even further, the operator has been turned into an `OnSubscribe`-based implementation to avoid the extra depth due to `lift`.

Related: [rxjava StackOverflowError exception in long chain
](http://stackoverflow.com/questions/42363452/rxjava-stackoverflowerror-exception-in-long-chain)