### PR TITLE
2.x: improve BaseTestConsumer with awaitCount & timeout

### DIFF
--- a/src/main/java/io/reactivex/internal/util/VolatileSizeArrayList.java
+++ b/src/main/java/io/reactivex/internal/util/VolatileSizeArrayList.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.util;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tracks the current underlying array size in a volatile field.
+ *
+ * @param <T> the element type
+ * @since 2.0.7
+ */
+public final class VolatileSizeArrayList<T> extends AtomicInteger implements List<T> {
+
+    private static final long serialVersionUID = 3972397474470203923L;
+
+    final ArrayList<T> list;
+
+    public VolatileSizeArrayList() {
+        list = new ArrayList<T>();
+    }
+
+    public VolatileSizeArrayList(int initialCapacity) {
+        list = new ArrayList<T>(initialCapacity);
+    }
+
+    @Override
+    public int size() {
+        return get();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return get() == 0;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return list.contains(o);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return list.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return list.toArray();
+    }
+
+    @Override
+    public <E> E[] toArray(E[] a) {
+        return list.toArray(a);
+    }
+
+    @Override
+    public boolean add(T e) {
+        boolean b = list.add(e);
+        lazySet(list.size());
+        return b;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        boolean b = list.remove(o);
+        lazySet(list.size());
+        return b;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return list.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        boolean b = list.addAll(c);
+        lazySet(list.size());
+        return b;
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends T> c) {
+        boolean b = list.addAll(index, c);
+        lazySet(list.size());
+        return b;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        boolean b = list.removeAll(c);
+        lazySet(list.size());
+        return b;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        boolean b = list.retainAll(c);
+        lazySet(list.size());
+        return b;
+    }
+
+    @Override
+    public void clear() {
+        list.clear();
+        lazySet(0);
+    }
+
+    @Override
+    public T get(int index) {
+        return list.get(index);
+    }
+
+    @Override
+    public T set(int index, T element) {
+        return list.set(index, element);
+    }
+
+    @Override
+    public void add(int index, T element) {
+        list.add(index, element);
+        lazySet(list.size());
+    }
+
+    @Override
+    public T remove(int index) {
+        T v = list.remove(index);
+        lazySet(list.size());
+        return v;
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return list.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return list.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<T> listIterator() {
+        return list.listIterator();
+    }
+
+    @Override
+    public ListIterator<T> listIterator(int index) {
+        return list.listIterator(index);
+    }
+
+    @Override
+    public List<T> subList(int fromIndex, int toIndex) {
+        return list.subList(fromIndex, toIndex);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof VolatileSizeArrayList) {
+            return list.equals(((VolatileSizeArrayList<?>)obj).list);
+        }
+        return list.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return list.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return list.toString();
+    }
+}

--- a/src/test/java/io/reactivex/internal/util/VolatileSizeArrayListTest.java
+++ b/src/test/java/io/reactivex/internal/util/VolatileSizeArrayListTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.util;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.junit.Test;
+
+public class VolatileSizeArrayListTest {
+
+    @Test
+    public void normal() {
+        List<Integer> list = new VolatileSizeArrayList<Integer>();
+
+        assertTrue(list.isEmpty());
+        assertEquals(0, list.size());
+        assertFalse(list.contains(1));
+        assertFalse(list.remove((Integer)1));
+
+        list = new VolatileSizeArrayList<Integer>(16);
+        assertTrue(list.add(1));
+        assertTrue(list.addAll(Arrays.asList(3, 4, 7)));
+        list.add(1, 2);
+        assertTrue(list.addAll(4, Arrays.asList(5, 6)));
+
+        assertTrue(list.contains(2));
+        assertFalse(list.remove((Integer)10));
+
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7), list);
+        assertFalse(list.isEmpty());
+        assertEquals(7, list.size());
+
+        Iterator<Integer> it = list.iterator();
+        for (int i = 1; i < 8; i++) {
+            assertEquals(i, it.next().intValue());
+        }
+
+        assertArrayEquals(new Object[] { 1, 2, 3, 4, 5, 6, 7 }, list.toArray());
+        assertArrayEquals(new Integer[] { 1, 2, 3, 4, 5, 6, 7 }, list.toArray(new Integer[7]));
+
+        assertTrue(list.containsAll(Arrays.asList(2, 4, 6)));
+        assertFalse(list.containsAll(Arrays.asList(2, 4, 6, 10)));
+
+        assertFalse(list.removeAll(Arrays.asList(10, 11, 12)));
+
+        assertFalse(list.retainAll(Arrays.asList(1, 2, 3, 4, 5, 6, 7)));
+
+        assertEquals(7, list.size());
+
+        for (int i = 1; i < 8; i++) {
+            assertEquals(i, list.get(i - 1).intValue());
+        }
+
+        for (int i = 1; i < 8; i++) {
+            assertEquals(i, list.set(i - 1, i).intValue());
+        }
+
+        assertEquals(2, list.indexOf(3));
+
+        assertEquals(5, list.lastIndexOf(6));
+
+        ListIterator<Integer> lit = list.listIterator(7);
+        for (int i = 7; i > 0; i--) {
+            assertEquals(i, lit.previous().intValue());
+        }
+
+        assertEquals(Arrays.asList(3, 4, 5), list.subList(2, 5));
+
+        VolatileSizeArrayList<Integer> list2 = new VolatileSizeArrayList<Integer>();
+        list2.addAll(Arrays.asList(1, 2, 3, 4, 5, 6));
+
+        assertFalse(list2.equals(list));
+        assertFalse(list.equals(list2));
+
+        list2.add(7);
+        assertTrue(list2.equals(list));
+        assertTrue(list.equals(list2));
+
+        List<Integer> list3 = new ArrayList<Integer>();
+        list3.addAll(Arrays.asList(1, 2, 3, 4, 5, 6));
+
+        assertFalse(list3.equals(list));
+        assertFalse(list.equals(list3));
+
+        list3.add(7);
+        assertTrue(list3.equals(list));
+        assertTrue(list.equals(list3));
+
+        assertEquals(list.hashCode(), list3.hashCode());
+        assertEquals(list.toString(), list3.toString());
+
+        list.remove(0);
+        assertEquals(6, list.size());
+
+        list.clear();
+        assertEquals(0, list.size());
+        assertTrue(list.isEmpty());
+    }
+}

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -1956,4 +1956,45 @@ public class TestSubscriberTest {
             assertTrue(ex.toString(), ex.getMessage().contains("Timeout?!"));
         }
     }
+
+    @Test
+    public void assertNeverPredicateThrows() {
+        try {
+            Flowable.just(1)
+            .test()
+            .assertNever(new Predicate<Integer>() {
+                @Override
+                public boolean test(Integer t) throws Exception {
+                    throw new IllegalArgumentException();
+                }
+            });
+            fail("Should have thrown!");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueAtPredicateThrows() {
+        try {
+            Flowable.just(1)
+            .test()
+            .assertValueAt(0, new Predicate<Integer>() {
+                @Override
+                public boolean test(Integer t) throws Exception {
+                    throw new IllegalArgumentException();
+                }
+            });
+            fail("Should have thrown!");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void waitStrategyRuns() {
+        for (TestWaitStrategy ws : TestWaitStrategy.values()) {
+            ws.run();
+        }
+    }
 }

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -33,6 +33,8 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.*;
+import io.reactivex.observers.BaseTestConsumer;
+import io.reactivex.observers.BaseTestConsumer.TestWaitStrategy;
 import io.reactivex.processors.*;
 import io.reactivex.schedulers.Schedulers;
 
@@ -1791,6 +1793,167 @@ public class TestSubscriberTest {
             fail("Should have thrown!");
         } catch (AssertionError ex) {
             assertTrue(ex.toString(), ex.toString().contains("testing with item=2"));
+        }
+    }
+
+    @Test
+    public void timeoutIndicated() throws InterruptedException {
+        Thread.interrupted(); // clear flag
+
+        TestSubscriber<Object> ts = Flowable.never()
+        .test();
+        assertFalse(ts.await(1, TimeUnit.MILLISECONDS));
+
+        try {
+            ts.assertResult(1);
+            fail("Should have thrown!");
+        } catch (AssertionError ex) {
+            assertTrue(ex.toString(), ex.toString().contains("timeout!"));
+        }
+    }
+
+    @Test
+    public void timeoutIndicated2() throws InterruptedException {
+        try {
+            Flowable.never()
+            .test()
+            .awaitDone(1, TimeUnit.MILLISECONDS)
+            .assertResult(1);
+
+            fail("Should have thrown!");
+        } catch (AssertionError ex) {
+            assertTrue(ex.toString(), ex.toString().contains("timeout!"));
+        }
+    }
+
+
+    @Test
+    public void timeoutIndicated3() throws InterruptedException {
+        TestSubscriber<Object> ts = Flowable.never()
+        .test();
+        assertFalse(ts.awaitTerminalEvent(1, TimeUnit.MILLISECONDS));
+
+        try {
+            ts.assertResult(1);
+            fail("Should have thrown!");
+        } catch (AssertionError ex) {
+            assertTrue(ex.toString(), ex.toString().contains("timeout!"));
+        }
+    }
+
+    @Test
+    public void disposeIndicated() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        ts.cancel();
+
+        try {
+            ts.assertResult(1);
+            fail("Should have thrown!");
+        } catch (Throwable ex) {
+            assertTrue(ex.toString(), ex.toString().contains("disposed!"));
+        }
+    }
+
+    @Test
+    public void checkTestWaitStrategyEnum() {
+        TestHelper.checkEnum(BaseTestConsumer.TestWaitStrategy.class);
+    }
+
+    @Test
+    public void awaitCount() {
+        Flowable.range(1, 10).delay(100, TimeUnit.MILLISECONDS)
+        .test(5)
+        .awaitCount(5)
+        .assertValues(1, 2, 3, 4, 5)
+        .requestMore(5)
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void awaitCountLess() {
+        Flowable.range(1, 4)
+        .test()
+        .awaitCount(5)
+        .assertResult(1, 2, 3, 4);
+    }
+
+    @Test
+    public void awaitCountLess2() {
+        Flowable.range(1, 4)
+        .test()
+        .awaitCount(5, TestWaitStrategy.YIELD)
+        .assertResult(1, 2, 3, 4);
+    }
+
+    @Test
+    public void awaitCountLess3() {
+        Flowable.range(1, 4).delay(50, TimeUnit.MILLISECONDS)
+        .test()
+        .awaitCount(5, TestWaitStrategy.SLEEP_1MS)
+        .assertResult(1, 2, 3, 4);
+    }
+
+    @Test
+    public void interruptTestWaitStrategy() {
+        try {
+            Thread.currentThread().interrupt();
+            TestWaitStrategy.SLEEP_1000MS.run();
+        } catch (RuntimeException ex) {
+            assertTrue(ex.toString(), ex.getCause() instanceof InterruptedException);
+        }
+    }
+
+    @Test
+    public void awaitCountTimeout() {
+        TestSubscriber<Object> ts = Flowable.never()
+        .test()
+        .awaitCount(1, TestWaitStrategy.SLEEP_1MS, 50);
+
+        assertTrue(ts.isTimeout());
+        ts.clearTimeout();
+        assertFalse(ts.isTimeout());
+    }
+
+    @Test
+    public void assertTimeout() {
+        Flowable.never()
+        .test()
+        .awaitCount(1, TestWaitStrategy.SLEEP_1MS, 50)
+        .assertTimeout();
+    }
+
+    @Test
+    public void assertTimeout2() {
+        try {
+            Flowable.empty()
+            .test()
+            .awaitCount(1, TestWaitStrategy.SLEEP_1MS, 50)
+            .assertTimeout();
+            fail("Should have thrown!");
+        } catch (AssertionError ex) {
+            assertTrue(ex.toString(), ex.getMessage().contains("No timeout?!"));
+        }
+    }
+
+    @Test
+    public void assertNoTimeout() {
+        Flowable.just(1)
+        .test()
+        .awaitCount(1, TestWaitStrategy.SLEEP_1MS, 50)
+        .assertNoTimeout();
+    }
+
+    @Test
+    public void assertNoTimeout2() {
+        try {
+            Flowable.never()
+            .test()
+            .awaitCount(1, TestWaitStrategy.SLEEP_1MS, 50)
+            .assertNoTimeout();
+            fail("Should have thrown!");
+        } catch (AssertionError ex) {
+            assertTrue(ex.toString(), ex.getMessage().contains("Timeout?!"));
         }
     }
 }


### PR DESCRIPTION
This PR enhances the timeout detection and reporting of the `TestSubscriber`/`TestObserver` base class `BaseTestConsumer`:

   - `awaitCount(int atLeast [, Runnable waitStrategy [, timeout]])`: wait until at least the given amount of onNext events have been observed or the upstream terminated.
  - Enhance `awaitX` methods to set a `timeout` flag.
  - Show the `timeout!` string in the assertion failures set by the `awaitX` methods.
  - Show the `disposed!` string in the assertion failures if the consumer has been cancelled/disposed.
  - `assertTimeout` and `assertNoTimeout` to assert explicitly after an `awaitX` method.
  - `isTimeout` and `clearTimeout` to check and clear the flag status.

In addition, the internal array that collects the items has been replaced with a new custom `List` implementation: `VolatileSizeArrayList` that makes sure `size()` is a volatile read and happens before the committing the size in another thread due to `add()`. (In theory, one shouldn't cast `values()` unconditionally to `ArrayList` anyway.)