### PR TITLE
2.x: Single.subscribe() to report isDisposed() true on success/error

### DIFF
--- a/src/main/java/io/reactivex/internal/observers/ConsumerSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/ConsumerSingleObserver.java
@@ -40,6 +40,7 @@ implements SingleObserver<T>, Disposable {
 
     @Override
     public void onError(Throwable e) {
+        lazySet(DisposableHelper.DISPOSED);
         try {
             onError.accept(e);
         } catch (Throwable ex) {
@@ -55,6 +56,7 @@ implements SingleObserver<T>, Disposable {
 
     @Override
     public void onSuccess(T value) {
+        lazySet(DisposableHelper.DISPOSED);
         try {
             onSuccess.accept(value);
         } catch (Throwable ex) {

--- a/src/test/java/io/reactivex/single/SingleSubscribeTest.java
+++ b/src/test/java/io/reactivex/single/SingleSubscribeTest.java
@@ -217,4 +217,14 @@ public class SingleSubscribeTest {
 
         assertTrue(ps.hasObservers());
     }
+
+    @Test
+    public void successIsDisposed() {
+        assertTrue(Single.just(1).subscribe().isDisposed());
+    }
+
+    @Test
+    public void errorIsDisposed() {
+        assertTrue(Single.error(new TestException()).subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()).isDisposed());
+    }
 }


### PR DESCRIPTION
The `ConsumerSingleObserver` didn't report `isDisposed` consistently with its state.

Reported in #5160.