### PR TITLE
2.x: fix flatMap not cancelling the upstream eagerly

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -28,10 +28,12 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
@@ -1629,5 +1631,22 @@ public class FlowableMergeTest {
         Flowable.mergeArray(Flowable.just(1), Flowable.just(2))
         .test()
         .assertResult(1, 2);
+    }
+
+    @Test
+    public void mergeErrors() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable<Integer> source1 = Flowable.error(new TestException("First"));
+            Flowable<Integer> source2 = Flowable.error(new TestException("Second"));
+
+            Flowable.merge(source1, source2)
+            .test()
+            .assertFailureAndMessage(TestException.class, "First");
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
@@ -27,8 +27,10 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.observers.*;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.*;
 
 public class ObservableMergeTest {
@@ -1124,5 +1126,22 @@ public class ObservableMergeTest {
         Observable.mergeArray(Observable.just(1), Observable.just(2))
         .test()
         .assertResult(1, 2);
+    }
+
+    @Test
+    public void mergeErrors() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable<Integer> source1 = Observable.error(new TestException("First"));
+            Observable<Integer> source2 = Observable.error(new TestException("Second"));
+
+            Observable.merge(source1, source2)
+            .test()
+            .assertFailureAndMessage(TestException.class, "First");
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMergeTest.java
@@ -13,9 +13,15 @@
 
 package io.reactivex.internal.operators.single;
 
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
 import org.junit.Test;
 
-import io.reactivex.Single;
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public class SingleMergeTest {
 
@@ -48,4 +54,20 @@ public class SingleMergeTest {
         .assertResult(1, 2, 3, 4);
     }
 
+    @Test
+    public void mergeErrors() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Single<Integer> source1 = Single.error(new TestException("First"));
+            Single<Integer> source2 = Single.error(new TestException("Second"));
+
+            Single.merge(source1, source2)
+            .test()
+            .assertFailureAndMessage(TestException.class, "First");
+
+            assertTrue(errors.toString(), errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes the lack of eager cancellation when flatmapping sources and not stopping the upstream if the inner source fails.

Unit tests were added to verify `Single` (in case it receives a dedicated implementation one day as currently it delegates to `Flowable`), `Flowable` and `Observable`.

Reported in #5132.