### PR TITLE
2.x: fix flatMap emitting the terminal exception indicator on cancel

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -421,10 +421,12 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
 
                 if (d && (svq == null || svq.isEmpty()) && n == 0) {
                     Throwable ex = errs.terminate();
-                    if (ex == null) {
-                        child.onComplete();
-                    } else {
-                        child.onError(ex);
+                    if (ex != ExceptionHelper.TERMINATED) {
+                        if (ex == null) {
+                            child.onComplete();
+                        } else {
+                            child.onError(ex);
+                        }
                     }
                     return;
                 }
@@ -556,7 +558,10 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
             }
             if (!delayErrors && errs.get() != null) {
                 clearScalarQueue();
-                actual.onError(errs.terminate());
+                Throwable ex = errs.terminate();
+                if (ex != ExceptionHelper.TERMINATED) {
+                    actual.onError(ex);
+                }
                 return true;
             }
             return false;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -361,11 +361,13 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                 int n = inner.length;
 
                 if (d && (svq == null || svq.isEmpty()) && n == 0) {
-                    Throwable ex = errors.get();
-                    if (ex == null) {
-                        child.onComplete();
-                    } else {
-                        child.onError(errors.terminate());
+                    Throwable ex = errors.terminate();
+                    if (ex != ExceptionHelper.TERMINATED) {
+                        if (ex == null) {
+                            child.onComplete();
+                        } else {
+                            child.onError(ex);
+                        }
                     }
                     return;
                 }
@@ -488,7 +490,10 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
             Throwable e = errors.get();
             if (!delayErrors && (e != null)) {
                 disposeAll();
-                actual.onError(errors.terminate());
+                e = errors.terminate();
+                if (e != ExceptionHelper.TERMINATED) {
+                    actual.onError(e);
+                }
                 return true;
             }
             return false;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -28,6 +28,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
@@ -924,6 +925,76 @@ public class FlowableFlatMapTest {
 
             assertTrue(list.toString(), list.contains("RxSi"));
             assertTrue(list.toString(), list.contains("RxCo"));
+        }
+    }
+
+    @Test
+    public void cancelScalarDrainRace() {
+        for (int i = 0; i < 1000; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+
+                final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
+
+                final TestSubscriber<Integer> ts = pp.flatMap(Functions.<Flowable<Integer>>identity()).test(0);
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ts.cancel();
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        pp.onComplete();
+                    }
+                };
+
+                TestHelper.race(r1, r2);
+
+                assertTrue(errors.toString(), errors.isEmpty());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void cancelDrainRace() {
+        for (int i = 0; i < 1000; i++) {
+            for (int j = 1; j < 50; j += 5) {
+                List<Throwable> errors = TestHelper.trackPluginErrors();
+                try {
+
+                    final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
+
+                    final TestSubscriber<Integer> ts = pp.flatMap(Functions.<Flowable<Integer>>identity()).test(0);
+
+                    final PublishProcessor<Integer> just = PublishProcessor.create();
+                    pp.onNext(just);
+
+                    Runnable r1 = new Runnable() {
+                        @Override
+                        public void run() {
+                            ts.request(1);
+                            ts.cancel();
+                        }
+                    };
+                    Runnable r2 = new Runnable() {
+                        @Override
+                        public void run() {
+                            just.onNext(1);
+                        }
+                    };
+
+                    TestHelper.race(r1, r2);
+
+                    assertTrue(errors.toString(), errors.isEmpty());
+                } finally {
+                    RxJavaPlugins.reset();
+                }
+            }
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
@@ -29,7 +29,9 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
@@ -782,6 +784,78 @@ public class ObservableFlatMapTest {
 
             assertTrue(list.toString(), list.contains("RxSi"));
             assertTrue(list.toString(), list.contains("RxCo"));
+        }
+    }
+
+    @Test
+    public void cancelScalarDrainRace() {
+        for (int i = 0; i < 1000; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+
+                final PublishSubject<Observable<Integer>> pp = PublishSubject.create();
+
+                final TestObserver<Integer> ts = pp.flatMap(Functions.<Observable<Integer>>identity()).test();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ts.cancel();
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        pp.onComplete();
+                    }
+                };
+
+                TestHelper.race(r1, r2);
+
+                assertTrue(errors.toString(), errors.isEmpty());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void cancelDrainRace() {
+        for (int i = 0; i < 1000; i++) {
+            for (int j = 1; j < 50; j += 5) {
+                List<Throwable> errors = TestHelper.trackPluginErrors();
+                try {
+
+                    final PublishSubject<Observable<Integer>> pp = PublishSubject.create();
+
+                    final TestObserver<Integer> ts = pp.flatMap(Functions.<Observable<Integer>>identity()).test();
+
+                    final PublishSubject<Integer> just = PublishSubject.create();
+                    final PublishSubject<Integer> just2 = PublishSubject.create();
+                    pp.onNext(just);
+                    pp.onNext(just2);
+
+                    Runnable r1 = new Runnable() {
+                        @Override
+                        public void run() {
+                            just2.onNext(1);
+                            ts.cancel();
+                        }
+                    };
+                    Runnable r2 = new Runnable() {
+                        @Override
+                        public void run() {
+                            just.onNext(1);
+                        }
+                    };
+
+                    TestHelper.race(r1, r2);
+
+                    assertTrue(errors.toString(), errors.isEmpty());
+                } finally {
+                    RxJavaPlugins.reset();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes the case when `Flowable.flatMap` and `Observable.flatMap` would emit the `ExceptionHelper.TERMINTED` indicator exception to downstream due to emission-cancellation race.

Reported on [StackOverflow](http://stackoverflow.com/questions/42580195/what-is-the-meaning-of-no-further-exceptions).