### PR TITLE
2.x: add resilient versions of parallel map(), filter() & doOnNext()

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelDoOnNextTry.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelDoOnNextTry.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import org.reactivestreams.*;
+
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.parallel.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Calls a Consumer for each upstream value passing by
+ * and handles any failure with a handler function.
+ *
+ * @param <T> the input value type
+ * @since 2.0.8 - experimental
+ */
+public final class ParallelDoOnNextTry<T> extends ParallelFlowable<T> {
+
+    final ParallelFlowable<T> source;
+
+    final Consumer<? super T> onNext;
+
+    final BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler;
+
+    public ParallelDoOnNextTry(ParallelFlowable<T> source, Consumer<? super T> onNext,
+            BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+        this.source = source;
+        this.onNext = onNext;
+        this.errorHandler = errorHandler;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+        @SuppressWarnings("unchecked")
+        Subscriber<? super T>[] parents = new Subscriber[n];
+
+        for (int i = 0; i < n; i++) {
+            Subscriber<? super T> a = subscribers[i];
+            if (a instanceof ConditionalSubscriber) {
+                parents[i] = new ParallelDoOnNextConditionalSubscriber<T>((ConditionalSubscriber<? super T>)a, onNext, errorHandler);
+            } else {
+                parents[i] = new ParallelDoOnNextSubscriber<T>(a, onNext, errorHandler);
+            }
+        }
+
+        source.subscribe(parents);
+    }
+
+    @Override
+    public int parallelism() {
+        return source.parallelism();
+    }
+
+    static final class ParallelDoOnNextSubscriber<T> implements ConditionalSubscriber<T>, Subscription {
+
+        final Subscriber<? super T> actual;
+
+        final Consumer<? super T> onNext;
+
+        final BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler;
+
+        Subscription s;
+
+        boolean done;
+
+        ParallelDoOnNextSubscriber(Subscriber<? super T> actual, Consumer<? super T> onNext,
+                BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+            this.actual = actual;
+            this.onNext = onNext;
+            this.errorHandler = errorHandler;
+        }
+
+        @Override
+        public void request(long n) {
+            s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            s.cancel();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (!tryOnNext(t)) {
+                s.request(1);
+            }
+        }
+
+        @Override
+        public boolean tryOnNext(T t) {
+            if (done) {
+                return false;
+            }
+            long retries = 0;
+
+            for (;;) {
+                try {
+                    onNext.accept(t);
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+
+                    ParallelFailureHandling h;
+
+                    try {
+                        h = ObjectHelper.requireNonNull(errorHandler.apply(++retries, ex), "The errorHandler returned a null item");
+                    } catch (Throwable exc) {
+                        Exceptions.throwIfFatal(exc);
+                        cancel();
+                        onError(new CompositeException(ex, exc));
+                        return false;
+                    }
+
+                    switch (h) {
+                    case RETRY:
+                        continue;
+                    case SKIP:
+                        return false;
+                    case STOP:
+                        cancel();
+                        onComplete();
+                        return false;
+                    default:
+                        cancel();
+                        onError(ex);
+                        return false;
+                    }
+                }
+
+                actual.onNext(t);
+                return true;
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            actual.onComplete();
+        }
+
+    }
+    static final class ParallelDoOnNextConditionalSubscriber<T> implements ConditionalSubscriber<T>, Subscription {
+
+        final ConditionalSubscriber<? super T> actual;
+
+        final Consumer<? super T> onNext;
+
+        final BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler;
+        Subscription s;
+
+        boolean done;
+
+        ParallelDoOnNextConditionalSubscriber(ConditionalSubscriber<? super T> actual,
+                Consumer<? super T> onNext,
+                BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+            this.actual = actual;
+            this.onNext = onNext;
+            this.errorHandler = errorHandler;
+        }
+
+        @Override
+        public void request(long n) {
+            s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            s.cancel();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (!tryOnNext(t) && !done) {
+                s.request(1);
+            }
+        }
+
+        @Override
+        public boolean tryOnNext(T t) {
+            if (done) {
+                return false;
+            }
+            long retries = 0;
+
+            for (;;) {
+                try {
+                    onNext.accept(t);
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+
+                    ParallelFailureHandling h;
+
+                    try {
+                        h = ObjectHelper.requireNonNull(errorHandler.apply(++retries, ex), "The errorHandler returned a null item");
+                    } catch (Throwable exc) {
+                        Exceptions.throwIfFatal(exc);
+                        cancel();
+                        onError(new CompositeException(ex, exc));
+                        return false;
+                    }
+
+                    switch (h) {
+                    case RETRY:
+                        continue;
+                    case SKIP:
+                        return false;
+                    case STOP:
+                        cancel();
+                        onComplete();
+                        return false;
+                    default:
+                        cancel();
+                        onError(ex);
+                        return false;
+                    }
+                }
+
+                return actual.tryOnNext(t);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            actual.onComplete();
+        }
+
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFilter.java
@@ -88,7 +88,7 @@ public final class ParallelFilter<T> extends ParallelFlowable<T> {
 
         @Override
         public final void onNext(T t) {
-            if (!tryOnNext(t)) {
+            if (!tryOnNext(t) && !done) {
                 s.request(1);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFilterTry.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFilterTry.java
@@ -1,0 +1,278 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import org.reactivestreams.*;
+
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.parallel.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Filters each 'rail' of the source ParallelFlowable with a predicate function.
+ *
+ * @param <T> the input value type
+ */
+public final class ParallelFilterTry<T> extends ParallelFlowable<T> {
+
+    final ParallelFlowable<T> source;
+
+    final Predicate<? super T> predicate;
+
+    final BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler;
+
+    public ParallelFilterTry(ParallelFlowable<T> source, Predicate<? super T> predicate,
+            BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+        this.source = source;
+        this.predicate = predicate;
+        this.errorHandler = errorHandler;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+        @SuppressWarnings("unchecked")
+        Subscriber<? super T>[] parents = new Subscriber[n];
+
+        for (int i = 0; i < n; i++) {
+            Subscriber<? super T> a = subscribers[i];
+            if (a instanceof ConditionalSubscriber) {
+                parents[i] = new ParallelFilterConditionalSubscriber<T>((ConditionalSubscriber<? super T>)a, predicate, errorHandler);
+            } else {
+                parents[i] = new ParallelFilterSubscriber<T>(a, predicate, errorHandler);
+            }
+        }
+
+        source.subscribe(parents);
+    }
+
+    @Override
+    public int parallelism() {
+        return source.parallelism();
+    }
+
+    abstract static class BaseFilterSubscriber<T> implements ConditionalSubscriber<T>, Subscription {
+        final Predicate<? super T> predicate;
+
+        final BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler;
+
+        Subscription s;
+
+        boolean done;
+
+        BaseFilterSubscriber(Predicate<? super T> predicate, BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+            this.predicate = predicate;
+            this.errorHandler = errorHandler;
+        }
+
+        @Override
+        public final void request(long n) {
+            s.request(n);
+        }
+
+        @Override
+        public final void cancel() {
+            s.cancel();
+        }
+
+        @Override
+        public final void onNext(T t) {
+            if (!tryOnNext(t) && !done) {
+                s.request(1);
+            }
+        }
+    }
+
+    static final class ParallelFilterSubscriber<T> extends BaseFilterSubscriber<T> {
+
+        final Subscriber<? super T> actual;
+
+        ParallelFilterSubscriber(Subscriber<? super T> actual, Predicate<? super T> predicate, BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+            super(predicate, errorHandler);
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public boolean tryOnNext(T t) {
+            if (!done) {
+                long retries = 0L;
+
+                for (;;) {
+                    boolean b;
+
+                    try {
+                        b = predicate.test(t);
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+
+                        ParallelFailureHandling h;
+
+                        try {
+                            h = ObjectHelper.requireNonNull(errorHandler.apply(++retries, ex), "The errorHandler returned a null item");
+                        } catch (Throwable exc) {
+                            Exceptions.throwIfFatal(exc);
+                            cancel();
+                            onError(new CompositeException(ex, exc));
+                            return false;
+                        }
+
+                        switch (h) {
+                        case RETRY:
+                            continue;
+                        case SKIP:
+                            return false;
+                        case STOP:
+                            cancel();
+                            onComplete();
+                            return false;
+                        default:
+                            cancel();
+                            onError(ex);
+                            return false;
+                        }
+                    }
+
+                    if (b) {
+                        actual.onNext(t);
+                        return true;
+                    }
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (!done) {
+                done = true;
+                actual.onComplete();
+            }
+        }
+    }
+
+    static final class ParallelFilterConditionalSubscriber<T> extends BaseFilterSubscriber<T> {
+
+        final ConditionalSubscriber<? super T> actual;
+
+        ParallelFilterConditionalSubscriber(ConditionalSubscriber<? super T> actual,
+                Predicate<? super T> predicate,
+                BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+            super(predicate, errorHandler);
+            this.actual = actual;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public boolean tryOnNext(T t) {
+            if (!done) {
+                long retries = 0L;
+
+                for (;;) {
+                    boolean b;
+
+                    try {
+                        b = predicate.test(t);
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+
+                        ParallelFailureHandling h;
+
+                        try {
+                            h = ObjectHelper.requireNonNull(errorHandler.apply(++retries, ex), "The errorHandler returned a null item");
+                        } catch (Throwable exc) {
+                            Exceptions.throwIfFatal(exc);
+                            cancel();
+                            onError(new CompositeException(ex, exc));
+                            return false;
+                        }
+
+                        switch (h) {
+                        case RETRY:
+                            continue;
+                        case SKIP:
+                            return false;
+                        case STOP:
+                            cancel();
+                            onComplete();
+                            return false;
+                        default:
+                            cancel();
+                            onError(ex);
+                            return false;
+                        }
+                    }
+
+                    if (b) {
+                        return actual.tryOnNext(t);
+                    }
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (!done) {
+                done = true;
+                actual.onComplete();
+            }
+        }
+    }}

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelMapTry.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelMapTry.java
@@ -1,0 +1,299 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.parallel;
+
+import org.reactivestreams.*;
+
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.parallel.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Maps each 'rail' of the source ParallelFlowable with a mapper function
+ * and handle any failure based on a handler function.
+ *
+ * @param <T> the input value type
+ * @param <R> the output value type
+ * @since 2.0.8 - experimental
+ */
+public final class ParallelMapTry<T, R> extends ParallelFlowable<R> {
+
+    final ParallelFlowable<T> source;
+
+    final Function<? super T, ? extends R> mapper;
+
+    final BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler;
+
+    public ParallelMapTry(ParallelFlowable<T> source, Function<? super T, ? extends R> mapper,
+            BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+        this.source = source;
+        this.mapper = mapper;
+        this.errorHandler = errorHandler;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super R>[] subscribers) {
+        if (!validate(subscribers)) {
+            return;
+        }
+
+        int n = subscribers.length;
+        @SuppressWarnings("unchecked")
+        Subscriber<? super T>[] parents = new Subscriber[n];
+
+        for (int i = 0; i < n; i++) {
+            Subscriber<? super R> a = subscribers[i];
+            if (a instanceof ConditionalSubscriber) {
+                parents[i] = new ParallelMapTryConditionalSubscriber<T, R>((ConditionalSubscriber<? super R>)a, mapper, errorHandler);
+            } else {
+                parents[i] = new ParallelMapTrySubscriber<T, R>(a, mapper, errorHandler);
+            }
+        }
+
+        source.subscribe(parents);
+    }
+
+    @Override
+    public int parallelism() {
+        return source.parallelism();
+    }
+
+    static final class ParallelMapTrySubscriber<T, R> implements ConditionalSubscriber<T>, Subscription {
+
+        final Subscriber<? super R> actual;
+
+        final Function<? super T, ? extends R> mapper;
+
+        final BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler;
+
+        Subscription s;
+
+        boolean done;
+
+        ParallelMapTrySubscriber(Subscriber<? super R> actual, Function<? super T, ? extends R> mapper,
+                BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+            this.actual = actual;
+            this.mapper = mapper;
+            this.errorHandler = errorHandler;
+        }
+
+        @Override
+        public void request(long n) {
+            s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            s.cancel();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (!tryOnNext(t) && !done) {
+                s.request(1);
+            }
+        }
+
+        @Override
+        public boolean tryOnNext(T t) {
+            if (done) {
+                return false;
+            }
+            long retries = 0;
+
+            for (;;) {
+                R v;
+
+                try {
+                    v = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null value");
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+
+                    ParallelFailureHandling h;
+
+                    try {
+                        h = ObjectHelper.requireNonNull(errorHandler.apply(++retries, ex), "The errorHandler returned a null item");
+                    } catch (Throwable exc) {
+                        Exceptions.throwIfFatal(exc);
+                        cancel();
+                        onError(new CompositeException(ex, exc));
+                        return false;
+                    }
+
+                    switch (h) {
+                    case RETRY:
+                        continue;
+                    case SKIP:
+                        return false;
+                    case STOP:
+                        cancel();
+                        onComplete();
+                        return false;
+                    default:
+                        cancel();
+                        onError(ex);
+                        return false;
+                    }
+                }
+
+                actual.onNext(v);
+                return true;
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            actual.onComplete();
+        }
+
+    }
+    static final class ParallelMapTryConditionalSubscriber<T, R> implements ConditionalSubscriber<T>, Subscription {
+
+        final ConditionalSubscriber<? super R> actual;
+
+        final Function<? super T, ? extends R> mapper;
+
+        final BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler;
+        Subscription s;
+
+        boolean done;
+
+        ParallelMapTryConditionalSubscriber(ConditionalSubscriber<? super R> actual,
+                Function<? super T, ? extends R> mapper,
+                BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+            this.actual = actual;
+            this.mapper = mapper;
+            this.errorHandler = errorHandler;
+        }
+
+        @Override
+        public void request(long n) {
+            s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            s.cancel();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.s, s)) {
+                this.s = s;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (!tryOnNext(t) && !done) {
+                s.request(1);
+            }
+        }
+
+        @Override
+        public boolean tryOnNext(T t) {
+            if (done) {
+                return false;
+            }
+            long retries = 0;
+
+            for (;;) {
+                R v;
+
+                try {
+                    v = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null value");
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+
+                    ParallelFailureHandling h;
+
+                    try {
+                        h = ObjectHelper.requireNonNull(errorHandler.apply(++retries, ex), "The errorHandler returned a null item");
+                    } catch (Throwable exc) {
+                        Exceptions.throwIfFatal(exc);
+                        cancel();
+                        onError(new CompositeException(ex, exc));
+                        return false;
+                    }
+
+                    switch (h) {
+                    case RETRY:
+                        continue;
+                    case SKIP:
+                        return false;
+                    case STOP:
+                        cancel();
+                        onComplete();
+                        return false;
+                    default:
+                        cancel();
+                        onError(ex);
+                        return false;
+                    }
+                }
+
+                return actual.tryOnNext(v);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            actual.onComplete();
+        }
+
+    }
+}

--- a/src/main/java/io/reactivex/parallel/ParallelFailureHandling.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFailureHandling.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import io.reactivex.annotations.Experimental;
+import io.reactivex.functions.BiFunction;
+
+/**
+ * Enumerations for handling failure within a parallel operator.
+ * @since 2.0.8 - experimental
+ */
+@Experimental
+public enum ParallelFailureHandling implements BiFunction<Long, Throwable, ParallelFailureHandling> {
+    /**
+     * The current rail is stopped and the error is dropped.
+     */
+    STOP,
+    /**
+     * The current rail is stopped and the error is signalled.
+     */
+    ERROR,
+    /**
+     * The current value and error is ignored and the rail resumes with the next item.
+     */
+    SKIP,
+    /**
+     * Retry the current value.
+     */
+    RETRY;
+
+    @Override
+    public ParallelFailureHandling apply(Long t1, Throwable t2) {
+        return this;
+    }
+}

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -136,6 +136,47 @@ public abstract class ParallelFlowable<T> {
     }
 
     /**
+     * Maps the source values on each 'rail' to another value and
+     * handles errors based on the given {@link ParallelFailureHandling} enumeration value.
+     * <p>
+     * Note that the same mapper function may be called from multiple threads concurrently.
+     * @param <R> the output value type
+     * @param mapper the mapper function turning Ts into Us.
+     * @param errorHandler the enumeration that defines how to handle errors thrown
+     *                     from the mapper function
+     * @return the new ParallelFlowable instance
+     * @since 2.0.8 - experimental
+     */
+    @CheckReturnValue
+    @Experimental
+    public final <R> ParallelFlowable<R> map(@NonNull Function<? super T, ? extends R> mapper, @NonNull ParallelFailureHandling errorHandler) {
+        ObjectHelper.requireNonNull(mapper, "mapper");
+        ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
+        return RxJavaPlugins.onAssembly(new ParallelMapTry<T, R>(this, mapper, errorHandler));
+    }
+
+    /**
+     * Maps the source values on each 'rail' to another value and
+     * handles errors based on the returned value by the handler function.
+     * <p>
+     * Note that the same mapper function may be called from multiple threads concurrently.
+     * @param <R> the output value type
+     * @param mapper the mapper function turning Ts into Us.
+     * @param errorHandler the function called with the current repeat count and
+     *                     failure Throwable and should return one of the {@link ParallelFailureHandling}
+     *                     enumeration values to indicate how to proceed.
+     * @return the new ParallelFlowable instance
+     * @since 2.0.8 - experimental
+     */
+    @CheckReturnValue
+    @Experimental
+    public final <R> ParallelFlowable<R> map(@NonNull Function<? super T, ? extends R> mapper, @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+        ObjectHelper.requireNonNull(mapper, "mapper");
+        ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
+        return RxJavaPlugins.onAssembly(new ParallelMapTry<T, R>(this, mapper, errorHandler));
+    }
+
+    /**
      * Filters the source values on each 'rail'.
      * <p>
      * Note that the same predicate may be called from multiple threads concurrently.
@@ -146,6 +187,46 @@ public abstract class ParallelFlowable<T> {
     public final ParallelFlowable<T> filter(@NonNull Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate");
         return RxJavaPlugins.onAssembly(new ParallelFilter<T>(this, predicate));
+    }
+
+    /**
+     * Filters the source values on each 'rail' and
+     * handles errors based on the given {@link ParallelFailureHandling} enumeration value.
+     * <p>
+     * Note that the same predicate may be called from multiple threads concurrently.
+     * @param predicate the function returning true to keep a value or false to drop a value
+     * @param errorHandler the enumeration that defines how to handle errors thrown
+     *                     from the predicate
+     * @return the new ParallelFlowable instance
+     * @since 2.0.8 - experimental
+     */
+    @CheckReturnValue
+    @Experimental
+    public final ParallelFlowable<T> filter(@NonNull Predicate<? super T> predicate, @NonNull ParallelFailureHandling errorHandler) {
+        ObjectHelper.requireNonNull(predicate, "predicate");
+        ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
+        return RxJavaPlugins.onAssembly(new ParallelFilterTry<T>(this, predicate, errorHandler));
+    }
+
+
+    /**
+     * Filters the source values on each 'rail' and
+     * handles errors based on the returned value by the handler function.
+     * <p>
+     * Note that the same predicate may be called from multiple threads concurrently.
+     * @param predicate the function returning true to keep a value or false to drop a value
+     * @param errorHandler the function called with the current repeat count and
+     *                     failure Throwable and should return one of the {@link ParallelFailureHandling}
+     *                     enumeration values to indicate how to proceed.
+     * @return the new ParallelFlowable instance
+     * @since 2.0.8 - experimental
+     */
+    @CheckReturnValue
+    @Experimental
+    public final ParallelFlowable<T> filter(@NonNull Predicate<? super T> predicate, @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+        ObjectHelper.requireNonNull(predicate, "predicate");
+        ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
+        return RxJavaPlugins.onAssembly(new ParallelFilterTry<T>(this, predicate, errorHandler));
     }
 
     /**
@@ -420,6 +501,44 @@ public abstract class ParallelFlowable<T> {
                 Functions.EMPTY_LONG_CONSUMER,
                 Functions.EMPTY_ACTION
                 ));
+    }
+
+
+    /**
+     * Call the specified consumer with the current element passing through any 'rail' and
+     * handles errors based on the given {@link ParallelFailureHandling} enumeration value.
+     *
+     * @param onNext the callback
+     * @param errorHandler the enumeration that defines how to handle errors thrown
+     *                     from the onNext consumer
+     * @return the new ParallelFlowable instance
+     * @since 2.0.8 - experimental
+     */
+    @CheckReturnValue
+    @Experimental
+    public final ParallelFlowable<T> doOnNext(@NonNull Consumer<? super T> onNext, @NonNull ParallelFailureHandling errorHandler) {
+        ObjectHelper.requireNonNull(onNext, "onNext is null");
+        ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
+        return RxJavaPlugins.onAssembly(new ParallelDoOnNextTry<T>(this, onNext, errorHandler));
+    }
+
+    /**
+     * Call the specified consumer with the current element passing through any 'rail' and
+     * handles errors based on the returned value by the handler function.
+     *
+     * @param onNext the callback
+     * @param errorHandler the function called with the current repeat count and
+     *                     failure Throwable and should return one of the {@link ParallelFailureHandling}
+     *                     enumeration values to indicate how to proceed.
+     * @return the new ParallelFlowable instance
+     * @since 2.0.8 - experimental
+     */
+    @CheckReturnValue
+    @Experimental
+    public final ParallelFlowable<T> doOnNext(@NonNull Consumer<? super T> onNext, @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+        ObjectHelper.requireNonNull(onNext, "onNext is null");
+        ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
+        return RxJavaPlugins.onAssembly(new ParallelDoOnNextTry<T>(this, onNext, errorHandler));
     }
 
     /**

--- a/src/test/java/io/reactivex/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/ParamValidationCheckerTest.java
@@ -554,6 +554,9 @@ public class ParamValidationCheckerTest {
 
         defaultValues.put(ParallelFlowable.class, ParallelFlowable.from(Flowable.never()));
         defaultValues.put(Subscriber[].class, new Subscriber[] { new AllFunctionals() });
+
+        defaultValues.put(ParallelFailureHandling.class, ParallelFailureHandling.ERROR);
+
         // -----------------------------------------------------------------------------------
 
         defaultInstances = new HashMap<Class<?>, List<Object>>();

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -38,6 +38,7 @@ import io.reactivex.internal.operators.single.SingleToFlowable;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observers.TestObserver;
+import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
@@ -2633,6 +2634,22 @@ public enum TestHelper {
             throw new RuntimeException(ex);
         } finally {
             RxJavaPlugins.reset();
+        }
+    }
+
+    public static <T> void checkInvalidParallelSubscribers(ParallelFlowable<T> source) {
+        int n = source.parallelism();
+
+        @SuppressWarnings("unchecked")
+        TestSubscriber<Object>[] tss = new TestSubscriber[n + 1];
+        for (int i = 0; i <= n; i++) {
+            tss[i] = new TestSubscriber<Object>().withTag("" + i);
+        }
+
+        source.subscribe(tss);
+
+        for (int i = 0; i <= n; i++) {
+            tss[i].assertFailure(IllegalArgumentException.class);
         }
     }
 }

--- a/src/test/java/io/reactivex/parallel/ParallelDoOnNextTryTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelDoOnNextTryTest.java
@@ -1,0 +1,388 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ParallelDoOnNextTryTest implements Consumer<Object> {
+
+    volatile int calls;
+
+    @Override
+    public void accept(Object t) throws Exception {
+        calls++;
+    }
+
+    @Test
+    public void doOnNextNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.just(1)
+            .parallel(1)
+            .doOnNext(this, e)
+            .sequential()
+            .test()
+            .assertResult(1);
+
+            assertEquals(calls, 1);
+            calls = 0;
+        }
+    }
+    @Test
+    public void doOnNextErrorNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.<Integer>error(new TestException())
+            .parallel(1)
+            .doOnNext(this, e)
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+
+            assertEquals(calls, 0);
+        }
+    }
+
+    @Test
+    public void doOnNextConditionalNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.just(1)
+            .parallel(1)
+            .doOnNext(this, e)
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test()
+            .assertResult(1);
+
+            assertEquals(calls, 1);
+            calls = 0;
+        }
+    }
+
+    @Test
+    public void doOnNextErrorConditionalNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.<Integer>error(new TestException())
+            .parallel(1)
+            .doOnNext(this, e)
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+
+            assertEquals(calls, 0);
+        }
+    }
+
+    @Test
+    public void doOnNextFailWithError() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, ParallelFailureHandling.ERROR)
+        .sequential()
+        .test()
+        .assertFailure(ArithmeticException.class);
+    }
+
+    @Test
+    public void doOnNextFailWithStop() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, ParallelFailureHandling.STOP)
+        .sequential()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void doOnNextFailWithRetry() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            int count;
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (count++ == 1) {
+                    return;
+                }
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, ParallelFailureHandling.RETRY)
+        .sequential()
+        .test()
+        .assertResult(0, 1);
+    }
+
+    @Test
+    public void doOnNextFailWithRetryLimited() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
+            }
+        })
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void doOnNextFailWithSkip() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, ParallelFailureHandling.SKIP)
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void doOnNextFailHandlerThrows() {
+        TestSubscriber<Integer> ts = Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(CompositeException.class);
+
+        TestHelper.assertCompositeExceptions(ts, ArithmeticException.class, TestException.class);
+    }
+
+    @Test
+    public void doOnNextWrongParallelism() {
+        TestHelper.checkInvalidParallelSubscribers(
+            Flowable.just(1).parallel(1)
+            .doOnNext(Functions.emptyConsumer(), ParallelFailureHandling.ERROR)
+        );
+    }
+
+    @Test
+    public void filterInvalidSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .doOnNext(Functions.emptyConsumer(), ParallelFailureHandling.ERROR)
+            .sequential()
+            .test();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void doOnNextFailWithErrorConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, ParallelFailureHandling.ERROR)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertFailure(ArithmeticException.class);
+    }
+
+    @Test
+    public void doOnNextFailWithStopConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, ParallelFailureHandling.STOP)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void doOnNextFailWithRetryConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            int count;
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (count++ == 1) {
+                    return;
+                }
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, ParallelFailureHandling.RETRY)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult(0, 1);
+    }
+
+    @Test
+    public void doOnNextFailWithRetryLimitedConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void doOnNextFailWithSkipConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, ParallelFailureHandling.SKIP)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void doOnNextFailHandlerThrowsConditional() {
+        TestSubscriber<Integer> ts = Flowable.range(0, 2)
+        .parallel(1)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                if (1 / v < 0) {
+                    System.out.println("Should not happen!");
+                }
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertFailure(CompositeException.class);
+
+        TestHelper.assertCompositeExceptions(ts, ArithmeticException.class, TestException.class);
+    }
+
+    @Test
+    public void doOnNextWrongParallelismConditional() {
+        TestHelper.checkInvalidParallelSubscribers(
+            Flowable.just(1).parallel(1)
+            .doOnNext(Functions.emptyConsumer(), ParallelFailureHandling.ERROR)
+            .filter(Functions.alwaysTrue())
+        );
+    }
+
+    @Test
+    public void filterInvalidSourceConditional() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .doOnNext(Functions.emptyConsumer(), ParallelFailureHandling.ERROR)
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/parallel/ParallelFilterTryTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFilterTryTest.java
@@ -1,0 +1,377 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ParallelFilterTryTest implements Consumer<Object> {
+
+    volatile int calls;
+
+    @Override
+    public void accept(Object t) throws Exception {
+        calls++;
+    }
+
+    @Test
+    public void filterNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.just(1)
+            .parallel(1)
+            .filter(Functions.alwaysTrue(), e)
+            .sequential()
+            .test()
+            .assertResult(1);
+        }
+    }
+
+    @Test
+    public void filterFalse() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.just(1)
+            .parallel(1)
+            .filter(Functions.alwaysFalse(), e)
+            .sequential()
+            .test()
+            .assertResult();
+        }
+    }
+
+    @Test
+    public void filterFalseConditional() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.just(1)
+            .parallel(1)
+            .filter(Functions.alwaysFalse(), e)
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test()
+            .assertResult();
+        }
+    }
+
+    @Test
+    public void filterErrorNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.<Integer>error(new TestException())
+            .parallel(1)
+            .filter(Functions.alwaysTrue(), e)
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+        }
+    }
+
+    @Test
+    public void filterConditionalNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.just(1)
+            .parallel(1)
+            .filter(Functions.alwaysTrue(), e)
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test()
+            .assertResult(1);
+        }
+    }
+    @Test
+    public void filterErrorConditionalNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.<Integer>error(new TestException())
+            .parallel(1)
+            .filter(Functions.alwaysTrue(), e)
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+        }
+    }
+
+    @Test
+    public void filterFailWithError() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return 1 / v > 0;
+            }
+        }, ParallelFailureHandling.ERROR)
+        .sequential()
+        .test()
+        .assertFailure(ArithmeticException.class);
+    }
+
+    @Test
+    public void filterFailWithStop() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return 1 / v > 0;
+            }
+        }, ParallelFailureHandling.STOP)
+        .sequential()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void filterFailWithRetry() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            int count;
+            @Override
+            public boolean test(Integer v) throws Exception {
+                if (count++ == 1) {
+                    return true;
+                }
+                return 1 / v > 0;
+            }
+        }, ParallelFailureHandling.RETRY)
+        .sequential()
+        .test()
+        .assertResult(0, 1);
+    }
+
+    @Test
+    public void filterFailWithRetryLimited() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return 1 / v > 0;
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
+            }
+        })
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void filterFailWithSkip() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return 1 / v > 0;
+            }
+        }, ParallelFailureHandling.SKIP)
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void filterFailHandlerThrows() {
+        TestSubscriber<Integer> ts = Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return 1 / v > 0;
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(CompositeException.class);
+
+        TestHelper.assertCompositeExceptions(ts, ArithmeticException.class, TestException.class);
+    }
+
+    @Test
+    public void filterWrongParallelism() {
+        TestHelper.checkInvalidParallelSubscribers(
+            Flowable.just(1).parallel(1)
+            .filter(Functions.alwaysTrue(), ParallelFailureHandling.ERROR)
+        );
+    }
+
+    @Test
+    public void filterInvalidSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .filter(Functions.alwaysTrue(), ParallelFailureHandling.ERROR)
+            .sequential()
+            .test();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void filterFailWithErrorConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return 1 / v > 0;
+            }
+        }, ParallelFailureHandling.ERROR)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertFailure(ArithmeticException.class);
+    }
+
+    @Test
+    public void filterFailWithStopConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return 1 / v > 0;
+            }
+        }, ParallelFailureHandling.STOP)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void filterFailWithRetryConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            int count;
+            @Override
+            public boolean test(Integer v) throws Exception {
+                if (count++ == 1) {
+                    return true;
+                }
+                return 1 / v > 0;
+            }
+        }, ParallelFailureHandling.RETRY)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult(0, 1);
+    }
+
+    @Test
+    public void filterFailWithRetryLimitedConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return 1 / v > 0;
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void filterFailWithSkipConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return 1 / v > 0;
+            }
+        }, ParallelFailureHandling.SKIP)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void filterFailHandlerThrowsConditional() {
+        TestSubscriber<Integer> ts = Flowable.range(0, 2)
+        .parallel(1)
+        .filter(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return 1 / v > 0;
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertFailure(CompositeException.class);
+
+        TestHelper.assertCompositeExceptions(ts, ArithmeticException.class, TestException.class);
+    }
+
+    @Test
+    public void filterWrongParallelismConditional() {
+        TestHelper.checkInvalidParallelSubscribers(
+            Flowable.just(1).parallel(1)
+            .filter(Functions.alwaysTrue(), ParallelFailureHandling.ERROR)
+            .filter(Functions.alwaysTrue())
+        );
+    }
+
+    @Test
+    public void filterInvalidSourceConditional() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .filter(Functions.alwaysTrue(), ParallelFailureHandling.ERROR)
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/parallel/ParallelMapTryTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelMapTryTest.java
@@ -1,0 +1,351 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ParallelMapTryTest implements Consumer<Object> {
+
+    volatile int calls;
+
+    @Override
+    public void accept(Object t) throws Exception {
+        calls++;
+    }
+
+    @Test
+    public void mapNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.just(1)
+            .parallel(1)
+            .map(Functions.identity(), e)
+            .sequential()
+            .test()
+            .assertResult(1);
+        }
+    }
+    @Test
+    public void mapErrorNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.<Integer>error(new TestException())
+            .parallel(1)
+            .map(Functions.identity(), e)
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+        }
+    }
+
+    @Test
+    public void mapConditionalNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.just(1)
+            .parallel(1)
+            .map(Functions.identity(), e)
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test()
+            .assertResult(1);
+        }
+    }
+    @Test
+    public void mapErrorConditionalNoError() {
+        for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
+            Flowable.<Integer>error(new TestException())
+            .parallel(1)
+            .map(Functions.identity(), e)
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test()
+            .assertFailure(TestException.class);
+        }
+    }
+
+    @Test
+    public void mapFailWithError() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                return 1 / v;
+            }
+        }, ParallelFailureHandling.ERROR)
+        .sequential()
+        .test()
+        .assertFailure(ArithmeticException.class);
+    }
+
+    @Test
+    public void mapFailWithStop() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                return 1 / v;
+            }
+        }, ParallelFailureHandling.STOP)
+        .sequential()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void mapFailWithRetry() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            int count;
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                if (count++ == 1) {
+                    return -1;
+                }
+                return 1 / v;
+            }
+        }, ParallelFailureHandling.RETRY)
+        .sequential()
+        .test()
+        .assertResult(-1, 1);
+    }
+
+    @Test
+    public void mapFailWithRetryLimited() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                return 1 / v;
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
+            }
+        })
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void mapFailWithSkip() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                return 1 / v;
+            }
+        }, ParallelFailureHandling.SKIP)
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mapFailHandlerThrows() {
+        TestSubscriber<Integer> ts = Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                return 1 / v;
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .sequential()
+        .test()
+        .assertFailure(CompositeException.class);
+
+        TestHelper.assertCompositeExceptions(ts, ArithmeticException.class, TestException.class);
+    }
+
+    @Test
+    public void mapWrongParallelism() {
+        TestHelper.checkInvalidParallelSubscribers(
+            Flowable.just(1).parallel(1)
+            .map(Functions.identity(), ParallelFailureHandling.ERROR)
+        );
+    }
+
+    @Test
+    public void mapInvalidSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .map(Functions.identity(), ParallelFailureHandling.ERROR)
+            .sequential()
+            .test();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void mapFailWithErrorConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                return 1 / v;
+            }
+        }, ParallelFailureHandling.ERROR)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertFailure(ArithmeticException.class);
+    }
+
+    @Test
+    public void mapFailWithStopConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                return 1 / v;
+            }
+        }, ParallelFailureHandling.STOP)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void mapFailWithRetryConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            int count;
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                if (count++ == 1) {
+                    return -1;
+                }
+                return 1 / v;
+            }
+        }, ParallelFailureHandling.RETRY)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult(-1, 1);
+    }
+
+    @Test
+    public void mapFailWithRetryLimitedConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                return 1 / v;
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void mapFailWithSkipConditional() {
+        Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                return 1 / v;
+            }
+        }, ParallelFailureHandling.SKIP)
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertResult(1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mapFailHandlerThrowsConditional() {
+        TestSubscriber<Integer> ts = Flowable.range(0, 2)
+        .parallel(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                return 1 / v;
+            }
+        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
+            @Override
+            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
+                throw new TestException();
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .sequential()
+        .test()
+        .assertFailure(CompositeException.class);
+
+        TestHelper.assertCompositeExceptions(ts, ArithmeticException.class, TestException.class);
+    }
+
+    @Test
+    public void mapWrongParallelismConditional() {
+        TestHelper.checkInvalidParallelSubscribers(
+            Flowable.just(1).parallel(1)
+            .map(Functions.identity(), ParallelFailureHandling.ERROR)
+            .filter(Functions.alwaysTrue())
+        );
+    }
+
+    @Test
+    public void mapInvalidSourceConditional() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new ParallelInvalid()
+            .map(Functions.identity(), ParallelFailureHandling.ERROR)
+            .filter(Functions.alwaysTrue())
+            .sequential()
+            .test();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds 2 new overloads to `ParallelFlowable` operators `map`, `filter` and `doOnNext` to enable per item error handling in case the main function fails with some exception.

```java
Flowable.range(0, 2)
.parallel(1)
.map(v -> 1 / v, ParallelFailureHandling.SKIP)
.sequential()
.test()
.assertResult(1);
```

The new `ParallelFailureHandling` has some default enumeration values to handle the common cases. In addition, the `BiFunction` overload allows bounded retries and/or conditional handling of failures.


Related: #5128.