### PR TITLE
Correct java doc for refCount() return type. v2.0.7

### DIFF
--- a/src/main/java/io/reactivex/observables/ConnectableObservable.java
+++ b/src/main/java/io/reactivex/observables/ConnectableObservable.java
@@ -68,7 +68,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      * Returns an {@code Observable} that stays connected to this {@code ConnectableObservable} as long as there
      * is at least one subscription to this {@code ConnectableObservable}.
      *
-     * @return a {@link Flowable}
+     * @return an {@link Observable}
      * @see <a href="http://reactivex.io/documentation/operators/refcount.html">ReactiveX documentation: RefCount</a>
      */
     public Observable<T> refCount() {


### PR DESCRIPTION
Java doc for `ConnectableObservable.refCount()` says  it returns a `Flowable`, but it should be `Observable`