### PR TITLE
2.x: add TestSubscriber.withTag

### DIFF
--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -48,6 +48,8 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     protected int establishedFusionMode;
 
+    protected CharSequence tag;
+
     public BaseTestConsumer() {
         this.values = new ArrayList<T>();
         this.errors = new ArrayList<Throwable>();
@@ -129,6 +131,15 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
         .append("values = ").append(values.size()).append(", ")
         .append("errors = ").append(errors.size()).append(", ")
         .append("completions = ").append(completions)
+        ;
+
+        CharSequence tag = this.tag;
+        if (tag != null) {
+            b.append(", tag = ")
+            .append(tag);
+        }
+
+        b
         .append(')')
         ;
 
@@ -746,5 +757,19 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
                 .assertNoValues()
                 .assertNoErrors()
                 .assertNotComplete();
+    }
+
+    /**
+     * Set the tag displayed along with an assertion failure's
+     * other state information.
+     * @param tag the string to display (null won't print any tag)
+     * @return this
+     * @since 2.0.7 - experimental
+     */
+    @SuppressWarnings("unchecked")
+    @Experimental
+    public final U withTag(CharSequence tag) {
+        this.tag = tag;
+        return (U)this;
     }
 }

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -1381,4 +1381,20 @@ public class TestObserverTest {
             }
         });
     }
+
+    @Test
+    public void withTag() {
+        try {
+            for (int i = 1; i < 3; i++) {
+                Observable.just(i)
+                .test()
+                .withTag("testing with item=" + i)
+                .assertResult(1)
+                ;
+            }
+            fail("Should have thrown!");
+        } catch (AssertionError ex) {
+            assertTrue(ex.toString(), ex.toString().contains("testing with item=2"));
+        }
+    }
 }

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -1777,4 +1777,20 @@ public class TestSubscriberTest {
         .requestMore(3)
         .assertResult(1, 2, 3, 4, 5);
     }
+
+    @Test
+    public void withTag() {
+        try {
+            for (int i = 1; i < 3; i++) {
+                Flowable.just(i)
+                .test()
+                .withTag("testing with item=" + i)
+                .assertResult(1)
+                ;
+            }
+            fail("Should have thrown!");
+        } catch (AssertionError ex) {
+            assertTrue(ex.toString(), ex.toString().contains("testing with item=2"));
+        }
+    }
 }


### PR DESCRIPTION
This PR adds the method `withTag` to the `TestBaseConsumer` that allows setting a textual tag which is then appended to the assertion failure's message:

```
Failure message (latch = 1, values = 0, errors = 0, completions = 0, tag = x: 5, y: 7)
```

Use case, for example, is to add the parameters of the current flow to help identify what settings caused the failure. This comes up with unit tests that have some form of (nested) loop(s) to verify multiple parameter ranges. (It is often much easier than trying to work out JUnit rules and such.) 