### PR TITLE
1.x: replay().refCount() avoid leaking items between connections

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeRefCount.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeRefCount.java
@@ -129,7 +129,13 @@ public final class OnSubscribeRefCount<T> implements OnSubscribe<T> {
                 // and set the subscriptionCount to 0
                 lock.lock();
                 try {
+
                     if (baseSubscription == currentBase) {
+                        // backdoor into the ConnectableObservable to cleanup and reset its state
+                        if (source instanceof Subscription) {
+                            ((Subscription)source).unsubscribe();
+                        }
+
                         baseSubscription.unsubscribe();
                         baseSubscription = new CompositeSubscription();
                         subscriptionCount.set(0);
@@ -148,7 +154,13 @@ public final class OnSubscribeRefCount<T> implements OnSubscribe<T> {
                 lock.lock();
                 try {
                     if (baseSubscription == current) {
+
                         if (subscriptionCount.decrementAndGet() == 0) {
+                            // backdoor into the ConnectableObservable to cleanup and reset its state
+                            if (source instanceof Subscription) {
+                                ((Subscription)source).unsubscribe();
+                            }
+
                             baseSubscription.unsubscribe();
                             // need a new baseSubscription because once
                             // unsubscribed stays that way

--- a/src/main/java/rx/internal/operators/OperatorReplay.java
+++ b/src/main/java/rx/internal/operators/OperatorReplay.java
@@ -28,7 +28,7 @@ import rx.observables.ConnectableObservable;
 import rx.schedulers.Timestamped;
 import rx.subscriptions.Subscriptions;
 
-public final class OperatorReplay<T> extends ConnectableObservable<T> {
+public final class OperatorReplay<T> extends ConnectableObservable<T> implements Subscription {
     /** The source observable. */
     final Observable<? extends T> source;
     /** Holds the current subscriber that is, will be or just was subscribed to the source observable. */
@@ -252,6 +252,17 @@ public final class OperatorReplay<T> extends ConnectableObservable<T> {
         this.source = source;
         this.current = current;
         this.bufferFactory = bufferFactory;
+    }
+
+    @Override
+    public void unsubscribe() {
+        current.lazySet(null);
+    }
+
+    @Override
+    public boolean isUnsubscribed() {
+        ReplaySubscriber<T> ps = current.get();
+        return ps == null || ps.isUnsubscribed();
     }
 
     @Override

--- a/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
@@ -32,9 +32,10 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
 import rx.functions.*;
+import rx.observables.ConnectableObservable;
 import rx.observers.*;
 import rx.schedulers.*;
-import rx.subjects.*;
+import rx.subjects.ReplaySubject;
 import rx.subscriptions.Subscriptions;
 
 public class OnSubscribeRefCountTest {
@@ -746,5 +747,21 @@ public class OnSubscribeRefCountTest {
 
         source = null;
         assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);
+    }
+
+    @Test
+    public void replayIsUnsubscribed() {
+        ConnectableObservable<Integer> co = Observable.just(1)
+        .replay();
+
+        assertTrue(((Subscription)co).isUnsubscribed());
+
+        Subscription s = co.connect();
+
+        assertFalse(((Subscription)co).isUnsubscribed());
+
+        s.unsubscribe();
+
+        assertTrue(((Subscription)co).isUnsubscribed());
     }
 }

--- a/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
+++ b/src/test/java/rx/internal/operators/OnSubscribeRefCountTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
+import java.lang.management.ManagementFactory;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -33,7 +34,7 @@ import rx.Observer;
 import rx.functions.*;
 import rx.observers.*;
 import rx.schedulers.*;
-import rx.subjects.ReplaySubject;
+import rx.subjects.*;
 import rx.subscriptions.Subscriptions;
 
 public class OnSubscribeRefCountTest {
@@ -610,5 +611,140 @@ public class OnSubscribeRefCountTest {
 
         assertNotNull("First subscriber didn't get the error", err1);
         assertNotNull("Second subscriber didn't get the error", err2);
+    }
+
+    Observable<Object> source;
+
+    @Test
+    public void replayNoLeak() throws Exception {
+        System.gc();
+        Thread.sleep(100);
+
+        long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+
+        source = Observable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return new byte[100 * 1000 * 1000];
+            }
+        })
+        .replay(1)
+        .refCount();
+
+        source.subscribe();
+
+        System.gc();
+        Thread.sleep(100);
+
+        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+
+        source = null;
+        assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);
+    }
+
+    @Test
+    public void replayNoLeak2() throws Exception {
+        System.gc();
+        Thread.sleep(100);
+
+        long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+
+        source = Observable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return new byte[100 * 1000 * 1000];
+            }
+        }).concatWith(Observable.never())
+        .replay(1)
+        .refCount();
+
+        Subscription s1 = source.subscribe();
+        Subscription s2 = source.subscribe();
+
+        s1.unsubscribe();
+        s2.unsubscribe();
+
+        s1 = null;
+        s2 = null;
+
+        System.gc();
+        Thread.sleep(100);
+
+        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+
+        source = null;
+        assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);
+    }
+
+    static final class ExceptionData extends Exception {
+        private static final long serialVersionUID = -6763898015338136119L;
+
+        public final Object data;
+
+        public ExceptionData(Object data) {
+            this.data = data;
+        }
+    }
+
+    @Test
+    public void publishNoLeak() throws Exception {
+        System.gc();
+        Thread.sleep(100);
+
+        long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+
+        source = Observable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                throw new ExceptionData(new byte[100 * 1000 * 1000]);
+            }
+        })
+        .publish()
+        .refCount();
+
+        Action1<Throwable> err = Actions.empty();
+        source.subscribe(Actions.empty(), err);
+
+        System.gc();
+        Thread.sleep(100);
+
+        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+
+        source = null;
+        assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);
+    }
+
+    @Test
+    public void publishNoLeak2() throws Exception {
+        System.gc();
+        Thread.sleep(100);
+
+        long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+
+        source = Observable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return new byte[100 * 1000 * 1000];
+            }
+        }).concatWith(Observable.never())
+        .publish()
+        .refCount();
+
+        Subscription s1 = source.test(0);
+        Subscription s2 = source.test(0);
+
+        s1.unsubscribe();
+        s2.unsubscribe();
+
+        s1 = null;
+        s2 = null;
+
+        System.gc();
+        Thread.sleep(100);
+
+        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+
+        source = null;
+        assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);
     }
 }


### PR DESCRIPTION
This PR updates `replay()` to not leak items between reconnections when run with `.refCount()`. The `replay()` operator is designed to hold onto the buffer even after its completion so late subscribers can still receive the cached data. Only a new `connect()` clears this data which may or may not happen. Since `refCount` ensures that there won't be any latecommers to an already completed connection (because it also drops its current subscribers on termination or when reaching zero), the `replay()` can be reset to an empty state.

Reported in #5172 
