### PR TITLE
2.x: fix private field access, few generics problems

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDelay.java
@@ -48,7 +48,7 @@ public final class CompletableDelay extends Completable {
     final class Delay implements CompletableObserver {
 
         private final CompositeDisposable set;
-        private final CompletableObserver s;
+        final CompletableObserver s;
 
         Delay(CompositeDisposable set, CompletableObserver s) {
             this.set = set;

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
@@ -57,7 +57,7 @@ public final class CompletablePeek extends Completable {
 
         Disposable d;
 
-        private CompletableObserverImplementation(CompletableObserver actual) {
+        CompletableObserverImplementation(CompletableObserver actual) {
             this.actual = actual;
         }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
@@ -43,8 +43,8 @@ public final class CompletableResumeNext extends Completable {
 
     final class ResumeNext implements CompletableObserver {
 
-        private final CompletableObserver s;
-        private final SequentialDisposable sd;
+        final CompletableObserver s;
+        final SequentialDisposable sd;
 
         ResumeNext(CompletableObserver s, SequentialDisposable sd) {
             this.s = s;

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableTimeout.java
@@ -90,8 +90,8 @@ public final class CompletableTimeout extends Completable {
 
     final class DisposeTask implements Runnable {
         private final AtomicBoolean once;
-        private final CompositeDisposable set;
-        private final CompletableObserver s;
+        final CompositeDisposable set;
+        final CompletableObserver s;
 
         DisposeTask(AtomicBoolean once, CompositeDisposable set, CompletableObserver s) {
             this.once = once;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
@@ -44,8 +44,8 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
     }
 
     final class DelaySubscriber implements FlowableSubscriber<U> {
-        private final SubscriptionArbiter serial;
-        private final Subscriber<? super T> child;
+        final SubscriptionArbiter serial;
+        final Subscriber<? super T> child;
         boolean done;
 
         DelaySubscriber(SubscriptionArbiter serial, Subscriber<? super T> child) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -1256,7 +1256,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
         }
     }
 
-    static final class DefaultUnboundedFactory implements Callable {
+    static final class DefaultUnboundedFactory implements Callable<Object> {
         @Override
         public Object call() {
             return new UnboundedReplayBuffer<Object>(16);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFrom.java
@@ -40,7 +40,7 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
 
         serial.onSubscribe(wlf);
 
-        other.subscribe(new FlowableWithLatestSubscriber<U>(wlf));
+        other.subscribe(new FlowableWithLatestSubscriber(wlf));
 
         source.subscribe(wlf);
     }
@@ -117,7 +117,7 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
         }
     }
 
-    final class FlowableWithLatestSubscriber<U> implements FlowableSubscriber<U> {
+    final class FlowableWithLatestSubscriber implements FlowableSubscriber<U> {
         private final WithLatestFromSubscriber<T, U, R> wlf;
 
         FlowableWithLatestSubscriber(WithLatestFromSubscriber<T, U, R> wlf) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOther.java
@@ -44,8 +44,8 @@ public final class ObservableDelaySubscriptionOther<T, U> extends Observable<T> 
     }
 
     final class DelayObserver implements Observer<U> {
-        private final SequentialDisposable serial;
-        private final Observer<? super T> child;
+        final SequentialDisposable serial;
+        final Observer<? super T> child;
         boolean done;
 
         DelayObserver(SequentialDisposable serial, Observer<? super T> child) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -892,9 +892,9 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
         }
     }
 
-    static final class UnBoundedFactory implements BufferSupplier {
+    static final class UnBoundedFactory implements BufferSupplier<Object> {
         @Override
-        public ReplayBuffer call() {
+        public ReplayBuffer<Object> call() {
             return new UnboundedReplayBuffer<Object>(16);
         }
     }
@@ -1027,7 +1027,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
 
             observable.subscribe(srw);
 
-            co.connect(new DisposeConsumer(srw));
+            co.connect(new DisposeConsumer<R>(srw));
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
@@ -44,7 +44,7 @@ public final class SingleDelay<T> extends Single<T> {
 
     final class Delay implements SingleObserver<T> {
         private final SequentialDisposable sd;
-        private final SingleObserver<? super T> s;
+        final SingleObserver<? super T> s;
 
         Delay(SequentialDisposable sd, SingleObserver<? super T> s) {
             this.sd = sd;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTimeout.java
@@ -58,8 +58,8 @@ public final class SingleTimeout<T> extends Single<T> {
 
     final class TimeoutDispose implements Runnable {
         private final AtomicBoolean once;
-        private final CompositeDisposable set;
-        private final SingleObserver<? super T> s;
+        final CompositeDisposable set;
+        final SingleObserver<? super T> s;
 
         TimeoutDispose(AtomicBoolean once, CompositeDisposable set, SingleObserver<? super T> s) {
             this.once = once;


### PR DESCRIPTION
This PR fixes some private field accessor problems introduced by #5174 as well as a couple of generics warnings.

Note that in IntelliJ, there is a J2ME inspection for private access checks between parent and inner classes.