### PR TITLE
2.x: fix repeatWhen and retryWhen signatures

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -1441,7 +1441,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable repeatWhen(Function<? super Flowable<Object>, ? extends Publisher<Object>> handler) {
+    public final Completable repeatWhen(Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
         return fromPublisher(toFlowable().repeatWhen(handler));
     }
 
@@ -1526,7 +1526,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable retryWhen(Function<? super Flowable<Throwable>, ? extends Publisher<Object>> handler) {
+    public final Completable retryWhen(Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
         return fromPublisher(toFlowable().retryWhen(handler));
     }
 

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -8217,8 +8217,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@link #bufferSize()} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@link #bufferSize()} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8249,8 +8249,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@link #bufferSize()} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@link #bufferSize()} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8285,8 +8285,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8321,8 +8321,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8360,8 +8360,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8411,8 +8411,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@link #bufferSize()} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@link #bufferSize()} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8454,8 +8454,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8501,8 +8501,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8537,8 +8537,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      * <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@link #bufferSize()} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@link #bufferSize()} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8577,8 +8577,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8620,8 +8620,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@code maxConcurrency} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8667,8 +8667,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The upstream Flowable is consumed
-     *  in a bounded manner (up to {@link #bufferSize()} outstanding request amount for items). 
-     *  The inner {@code Publisher}s are expected to honor backpressure; if violated, 
+     *  in a bounded manner (up to {@link #bufferSize()} outstanding request amount for items).
+     *  The inner {@code Publisher}s are expected to honor backpressure; if violated,
      *  the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2467,7 +2467,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> repeatWhen(Function<? super Flowable<Object>, ? extends Publisher<Object>> handler) {
+    public final Flowable<T> repeatWhen(Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
         return toFlowable().repeatWhen(handler);
     }
 
@@ -2577,7 +2577,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> retryWhen(Function<? super Flowable<Throwable>, ? extends Publisher<Object>> handler) {
+    public final Single<T> retryWhen(Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
         return toSingle(toFlowable().retryWhen(handler));
     }
 


### PR DESCRIPTION
Adjust the `repeatWhen` and `retryWhen` signatures to accept `Publisher<?>` on `Single` and `Completable`, matching `Flowable`'s signature.

Reported in #5135.