### PR TITLE
2.x: test to disallow anonymous inner classes

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableTimeout.java
@@ -57,7 +57,7 @@ public final class CompletableTimeout extends Completable {
         private final AtomicBoolean once;
         private final CompletableObserver s;
 
-        public TimeOutObserver(CompositeDisposable set, AtomicBoolean once, CompletableObserver s) {
+        TimeOutObserver(CompositeDisposable set, AtomicBoolean once, CompletableObserver s) {
             this.set = set;
             this.once = once;
             this.s = s;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
@@ -87,7 +87,7 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
         final class DelaySubscription implements Subscription {
             private final Subscription s;
 
-            public DelaySubscription(Subscription s) {
+            DelaySubscription(Subscription s) {
                 this.s = s;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableInternalHelper.java
@@ -241,7 +241,7 @@ public final class FlowableInternalHelper {
     static final class ReplayCallable<T> implements Callable<ConnectableFlowable<T>> {
         private final Flowable<T> parent;
 
-        public ReplayCallable(Flowable<T> parent) {
+        ReplayCallable(Flowable<T> parent) {
             this.parent = parent;
         }
 
@@ -310,7 +310,7 @@ public final class FlowableInternalHelper {
         private final Function<? super Flowable<T>, ? extends Publisher<R>> selector;
         private final Scheduler scheduler;
 
-        public ReplayFunction(Function<? super Flowable<T>, ? extends Publisher<R>> selector, Scheduler scheduler) {
+        ReplayFunction(Function<? super Flowable<T>, ? extends Publisher<R>> selector, Scheduler scheduler) {
             this.selector = selector;
             this.scheduler = scheduler;
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -833,7 +833,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
         final class Completion implements Runnable {
             private final UnicastProcessor<T> processor;
 
-            public Completion(UnicastProcessor<T> processor) {
+            Completion(UnicastProcessor<T> processor) {
                 this.processor = processor;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
@@ -118,7 +118,7 @@ public final class ObservableDelay<T> extends AbstractObservableWithUpstream<T, 
         final class OnError implements Runnable {
             private final Throwable throwable;
 
-            public OnError(Throwable throwable) {
+            OnError(Throwable throwable) {
                 this.throwable = throwable;
             }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
@@ -341,7 +341,7 @@ public final class ObservableInternalHelper {
         private final Observable<T> parent;
         private final int bufferSize;
 
-        public BufferedReplayCallable(Observable<T> parent, int bufferSize) {
+        BufferedReplayCallable(Observable<T> parent, int bufferSize) {
             this.parent = parent;
             this.bufferSize = bufferSize;
         }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
@@ -82,7 +82,7 @@ public final class SingleDelay<T> extends Single<T> {
         final class OnError implements Runnable {
             private final Throwable e;
 
-            public OnError(Throwable e) {
+            OnError(Throwable e) {
                 this.e = e;
             }
 

--- a/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
@@ -106,7 +106,7 @@ public final class ExceptionHelper {
         return list;
     }
 
-    final static class Termination extends Throwable {
+    static final class Termination extends Throwable {
 
         private static final long serialVersionUID = -4649703670690200604L;
 

--- a/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
+++ b/src/perf/java/io/reactivex/InputWithIncrementingInteger.java
@@ -26,6 +26,73 @@ import io.reactivex.subscribers.DefaultSubscriber;
  * Exposes an Observable and Observer that increments n Integers and consumes them in a Blackhole.
  */
 public abstract class InputWithIncrementingInteger {
+    final class DefaultSubscriberImpl extends DefaultSubscriber<Integer> {
+        @Override
+        public void onComplete() {
+
+        }
+
+        @Override
+        public void onError(Throwable e) {
+
+        }
+
+        @Override
+        public void onNext(Integer t) {
+            bh.consume(t);
+        }
+    }
+
+    final class IncrementingIterable implements Iterable<Integer> {
+        private final class IncrementingIterator implements Iterator<Integer> {
+            int i;
+
+            @Override
+            public boolean hasNext() {
+                return i < size;
+            }
+
+            @Override
+            public Integer next() {
+                Blackhole.consumeCPU(10);
+                return i++;
+            }
+
+            @Override
+            public void remove() {
+
+            }
+        }
+
+        private final int size;
+
+        private IncrementingIterable(int size) {
+            this.size = size;
+        }
+
+        @Override
+        public Iterator<Integer> iterator() {
+            return new IncrementingIterator();
+        }
+    }
+
+    final class IncrementingPublisher implements Publisher<Integer> {
+        private final int size;
+
+        IncrementingPublisher(int size) {
+            this.size = size;
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super Integer> s) {
+            s.onSubscribe(EmptySubscription.INSTANCE);
+            for (int i = 0; i < size; i++) {
+                s.onNext(i);
+            }
+            s.onComplete();
+        }
+    }
+
     public Iterable<Integer> iterable;
     public Flowable<Integer> observable;
     public Flowable<Integer> firehose;
@@ -39,42 +106,8 @@ public abstract class InputWithIncrementingInteger {
         final int size = getSize();
         observable = Flowable.range(0, size);
 
-        firehose = Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(EmptySubscription.INSTANCE);
-                for (int i = 0; i < size; i++) {
-                    s.onNext(i);
-                }
-                s.onComplete();
-            }
-
-        });
-        iterable = new Iterable<Integer>() {
-            @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    int i;
-
-                    @Override
-                    public boolean hasNext() {
-                        return i < size;
-                    }
-
-                    @Override
-                    public Integer next() {
-                        Blackhole.consumeCPU(10);
-                        return i++;
-                    }
-
-                    @Override
-                    public void remove() {
-
-                    }
-                };
-            }
-        };
+        firehose = Flowable.unsafeCreate(new IncrementingPublisher(size));
+        iterable = new IncrementingIterable(size);
 
     }
 
@@ -83,24 +116,7 @@ public abstract class InputWithIncrementingInteger {
     }
 
     public FlowableSubscriber<Integer> newSubscriber() {
-        return new DefaultSubscriber<Integer>() {
-
-            @Override
-            public void onComplete() {
-
-            }
-
-            @Override
-            public void onError(Throwable e) {
-
-            }
-
-            @Override
-            public void onNext(Integer t) {
-                bh.consume(t);
-            }
-
-        };
+        return new DefaultSubscriberImpl();
     }
 
 }

--- a/src/test/java/io/reactivex/NoAnonymousInnerClassesTest.java
+++ b/src/test/java/io/reactivex/NoAnonymousInnerClassesTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.io.File;
+import java.net.URL;
+import java.util.*;
+
+import org.junit.Test;
+
+public class NoAnonymousInnerClassesTest {
+
+    @Test
+    public void verify() throws Exception {
+        URL u = NoAnonymousInnerClassesTest.class.getResource("/");
+        File f = new File(u.toURI());
+
+        StringBuilder b = new StringBuilder("Anonymous inner classes found:");
+
+        Queue<File> queue = new ArrayDeque<File>();
+
+        queue.offer(f);
+
+        String prefix = f.getAbsolutePath();
+        int count = 0;
+        while (!queue.isEmpty()) {
+
+            f = queue.poll();
+
+            if (f.isDirectory()) {
+                File[] dir = f.listFiles();
+                if (dir != null && dir.length != 0) {
+                    for (File g : dir) {
+                        queue.offer(g);
+                    }
+                }
+            } else {
+                String name = f.getName();
+                if (name.endsWith(".class") && name.contains("$")
+                        && !name.contains("Perf") && !name.contains("Test")
+                        && !name.startsWith("Test")) {
+                    String[] parts = name.split("\\$");
+                    for (String s : parts) {
+                        if (Character.isDigit(s.charAt(0))) {
+                            String n = f.getAbsolutePath().substring(prefix.length()).replace('\\', '.').replace('/', '.');
+                            if (n.startsWith(".")) {
+                                n = n.substring(1);
+                            }
+                            b.append("\r\n").append(n);
+                            count++;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (count != 0) {
+            throw new AssertionError(b.toString());
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -690,7 +690,7 @@ public class FlowableRefCountTest {
 
         public final Object data;
 
-        public ExceptionData(Object data) {
+        ExceptionData(Object data) {
             this.data = data;
         }
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/Burst.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/Burst.java
@@ -27,10 +27,10 @@ import io.reactivex.disposables.Disposables;
  */
 public final class Burst<T> extends Observable<T> {
 
-    private final List<T> items;
-    private final Throwable error;
+    final List<T> items;
+    final Throwable error;
 
-    private Burst(Throwable error, List<T> items) {
+    Burst(Throwable error, List<T> items) {
         this.error = error;
         this.items = items;
     }
@@ -62,7 +62,7 @@ public final class Burst<T> extends Observable<T> {
         private final List<T> items;
         private Throwable error;
 
-        private Builder(List<T> items) {
+        Builder(List<T> items) {
             this.items = items;
         }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -689,7 +689,7 @@ public class ObservableRefCountTest {
 
         public final Object data;
 
-        public ExceptionData(Object data) {
+        ExceptionData(Object data) {
             this.data = data;
         }
     }

--- a/src/test/java/io/reactivex/observable/ObservableEventStream.java
+++ b/src/test/java/io/reactivex/observable/ObservableEventStream.java
@@ -29,19 +29,7 @@ public final class ObservableEventStream {
     }
     public static Observable<Event> getEventStream(final String type, final int numInstances) {
 
-        return Observable.<Event>generate(new Consumer<Emitter<Event>>() {
-            @Override
-            public void accept(Emitter<Event> s) {
-                s.onNext(randomEvent(type, numInstances));
-                try {
-                    // slow it down somewhat
-                    Thread.sleep(50);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    s.onError(e);
-                }
-            }
-        }).subscribeOn(Schedulers.newThread());
+        return Observable.<Event>generate(new EventConsumer(numInstances, type)).subscribeOn(Schedulers.newThread());
     }
 
     public static Event randomEvent(String type, int numInstances) {
@@ -59,6 +47,28 @@ public final class ObservableEventStream {
         x ^= (x >>> 35);
         x ^= (x << 4);
         return Math.abs((int) x % max);
+    }
+
+    static final class EventConsumer implements Consumer<Emitter<Event>> {
+        private final int numInstances;
+        private final String type;
+
+        EventConsumer(int numInstances, String type) {
+            this.numInstances = numInstances;
+            this.type = type;
+        }
+
+        @Override
+        public void accept(Emitter<Event> s) {
+            s.onNext(randomEvent(type, numInstances));
+            try {
+                // slow it down somewhat
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                s.onError(e);
+            }
+        }
     }
 
     public static class Event {


### PR DESCRIPTION
This PR adds an unit test that scans the compiled .class files for anonymous inner classes naming (i.e., dollar sign followed by a number). Since all the main, test and perf classes end up in the same place, the test has exceptions for file names containing `Perf` or `Test`.

The PR also fixes a few Checkstyle warnings from #5177 and fixes a couple classes from tests that don't have the word `Test` in their name and thus were detected.