### PR TITLE
2.x: fix LambdaObserver not cancelling the upstream

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -10894,7 +10894,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> switchMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return ObservableInternalHelper.switchMapSingle(this, mapper);
     }
-    
+
     /**
      * Returns a new ObservableSource by applying a function that you supply to each item emitted by the source
      * ObservableSource that returns a SingleSource, and then emitting the item emitted by the most recently emitted
@@ -10925,7 +10925,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> switchMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return ObservableInternalHelper.switchMapSingleDelayError(this, mapper);
     }
-    
+
     /**
      * Returns a new ObservableSource by applying a function that you supply to each item emitted by the source
      * ObservableSource that returns an ObservableSource, and then emitting the items emitted by the most recently emitted

--- a/src/main/java/io/reactivex/internal/observers/LambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/LambdaObserver.java
@@ -47,6 +47,7 @@ public final class LambdaObserver<T> extends AtomicReference<Disposable> impleme
                 onSubscribe.accept(this);
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
+                s.dispose();
                 onError(ex);
             }
         }
@@ -59,6 +60,7 @@ public final class LambdaObserver<T> extends AtomicReference<Disposable> impleme
                 onNext.accept(t);
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
+                get().dispose();
                 onError(e);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
@@ -326,27 +326,27 @@ public final class ObservableInternalHelper {
             Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return source.switchMapDelayError(convertSingleMapperToObservableMapper(mapper), 1);
     }
-    
+
     private static <T, R> Function<T, Observable<R>> convertSingleMapperToObservableMapper(
             final Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return new ObservableMapper<T,R>(mapper);
     }
-    
+
     static final class ObservableMapper<T,R> implements Function<T,Observable<R>> {
-        
+
         final Function<? super T, ? extends SingleSource<? extends R>> mapper;
 
         ObservableMapper(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
             this.mapper = mapper;
         }
-        
+
         @Override
         public Observable<R> apply(T t) throws Exception {
             return RxJavaPlugins.onAssembly(new SingleToObservable<R>(
                 ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null value")));
         }
-        
+
     }
 
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
@@ -622,7 +622,7 @@ public class ObservableSwitchTest {
 
         assertFalse(pp.hasObservers());
     }
-    
+
     @Test
     public void switchMapSingleJustSource() {
         Observable.just(0)
@@ -635,7 +635,7 @@ public class ObservableSwitchTest {
         .test()
         .assertResult(1);
     }
-    
+
     @Test
     public void switchMapSingleMapperReturnsNull() {
         Observable.just(0)
@@ -648,13 +648,13 @@ public class ObservableSwitchTest {
         .test()
         .assertError(NullPointerException.class);
     }
-    
-    @Test(expected=NullPointerException.class)
+
+    @Test(expected = NullPointerException.class)
     public void switchMapSingleMapperIsNull() {
         Observable.just(0)
         .switchMapSingle(null);
     }
-    
+
     @Test
     public void switchMapSingleFunctionDoesntReturnSingle() {
         Observable.just(0)
@@ -698,7 +698,7 @@ public class ObservableSwitchTest {
         .assertError(RuntimeException.class);
         assertTrue(completed.get());
     }
-    
+
     @Test
     public void scalarMap() {
         Observable.switchOnNext(Observable.just(Observable.just(1)))


### PR DESCRIPTION
The `LambdaObserver` didn't cancel the upstream when its `onSubscribe` and `onNext` callbacks crashed. Also reported on the mailing list:

> Dave Smith: When I am using an operator in Observable that calls subscribe (forEach as a example) and the onNext function throws an Exception the underlying class (LambdaObserver) marks the subscription disposed but does not notify upstream that is is disposed. What is the reason for this?

The `LambdaSubscriber` was working correctly. Both received unit tests to ensure the correct behavior.