### PR TITLE
2.x: WIP removes anonymous inner classes.

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableAmb.java
@@ -63,31 +63,7 @@ public final class CompletableAmb extends Completable {
 
         final AtomicBoolean once = new AtomicBoolean();
 
-        CompletableObserver inner = new CompletableObserver() {
-            @Override
-            public void onComplete() {
-                if (once.compareAndSet(false, true)) {
-                    set.dispose();
-                    s.onComplete();
-                }
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                if (once.compareAndSet(false, true)) {
-                    set.dispose();
-                    s.onError(e);
-                } else {
-                    RxJavaPlugins.onError(e);
-                }
-            }
-
-            @Override
-            public void onSubscribe(Disposable d) {
-                set.add(d);
-            }
-
-        };
+        CompletableObserver inner = new Amb(once, set, s);
 
         for (int i = 0; i < count; i++) {
             CompletableSource c = sources[i];
@@ -112,5 +88,41 @@ public final class CompletableAmb extends Completable {
         if (count == 0) {
             s.onComplete();
         }
+    }
+
+    static final class Amb implements CompletableObserver {
+        private final AtomicBoolean once;
+        private final CompositeDisposable set;
+        private final CompletableObserver s;
+
+        Amb(AtomicBoolean once, CompositeDisposable set, CompletableObserver s) {
+            this.once = once;
+            this.set = set;
+            this.s = s;
+        }
+
+        @Override
+        public void onComplete() {
+            if (once.compareAndSet(false, true)) {
+                set.dispose();
+                s.onComplete();
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (once.compareAndSet(false, true)) {
+                set.dispose();
+                s.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            set.add(d);
+        }
+
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDelay.java
@@ -42,36 +42,53 @@ public final class CompletableDelay extends Completable {
     protected void subscribeActual(final CompletableObserver s) {
         final CompositeDisposable set = new CompositeDisposable();
 
-        source.subscribe(new CompletableObserver() {
-
-
-            @Override
-            public void onComplete() {
-                set.add(scheduler.scheduleDirect(new Runnable() {
-                    @Override
-                    public void run() {
-                        s.onComplete();
-                    }
-                }, delay, unit));
-            }
-
-            @Override
-            public void onError(final Throwable e) {
-                set.add(scheduler.scheduleDirect(new Runnable() {
-                    @Override
-                    public void run() {
-                        s.onError(e);
-                    }
-                }, delayError ? delay : 0, unit));
-            }
-
-            @Override
-            public void onSubscribe(Disposable d) {
-                set.add(d);
-                s.onSubscribe(set);
-            }
-
-        });
+        source.subscribe(new Delay(set, s));
     }
 
+    final class Delay implements CompletableObserver {
+
+        private final CompositeDisposable set;
+        private final CompletableObserver s;
+
+        Delay(CompositeDisposable set, CompletableObserver s) {
+            this.set = set;
+            this.s = s;
+        }
+
+        @Override
+        public void onComplete() {
+            set.add(scheduler.scheduleDirect(new OnComplete(), delay, unit));
+        }
+
+        @Override
+        public void onError(final Throwable e) {
+            set.add(scheduler.scheduleDirect(new OnError(e), delayError ? delay : 0, unit));
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            set.add(d);
+            s.onSubscribe(set);
+        }
+
+        final class OnComplete implements Runnable {
+            @Override
+            public void run() {
+                s.onComplete();
+            }
+        }
+
+        final class OnError implements Runnable {
+            private final Throwable e;
+
+            OnError(Throwable e) {
+                this.e = e;
+            }
+
+            @Override
+            public void run() {
+                s.onError(e);
+            }
+        }
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDoOnEvent.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDoOnEvent.java
@@ -32,36 +32,44 @@ public final class CompletableDoOnEvent extends Completable {
 
     @Override
     protected void subscribeActual(final CompletableObserver s) {
-        source.subscribe(new CompletableObserver() {
-            @Override
-            public void onComplete() {
-                try {
-                    onEvent.accept(null);
-                } catch (Throwable e) {
-                    Exceptions.throwIfFatal(e);
-                    s.onError(e);
-                    return;
-                }
+        source.subscribe(new DoOnEvent(s));
+    }
 
-                s.onComplete();
+    final class DoOnEvent implements CompletableObserver {
+        private final CompletableObserver observer;
+
+        DoOnEvent(CompletableObserver observer) {
+            this.observer = observer;
+        }
+
+        @Override
+        public void onComplete() {
+            try {
+                onEvent.accept(null);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                observer.onError(e);
+                return;
             }
 
-            @Override
-            public void onError(Throwable e) {
-                try {
-                    onEvent.accept(e);
-                } catch (Throwable ex) {
-                    Exceptions.throwIfFatal(ex);
-                    e = new CompositeException(e, ex);
-                }
+            observer.onComplete();
+        }
 
-                s.onError(e);
+        @Override
+        public void onError(Throwable e) {
+            try {
+                onEvent.accept(e);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                e = new CompositeException(e, ex);
             }
 
-            @Override
-            public void onSubscribe(final Disposable d) {
-                s.onSubscribe(d);
-            }
-        });
+            observer.onError(e);
+        }
+
+        @Override
+        public void onSubscribe(final Disposable d) {
+            observer.onSubscribe(d);
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnErrorComplete.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnErrorComplete.java
@@ -32,38 +32,45 @@ public final class CompletableOnErrorComplete extends Completable {
     @Override
     protected void subscribeActual(final CompletableObserver s) {
 
-        source.subscribe(new CompletableObserver() {
-
-            @Override
-            public void onComplete() {
-                s.onComplete();
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                boolean b;
-
-                try {
-                    b = predicate.test(e);
-                } catch (Throwable ex) {
-                    Exceptions.throwIfFatal(ex);
-                    s.onError(new CompositeException(e, ex));
-                    return;
-                }
-
-                if (b) {
-                    s.onComplete();
-                } else {
-                    s.onError(e);
-                }
-            }
-
-            @Override
-            public void onSubscribe(Disposable d) {
-                s.onSubscribe(d);
-            }
-
-        });
+        source.subscribe(new OnError(s));
     }
 
+    final class OnError implements CompletableObserver {
+
+        private final CompletableObserver s;
+
+        OnError(CompletableObserver s) {
+            this.s = s;
+        }
+
+        @Override
+        public void onComplete() {
+            s.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            boolean b;
+
+            try {
+                b = predicate.test(e);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                s.onError(new CompositeException(e, ex));
+                return;
+            }
+
+            if (b) {
+                s.onComplete();
+            } else {
+                s.onError(e);
+            }
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            s.onSubscribe(d);
+        }
+
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
@@ -38,7 +38,52 @@ public final class CompletableResumeNext extends Completable {
 
         final SequentialDisposable sd = new SequentialDisposable();
         s.onSubscribe(sd);
-        source.subscribe(new CompletableObserver() {
+        source.subscribe(new ResumeNext(s, sd));
+    }
+
+    final class ResumeNext implements CompletableObserver {
+
+        private final CompletableObserver s;
+        private final SequentialDisposable sd;
+
+        ResumeNext(CompletableObserver s, SequentialDisposable sd) {
+            this.s = s;
+            this.sd = sd;
+        }
+
+        @Override
+        public void onComplete() {
+            s.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            CompletableSource c;
+
+            try {
+                c = errorMapper.apply(e);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                s.onError(new CompositeException(ex, e));
+                return;
+            }
+
+            if (c == null) {
+                NullPointerException npe = new NullPointerException("The CompletableConsumable returned is null");
+                npe.initCause(e);
+                s.onError(npe);
+                return;
+            }
+
+            c.subscribe(new OnErrorObserver());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            sd.update(d);
+        }
+
+        final class OnErrorObserver implements CompletableObserver {
 
             @Override
             public void onComplete() {
@@ -47,41 +92,7 @@ public final class CompletableResumeNext extends Completable {
 
             @Override
             public void onError(Throwable e) {
-                CompletableSource c;
-
-                try {
-                    c = errorMapper.apply(e);
-                } catch (Throwable ex) {
-                    Exceptions.throwIfFatal(ex);
-                    s.onError(new CompositeException(ex, e));
-                    return;
-                }
-
-                if (c == null) {
-                    NullPointerException npe = new NullPointerException("The CompletableConsumable returned is null");
-                    npe.initCause(e);
-                    s.onError(npe);
-                    return;
-                }
-
-                c.subscribe(new CompletableObserver() {
-
-                    @Override
-                    public void onComplete() {
-                        s.onComplete();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                        s.onError(e);
-                    }
-
-                    @Override
-                    public void onSubscribe(Disposable d) {
-                        sd.update(d);
-                    }
-
-                });
+                s.onError(e);
             }
 
             @Override
@@ -89,7 +100,6 @@ public final class CompletableResumeNext extends Completable {
                 sd.update(d);
             }
 
-        });
+        }
     }
-
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableTimeout.java
@@ -44,42 +44,74 @@ public final class CompletableTimeout extends Completable {
 
         final AtomicBoolean once = new AtomicBoolean();
 
-        Disposable timer = scheduler.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                if (once.compareAndSet(false, true)) {
-                    set.clear();
-                    if (other == null) {
-                        s.onError(new TimeoutException());
-                    } else {
-                        other.subscribe(new CompletableObserver() {
-
-                            @Override
-                            public void onSubscribe(Disposable d) {
-                                set.add(d);
-                            }
-
-                            @Override
-                            public void onError(Throwable e) {
-                                set.dispose();
-                                s.onError(e);
-                            }
-
-                            @Override
-                            public void onComplete() {
-                                set.dispose();
-                                s.onComplete();
-                            }
-
-                        });
-                    }
-                }
-            }
-        }, timeout, unit);
+        Disposable timer = scheduler.scheduleDirect(new DisposeTask(once, set, s), timeout, unit);
 
         set.add(timer);
 
-        source.subscribe(new CompletableObserver() {
+        source.subscribe(new TimeOutObserver(set, once, s));
+    }
+
+    static final class TimeOutObserver implements CompletableObserver {
+
+        private final CompositeDisposable set;
+        private final AtomicBoolean once;
+        private final CompletableObserver s;
+
+        public TimeOutObserver(CompositeDisposable set, AtomicBoolean once, CompletableObserver s) {
+            this.set = set;
+            this.once = once;
+            this.s = s;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            set.add(d);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (once.compareAndSet(false, true)) {
+                set.dispose();
+                s.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (once.compareAndSet(false, true)) {
+                set.dispose();
+                s.onComplete();
+            }
+        }
+
+    }
+
+    final class DisposeTask implements Runnable {
+        private final AtomicBoolean once;
+        private final CompositeDisposable set;
+        private final CompletableObserver s;
+
+        DisposeTask(AtomicBoolean once, CompositeDisposable set, CompletableObserver s) {
+            this.once = once;
+            this.set = set;
+            this.s = s;
+        }
+
+        @Override
+        public void run() {
+            if (once.compareAndSet(false, true)) {
+                set.clear();
+                if (other == null) {
+                    s.onError(new TimeoutException());
+                } else {
+                    other.subscribe(new DisposeObserver());
+                }
+            }
+        }
+
+        final class DisposeObserver implements CompletableObserver {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -88,22 +120,16 @@ public final class CompletableTimeout extends Completable {
 
             @Override
             public void onError(Throwable e) {
-                if (once.compareAndSet(false, true)) {
-                    set.dispose();
-                    s.onError(e);
-                } else {
-                    RxJavaPlugins.onError(e);
-                }
+                set.dispose();
+                s.onError(e);
             }
 
             @Override
             public void onComplete() {
-                if (once.compareAndSet(false, true)) {
-                    set.dispose();
-                    s.onComplete();
-                }
+                set.dispose();
+                s.onComplete();
             }
 
-        });
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecent.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecent.java
@@ -78,44 +78,46 @@ public final class BlockingFlowableMostRecent<T> implements Iterable<T> {
          * thread expect {@link Iterator#next()} called from a different thread to work.
          * @return the Iterator
          */
-        public Iterator<T> getIterable() {
-            return new Iterator<T>() {
-                /**
-                 * buffer to make sure that the state of the iterator doesn't change between calling hasNext() and next().
-                 */
-                private Object buf;
+        public Iterator getIterable() {
+            return new Iterator();
+        }
 
-                @Override
-                public boolean hasNext() {
-                    buf = value;
-                    return !NotificationLite.isComplete(buf);
-                }
+        private class Iterator implements java.util.Iterator<T> {
+            /**
+             * buffer to make sure that the state of the iterator doesn't change between calling hasNext() and next().
+             */
+            private Object buf;
 
-                @Override
-                public T next() {
-                    try {
-                        // if hasNext wasn't called before calling next.
-                        if (buf == null) {
-                            buf = value;
-                        }
-                        if (NotificationLite.isComplete(buf)) {
-                            throw new NoSuchElementException();
-                        }
-                        if (NotificationLite.isError(buf)) {
-                            throw ExceptionHelper.wrapOrThrow(NotificationLite.getError(buf));
-                        }
-                        return NotificationLite.getValue(buf);
+            @Override
+            public boolean hasNext() {
+                buf = value;
+                return !NotificationLite.isComplete(buf);
+            }
+
+            @Override
+            public T next() {
+                try {
+                    // if hasNext wasn't called before calling next.
+                    if (buf == null) {
+                        buf = value;
                     }
-                    finally {
-                        buf = null;
+                    if (NotificationLite.isComplete(buf)) {
+                        throw new NoSuchElementException();
                     }
+                    if (NotificationLite.isError(buf)) {
+                        throw ExceptionHelper.wrapOrThrow(NotificationLite.getError(buf));
+                    }
+                    return NotificationLite.getValue(buf);
                 }
+                finally {
+                    buf = null;
+                }
+            }
 
-                @Override
-                public void remove() {
-                    throw new UnsupportedOperationException("Read only iterator");
-                }
-            };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Read only iterator");
+            }
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecent.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecent.java
@@ -82,7 +82,7 @@ public final class BlockingFlowableMostRecent<T> implements Iterable<T> {
             return new Iterator();
         }
 
-        private class Iterator implements java.util.Iterator<T> {
+        final class Iterator implements java.util.Iterator<T> {
             /**
              * buffer to make sure that the state of the iterator doesn't change between calling hasNext() and next().
              */

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -280,16 +280,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
 
             w.schedulePeriodically(this, timeskip, timeskip, unit);
 
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    synchronized (BufferSkipBoundedSubscriber.this) {
-                        buffers.remove(b);
-                    }
-
-                    fastPathOrderedEmitMax(b, false, w);
-                }
-            }, timespan, unit);
+            w.schedule(new RemoveFromBuffer(b), timespan, unit);
         }
 
         @Override
@@ -367,22 +358,30 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
                 buffers.add(b);
             }
 
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    synchronized (BufferSkipBoundedSubscriber.this) {
-                        buffers.remove(b);
-                    }
-
-                    fastPathOrderedEmitMax(b, false, w);
-                }
-            }, timespan, unit);
+            w.schedule(new RemoveFromBuffer(b), timespan, unit);
         }
 
         @Override
         public boolean accept(Subscriber<? super U> a, U v) {
             a.onNext(v);
             return true;
+        }
+
+        private final class RemoveFromBuffer implements Runnable {
+            private final U buffer;
+
+            RemoveFromBuffer(U buffer) {
+                this.buffer = buffer;
+            }
+
+            @Override
+            public void run() {
+                synchronized (BufferSkipBoundedSubscriber.this) {
+                    buffers.remove(buffer);
+                }
+
+                fastPathOrderedEmitMax(buffer, false, w);
+            }
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -367,7 +367,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             return true;
         }
 
-        private final class RemoveFromBuffer implements Runnable {
+        final class RemoveFromBuffer implements Runnable {
             private final U buffer;
 
             RemoveFromBuffer(U buffer) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -132,12 +132,7 @@ extends Flowable<R> {
             return;
         }
         if (n == 1) {
-            ((Publisher<T>)a[0]).subscribe(new MapSubscriber<T, R>(s, new Function<T, R>() {
-                @Override
-                public R apply(T t) throws Exception {
-                    return combiner.apply(new Object[] { t });
-                }
-            }));
+            ((Publisher<T>)a[0]).subscribe(new MapSubscriber<T, R>(s, new SingletonArrayFunc()));
             return;
         }
 
@@ -555,6 +550,13 @@ extends Flowable<R> {
                 produced = p;
             }
 
+        }
+    }
+
+    private final class SingletonArrayFunc implements Function<T, R> {
+        @Override
+        public R apply(T t) throws Exception {
+            return combiner.apply(new Object[] { t });
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -553,7 +553,7 @@ extends Flowable<R> {
         }
     }
 
-    private final class SingletonArrayFunc implements Function<T, R> {
+    final class SingletonArrayFunc implements Function<T, R> {
         @Override
         public R apply(T t) throws Exception {
             return combiner.apply(new Object[] { t });

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
@@ -78,40 +78,17 @@ public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
 
         @Override
         public void onNext(final T t) {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    actual.onNext(t);
-                }
-            }, delay, unit);
+            w.schedule(new OnNext(t), delay, unit);
         }
 
         @Override
         public void onError(final Throwable t) {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        actual.onError(t);
-                    } finally {
-                        w.dispose();
-                    }
-                }
-            }, delayError ? delay : 0, unit);
+            w.schedule(new OnError(t), delayError ? delay : 0, unit);
         }
 
         @Override
         public void onComplete() {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        actual.onComplete();
-                    } finally {
-                        w.dispose();
-                    }
-                }
-            }, delay, unit);
+            w.schedule(new OnComplete(), delay, unit);
         }
 
         @Override
@@ -125,5 +102,45 @@ public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
             w.dispose();
         }
 
+        private final class OnNext implements Runnable {
+            private final T t;
+
+            OnNext(T t) {
+                this.t = t;
+            }
+
+            @Override
+            public void run() {
+                actual.onNext(t);
+            }
+        }
+
+        private class OnError implements Runnable {
+            private final Throwable t;
+
+            public OnError(Throwable t) {
+                this.t = t;
+            }
+
+            @Override
+            public void run() {
+                try {
+                    actual.onError(t);
+                } finally {
+                    w.dispose();
+                }
+            }
+        }
+
+        private class OnComplete implements Runnable {
+            @Override
+            public void run() {
+                try {
+                    actual.onComplete();
+                } finally {
+                    w.dispose();
+                }
+            }
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
@@ -115,10 +115,10 @@ public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
             }
         }
 
-        private class OnError implements Runnable {
+        final class OnError implements Runnable {
             private final Throwable t;
 
-            public OnError(Throwable t) {
+            OnError(Throwable t) {
                 this.t = t;
             }
 
@@ -132,7 +132,7 @@ public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
             }
         }
 
-        private class OnComplete implements Runnable {
+        final class OnComplete implements Runnable {
             @Override
             public void run() {
                 try {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelay.java
@@ -102,7 +102,7 @@ public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
             w.dispose();
         }
 
-        private final class OnNext implements Runnable {
+        final class OnNext implements Runnable {
             private final T t;
 
             OnNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
@@ -43,7 +43,7 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
         other.subscribe(otherSubscriber);
     }
 
-    private final class DelaySubscriber implements FlowableSubscriber<U> {
+    final class DelaySubscriber implements FlowableSubscriber<U> {
         private final SubscriptionArbiter serial;
         private final Subscriber<? super T> child;
         boolean done;
@@ -84,7 +84,7 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
             main.subscribe(new OnCompleteSubscriber());
         }
 
-        private class DelaySubscription implements Subscription {
+        final class DelaySubscription implements Subscription {
             private final Subscription s;
 
             public DelaySubscription(Subscription s) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
@@ -102,7 +102,7 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
             }
         }
 
-        private final class OnCompleteSubscriber implements FlowableSubscriber<T> {
+        final class OnCompleteSubscriber implements FlowableSubscriber<T> {
             @Override
             public void onSubscribe(Subscription s) {
                 serial.setSubscription(s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
@@ -38,71 +38,90 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
         final SubscriptionArbiter serial = new SubscriptionArbiter();
         child.onSubscribe(serial);
 
-        FlowableSubscriber<U> otherSubscriber = new FlowableSubscriber<U>() {
-            boolean done;
+        FlowableSubscriber<U> otherSubscriber = new DelaySubscriber(serial, child);
 
-            @Override
-            public void onSubscribe(final Subscription s) {
-                serial.setSubscription(new Subscription() {
-                    @Override
-                    public void request(long n) {
-                        // ignored
-                    }
+        other.subscribe(otherSubscriber);
+    }
 
-                    @Override
-                    public void cancel() {
-                        s.cancel();
-                    }
-                });
-                s.request(Long.MAX_VALUE);
+    private final class DelaySubscriber implements FlowableSubscriber<U> {
+        private final SubscriptionArbiter serial;
+        private final Subscriber<? super T> child;
+        boolean done;
+
+        DelaySubscriber(SubscriptionArbiter serial, Subscriber<? super T> child) {
+            this.serial = serial;
+            this.child = child;
+        }
+
+        @Override
+        public void onSubscribe(final Subscription s) {
+            serial.setSubscription(new DelaySubscription(s));
+            s.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(U t) {
+            onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (done) {
+                RxJavaPlugins.onError(e);
+                return;
+            }
+            done = true;
+            child.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+
+            main.subscribe(new OnCompleteSubscriber());
+        }
+
+        private class DelaySubscription implements Subscription {
+            private final Subscription s;
+
+            public DelaySubscription(Subscription s) {
+                this.s = s;
             }
 
             @Override
-            public void onNext(U t) {
-                onComplete();
+            public void request(long n) {
+                // ignored
             }
 
             @Override
-            public void onError(Throwable e) {
-                if (done) {
-                    RxJavaPlugins.onError(e);
-                    return;
-                }
-                done = true;
-                child.onError(e);
+            public void cancel() {
+                s.cancel();
+            }
+        }
+
+        private final class OnCompleteSubscriber implements FlowableSubscriber<T> {
+            @Override
+            public void onSubscribe(Subscription s) {
+                serial.setSubscription(s);
+            }
+
+            @Override
+            public void onNext(T t) {
+                child.onNext(t);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                child.onError(t);
             }
 
             @Override
             public void onComplete() {
-                if (done) {
-                    return;
-                }
-                done = true;
-
-                main.subscribe(new FlowableSubscriber<T>() {
-                    @Override
-                    public void onSubscribe(Subscription s) {
-                        serial.setSubscription(s);
-                    }
-
-                    @Override
-                    public void onNext(T t) {
-                        child.onNext(t);
-                    }
-
-                    @Override
-                    public void onError(Throwable t) {
-                        child.onError(t);
-                    }
-
-                    @Override
-                    public void onComplete() {
-                        child.onComplete();
-                    }
-                });
+                child.onComplete();
             }
-        };
-
-        other.subscribe(otherSubscriber);
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
@@ -173,7 +173,7 @@ public final class FlowableRefCount<T> extends AbstractFlowableWithUpstream<T, T
         return Disposables.fromRunnable(new DisposeTask(current));
     }
 
-    private final class DisposeConsumer implements Consumer<Disposable> {
+    final class DisposeConsumer implements Consumer<Disposable> {
         private final Subscriber<? super T> subscriber;
         private final AtomicBoolean writeLocked;
 
@@ -196,7 +196,7 @@ public final class FlowableRefCount<T> extends AbstractFlowableWithUpstream<T, T
         }
     }
 
-    private final class DisposeTask implements Runnable {
+    final class DisposeTask implements Runnable {
         private final CompositeDisposable current;
 
         DisposeTask(CompositeDisposable current) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
@@ -156,20 +156,7 @@ public final class FlowableRefCount<T> extends AbstractFlowableWithUpstream<T, T
 
     private Consumer<Disposable> onSubscribe(final Subscriber<? super T> subscriber,
             final AtomicBoolean writeLocked) {
-        return new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable subscription) {
-                try {
-                    baseDisposable.add(subscription);
-                    // ready to subscribe to source so do it
-                    doSubscribe(subscriber, baseDisposable);
-                } finally {
-                    // release the write lock
-                    lock.unlock();
-                    writeLocked.set(false);
-                }
-            }
-        };
+        return new DisposeConsumer(subscriber, writeLocked);
     }
 
     void doSubscribe(final Subscriber<? super T> subscriber, final CompositeDisposable currentBase) {
@@ -183,23 +170,54 @@ public final class FlowableRefCount<T> extends AbstractFlowableWithUpstream<T, T
     }
 
     private Disposable disconnect(final CompositeDisposable current) {
-        return Disposables.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                lock.lock();
-                try {
-                    if (baseDisposable == current) {
-                        if (subscriptionCount.decrementAndGet() == 0) {
-                            baseDisposable.dispose();
-                            // need a new baseDisposable because once
-                            // disposed stays that way
-                            baseDisposable = new CompositeDisposable();
-                        }
-                    }
-                } finally {
-                    lock.unlock();
-                }
+        return Disposables.fromRunnable(new DisposeTask(current));
+    }
+
+    private final class DisposeConsumer implements Consumer<Disposable> {
+        private final Subscriber<? super T> subscriber;
+        private final AtomicBoolean writeLocked;
+
+        DisposeConsumer(Subscriber<? super T> subscriber, AtomicBoolean writeLocked) {
+            this.subscriber = subscriber;
+            this.writeLocked = writeLocked;
+        }
+
+        @Override
+        public void accept(Disposable subscription) {
+            try {
+                baseDisposable.add(subscription);
+                // ready to subscribe to source so do it
+                doSubscribe(subscriber, baseDisposable);
+            } finally {
+                // release the write lock
+                lock.unlock();
+                writeLocked.set(false);
             }
-        });
+        }
+    }
+
+    private final class DisposeTask implements Runnable {
+        private final CompositeDisposable current;
+
+        DisposeTask(CompositeDisposable current) {
+            this.current = current;
+        }
+
+        @Override
+        public void run() {
+            lock.lock();
+            try {
+                if (baseDisposable == current) {
+                    if (subscriptionCount.decrementAndGet() == 0) {
+                        baseDisposable.dispose();
+                        // need a new baseDisposable because once
+                        // disposed stays that way
+                        baseDisposable = new CompositeDisposable();
+                    }
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -1125,7 +1125,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
             co.connect(new DisposableConsumer(srw));
         }
 
-        private final class DisposableConsumer implements Consumer<Disposable> {
+        final class DisposableConsumer implements Consumer<Disposable> {
             private final SubscriberResourceWrapper<R> srw;
 
             DisposableConsumer(SubscriberResourceWrapper<R> srw) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -43,12 +43,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
     final Publisher<T> onSubscribe;
 
     @SuppressWarnings("rawtypes")
-    static final Callable DEFAULT_UNBOUNDED_FACTORY = new Callable() {
-        @Override
-        public Object call() {
-            return new UnboundedReplayBuffer<Object>(16);
-        }
-    };
+    static final Callable DEFAULT_UNBOUNDED_FACTORY = new DefaultUnboundedFactory();
 
     /**
      * Given a connectable observable factory, it multicasts over the generated
@@ -62,39 +57,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
     public static <U, R> Flowable<R> multicastSelector(
             final Callable<? extends ConnectableFlowable<U>> connectableFactory,
             final Function<? super Flowable<U>, ? extends Publisher<R>> selector) {
-        return Flowable.unsafeCreate(new Publisher<R>() {
-            @Override
-            public void subscribe(Subscriber<? super R> child) {
-                ConnectableFlowable<U> co;
-                try {
-                    co = ObjectHelper.requireNonNull(connectableFactory.call(), "The connectableFactory returned null");
-                } catch (Throwable e) {
-                    Exceptions.throwIfFatal(e);
-                    EmptySubscription.error(e, child);
-                    return;
-                }
-
-                Publisher<R> observable;
-                try {
-                    observable = ObjectHelper.requireNonNull(selector.apply(co), "The selector returned a null Publisher");
-                } catch (Throwable e) {
-                    Exceptions.throwIfFatal(e);
-                    EmptySubscription.error(e, child);
-                    return;
-                }
-
-                final SubscriberResourceWrapper<R> srw = new SubscriberResourceWrapper<R>(child);
-
-                observable.subscribe(srw);
-
-                co.connect(new Consumer<Disposable>() {
-                    @Override
-                    public void accept(Disposable r) {
-                        srw.setResource(r);
-                    }
-                });
-            }
-        });
+        return Flowable.unsafeCreate(new MultiCastPublisher<R, U>(connectableFactory, selector));
     }
 
     /**
@@ -107,17 +70,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      */
     public static <T> ConnectableFlowable<T> observeOn(final ConnectableFlowable<T> co, final Scheduler scheduler) {
         final Flowable<T> observable = co.observeOn(scheduler);
-        return RxJavaPlugins.onAssembly(new ConnectableFlowable<T>() {
-            @Override
-            public void connect(Consumer<? super Disposable> connection) {
-                co.connect(connection);
-            }
-
-            @Override
-            protected void subscribeActual(Subscriber<? super T> s) {
-                observable.subscribe(s);
-            }
-        });
+        return RxJavaPlugins.onAssembly(new ConnectableFlowableReplay<T>(co, observable));
     }
 
     /**
@@ -143,12 +96,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
         if (bufferSize == Integer.MAX_VALUE) {
             return createFrom(source);
         }
-        return create(source, new Callable<ReplayBuffer<T>>() {
-            @Override
-            public ReplayBuffer<T> call() {
-                return new SizeBoundReplayBuffer<T>(bufferSize);
-            }
-        });
+        return create(source, new ReplayBufferTask<T>(bufferSize));
     }
 
     /**
@@ -177,12 +125,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      */
     public static <T> ConnectableFlowable<T> create(Flowable<T> source,
             final long maxAge, final TimeUnit unit, final Scheduler scheduler, final int bufferSize) {
-        return create(source, new Callable<ReplayBuffer<T>>() {
-            @Override
-            public ReplayBuffer<T> call() {
-                return new SizeAndTimeBoundReplayBuffer<T>(bufferSize, maxAge, unit, scheduler);
-            }
-        });
+        return create(source, new ScheduledReplayBufferTask<T>(bufferSize, maxAge, unit, scheduler));
     }
 
     /**
@@ -195,62 +138,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
             final Callable<? extends ReplayBuffer<T>> bufferFactory) {
         // the current connection to source needs to be shared between the operator and its onSubscribe call
         final AtomicReference<ReplaySubscriber<T>> curr = new AtomicReference<ReplaySubscriber<T>>();
-        Publisher<T> onSubscribe = new Publisher<T>() {
-            @Override
-            public void subscribe(Subscriber<? super T> child) {
-                // concurrent connection/disconnection may change the state,
-                // we loop to be atomic while the child subscribes
-                for (;;) {
-                    // get the current subscriber-to-source
-                    ReplaySubscriber<T> r = curr.get();
-                    // if there isn't one
-                    if (r == null) {
-                        ReplayBuffer<T> buf;
-
-                        try {
-                            buf = bufferFactory.call();
-                        } catch (Throwable ex) {
-                            Exceptions.throwIfFatal(ex);
-                            throw ExceptionHelper.wrapOrThrow(ex);
-                        }
-                        // create a new subscriber to source
-                        ReplaySubscriber<T> u = new ReplaySubscriber<T>(buf);
-                        // let's try setting it as the current subscriber-to-source
-                        if (!curr.compareAndSet(null, u)) {
-                            // didn't work, maybe someone else did it or the current subscriber
-                            // to source has just finished
-                            continue;
-                        }
-                        // we won, let's use it going onwards
-                        r = u;
-                    }
-
-                    // create the backpressure-managing producer for this child
-                    InnerSubscription<T> inner = new InnerSubscription<T>(r, child);
-                    // the producer has been registered with the current subscriber-to-source so
-                    // at least it will receive the next terminal event
-                    // setting the producer will trigger the first request to be considered by
-                    // the subscriber-to-source.
-                    child.onSubscribe(inner);
-                    // we try to add it to the array of subscribers
-                    // if it fails, no worries because we will still have its buffer
-                    // so it is going to replay it for us
-                    r.add(inner);
-
-                    if (inner.isDisposed()) {
-                        r.remove(inner);
-                        return;
-                    }
-
-                    r.manageRequests();
-
-                    // trigger the capturing of the current node and total requested
-                    r.buffer.replay(inner);
-
-                    break; // NOPMD
-                }
-            }
-        };
+        Publisher<T> onSubscribe = new ReplayPublisher<T>(curr, bufferFactory);
         return RxJavaPlugins.onAssembly(new FlowableReplay<T>(onSubscribe, source, curr, bufferFactory));
     }
 
@@ -1198,6 +1086,180 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
                 }
             }
             return prev;
+        }
+    }
+
+    static final class MultiCastPublisher<R, U> implements Publisher<R> {
+        private final Callable<? extends ConnectableFlowable<U>> connectableFactory;
+        private final Function<? super Flowable<U>, ? extends Publisher<R>> selector;
+
+        MultiCastPublisher(Callable<? extends ConnectableFlowable<U>> connectableFactory, Function<? super Flowable<U>, ? extends Publisher<R>> selector) {
+            this.connectableFactory = connectableFactory;
+            this.selector = selector;
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super R> child) {
+            ConnectableFlowable<U> co;
+            try {
+                co = ObjectHelper.requireNonNull(connectableFactory.call(), "The connectableFactory returned null");
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                EmptySubscription.error(e, child);
+                return;
+            }
+
+            Publisher<R> observable;
+            try {
+                observable = ObjectHelper.requireNonNull(selector.apply(co), "The selector returned a null Publisher");
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                EmptySubscription.error(e, child);
+                return;
+            }
+
+            final SubscriberResourceWrapper<R> srw = new SubscriberResourceWrapper<R>(child);
+
+            observable.subscribe(srw);
+
+            co.connect(new DisposableConsumer(srw));
+        }
+
+        private final class DisposableConsumer implements Consumer<Disposable> {
+            private final SubscriberResourceWrapper<R> srw;
+
+            DisposableConsumer(SubscriberResourceWrapper<R> srw) {
+                this.srw = srw;
+            }
+
+            @Override
+            public void accept(Disposable r) {
+                srw.setResource(r);
+            }
+        }
+    }
+
+    static final class ConnectableFlowableReplay<T> extends ConnectableFlowable<T> {
+        private final ConnectableFlowable<T> co;
+        private final Flowable<T> observable;
+
+        ConnectableFlowableReplay(ConnectableFlowable<T> co, Flowable<T> observable) {
+            this.co = co;
+            this.observable = observable;
+        }
+
+        @Override
+        public void connect(Consumer<? super Disposable> connection) {
+            co.connect(connection);
+        }
+
+        @Override
+        protected void subscribeActual(Subscriber<? super T> s) {
+            observable.subscribe(s);
+        }
+    }
+
+    static final class ReplayBufferTask<T> implements Callable<ReplayBuffer<T>> {
+        private final int bufferSize;
+
+        ReplayBufferTask(int bufferSize) {
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ReplayBuffer<T> call() {
+            return new SizeBoundReplayBuffer<T>(bufferSize);
+        }
+    }
+
+    static final class ScheduledReplayBufferTask<T> implements Callable<ReplayBuffer<T>> {
+        private final int bufferSize;
+        private final long maxAge;
+        private final TimeUnit unit;
+        private final Scheduler scheduler;
+
+        ScheduledReplayBufferTask(int bufferSize, long maxAge, TimeUnit unit, Scheduler scheduler) {
+            this.bufferSize = bufferSize;
+            this.maxAge = maxAge;
+            this.unit = unit;
+            this.scheduler = scheduler;
+        }
+
+        @Override
+        public ReplayBuffer<T> call() {
+            return new SizeAndTimeBoundReplayBuffer<T>(bufferSize, maxAge, unit, scheduler);
+        }
+    }
+
+    static final class ReplayPublisher<T> implements Publisher<T> {
+        private final AtomicReference<ReplaySubscriber<T>> curr;
+        private final Callable<? extends ReplayBuffer<T>> bufferFactory;
+
+        ReplayPublisher(AtomicReference<ReplaySubscriber<T>> curr, Callable<? extends ReplayBuffer<T>> bufferFactory) {
+            this.curr = curr;
+            this.bufferFactory = bufferFactory;
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super T> child) {
+            // concurrent connection/disconnection may change the state,
+            // we loop to be atomic while the child subscribes
+            for (;;) {
+                // get the current subscriber-to-source
+                ReplaySubscriber<T> r = curr.get();
+                // if there isn't one
+                if (r == null) {
+                    ReplayBuffer<T> buf;
+
+                    try {
+                        buf = bufferFactory.call();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        throw ExceptionHelper.wrapOrThrow(ex);
+                    }
+                    // create a new subscriber to source
+                    ReplaySubscriber<T> u = new ReplaySubscriber<T>(buf);
+                    // let's try setting it as the current subscriber-to-source
+                    if (!curr.compareAndSet(null, u)) {
+                        // didn't work, maybe someone else did it or the current subscriber
+                        // to source has just finished
+                        continue;
+                    }
+                    // we won, let's use it going onwards
+                    r = u;
+                }
+
+                // create the backpressure-managing producer for this child
+                InnerSubscription<T> inner = new InnerSubscription<T>(r, child);
+                // the producer has been registered with the current subscriber-to-source so
+                // at least it will receive the next terminal event
+                // setting the producer will trigger the first request to be considered by
+                // the subscriber-to-source.
+                child.onSubscribe(inner);
+                // we try to add it to the array of subscribers
+                // if it fails, no worries because we will still have its buffer
+                // so it is going to replay it for us
+                r.add(inner);
+
+                if (inner.isDisposed()) {
+                    r.remove(inner);
+                    return;
+                }
+
+                r.manageRequests();
+
+                // trigger the capturing of the current node and total requested
+                r.buffer.replay(inner);
+
+                break; // NOPMD
+            }
+        }
+    }
+
+    static final class DefaultUnboundedFactory implements Callable {
+        @Override
+        public Object call() {
+            return new UnboundedReplayBuffer<Object>(16);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
@@ -132,12 +132,7 @@ public final class FlowableSubscribeOn<T> extends AbstractFlowableWithUpstream<T
             if (nonScheduledRequests || Thread.currentThread() == get()) {
                 s.request(n);
             } else {
-                worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        s.request(n);
-                    }
-                });
+                worker.schedule(new Request(s, n));
             }
         }
 
@@ -145,6 +140,21 @@ public final class FlowableSubscribeOn<T> extends AbstractFlowableWithUpstream<T
         public void cancel() {
             SubscriptionHelper.cancel(s);
             worker.dispose();
+        }
+
+        static final class Request implements Runnable {
+            private final Subscription s;
+            private final long n;
+
+            Request(Subscription s, long n) {
+                this.s = s;
+                this.n = n;
+            }
+
+            @Override
+            public void run() {
+                s.request(n);
+            }
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -33,15 +33,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
     final Scheduler scheduler;
     final Publisher<? extends T> other;
 
-    static final Disposable NEW_TIMER = new Disposable() {
-        @Override
-        public void dispose() { }
-
-        @Override
-        public boolean isDisposed() {
-            return true;
-        }
-    };
+    static final Disposable NEW_TIMER = new EmptyDispose();
 
     public FlowableTimeoutTimed(Flowable<T> source,
             long timeout, TimeUnit unit, Scheduler scheduler, Publisher<? extends T> other) {
@@ -124,20 +116,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
             }
 
             if (timer.compareAndSet(d, NEW_TIMER)) {
-                d = worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (idx == index) {
-                            done = true;
-                            s.cancel();
-                            DisposableHelper.dispose(timer);
-
-                            subscribeNext();
-
-                            worker.dispose();
-                        }
-                    }
-                }, timeout, unit);
+                d = worker.schedule(new TimeoutTask(idx), timeout, unit);
 
                 DisposableHelper.replace(timer, d);
             }
@@ -177,6 +156,27 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
         @Override
         public boolean isDisposed() {
             return worker.isDisposed();
+        }
+
+        private final class TimeoutTask implements Runnable {
+            private final long idx;
+
+            TimeoutTask(long idx) {
+                this.idx = idx;
+            }
+
+            @Override
+            public void run() {
+                if (idx == index) {
+                    done = true;
+                    s.cancel();
+                    DisposableHelper.dispose(timer);
+
+                    subscribeNext();
+
+                    worker.dispose();
+                }
+            }
         }
     }
 
@@ -230,17 +230,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
             }
 
             if (timer.compareAndSet(d, NEW_TIMER)) {
-                d = worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (idx == index) {
-                            done = true;
-                            dispose();
-
-                            actual.onError(new TimeoutException());
-                        }
-                    }
-                }, timeout, unit);
+                d = worker.schedule(new TimeoutTask(idx), timeout, unit);
 
                 DisposableHelper.replace(timer, d);
             }
@@ -289,5 +279,35 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
         public void cancel() {
             dispose();
         }
+
+        private final class TimeoutTask implements Runnable {
+            private final long idx;
+
+            TimeoutTask(long idx) {
+                this.idx = idx;
+            }
+
+            @Override
+            public void run() {
+                if (idx == index) {
+                    done = true;
+                    dispose();
+
+                    actual.onError(new TimeoutException());
+                }
+            }
+        }
     }
+
+    static final class EmptyDispose implements Disposable {
+        @Override
+        public void dispose() { }
+
+        @Override
+        public boolean isDisposed() {
+            return true;
+        }
+    }
+
+
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -158,7 +158,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
             return worker.isDisposed();
         }
 
-        private final class TimeoutTask implements Runnable {
+        final class TimeoutTask implements Runnable {
             private final long idx;
 
             TimeoutTask(long idx) {
@@ -280,7 +280,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
             dispose();
         }
 
-        private final class TimeoutTask implements Runnable {
+        final class TimeoutTask implements Runnable {
             private final long idx;
 
             TimeoutTask(long idx) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
@@ -86,12 +86,14 @@ public final class FlowableUnsubscribeOn<T> extends AbstractFlowableWithUpstream
         @Override
         public void cancel() {
             if (compareAndSet(false, true)) {
-                scheduler.scheduleDirect(new Runnable() {
-                    @Override
-                    public void run() {
-                        s.cancel();
-                    }
-                });
+                scheduler.scheduleDirect(new Cancellation());
+            }
+        }
+
+        private final class Cancellation implements Runnable {
+            @Override
+            public void run() {
+                s.cancel();
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOn.java
@@ -90,7 +90,7 @@ public final class FlowableUnsubscribeOn<T> extends AbstractFlowableWithUpstream
             }
         }
 
-        private final class Cancellation implements Runnable {
+        final class Cancellation implements Runnable {
             @Override
             public void run() {
                 s.cancel();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -830,7 +830,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             }
         }
 
-        private final class Completion implements Runnable {
+        final class Completion implements Runnable {
             private final UnicastProcessor<T> processor;
 
             public Completion(UnicastProcessor<T> processor) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -641,12 +641,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     if (r != Long.MAX_VALUE) {
                         produced(1);
                     }
-                    worker.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            complete(w);
-                        }
-                    }, timespan, unit);
+                    worker.schedule(new Completion(w), timespan, unit);
 
                     worker.schedulePeriodically(this, timeskip, timeskip, unit);
 
@@ -785,12 +780,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                                     produced(1);
                                 }
 
-                                worker.schedule(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        complete(w);
-                                    }
-                                }, timespan, unit);
+                                worker.schedule(new Completion(w), timespan, unit);
                             } else {
                                 a.onError(new MissingBackpressureException("Can't emit window due to lack of requests"));
                                 continue;
@@ -837,6 +827,19 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             SubjectWork(UnicastProcessor<T> w, boolean open) {
                 this.w = w;
                 this.open = open;
+            }
+        }
+
+        private final class Completion implements Runnable {
+            private final UnicastProcessor<T> processor;
+
+            public Completion(UnicastProcessor<T> processor) {
+                this.processor = processor;
+            }
+
+            @Override
+            public void run() {
+                complete(processor);
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
@@ -117,7 +117,7 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
         }
     }
 
-    private final class FlowableWithLatestSubscriber<U> implements FlowableSubscriber<U> {
+    final class FlowableWithLatestSubscriber<U> implements FlowableSubscriber<U> {
         private final WithLatestFromSubscriber<T, U, R> wlf;
 
         FlowableWithLatestSubscriber(WithLatestFromSubscriber<T, U, R> wlf) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
@@ -40,29 +40,7 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
 
         serial.onSubscribe(wlf);
 
-        other.subscribe(new FlowableSubscriber<U>() {
-            @Override
-            public void onSubscribe(Subscription s) {
-                if (wlf.setOther(s)) {
-                    s.request(Long.MAX_VALUE);
-                }
-            }
-
-            @Override
-            public void onNext(U t) {
-                wlf.lazySet(t);
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                wlf.otherError(t);
-            }
-
-            @Override
-            public void onComplete() {
-                // nothing to do, the wlf will complete on its own pace
-            }
-        });
+        other.subscribe(new FlowableWithLatestSubscriber<U>(wlf));
 
         source.subscribe(wlf);
     }
@@ -136,6 +114,36 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
         public void otherError(Throwable e) {
             SubscriptionHelper.cancel(s);
             actual.onError(e);
+        }
+    }
+
+    private final class FlowableWithLatestSubscriber<U> implements FlowableSubscriber<U> {
+        private final WithLatestFromSubscriber<T, U, R> wlf;
+
+        FlowableWithLatestSubscriber(WithLatestFromSubscriber<T, U, R> wlf) {
+            this.wlf = wlf;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (wlf.setOther(s)) {
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(U t) {
+            wlf.lazySet(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            wlf.otherError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            // nothing to do, the wlf will complete on its own pace
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -82,12 +82,7 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
         }
 
         if (n == 0) {
-            new FlowableMap<T, R>(source, new Function<T, R>() {
-                @Override
-                public R apply(T t) throws Exception {
-                    return combiner.apply(new Object[] { t });
-                }
-            }).subscribeActual(s);
+            new FlowableMap<T, R>(source, new SingletonArrayFunc()).subscribeActual(s);
             return;
         }
 
@@ -296,6 +291,13 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
         @Override
         public void dispose() {
             SubscriptionHelper.cancel(this);
+        }
+    }
+
+    private final class SingletonArrayFunc implements Function<T, R> {
+        @Override
+        public R apply(T t) throws Exception {
+            return combiner.apply(new Object[] { t });
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -294,7 +294,7 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
         }
     }
 
-    private final class SingletonArrayFunc implements Function<T, R> {
+    final class SingletonArrayFunc implements Function<T, R> {
         @Override
         public R apply(T t) throws Exception {
             return combiner.apply(new Object[] { t });

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeZipArray.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeZipArray.java
@@ -41,12 +41,7 @@ public final class MaybeZipArray<T, R> extends Maybe<R> {
 
 
         if (n == 1) {
-            sources[0].subscribe(new MaybeMap.MapMaybeObserver<T, R>(observer, new Function<T, R>() {
-                @Override
-                public R apply(T t) throws Exception {
-                    return zipper.apply(new Object[] { t });
-                }
-            }));
+            sources[0].subscribe(new MaybeMap.MapMaybeObserver<T, R>(observer, new SingletonArrayFunc()));
             return;
         }
 
@@ -191,6 +186,13 @@ public final class MaybeZipArray<T, R> extends Maybe<R> {
         @Override
         public void onComplete() {
             parent.innerComplete(index);
+        }
+    }
+
+    final class SingletonArrayFunc implements Function<T, R> {
+        @Override
+        public R apply(T t) throws Exception {
+            return zipper.apply(new Object[] { t });
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeZipIterable.java
@@ -61,12 +61,7 @@ public final class MaybeZipIterable<T, R> extends Maybe<R> {
         }
 
         if (n == 1) {
-            a[0].subscribe(new MaybeMap.MapMaybeObserver<T, R>(observer, new Function<T, R>() {
-                @Override
-                public R apply(T t) throws Exception {
-                    return zipper.apply(new Object[] { t });
-                }
-            }));
+            a[0].subscribe(new MaybeMap.MapMaybeObserver<T, R>(observer, new SingletonArrayFunc()));
             return;
         }
 
@@ -83,4 +78,10 @@ public final class MaybeZipIterable<T, R> extends Maybe<R> {
         }
     }
 
+    final class SingletonArrayFunc implements Function<T, R> {
+        @Override
+        public R apply(T t) throws Exception {
+            return zipper.apply(new Object[] { t });
+        }
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableMostRecent.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableMostRecent.java
@@ -79,44 +79,46 @@ public final class BlockingObservableMostRecent<T> implements Iterable<T> {
          * thread expect {@link Iterator#next()} called from a different thread to work.
          * @return the Iterator
          */
-        public Iterator<T> getIterable() {
-            return new Iterator<T>() {
-                /**
-                 * buffer to make sure that the state of the iterator doesn't change between calling hasNext() and next().
-                 */
-                private Object buf;
+        public Iterator getIterable() {
+            return new Iterator();
+        }
 
-                @Override
-                public boolean hasNext() {
-                    buf = value;
-                    return !NotificationLite.isComplete(buf);
-                }
+        final class Iterator implements java.util.Iterator<T> {
+            /**
+             * buffer to make sure that the state of the iterator doesn't change between calling hasNext() and next().
+             */
+            private Object buf;
 
-                @Override
-                public T next() {
-                    try {
-                        // if hasNext wasn't called before calling next.
-                        if (buf == null) {
-                            buf = value;
-                        }
-                        if (NotificationLite.isComplete(buf)) {
-                            throw new NoSuchElementException();
-                        }
-                        if (NotificationLite.isError(buf)) {
-                            throw ExceptionHelper.wrapOrThrow(NotificationLite.getError(buf));
-                        }
-                        return NotificationLite.getValue(buf);
+            @Override
+            public boolean hasNext() {
+                buf = value;
+                return !NotificationLite.isComplete(buf);
+            }
+
+            @Override
+            public T next() {
+                try {
+                    // if hasNext wasn't called before calling next.
+                    if (buf == null) {
+                        buf = value;
                     }
-                    finally {
-                        buf = null;
+                    if (NotificationLite.isComplete(buf)) {
+                        throw new NoSuchElementException();
                     }
+                    if (NotificationLite.isError(buf)) {
+                        throw ExceptionHelper.wrapOrThrow(NotificationLite.getError(buf));
+                    }
+                    return NotificationLite.getValue(buf);
                 }
+                finally {
+                    buf = null;
+                }
+            }
 
-                @Override
-                public void remove() {
-                    throw new UnsupportedOperationException("Read only iterator");
-                }
-            };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Read only iterator");
+            }
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -261,16 +261,7 @@ extends AbstractObservableWithUpstream<T, U> {
 
                 w.schedulePeriodically(this, timeskip, timeskip, unit);
 
-                w.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        synchronized (BufferSkipBoundedObserver.this) {
-                            buffers.remove(b);
-                        }
-
-                        fastPathOrderedEmit(b, false, w);
-                    }
-                }, timespan, unit);
+                w.schedule(new RemoveFromBufferEmit(b), timespan, unit);
             }
         }
 
@@ -352,21 +343,46 @@ extends AbstractObservableWithUpstream<T, U> {
                 buffers.add(b);
             }
 
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    synchronized (BufferSkipBoundedObserver.this) {
-                        buffers.remove(b);
-                    }
-
-                    fastPathOrderedEmit(b, false, w);
-                }
-            }, timespan, unit);
+            w.schedule(new RemoveFromBuffer(b), timespan, unit);
         }
 
         @Override
         public void accept(Observer<? super U> a, U v) {
             a.onNext(v);
+        }
+
+        final class RemoveFromBuffer implements Runnable {
+            private final U b;
+
+            RemoveFromBuffer(U b) {
+                this.b = b;
+            }
+
+            @Override
+            public void run() {
+                synchronized (BufferSkipBoundedObserver.this) {
+                    buffers.remove(b);
+                }
+
+                fastPathOrderedEmit(b, false, w);
+            }
+        }
+
+        final class RemoveFromBufferEmit implements Runnable {
+            private final U buffer;
+
+            RemoveFromBufferEmit(U buffer) {
+                this.buffer = buffer;
+            }
+
+            @Override
+            public void run() {
+                synchronized (BufferSkipBoundedObserver.this) {
+                    buffers.remove(buffer);
+                }
+
+                fastPathOrderedEmit(buffer, false, w);
+            }
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
@@ -78,40 +78,17 @@ public final class ObservableDelay<T> extends AbstractObservableWithUpstream<T, 
 
         @Override
         public void onNext(final T t) {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    actual.onNext(t);
-                }
-            }, delay, unit);
+            w.schedule(new OnNext(t), delay, unit);
         }
 
         @Override
         public void onError(final Throwable t) {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        actual.onError(t);
-                    } finally {
-                        w.dispose();
-                    }
-                }
-            }, delayError ? delay : 0, unit);
+            w.schedule(new OnError(t), delayError ? delay : 0, unit);
         }
 
         @Override
         public void onComplete() {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        actual.onComplete();
-                    } finally {
-                        w.dispose();
-                    }
-                }
-            }, delay, unit);
+            w.schedule(new OnComplete(), delay, unit);
         }
 
         @Override
@@ -123,6 +100,47 @@ public final class ObservableDelay<T> extends AbstractObservableWithUpstream<T, 
         @Override
         public boolean isDisposed() {
             return w.isDisposed();
+        }
+
+        final class OnNext implements Runnable {
+            private final T t;
+
+            OnNext(T t) {
+                this.t = t;
+            }
+
+            @Override
+            public void run() {
+                actual.onNext(t);
+            }
+        }
+
+        final class OnError implements Runnable {
+            private final Throwable throwable;
+
+            public OnError(Throwable throwable) {
+                this.throwable = throwable;
+            }
+
+            @Override
+            public void run() {
+                try {
+                    actual.onError(throwable);
+                } finally {
+                    w.dispose();
+                }
+            }
+        }
+
+        final class OnComplete implements Runnable {
+            @Override
+            public void run() {
+                try {
+                    actual.onComplete();
+                } finally {
+                    w.dispose();
+                }
+            }
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOther.java
@@ -38,59 +38,69 @@ public final class ObservableDelaySubscriptionOther<T, U> extends Observable<T> 
         final SequentialDisposable serial = new SequentialDisposable();
         child.onSubscribe(serial);
 
-        Observer<U> otherObserver = new Observer<U>() {
-            boolean done;
-            @Override
-            public void onSubscribe(Disposable d) {
-                serial.update(d);
-            }
-
-            @Override
-            public void onNext(U t) {
-                onComplete();
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                if (done) {
-                    RxJavaPlugins.onError(e);
-                    return;
-                }
-                done = true;
-                child.onError(e);
-            }
-
-            @Override
-            public void onComplete() {
-                if (done) {
-                    return;
-                }
-                done = true;
-
-                main.subscribe(new Observer<T>() {
-                    @Override
-                    public void onSubscribe(Disposable d) {
-                        serial.update(d);
-                    }
-
-                    @Override
-                    public void onNext(T value) {
-                        child.onNext(value);
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                        child.onError(e);
-                    }
-
-                    @Override
-                    public void onComplete() {
-                        child.onComplete();
-                    }
-                });
-            }
-        };
+        Observer<U> otherObserver = new DelayObserver(serial, child);
 
         other.subscribe(otherObserver);
+    }
+
+    final class DelayObserver implements Observer<U> {
+        private final SequentialDisposable serial;
+        private final Observer<? super T> child;
+        boolean done;
+
+        DelayObserver(SequentialDisposable serial, Observer<? super T> child) {
+            this.serial = serial;
+            this.child = child;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            serial.update(d);
+        }
+
+        @Override
+        public void onNext(U t) {
+            onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (done) {
+                RxJavaPlugins.onError(e);
+                return;
+            }
+            done = true;
+            child.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+
+            main.subscribe(new Observer<T>() {
+                @Override
+                public void onSubscribe(Disposable d) {
+                    serial.update(d);
+                }
+
+                @Override
+                public void onNext(T value) {
+                    child.onNext(value);
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    child.onError(e);
+                }
+
+                @Override
+                public void onComplete() {
+                    child.onComplete();
+                }
+            });
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOther.java
@@ -80,27 +80,29 @@ public final class ObservableDelaySubscriptionOther<T, U> extends Observable<T> 
             }
             done = true;
 
-            main.subscribe(new Observer<T>() {
-                @Override
-                public void onSubscribe(Disposable d) {
-                    serial.update(d);
-                }
+            main.subscribe(new OnComplete());
+        }
 
-                @Override
-                public void onNext(T value) {
-                    child.onNext(value);
-                }
+        final class OnComplete implements Observer<T> {
+            @Override
+            public void onSubscribe(Disposable d) {
+                serial.update(d);
+            }
 
-                @Override
-                public void onError(Throwable e) {
-                    child.onError(e);
-                }
+            @Override
+            public void onNext(T value) {
+                child.onNext(value);
+            }
 
-                @Override
-                public void onComplete() {
-                    child.onComplete();
-                }
-            });
+            @Override
+            public void onError(Throwable e) {
+                child.onError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                child.onComplete();
+            }
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
@@ -220,48 +220,23 @@ public final class ObservableInternalHelper {
     }
 
     public static <T> Callable<ConnectableObservable<T>> replayCallable(final Observable<T> parent) {
-        return new Callable<ConnectableObservable<T>>() {
-            @Override
-            public ConnectableObservable<T> call() {
-                return parent.replay();
-            }
-        };
+        return new ReplayCallable<T>(parent);
     }
 
     public static <T> Callable<ConnectableObservable<T>> replayCallable(final Observable<T> parent, final int bufferSize) {
-        return new Callable<ConnectableObservable<T>>() {
-            @Override
-            public ConnectableObservable<T> call() {
-                return parent.replay(bufferSize);
-            }
-        };
+        return new BufferedReplayCallable<T>(parent, bufferSize);
     }
 
     public static <T> Callable<ConnectableObservable<T>> replayCallable(final Observable<T> parent, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
-        return new Callable<ConnectableObservable<T>>() {
-            @Override
-            public ConnectableObservable<T> call() {
-                return parent.replay(bufferSize, time, unit, scheduler);
-            }
-        };
+        return new BufferedTimedReplayCallable<T>(parent, bufferSize, time, unit, scheduler);
     }
 
     public static <T> Callable<ConnectableObservable<T>> replayCallable(final Observable<T> parent, final long time, final TimeUnit unit, final Scheduler scheduler) {
-        return new Callable<ConnectableObservable<T>>() {
-            @Override
-            public ConnectableObservable<T> call() {
-                return parent.replay(time, unit, scheduler);
-            }
-        };
+        return new TimedReplayCallable<T>(parent, time, unit, scheduler);
     }
 
     public static <T, R> Function<Observable<T>, ObservableSource<R>> replayFunction(final Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final Scheduler scheduler) {
-        return new Function<Observable<T>, ObservableSource<R>>() {
-            @Override
-            public ObservableSource<R> apply(Observable<T> t) throws Exception {
-                return Observable.wrap(selector.apply(t)).observeOn(scheduler);
-            }
-        };
+        return new ReplayFunction<T, R>(selector, scheduler);
     }
 
     enum ErrorMapperFilter implements Function<Notification<Object>, Throwable>, Predicate<Notification<Object>> {
@@ -349,4 +324,86 @@ public final class ObservableInternalHelper {
 
     }
 
+    static final class ReplayCallable<T> implements Callable<ConnectableObservable<T>> {
+        private final Observable<T> parent;
+
+        ReplayCallable(Observable<T> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public ConnectableObservable<T> call() {
+            return parent.replay();
+        }
+    }
+
+    static final class BufferedReplayCallable<T> implements Callable<ConnectableObservable<T>> {
+        private final Observable<T> parent;
+        private final int bufferSize;
+
+        public BufferedReplayCallable(Observable<T> parent, int bufferSize) {
+            this.parent = parent;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ConnectableObservable<T> call() {
+            return parent.replay(bufferSize);
+        }
+    }
+
+    static final class BufferedTimedReplayCallable<T> implements Callable<ConnectableObservable<T>> {
+        private final Observable<T> parent;
+        private final int bufferSize;
+        private final long time;
+        private final TimeUnit unit;
+        private final Scheduler scheduler;
+
+        BufferedTimedReplayCallable(Observable<T> parent, int bufferSize, long time, TimeUnit unit, Scheduler scheduler) {
+            this.parent = parent;
+            this.bufferSize = bufferSize;
+            this.time = time;
+            this.unit = unit;
+            this.scheduler = scheduler;
+        }
+
+        @Override
+        public ConnectableObservable<T> call() {
+            return parent.replay(bufferSize, time, unit, scheduler);
+        }
+    }
+
+    static final class TimedReplayCallable<T> implements Callable<ConnectableObservable<T>> {
+        private final Observable<T> parent;
+        private final long time;
+        private final TimeUnit unit;
+        private final Scheduler scheduler;
+
+        TimedReplayCallable(Observable<T> parent, long time, TimeUnit unit, Scheduler scheduler) {
+            this.parent = parent;
+            this.time = time;
+            this.unit = unit;
+            this.scheduler = scheduler;
+        }
+
+        @Override
+        public ConnectableObservable<T> call() {
+            return parent.replay(time, unit, scheduler);
+        }
+    }
+
+    static final class ReplayFunction<T, R> implements Function<Observable<T>, ObservableSource<R>> {
+        private final Function<? super Observable<T>, ? extends ObservableSource<R>> selector;
+        private final Scheduler scheduler;
+
+        ReplayFunction(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, Scheduler scheduler) {
+            this.selector = selector;
+            this.scheduler = scheduler;
+        }
+
+        @Override
+        public ObservableSource<R> apply(Observable<T> t) throws Exception {
+            return Observable.wrap(selector.apply(t)).observeOn(scheduler);
+        }
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -59,27 +59,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
     public static <U, R> Observable<R> multicastSelector(
             final Callable<? extends ConnectableObservable<U>> connectableFactory,
             final Function<? super Observable<U>, ? extends ObservableSource<R>> selector) {
-        return RxJavaPlugins.onAssembly(new Observable<R>() {
-            @Override
-            protected void subscribeActual(Observer<? super R> child) {
-                ConnectableObservable<U> co;
-                ObservableSource<R> observable;
-                try {
-                    co = connectableFactory.call();
-                    observable = selector.apply(co);
-                } catch (Throwable e) {
-                    Exceptions.throwIfFatal(e);
-                    EmptyDisposable.error(e, child);
-                    return;
-                }
-
-                final ObserverResourceWrapper<R> srw = new ObserverResourceWrapper<R>(child);
-
-                observable.subscribe(srw);
-
-                co.connect(new DisposeConsumer(srw));
-            }
-        });
+        return RxJavaPlugins.onAssembly(new MulticastReplay<R, U>(connectableFactory, selector));
     }
 
     /**
@@ -92,17 +72,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      */
     public static <T> ConnectableObservable<T> observeOn(final ConnectableObservable<T> co, final Scheduler scheduler) {
         final Observable<T> observable = co.observeOn(scheduler);
-        return RxJavaPlugins.onAssembly(new ConnectableObservable<T>() {
-            @Override
-            public void connect(Consumer<? super Disposable> connection) {
-                co.connect(connection);
-            }
-
-            @Override
-            protected void subscribeActual(Observer<? super T> observer) {
-                observable.subscribe(observer);
-            }
-        });
+        return RxJavaPlugins.onAssembly(new Replay<T>(co, observable));
     }
 
     /**
@@ -128,12 +98,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
         if (bufferSize == Integer.MAX_VALUE) {
             return createFrom(source);
         }
-        return create(source, new BufferSupplier<T>() {
-            @Override
-            public ReplayBuffer<T> call() {
-                return new SizeBoundReplayBuffer<T>(bufferSize);
-            }
-        });
+        return create(source, new ReplayBufferSupplier<T>(bufferSize));
     }
 
     /**
@@ -162,12 +127,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      */
     public static <T> ConnectableObservable<T> create(ObservableSource<T> source,
             final long maxAge, final TimeUnit unit, final Scheduler scheduler, final int bufferSize) {
-        return create(source, new BufferSupplier<T>() {
-            @Override
-            public ReplayBuffer<T> call() {
-                return new SizeAndTimeBoundReplayBuffer<T>(bufferSize, maxAge, unit, scheduler);
-            }
-        });
+        return create(source, new ScheduledReplaySupplier<T>(bufferSize, maxAge, unit, scheduler));
     }
 
     /**
@@ -180,54 +140,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
             final BufferSupplier<T> bufferFactory) {
         // the current connection to source needs to be shared between the operator and its onSubscribe call
         final AtomicReference<ReplayObserver<T>> curr = new AtomicReference<ReplayObserver<T>>();
-        ObservableSource<T> onSubscribe = new ObservableSource<T>() {
-            @Override
-            public void subscribe(Observer<? super T> child) {
-                // concurrent connection/disconnection may change the state,
-                // we loop to be atomic while the child subscribes
-                for (;;) {
-                    // get the current subscriber-to-source
-                    ReplayObserver<T> r = curr.get();
-                    // if there isn't one
-                    if (r == null) {
-                        // create a new subscriber to source
-                        ReplayBuffer<T> buf = bufferFactory.call();
-
-                        ReplayObserver<T> u = new ReplayObserver<T>(buf);
-                        // let's try setting it as the current subscriber-to-source
-                        if (!curr.compareAndSet(null, u)) {
-                            // didn't work, maybe someone else did it or the current subscriber
-                            // to source has just finished
-                            continue;
-                        }
-                        // we won, let's use it going onwards
-                        r = u;
-                    }
-
-                    // create the backpressure-managing producer for this child
-                    InnerDisposable<T> inner = new InnerDisposable<T>(r, child);
-                    // the producer has been registered with the current subscriber-to-source so
-                    // at least it will receive the next terminal event
-                    // setting the producer will trigger the first request to be considered by
-                    // the subscriber-to-source.
-                    child.onSubscribe(inner);
-                    // we try to add it to the array of observers
-                    // if it fails, no worries because we will still have its buffer
-                    // so it is going to replay it for us
-                    r.add(inner);
-
-                    if (inner.isDisposed()) {
-                        r.remove(inner);
-                        return;
-                    }
-
-                    // replay the contents of the buffer
-                    r.buffer.replay(inner);
-
-                    break; // NOPMD
-                }
-            }
-        };
+        ObservableSource<T> onSubscribe = new ReplaySource<T>(curr, bufferFactory);
         return RxJavaPlugins.onAssembly(new ObservableReplay<T>(onSubscribe, source, curr, bufferFactory));
     }
 
@@ -996,6 +909,145 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
         @Override
         public void accept(Disposable r) {
             srw.setResource(r);
+        }
+    }
+
+    static final class ReplayBufferSupplier<T> implements BufferSupplier<T> {
+        private final int bufferSize;
+
+        ReplayBufferSupplier(int bufferSize) {
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public ReplayBuffer<T> call() {
+            return new SizeBoundReplayBuffer<T>(bufferSize);
+        }
+    }
+
+    static final class ScheduledReplaySupplier<T> implements BufferSupplier<T> {
+        private final int bufferSize;
+        private final long maxAge;
+        private final TimeUnit unit;
+        private final Scheduler scheduler;
+
+        ScheduledReplaySupplier(int bufferSize, long maxAge, TimeUnit unit, Scheduler scheduler) {
+            this.bufferSize = bufferSize;
+            this.maxAge = maxAge;
+            this.unit = unit;
+            this.scheduler = scheduler;
+        }
+
+        @Override
+        public ReplayBuffer<T> call() {
+            return new SizeAndTimeBoundReplayBuffer<T>(bufferSize, maxAge, unit, scheduler);
+        }
+    }
+
+    static final class ReplaySource<T> implements ObservableSource<T> {
+        private final AtomicReference<ReplayObserver<T>> curr;
+        private final BufferSupplier<T> bufferFactory;
+
+        ReplaySource(AtomicReference<ReplayObserver<T>> curr, BufferSupplier<T> bufferFactory) {
+            this.curr = curr;
+            this.bufferFactory = bufferFactory;
+        }
+
+        @Override
+        public void subscribe(Observer<? super T> child) {
+            // concurrent connection/disconnection may change the state,
+            // we loop to be atomic while the child subscribes
+            for (;;) {
+                // get the current subscriber-to-source
+                ReplayObserver<T> r = curr.get();
+                // if there isn't one
+                if (r == null) {
+                    // create a new subscriber to source
+                    ReplayBuffer<T> buf = bufferFactory.call();
+
+                    ReplayObserver<T> u = new ReplayObserver<T>(buf);
+                    // let's try setting it as the current subscriber-to-source
+                    if (!curr.compareAndSet(null, u)) {
+                        // didn't work, maybe someone else did it or the current subscriber
+                        // to source has just finished
+                        continue;
+                    }
+                    // we won, let's use it going onwards
+                    r = u;
+                }
+
+                // create the backpressure-managing producer for this child
+                InnerDisposable<T> inner = new InnerDisposable<T>(r, child);
+                // the producer has been registered with the current subscriber-to-source so
+                // at least it will receive the next terminal event
+                // setting the producer will trigger the first request to be considered by
+                // the subscriber-to-source.
+                child.onSubscribe(inner);
+                // we try to add it to the array of observers
+                // if it fails, no worries because we will still have its buffer
+                // so it is going to replay it for us
+                r.add(inner);
+
+                if (inner.isDisposed()) {
+                    r.remove(inner);
+                    return;
+                }
+
+                // replay the contents of the buffer
+                r.buffer.replay(inner);
+
+                break; // NOPMD
+            }
+        }
+    }
+
+    static final class MulticastReplay<R, U> extends Observable<R> {
+        private final Callable<? extends ConnectableObservable<U>> connectableFactory;
+        private final Function<? super Observable<U>, ? extends ObservableSource<R>> selector;
+
+        MulticastReplay(Callable<? extends ConnectableObservable<U>> connectableFactory, Function<? super Observable<U>, ? extends ObservableSource<R>> selector) {
+            this.connectableFactory = connectableFactory;
+            this.selector = selector;
+        }
+
+        @Override
+        protected void subscribeActual(Observer<? super R> child) {
+            ConnectableObservable<U> co;
+            ObservableSource<R> observable;
+            try {
+                co = connectableFactory.call();
+                observable = selector.apply(co);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                EmptyDisposable.error(e, child);
+                return;
+            }
+
+            final ObserverResourceWrapper<R> srw = new ObserverResourceWrapper<R>(child);
+
+            observable.subscribe(srw);
+
+            co.connect(new DisposeConsumer(srw));
+        }
+    }
+
+    static final class Replay<T> extends ConnectableObservable<T> {
+        private final ConnectableObservable<T> co;
+        private final Observable<T> observable;
+
+        Replay(ConnectableObservable<T> co, Observable<T> observable) {
+            this.co = co;
+            this.observable = observable;
+        }
+
+        @Override
+        public void connect(Consumer<? super Disposable> connection) {
+            co.connect(connection);
+        }
+
+        @Override
+        protected void subscribeActual(Observer<? super T> observer) {
+            observable.subscribe(observer);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -45,12 +45,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
     }
 
     @SuppressWarnings("rawtypes")
-    static final BufferSupplier DEFAULT_UNBOUNDED_FACTORY = new BufferSupplier() {
-        @Override
-        public ReplayBuffer call() {
-            return new UnboundedReplayBuffer<Object>(16);
-        }
-    };
+    static final BufferSupplier DEFAULT_UNBOUNDED_FACTORY = new UnBoundedFactory();
 
     /**
      * Given a connectable observable factory, it multicasts over the generated
@@ -82,12 +77,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
 
                 observable.subscribe(srw);
 
-                co.connect(new Consumer<Disposable>() {
-                    @Override
-                    public void accept(Disposable r) {
-                        srw.setResource(r);
-                    }
-                });
+                co.connect(new DisposeConsumer(srw));
             }
         });
     }
@@ -986,6 +976,26 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
                 }
             }
             return prev;
+        }
+    }
+
+    static final class UnBoundedFactory implements BufferSupplier {
+        @Override
+        public ReplayBuffer call() {
+            return new UnboundedReplayBuffer<Object>(16);
+        }
+    }
+
+    static final class DisposeConsumer<R> implements Consumer<Disposable> {
+        private final ObserverResourceWrapper<R> srw;
+
+        DisposeConsumer(ObserverResourceWrapper<R> srw) {
+            this.srw = srw;
+        }
+
+        @Override
+        public void accept(Disposable r) {
+            srw.setResource(r);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSubscribeOn.java
@@ -33,12 +33,7 @@ public final class ObservableSubscribeOn<T> extends AbstractObservableWithUpstre
 
         s.onSubscribe(parent);
 
-        parent.setDisposable(scheduler.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                source.subscribe(parent);
-            }
-        }));
+        parent.setDisposable(scheduler.scheduleDirect(new SubscribeTask(parent)));
     }
 
     static final class SubscribeOnObserver<T> extends AtomicReference<Disposable> implements Observer<T>, Disposable {
@@ -86,6 +81,19 @@ public final class ObservableSubscribeOn<T> extends AbstractObservableWithUpstre
 
         void setDisposable(Disposable d) {
             DisposableHelper.setOnce(this, d);
+        }
+    }
+
+    final class SubscribeTask implements Runnable {
+        private final SubscribeOnObserver<T> parent;
+
+        SubscribeTask(SubscribeOnObserver<T> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public void run() {
+            source.subscribe(parent);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntil.java
@@ -36,27 +36,7 @@ public final class ObservableTakeUntil<T, U> extends AbstractObservableWithUpstr
 
         child.onSubscribe(frc);
 
-        other.subscribe(new Observer<U>() {
-            @Override
-            public void onSubscribe(Disposable s) {
-                frc.setResource(1, s);
-            }
-            @Override
-            public void onNext(U t) {
-                frc.dispose();
-                serial.onComplete();
-            }
-            @Override
-            public void onError(Throwable t) {
-                frc.dispose();
-                serial.onError(t);
-            }
-            @Override
-            public void onComplete() {
-                frc.dispose();
-                serial.onComplete();
-            }
-        });
+        other.subscribe(new TakeUntil(frc, serial));
 
         source.subscribe(tus);
     }
@@ -97,6 +77,39 @@ public final class ObservableTakeUntil<T, U> extends AbstractObservableWithUpstr
         public void onComplete() {
             frc.dispose();
             actual.onComplete();
+        }
+    }
+
+    final class TakeUntil implements Observer<U> {
+        private final ArrayCompositeDisposable frc;
+        private final SerializedObserver<T> serial;
+
+        TakeUntil(ArrayCompositeDisposable frc, SerializedObserver<T> serial) {
+            this.frc = frc;
+            this.serial = serial;
+        }
+
+        @Override
+        public void onSubscribe(Disposable s) {
+            frc.setResource(1, s);
+        }
+
+        @Override
+        public void onNext(U t) {
+            frc.dispose();
+            serial.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            frc.dispose();
+            serial.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            frc.dispose();
+            serial.onComplete();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOn.java
@@ -80,18 +80,20 @@ public final class ObservableUnsubscribeOn<T> extends AbstractObservableWithUpst
         @Override
         public void dispose() {
             if (compareAndSet(false, true)) {
-                scheduler.scheduleDirect(new Runnable() {
-                    @Override
-                    public void run() {
-                        s.dispose();
-                    }
-                });
+                scheduler.scheduleDirect(new DisposeTask());
             }
         }
 
         @Override
         public boolean isDisposed() {
             return get();
+        }
+
+        final class DisposeTask implements Runnable {
+            @Override
+            public void run() {
+                s.dispose();
+            }
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
@@ -552,12 +552,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                 windows.add(w);
 
                 actual.onNext(w);
-                worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        complete(w);
-                    }
-                }, timespan, unit);
+                worker.schedule(new CompletionTask(w), timespan, unit);
 
                 worker.schedulePeriodically(this, timeskip, timeskip, unit);
             }
@@ -685,12 +680,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                             ws.add(w);
                             a.onNext(w);
 
-                            worker.schedule(new Runnable() {
-                                @Override
-                                public void run() {
-                                    complete(w);
-                                }
-                            }, timespan, unit);
+                            worker.schedule(new CompletionTask(w), timespan, unit);
                         } else {
                             ws.remove(work.w);
                             work.w.onComplete();
@@ -733,6 +723,19 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
             SubjectWork(UnicastSubject<T> w, boolean open) {
                 this.w = w;
                 this.open = open;
+            }
+        }
+
+        final class CompletionTask implements Runnable {
+            private final UnicastSubject<T> w;
+
+            CompletionTask(UnicastSubject<T> w) {
+                this.w = w;
+            }
+
+            @Override
+            public void run() {
+                complete(w);
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFrom.java
@@ -40,27 +40,7 @@ public final class ObservableWithLatestFrom<T, U, R> extends AbstractObservableW
 
         serial.onSubscribe(wlf);
 
-        other.subscribe(new Observer<U>() {
-            @Override
-            public void onSubscribe(Disposable s) {
-                wlf.setOther(s);
-            }
-
-            @Override
-            public void onNext(U t) {
-                wlf.lazySet(t);
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                wlf.otherError(t);
-            }
-
-            @Override
-            public void onComplete() {
-                // nothing to do, the wlf will complete on its own pace
-            }
-        });
+        other.subscribe(new WithLastFrom(wlf));
 
         source.subscribe(wlf);
     }
@@ -133,6 +113,34 @@ public final class ObservableWithLatestFrom<T, U, R> extends AbstractObservableW
         public void otherError(Throwable e) {
             DisposableHelper.dispose(s);
             actual.onError(e);
+        }
+    }
+
+    final class WithLastFrom implements Observer<U> {
+        private final WithLatestFromObserver<T, U, R> wlf;
+
+        WithLastFrom(WithLatestFromObserver<T, U, R> wlf) {
+            this.wlf = wlf;
+        }
+
+        @Override
+        public void onSubscribe(Disposable s) {
+            wlf.setOther(s);
+        }
+
+        @Override
+        public void onNext(U t) {
+            wlf.lazySet(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            wlf.otherError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            // nothing to do, the wlf will complete on its own pace
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
@@ -83,12 +83,7 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
         }
 
         if (n == 0) {
-            new ObservableMap<T, R>(source, new Function<T, R>() {
-                @Override
-                public R apply(T t) throws Exception {
-                    return combiner.apply(new Object[] { t });
-                }
-            }).subscribeActual(s);
+            new ObservableMap<T, R>(source, new SingletonArrayFunc()).subscribeActual(s);
             return;
         }
 
@@ -285,6 +280,13 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
 
         public void dispose() {
             DisposableHelper.dispose(this);
+        }
+    }
+
+    final class SingletonArrayFunc implements Function<T, R> {
+        @Override
+        public R apply(T t) throws Exception {
+            return combiner.apply(new Object[] { t });
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleContains.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleContains.java
@@ -35,33 +35,40 @@ public final class SingleContains<T> extends Single<Boolean> {
     @Override
     protected void subscribeActual(final SingleObserver<? super Boolean> s) {
 
-        source.subscribe(new SingleObserver<T>() {
-
-            @Override
-            public void onSubscribe(Disposable d) {
-                s.onSubscribe(d);
-            }
-
-            @Override
-            public void onSuccess(T v) {
-                boolean b;
-
-                try {
-                    b = comparer.test(v, value);
-                } catch (Throwable ex) {
-                    Exceptions.throwIfFatal(ex);
-                    s.onError(ex);
-                    return;
-                }
-                s.onSuccess(b);
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                s.onError(e);
-            }
-
-        });
+        source.subscribe(new Single(s));
     }
 
+    final class Single implements SingleObserver<T> {
+
+        private final SingleObserver<? super Boolean> s;
+
+        Single(SingleObserver<? super Boolean> s) {
+            this.s = s;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            s.onSubscribe(d);
+        }
+
+        @Override
+        public void onSuccess(T v) {
+            boolean b;
+
+            try {
+                b = comparer.test(v, value);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                s.onError(ex);
+                return;
+            }
+            s.onSuccess(b);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            s.onError(e);
+        }
+
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
@@ -39,33 +39,57 @@ public final class SingleDelay<T> extends Single<T> {
 
         final SequentialDisposable sd = new SequentialDisposable();
         s.onSubscribe(sd);
-        source.subscribe(new SingleObserver<T>() {
-            @Override
-            public void onSubscribe(Disposable d) {
-                sd.replace(d);
-            }
-
-            @Override
-            public void onSuccess(final T value) {
-                sd.replace(scheduler.scheduleDirect(new Runnable() {
-                    @Override
-                    public void run() {
-                        s.onSuccess(value);
-                    }
-                }, time, unit));
-            }
-
-            @Override
-            public void onError(final Throwable e) {
-                sd.replace(scheduler.scheduleDirect(new Runnable() {
-                    @Override
-                    public void run() {
-                        s.onError(e);
-                    }
-                }, 0, unit));
-            }
-
-        });
+        source.subscribe(new Delay(sd, s));
     }
 
+    final class Delay implements SingleObserver<T> {
+        private final SequentialDisposable sd;
+        private final SingleObserver<? super T> s;
+
+        Delay(SequentialDisposable sd, SingleObserver<? super T> s) {
+            this.sd = sd;
+            this.s = s;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            sd.replace(d);
+        }
+
+        @Override
+        public void onSuccess(final T value) {
+            sd.replace(scheduler.scheduleDirect(new OnSuccess(value), time, unit));
+        }
+
+        @Override
+        public void onError(final Throwable e) {
+            sd.replace(scheduler.scheduleDirect(new OnError(e), 0, unit));
+        }
+
+        final class OnSuccess implements Runnable {
+            private final T value;
+
+            OnSuccess(T value) {
+                this.value = value;
+            }
+
+            @Override
+            public void run() {
+                s.onSuccess(value);
+            }
+        }
+
+        final class OnError implements Runnable {
+            private final Throwable e;
+
+            public OnError(Throwable e) {
+                this.e = e;
+            }
+
+            @Override
+            public void run() {
+                s.onError(e);
+            }
+        }
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnError.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnError.java
@@ -32,29 +32,36 @@ public final class SingleDoOnError<T> extends Single<T> {
     @Override
     protected void subscribeActual(final SingleObserver<? super T> s) {
 
-        source.subscribe(new SingleObserver<T>() {
-            @Override
-            public void onSubscribe(Disposable d) {
-                s.onSubscribe(d);
-            }
-
-            @Override
-            public void onSuccess(T value) {
-                s.onSuccess(value);
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                try {
-                    onError.accept(e);
-                } catch (Throwable ex) {
-                    Exceptions.throwIfFatal(ex);
-                    e = new CompositeException(e, ex);
-                }
-                s.onError(e);
-            }
-
-        });
+        source.subscribe(new DoOnError(s));
     }
 
+    final class DoOnError implements SingleObserver<T> {
+        private final SingleObserver<? super T> s;
+
+        DoOnError(SingleObserver<? super T> s) {
+            this.s = s;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            s.onSubscribe(d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            s.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            try {
+                onError.accept(e);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                e = new CompositeException(e, ex);
+            }
+            s.onError(e);
+        }
+
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSuccess.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSuccess.java
@@ -32,30 +32,37 @@ public final class SingleDoOnSuccess<T> extends Single<T> {
     @Override
     protected void subscribeActual(final SingleObserver<? super T> s) {
 
-        source.subscribe(new SingleObserver<T>() {
-            @Override
-            public void onSubscribe(Disposable d) {
-                s.onSubscribe(d);
-            }
-
-            @Override
-            public void onSuccess(T value) {
-                try {
-                    onSuccess.accept(value);
-                } catch (Throwable ex) {
-                    Exceptions.throwIfFatal(ex);
-                    s.onError(ex);
-                    return;
-                }
-                s.onSuccess(value);
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                s.onError(e);
-            }
-
-        });
+        source.subscribe(new DoOnSuccess(s));
     }
 
+    final class DoOnSuccess implements SingleObserver<T> {
+        private final SingleObserver<? super T> s;
+
+        DoOnSuccess(SingleObserver<? super T> s) {
+            this.s = s;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            s.onSubscribe(d);
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            try {
+                onSuccess.accept(value);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                s.onError(ex);
+                return;
+            }
+            s.onSuccess(value);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            s.onError(e);
+        }
+
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleZipArray.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleZipArray.java
@@ -41,12 +41,7 @@ public final class SingleZipArray<T, R> extends Single<R> {
 
 
         if (n == 1) {
-            sources[0].subscribe(new SingleMap.MapSingleObserver<T, R>(observer, new Function<T, R>() {
-                @Override
-                public R apply(T t) throws Exception {
-                    return zipper.apply(new Object[] { t });
-                }
-            }));
+            sources[0].subscribe(new SingleMap.MapSingleObserver<T, R>(observer, new SingletonArrayFunc()));
             return;
         }
 
@@ -180,6 +175,13 @@ public final class SingleZipArray<T, R> extends Single<R> {
         @Override
         public void onError(Throwable e) {
             parent.innerError(e, index);
+        }
+    }
+
+    final class SingletonArrayFunc implements Function<T, R> {
+        @Override
+        public R apply(T t) throws Exception {
+            return zipper.apply(new Object[] { t });
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleZipIterable.java
@@ -61,12 +61,7 @@ public final class SingleZipIterable<T, R> extends Single<R> {
         }
 
         if (n == 1) {
-            a[0].subscribe(new SingleMap.MapSingleObserver<T, R>(observer, new Function<T, R>() {
-                @Override
-                public R apply(T t) throws Exception {
-                    return zipper.apply(new Object[] { t });
-                }
-            }));
+            a[0].subscribe(new SingleMap.MapSingleObserver<T, R>(observer, new SingletonArrayFunc()));
             return;
         }
 
@@ -83,4 +78,10 @@ public final class SingleZipIterable<T, R> extends Single<R> {
         }
     }
 
+    final class SingletonArrayFunc implements Function<T, R> {
+        @Override
+        public R apply(T t) throws Exception {
+            return zipper.apply(new Object[] { t });
+        }
+    }
 }


### PR DESCRIPTION
This is a WIP. Since the changes are big, an incremental review and PR was recommended by @akarnokd 

 - Removes them  from flowable/observable/operators.
- Issue [#5150](https://github.com/ReactiveX/RxJava/issues/5150)