### PR TITLE
1.X: UnicastSubject fail-fast and delay-error behavior

### DIFF
--- a/src/main/java/rx/subjects/UnicastSubject.java
+++ b/src/main/java/rx/subjects/UnicastSubject.java
@@ -303,6 +303,7 @@ public final class UnicastSubject<T> extends Subject<T, T> {
                 emitting = true;
             }
             Queue<Object> q = queue;
+            boolean delayError = this.delayError;
             for (;;) {
                 Subscriber<? super T> s = subscriber.get();
                 boolean unlimited = false;

--- a/src/test/java/rx/subjects/UnicastSubjectTest.java
+++ b/src/test/java/rx/subjects/UnicastSubjectTest.java
@@ -1,0 +1,101 @@
+package rx.subjects;
+
+import org.junit.Test;
+import rx.functions.Action0;
+import rx.observers.TestSubscriber;
+
+public class UnicastSubjectTest {
+
+    @Test
+    public void testOneArgFactoryDelayError() throws Exception {
+        TestSubscriber<Long> subscriber = TestSubscriber.<Long>create();
+        UnicastSubject<Long> s = UnicastSubject.create(true);
+        s.onNext(1L);
+        s.onNext(2L);
+        s.onError(new RuntimeException());
+        s.subscribe(subscriber);
+        subscriber.assertValueCount(2);
+        subscriber.assertError(RuntimeException.class);
+    }
+
+    @Test
+    public void testOneArgFactoryNoDelayError() throws Exception {
+        TestSubscriber<Long> subscriber = TestSubscriber.<Long>create();
+        UnicastSubject<Long> s = UnicastSubject.create(false);
+        s.onNext(1L);
+        s.onNext(2L);
+        s.onError(new RuntimeException());
+        s.subscribe(subscriber);
+        subscriber.assertValueCount(0);
+        subscriber.assertError(RuntimeException.class);
+    }
+
+    @Test
+    public void testThreeArgsFactoryDelayError() throws Exception {
+        TestSubscriber<Long> subscriber = TestSubscriber.<Long>create();
+        UnicastSubject<Long> s = UnicastSubject.create(16, new NoopAction0(), true);
+        s.onNext(1L);
+        s.onNext(2L);
+        s.onError(new RuntimeException());
+        s.subscribe(subscriber);
+        subscriber.assertValueCount(2);
+        subscriber.assertError(RuntimeException.class);
+    }
+
+    @Test
+    public void testThreeArgsFactoryNoDelayError() throws Exception {
+        TestSubscriber<Long> subscriber = TestSubscriber.<Long>create();
+        UnicastSubject<Long> s = UnicastSubject.create(16, new NoopAction0(), false);
+        s.onNext(1L);
+        s.onNext(2L);
+        s.onError(new RuntimeException());
+        s.subscribe(subscriber);
+        subscriber.assertValueCount(0);
+        subscriber.assertError(RuntimeException.class);
+    }
+
+    @Test
+    public void testZeroArgsFactory() throws Exception {
+        TestSubscriber<Long> subscriber = TestSubscriber.<Long>create();
+        UnicastSubject<Long> s = UnicastSubject.create();
+        s.onNext(1L);
+        s.onNext(2L);
+        s.onError(new RuntimeException());
+        s.subscribe(subscriber);
+        subscriber.assertValueCount(0);
+        subscriber.assertError(RuntimeException.class);
+    }
+
+    @Test
+    public void testOneArgFactory() throws Exception {
+        TestSubscriber<Long> subscriber = TestSubscriber.<Long>create();
+        UnicastSubject<Long> s = UnicastSubject.create(16);
+        s.onNext(1L);
+        s.onNext(2L);
+        s.onError(new RuntimeException());
+        s.subscribe(subscriber);
+        subscriber.assertValueCount(0);
+        subscriber.assertError(RuntimeException.class);
+    }
+
+    @Test
+    public void testTwoArgsFactory() throws Exception {
+        TestSubscriber<Long> subscriber = TestSubscriber.<Long>create();
+        UnicastSubject<Long> s = UnicastSubject.create(16, new NoopAction0());
+        s.onNext(1L);
+        s.onNext(2L);
+        s.onError(new RuntimeException());
+        s.subscribe(subscriber);
+        subscriber.assertValueCount(0);
+        subscriber.assertError(RuntimeException.class);
+    }
+
+
+
+    private static final class NoopAction0 implements Action0 {
+
+        @Override
+        public void call() {
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for delay-error behavior to `UnicastSubject` with methods `UnicastSubject<T> create(boolean delayError)`, `UnicastSubject<T> create(int capacityHint, Action0 onTerminated, boolean delayError)`. Behavior of existing factory methods was not changed, and is fail-fast.

Relates to #5165 
