### PR TITLE
2.x: add offer() method to Publish & Behavior Processors

### DIFF
--- a/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
@@ -736,7 +736,11 @@ public class BehaviorProcessorTest extends DelayedFlowableProcessorTest<Object> 
             @Override
             public void run() {
                 while (!pp.hasSubscribers()) {
-                    Thread.yield();
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ex) {
+                        return;
+                    }
                 }
 
                 for (int i = 1; i <= 10; i++) {

--- a/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
@@ -699,4 +699,57 @@ public class BehaviorProcessorTest extends DelayedFlowableProcessorTest<Object> 
 
         assertFalse(p.hasSubscribers());
     }
+
+    @Test
+    public void offer() {
+        BehaviorProcessor<Integer> pp = BehaviorProcessor.create();
+
+        TestSubscriber<Integer> ts = pp.test(0);
+
+        assertFalse(pp.offer(1));
+
+        ts.request(1);
+
+        assertTrue(pp.offer(1));
+
+        assertFalse(pp.offer(2));
+
+        ts.cancel();
+
+        assertTrue(pp.offer(2));
+
+        ts = pp.test(1);
+
+        assertTrue(pp.offer(null));
+
+        ts.assertFailure(NullPointerException.class, 2);
+
+        assertTrue(pp.hasThrowable());
+        assertTrue(pp.getThrowable().toString(), pp.getThrowable() instanceof NullPointerException);
+    }
+
+    @Test
+    public void offerAsync() throws Exception {
+        final BehaviorProcessor<Integer> pp = BehaviorProcessor.create();
+
+        Schedulers.single().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                while (!pp.hasSubscribers()) {
+                    Thread.yield();
+                }
+
+                for (int i = 1; i <= 10; i++) {
+                    while (!pp.offer(i)) { }
+                }
+                pp.onComplete();
+            }
+        });
+
+        Thread.sleep(1);
+
+        pp.test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
 }

--- a/src/test/java/io/reactivex/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/PublishProcessorTest.java
@@ -621,5 +621,56 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         }
     }
 
+    @Test
+    public void offer() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
+        TestSubscriber<Integer> ts = pp.test(0);
+
+        assertFalse(pp.offer(1));
+
+        ts.request(1);
+
+        assertTrue(pp.offer(1));
+
+        assertFalse(pp.offer(2));
+
+        ts.cancel();
+
+        assertTrue(pp.offer(2));
+
+        ts = pp.test(0);
+
+        assertTrue(pp.offer(null));
+
+        ts.assertFailure(NullPointerException.class);
+
+        assertTrue(pp.hasThrowable());
+        assertTrue(pp.getThrowable().toString(), pp.getThrowable() instanceof NullPointerException);
+    }
+
+    @Test
+    public void offerAsync() throws Exception {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        Schedulers.single().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                while (!pp.hasSubscribers()) {
+                    Thread.yield();
+                }
+
+                for (int i = 1; i <= 10; i++) {
+                    while (!pp.offer(i)) { }
+                }
+                pp.onComplete();
+            }
+        });
+
+        Thread.sleep(1);
+
+        pp.test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
 }

--- a/src/test/java/io/reactivex/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/PublishProcessorTest.java
@@ -657,7 +657,11 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
             @Override
             public void run() {
                 while (!pp.hasSubscribers()) {
-                    Thread.yield();
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ex) {
+                        return;
+                    }
                 }
 
                 for (int i = 1; i <= 10; i++) {

--- a/src/test/java/io/reactivex/tck/AsyncProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/AsyncProcessorAsPublisherTckTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.processors.AsyncProcessor;
+import io.reactivex.schedulers.Schedulers;
+
+@Test
+public class AsyncProcessorAsPublisherTckTest extends BaseTck<Integer> {
+
+    public AsyncProcessorAsPublisherTckTest() {
+        super(100);
+    }
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        final AsyncProcessor<Integer> pp = AsyncProcessor.create();
+
+        Schedulers.io().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                long start = System.currentTimeMillis();
+                while (!pp.hasSubscribers()) {
+                    Thread.yield();
+                    if (System.currentTimeMillis() - start > 200) {
+                        return;
+                    }
+                }
+
+                for (int i = 0; i < elements; i++) {
+                    pp.onNext(i);
+                }
+                pp.onComplete();
+            }
+        });
+        return pp;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/src/test/java/io/reactivex/tck/AsyncProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/AsyncProcessorAsPublisherTckTest.java
@@ -35,7 +35,12 @@ public class AsyncProcessorAsPublisherTckTest extends BaseTck<Integer> {
             public void run() {
                 long start = System.currentTimeMillis();
                 while (!pp.hasSubscribers()) {
-                    Thread.yield();
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ex) {
+                        return;
+                    }
+
                     if (System.currentTimeMillis() - start > 200) {
                         return;
                     }

--- a/src/test/java/io/reactivex/tck/BehaviorProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/BehaviorProcessorAsPublisherTckTest.java
@@ -31,10 +31,15 @@ public class BehaviorProcessorAsPublisherTckTest extends BaseTck<Integer> {
             public void run() {
                 long start = System.currentTimeMillis();
                 while (!pp.hasSubscribers()) {
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ex) {
+                        return;
+                    }
+
                     if (System.currentTimeMillis() - start > 200) {
                         return;
                     }
-                    Thread.yield();
                 }
 
                 for (int i = 0; i < elements; i++) {

--- a/src/test/java/io/reactivex/tck/BehaviorProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/BehaviorProcessorAsPublisherTckTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.processors.BehaviorProcessor;
+import io.reactivex.schedulers.Schedulers;
+
+@Test
+public class BehaviorProcessorAsPublisherTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        final BehaviorProcessor<Integer> pp = BehaviorProcessor.create();
+
+        Schedulers.io().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                long start = System.currentTimeMillis();
+                while (!pp.hasSubscribers()) {
+                    if (System.currentTimeMillis() - start > 200) {
+                        return;
+                    }
+                    Thread.yield();
+                }
+
+                for (int i = 0; i < elements; i++) {
+                    while (!pp.offer(i)) {
+                        Thread.yield();
+                        if (System.currentTimeMillis() - start > 1000) {
+                            return;
+                        }
+                    }
+                }
+                pp.onComplete();
+            }
+        });
+        return pp;
+    }
+}

--- a/src/test/java/io/reactivex/tck/PublishProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/PublishProcessorAsPublisherTckTest.java
@@ -35,7 +35,12 @@ public class PublishProcessorAsPublisherTckTest extends BaseTck<Integer> {
             public void run() {
                 long start = System.currentTimeMillis();
                 while (!pp.hasSubscribers()) {
-                    Thread.yield();
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ex) {
+                        return;
+                    }
+
                     if (System.currentTimeMillis() - start > 200) {
                         return;
                     }

--- a/src/test/java/io/reactivex/tck/PublishProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/PublishProcessorAsPublisherTckTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
+
+@Test
+public class PublishProcessorAsPublisherTckTest extends BaseTck<Integer> {
+
+    public PublishProcessorAsPublisherTckTest() {
+        super(100);
+    }
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        Schedulers.io().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                long start = System.currentTimeMillis();
+                while (!pp.hasSubscribers()) {
+                    Thread.yield();
+                    if (System.currentTimeMillis() - start > 200) {
+                        return;
+                    }
+                }
+
+                for (int i = 0; i < elements; i++) {
+                    while (!pp.offer(i)) {
+                        Thread.yield();
+                        if (System.currentTimeMillis() - start > 1000) {
+                            return;
+                        }
+                    }
+                }
+                pp.onComplete();
+            }
+        });
+        return pp;
+    }
+}

--- a/src/test/java/io/reactivex/tck/ReplayProcessorSizeBoundAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReplayProcessorSizeBoundAsPublisherTckTest.java
@@ -35,7 +35,12 @@ public class ReplayProcessorSizeBoundAsPublisherTckTest extends BaseTck<Integer>
             public void run() {
                 long start = System.currentTimeMillis();
                 while (!pp.hasSubscribers()) {
-                    Thread.yield();
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ex) {
+                        return;
+                    }
+
                     if (System.currentTimeMillis() - start > 200) {
                         return;
                     }

--- a/src/test/java/io/reactivex/tck/ReplayProcessorSizeBoundAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReplayProcessorSizeBoundAsPublisherTckTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.processors.ReplayProcessor;
+import io.reactivex.schedulers.Schedulers;
+
+@Test
+public class ReplayProcessorSizeBoundAsPublisherTckTest extends BaseTck<Integer> {
+
+    public ReplayProcessorSizeBoundAsPublisherTckTest() {
+        super(100);
+    }
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        final ReplayProcessor<Integer> pp = ReplayProcessor.createWithSize((int)elements + 10);
+
+        Schedulers.io().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                long start = System.currentTimeMillis();
+                while (!pp.hasSubscribers()) {
+                    Thread.yield();
+                    if (System.currentTimeMillis() - start > 200) {
+                        return;
+                    }
+                }
+
+                for (int i = 0; i < elements; i++) {
+                    pp.onNext(i);
+                }
+                pp.onComplete();
+            }
+        });
+        return pp;
+    }
+}

--- a/src/test/java/io/reactivex/tck/ReplayProcessorTimeBoundAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReplayProcessorTimeBoundAsPublisherTckTest.java
@@ -37,7 +37,12 @@ public class ReplayProcessorTimeBoundAsPublisherTckTest extends BaseTck<Integer>
             public void run() {
                 long start = System.currentTimeMillis();
                 while (!pp.hasSubscribers()) {
-                    Thread.yield();
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ex) {
+                        return;
+                    }
+
                     if (System.currentTimeMillis() - start > 200) {
                         return;
                     }

--- a/src/test/java/io/reactivex/tck/ReplayProcessorTimeBoundAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReplayProcessorTimeBoundAsPublisherTckTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import java.util.concurrent.TimeUnit;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.processors.ReplayProcessor;
+import io.reactivex.schedulers.Schedulers;
+
+@Test
+public class ReplayProcessorTimeBoundAsPublisherTckTest extends BaseTck<Integer> {
+
+    public ReplayProcessorTimeBoundAsPublisherTckTest() {
+        super(100);
+    }
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        final ReplayProcessor<Integer> pp = ReplayProcessor.createWithTime(1, TimeUnit.MINUTES, Schedulers.computation());
+
+        Schedulers.io().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                long start = System.currentTimeMillis();
+                while (!pp.hasSubscribers()) {
+                    Thread.yield();
+                    if (System.currentTimeMillis() - start > 200) {
+                        return;
+                    }
+                }
+
+                for (int i = 0; i < elements; i++) {
+                    pp.onNext(i);
+                }
+                pp.onComplete();
+            }
+        });
+        return pp;
+    }
+}

--- a/src/test/java/io/reactivex/tck/ReplayProcessorUnboundedAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReplayProcessorUnboundedAsPublisherTckTest.java
@@ -35,7 +35,12 @@ public class ReplayProcessorUnboundedAsPublisherTckTest extends BaseTck<Integer>
             public void run() {
                 long start = System.currentTimeMillis();
                 while (!pp.hasSubscribers()) {
-                    Thread.yield();
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ex) {
+                        return;
+                    }
+
                     if (System.currentTimeMillis() - start > 200) {
                         return;
                     }

--- a/src/test/java/io/reactivex/tck/ReplayProcessorUnboundedAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReplayProcessorUnboundedAsPublisherTckTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.processors.ReplayProcessor;
+import io.reactivex.schedulers.Schedulers;
+
+@Test
+public class ReplayProcessorUnboundedAsPublisherTckTest extends BaseTck<Integer> {
+
+    public ReplayProcessorUnboundedAsPublisherTckTest() {
+        super(100);
+    }
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        final ReplayProcessor<Integer> pp = ReplayProcessor.create();
+
+        Schedulers.io().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                long start = System.currentTimeMillis();
+                while (!pp.hasSubscribers()) {
+                    Thread.yield();
+                    if (System.currentTimeMillis() - start > 200) {
+                        return;
+                    }
+                }
+
+                for (int i = 0; i < elements; i++) {
+                    pp.onNext(i);
+                }
+                pp.onComplete();
+            }
+        });
+        return pp;
+    }
+}

--- a/src/test/java/io/reactivex/tck/UnicastProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/UnicastProcessorAsPublisherTckTest.java
@@ -35,7 +35,12 @@ public class UnicastProcessorAsPublisherTckTest extends BaseTck<Integer> {
             public void run() {
                 long start = System.currentTimeMillis();
                 while (!pp.hasSubscribers()) {
-                    Thread.yield();
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ex) {
+                        return;
+                    }
+
                     if (System.currentTimeMillis() - start > 200) {
                         return;
                     }

--- a/src/test/java/io/reactivex/tck/UnicastProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/UnicastProcessorAsPublisherTckTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.processors.*;
+import io.reactivex.schedulers.Schedulers;
+
+@Test
+public class UnicastProcessorAsPublisherTckTest extends BaseTck<Integer> {
+
+    public UnicastProcessorAsPublisherTckTest() {
+        super(100);
+    }
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        final UnicastProcessor<Integer> pp = UnicastProcessor.create();
+
+        Schedulers.io().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                long start = System.currentTimeMillis();
+                while (!pp.hasSubscribers()) {
+                    Thread.yield();
+                    if (System.currentTimeMillis() - start > 200) {
+                        return;
+                    }
+                }
+
+                for (int i = 0; i < elements; i++) {
+                    pp.onNext(i);
+                }
+                pp.onComplete();
+            }
+        });
+        return pp;
+    }
+}


### PR DESCRIPTION
This PR adds the `boolean offer(T item)` method to `PublishProcessor` and `BehaviorProcessor` to prevent `MissingBackpressureException` when one of the `Subscriber`s is not ready to receive element by indicating a false return value. The sender can then retry the offer with any wait strategy it choses.

In addition, this PR adds Reactive-Streams Publisher TCK checks to verify `AsyncProcessor`, `BehaviorProcessor`, `PublishProcessor`, `ReplayProcessor` and `UnicastProcessor` as being `Publisher`s. Unfortunately, the TCK can't verify them as `Processor's because the TCK has certain expectations about how a `Processor` should behave (namely: expects fail-fast, refCount-like nature).