### PR TITLE
2.x: Java 9 compatibility fixes (March 3)

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableIterable.java
@@ -27,11 +27,11 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
 
 public final class BlockingFlowableIterable<T> implements Iterable<T> {
-    final Flowable<? extends T> source;
+    final Flowable<T> source;
 
     final int bufferSize;
 
-    public BlockingFlowableIterable(Flowable<? extends T> source, int bufferSize) {
+    public BlockingFlowableIterable(Flowable<T> source, int bufferSize) {
         this.source = source;
         this.bufferSize = bufferSize;
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecent.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecent.java
@@ -29,11 +29,11 @@ import io.reactivex.subscribers.DefaultSubscriber;
  */
 public final class BlockingFlowableMostRecent<T> implements Iterable<T> {
 
-    final Flowable<? extends T> source;
+    final Flowable<T> source;
 
     final T initialValue;
 
-    public BlockingFlowableMostRecent(Flowable<? extends T> source, T initialValue) {
+    public BlockingFlowableMostRecent(Flowable<T> source, T initialValue) {
         this.source = source;
         this.initialValue = initialValue;
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
@@ -93,7 +93,7 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
      */
     static final class CacheState<T> extends LinkedArrayList implements FlowableSubscriber<T> {
         /** The source observable to connect to. */
-        final Flowable<? extends T> source;
+        final Flowable<T> source;
         /** Holds onto the subscriber connected to source. */
         final AtomicReference<Subscription> connection = new AtomicReference<Subscription>();
         /** Guarded by connection (not this). */
@@ -114,7 +114,7 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
         boolean sourceDone;
 
         @SuppressWarnings("unchecked")
-        CacheState(Flowable<? extends T> source, int capacityHint) {
+        CacheState(Flowable<T> source, int capacityHint) {
             super(capacityHint);
             this.source = source;
             this.subscribers = new AtomicReference<ReplaySubscription<T>[]>(EMPTY);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
@@ -32,7 +32,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
  *            the value type
  */
 public final class FlowableRefCount<T> extends AbstractFlowableWithUpstream<T, T> {
-    final ConnectableFlowable<? extends T> source;
+    final ConnectableFlowable<T> source;
     volatile CompositeDisposable baseDisposable = new CompositeDisposable();
     final AtomicInteger subscriptionCount = new AtomicInteger();
 

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -644,7 +644,7 @@ public enum TestHelper {
      * isCancelled properly before and after calling dispose.
      * @param source the source to test
      */
-    public static void checkDisposed(Flowable<?> source) {
+    public static <T> void checkDisposed(Flowable<T> source) {
         final TestSubscriber<Object> ts = new TestSubscriber<Object>(0L);
         source.subscribe(new FlowableSubscriber<Object>() {
             @Override


### PR DESCRIPTION
Java 9 has changed its overload resolution algorithm and things that resolved unambiguously in Java 8 no longer resolve:

```java
Flowable<? extends T> source = ...

source.subscribe(new FlowableSubscriber<T>() { ... });
```

With the code above, javac 8, Eclipse and IntelliJ 2017 EAP picks `Flowable.subscribe(FlowableSubscriber<? super T> s)` as expected. However, javac 9 finds it ambiguous with `Flowable.subscribe(Subscriber<? super T> s)` despite IntelliJ 2017 EAP not indicating any error and still jumping to the right method via CTRL+Click.

The problem may come from the `? extends T` part of the declaration. Having just `Flowable<T>` compiles properly with javac9.

Luckily, we don't need `? extends T` and this PR changes the internal signatures of the affected components.