### PR TITLE
2.x: fix timed replay-like components replaying outdated items

### DIFF
--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -1066,8 +1066,8 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
         @Override
         @SuppressWarnings("unchecked")
         public T[] getValues(T[] array) {
-            TimedNode<Object> h = head;
-            int s = size();
+            TimedNode<Object> h = getHead();
+            int s = size(h);
 
             if (s == 0) {
                 if (array.length != 0) {
@@ -1093,6 +1093,22 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
             return array;
         }
 
+        TimedNode<Object> getHead() {
+            TimedNode<Object> index = head;
+            // skip old entries
+            long limit = scheduler.now(unit) - maxAge;
+            TimedNode<Object> next = index.get();
+            while (next != null) {
+                long ts = next.time;
+                if (ts > limit) {
+                    break;
+                }
+                index = next;
+                next = index.get();
+            }
+            return index;
+        }
+
         @Override
         @SuppressWarnings("unchecked")
         public void replay(ReplaySubscription<T> rs) {
@@ -1105,20 +1121,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
 
             TimedNode<Object> index = (TimedNode<Object>)rs.index;
             if (index == null) {
-                index = head;
-                if (!done) {
-                    // skip old entries
-                    long limit = scheduler.now(unit) - maxAge;
-                    TimedNode<Object> next = index.get();
-                    while (next != null) {
-                        long ts = next.time;
-                        if (ts > limit) {
-                            break;
-                        }
-                        index = next;
-                        next = index.get();
-                    }
-                }
+                index = getHead();
             }
 
             for (;;) {
@@ -1185,8 +1188,11 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
 
         @Override
         public int size() {
+            return size(getHead());
+        }
+
+        int size(TimedNode<Object> h) {
             int s = 0;
-            TimedNode<Object> h = head;
             while (s != Integer.MAX_VALUE) {
                 TimedNode<Object> next = h.get();
                 if (next == null) {

--- a/src/main/java/io/reactivex/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/subjects/ReplaySubject.java
@@ -1029,11 +1029,27 @@ public final class ReplaySubject<T> extends Subject<T> {
             return (T)v;
         }
 
+        TimedNode<Object> getHead() {
+            TimedNode<Object> index = head;
+            // skip old entries
+            long limit = scheduler.now(unit) - maxAge;
+            TimedNode<Object> next = index.get();
+            while (next != null) {
+                long ts = next.time;
+                if (ts > limit) {
+                    break;
+                }
+                index = next;
+                next = index.get();
+            }
+            return index;
+        }
+
         @Override
         @SuppressWarnings("unchecked")
         public T[] getValues(T[] array) {
-            TimedNode<Object> h = head;
-            int s = size();
+            TimedNode<Object> h = getHead();
+            int s = size(h);
 
             if (s == 0) {
                 if (array.length != 0) {
@@ -1071,20 +1087,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
             TimedNode<Object> index = (TimedNode<Object>)rs.index;
             if (index == null) {
-                index = head;
-                if (!done) {
-                    // skip old entries
-                    long limit = scheduler.now(unit) - maxAge;
-                    TimedNode<Object> next = index.get();
-                    while (next != null) {
-                        long ts = next.time;
-                        if (ts > limit) {
-                            break;
-                        }
-                        index = next;
-                        next = index.get();
-                    }
-                }
+                index = getHead();
             }
 
             for (;;) {
@@ -1142,8 +1145,11 @@ public final class ReplaySubject<T> extends Subject<T> {
 
         @Override
         public int size() {
+            return size(getHead());
+        }
+
+        int size(TimedNode<Object> h) {
             int s = 0;
-            TimedNode<Object> h = head;
             while (s != Integer.MAX_VALUE) {
                 TimedNode<Object> next = h.get();
                 if (next == null) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -175,7 +175,7 @@ public class FlowableReplayTest {
             InOrder inOrder = inOrder(observer1);
 
             co.subscribe(observer1);
-            inOrder.verify(observer1, times(1)).onNext(3);
+            inOrder.verify(observer1, never()).onNext(3);
 
             inOrder.verify(observer1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
@@ -451,7 +451,7 @@ public class FlowableReplayTest {
             InOrder inOrder = inOrder(observer1);
 
             co.subscribe(observer1);
-            inOrder.verify(observer1, times(1)).onNext(3);
+            inOrder.verify(observer1, never()).onNext(3);
 
             inOrder.verify(observer1, times(1)).onError(any(RuntimeException.class));
             inOrder.verifyNoMoreInteractions();
@@ -775,7 +775,7 @@ public class FlowableReplayTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(1, 2), values);
+        Assert.assertEquals(Arrays.asList(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -1648,7 +1648,7 @@ public class FlowableReplayTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(1, 2), values);
+        Assert.assertEquals(Arrays.asList(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -1730,5 +1730,22 @@ public class FlowableReplayTest {
         sub[0].onSubscribe(bs);
 
         assertTrue(bs.isCancelled());
+    }
+
+    @Test
+    public void timedNoOutdatedData() {
+        TestScheduler scheduler = new TestScheduler();
+
+        Flowable<Integer> source = Flowable.just(1)
+                .replay(2, TimeUnit.SECONDS, scheduler)
+                .autoConnect();
+
+        source.test().assertResult(1);
+
+        source.test().assertResult(1);
+
+        scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
+
+        source.test().assertResult();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -175,7 +175,7 @@ public class ObservableReplayTest {
             InOrder inOrder = inOrder(observer1);
 
             co.subscribe(observer1);
-            inOrder.verify(observer1, times(1)).onNext(3);
+            inOrder.verify(observer1, never()).onNext(3);
 
             inOrder.verify(observer1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
@@ -451,7 +451,7 @@ public class ObservableReplayTest {
             InOrder inOrder = inOrder(observer1);
 
             co.subscribe(observer1);
-            inOrder.verify(observer1, times(1)).onNext(3);
+            inOrder.verify(observer1, never()).onNext(3);
 
             inOrder.verify(observer1, times(1)).onError(any(RuntimeException.class));
             inOrder.verifyNoMoreInteractions();
@@ -762,7 +762,7 @@ public class ObservableReplayTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(1, 2), values);
+        Assert.assertEquals(Arrays.asList(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -805,7 +805,7 @@ public class ObservableReplayTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(1, 2), values);
+        Assert.assertEquals(Arrays.asList(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -1510,5 +1510,22 @@ public class ObservableReplayTest {
         sub[0].onSubscribe(bs);
 
         assertTrue(bs.isDisposed());
+    }
+
+    @Test
+    public void timedNoOutdatedData() {
+        TestScheduler scheduler = new TestScheduler();
+
+        Observable<Integer> source = Observable.just(1)
+                .replay(2, TimeUnit.SECONDS, scheduler)
+                .autoConnect();
+
+        source.test().assertResult(1);
+
+        source.test().assertResult(1);
+
+        scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
+
+        source.test().assertResult();
     }
 }


### PR DESCRIPTION
The timed versions of `Flowable.replay()`, `ReplayProcessor`, `Observable.replay()` and `ReplaySubject` all replay outdated items to new subscribers and through the `getValues()` and `size()` state-peeking methods, similar to issue #3917 resolved via #4023.

The fix includes a node-walk for new subscribers that skips old entries. Some unit tests weren't logically considering the emission pattern (i.e., items timed out shouldn't appear) and have been fixed as well.

Reported in #5139.