### PR TITLE
2.x: fix timer() to prevent a self-interrupt when signals its only value

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimer.java
@@ -73,8 +73,8 @@ public final class FlowableTimer extends Flowable<Long> {
         public void run() {
             if (get() != DisposableHelper.DISPOSED) {
                 if (requested) {
-                    actual.onNext(0L);
                     lazySet(EmptyDisposable.INSTANCE);
+                    actual.onNext(0L);
                     actual.onComplete();
                 } else {
                     lazySet(EmptyDisposable.INSTANCE);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimer.java
@@ -64,8 +64,8 @@ public final class ObservableTimer extends Observable<Long> {
         @Override
         public void run() {
             if (!isDisposed()) {
-                actual.onNext(0L);
                 lazySet(EmptyDisposable.INSTANCE);
+                actual.onNext(0L);
                 actual.onComplete();
             }
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
@@ -12,6 +12,7 @@
  */
 package io.reactivex.internal.operators.flowable;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
@@ -318,5 +319,22 @@ public class FlowableDelaySubscriptionOtherTest {
                 return Flowable.just(1).delaySubscription(o);
             }
         }, false, 1, 1, 1);
+    }
+
+    @Test
+    public void afterDelayNoInterrupt() {
+        final TestSubscriber<Boolean> observer = TestSubscriber.create();
+        Flowable.<Boolean>create(new FlowableOnSubscribe<Boolean>() {
+            @Override
+            public void subscribe(FlowableEmitter<Boolean> emitter) throws Exception {
+              emitter.onNext(Thread.interrupted());
+              emitter.onComplete();
+            }
+        }, BackpressureStrategy.MISSING)
+        .delaySubscription(100, TimeUnit.MICROSECONDS)
+        .subscribe(observer);
+
+        observer.awaitTerminalEvent();
+        observer.assertValue(false);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.*;
@@ -199,5 +200,22 @@ public class ObservableDelaySubscriptionOtherTest {
                 return Observable.just(1).delaySubscription(o);
             }
         }, false, 1, 1, 1);
+    }
+
+    @Test
+    public void afterDelayNoInterrupt() {
+        final TestObserver<Boolean> observer = TestObserver.create();
+        Observable.<Boolean>create(new ObservableOnSubscribe<Boolean>() {
+            @Override
+            public void subscribe(ObservableEmitter<Boolean> emitter) throws Exception {
+              emitter.onNext(Thread.interrupted());
+              emitter.onComplete();
+            }
+        })
+        .delaySubscription(100, TimeUnit.MICROSECONDS)
+        .subscribe(observer);
+
+        observer.awaitTerminalEvent();
+        observer.assertValue(false);
     }
 }


### PR DESCRIPTION
When the `timer()` is firing its `onNext(0L)`, there is no point in allowing a canellation to bubble up to the current `Future` as it just interrupts the current thread. The fix thus makes sure the cancellation chain is cut off before `onNext` and the current parent `Future` should complete normally.

Related: #5203.