### PR TITLE
2.x: better documentation on the abstract consumer classes

### DIFF
--- a/src/main/java/io/reactivex/observers/DefaultObserver.java
+++ b/src/main/java/io/reactivex/observers/DefaultObserver.java
@@ -18,9 +18,47 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
- * Abstract base implementation of an Observer with support for cancelling a
+ * Abstract base implementation of an {@link io.reactivex.Observer Observer} with support for cancelling a
  * subscription via {@link #cancel()} (synchronously) and calls {@link #onStart()}
  * when the subscription happens.
+ *
+ * <p>All pre-implemented final methods are thread-safe.
+ *
+ * <p>Use the protected {@link #cancel()} to dispose the sequence from within an
+ * {@code onNext} implementation.
+ *
+ * <p>Like all other consumers, {@code DefaultObserver} can be subscribed only once.
+ * Any subsequent attempt to subscribe it to a new source will yield an
+ * {@link IllegalStateException} with message {@code "Disposable already set!"}.
+ *
+ * <p>Implementation of {@link #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
+ * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
+ * If for some reason this can't be avoided, use {@link io.reactivex.Observable#safeSubscribe(io.reactivex.Observer)}
+ * instead of the standard {@code subscribe()} method.
+ *
+ * <p>Example<code><pre>
+ * Disposable d =
+ *     Observable.range(1, 5)
+ *     .subscribeWith(new DefaultObserver&lt;Integer>() {
+ *         &#64;Override public void onStart() {
+ *             System.out.println("Start!");
+ *         }
+ *         &#64;Override public void onNext(Integer t) {
+ *             if (t == 3) {
+ *                 cancel();
+ *             }
+ *             System.out.println(t);
+ *         }
+ *         &#64;Override public void onError(Throwable t) {
+ *             t.printStackTrace();
+ *         }
+ *         &#64;Override public void onComplete() {
+ *             System.out.println("Done!");
+ *         }
+ *     });
+ * // ...
+ * d.dispose();
+ * </pre></code>
  *
  * @param <T> the value type
  */

--- a/src/main/java/io/reactivex/observers/DisposableCompletableObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableCompletableObserver.java
@@ -21,6 +21,33 @@ import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
  * An abstract {@link CompletableObserver} that allows asynchronous cancellation by implementing Disposable.
+ *
+ * <p>All pre-implemented final methods are thread-safe.
+ *
+ * <p>Like all other consumers, {@code DisposableCompletableObserver} can be subscribed only once.
+ * Any subsequent attempt to subscribe it to a new source will yield an
+ * {@link IllegalStateException} with message {@code "Disposable already set!"}.
+ *
+ * <p>Implementation of {@link #onStart()}, {@link #onError(Throwable)} and
+ * {@link #onComplete()} are not allowed to throw any unchecked exceptions.
+ *
+ * <p>Example<code><pre>
+ * Disposable d =
+ *     Completable.complete().delay(1, TimeUnit.SECONDS)
+ *     .subscribeWith(new DisposableMaybeObserver&lt;Integer>() {
+ *         &#64;Override public void onStart() {
+ *             System.out.println("Start!");
+ *         }
+ *         &#64;Override public void onError(Throwable t) {
+ *             t.printStackTrace();
+ *         }
+ *         &#64;Override public void onComplete() {
+ *             System.out.println("Done!");
+ *         }
+ *     });
+ * // ...
+ * d.dispose();
+ * </pre></code>
  */
 public abstract class DisposableCompletableObserver implements CompletableObserver, Disposable {
     final AtomicReference<Disposable> s = new AtomicReference<Disposable>();

--- a/src/main/java/io/reactivex/observers/DisposableMaybeObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableMaybeObserver.java
@@ -22,6 +22,41 @@ import io.reactivex.internal.disposables.DisposableHelper;
 /**
  * An abstract {@link MaybeObserver} that allows asynchronous cancellation by implementing Disposable.
  *
+ * <p>All pre-implemented final methods are thread-safe.
+ *
+ * <p>Note that {@link #onSuccess(Object)}, {@link #onError(Throwable)} and {@link #onComplete()} are
+ * exclusive to each other, unlike a regular {@link io.reactivex.Observer Observer}, and
+ * {@code onComplete()} is never called after an {@code onSuccess()}.
+ *
+ * <p>Like all other consumers, {@code DisposableMaybeObserver} can be subscribed only once.
+ * Any subsequent attempt to subscribe it to a new source will yield an
+ * {@link IllegalStateException} with message {@code "Disposable already set!"}.
+ *
+ * <p>Implementation of {@link #onStart()}, {@link #onSuccess(Object)}, {@link #onError(Throwable)} and
+ * {@link #onComplete()} are not allowed to throw any unchecked exceptions.
+ *
+ * <p>Example<code><pre>
+ * Disposable d =
+ *     Maybe.just(1).delay(1, TimeUnit.SECONDS)
+ *     .subscribeWith(new DisposableMaybeObserver&lt;Integer>() {
+ *         &#64;Override public void onStart() {
+ *             System.out.println("Start!");
+ *         }
+ *         &#64;Override public void onSuccess(Integer t) {
+ *             System.out.println(t);
+ *         }
+ *         &#64;Override public void onError(Throwable t) {
+ *             t.printStackTrace();
+ *         }
+ *         &#64;Override public void onComplete() {
+ *             System.out.println("Done!");
+ *         }
+ *     });
+ * // ...
+ * d.dispose();
+ * </pre></code>
+ *
+ *
  * @param <T> the received value type
  */
 public abstract class DisposableMaybeObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/observers/DisposableObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableObserver.java
@@ -22,6 +22,44 @@ import io.reactivex.internal.disposables.*;
 /**
  * An abstract {@link Observer} that allows asynchronous cancellation by implementing Disposable.
  *
+ * <p>All pre-implemented final methods are thread-safe.
+ *
+ * <p>Use the protected {@link #dispose()} to dispose the sequence from within an
+ * {@code onNext} implementation.
+ *
+ * <p>Like all other consumers, {@code DefaultObserver} can be subscribed only once.
+ * Any subsequent attempt to subscribe it to a new source will yield an
+ * {@link IllegalStateException} with message {@code "Disposable already set!"}.
+ *
+ * <p>Implementation of {@link #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
+ * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
+ * If for some reason this can't be avoided, use {@link io.reactivex.Observable#safeSubscribe(io.reactivex.Observer)}
+ * instead of the standard {@code subscribe()} method.
+ *
+ * <p>Example<code><pre>
+ * Disposable d =
+ *     Observable.range(1, 5)
+ *     .subscribeWith(new DisposableObserver&lt;Integer>() {
+ *         &#64;Override public void onStart() {
+ *             System.out.println("Start!");
+ *         }
+ *         &#64;Override public void onNext(Integer t) {
+ *             if (t == 3) {
+ *                 dispose();
+ *             }
+ *             System.out.println(t);
+ *         }
+ *         &#64;Override public void onError(Throwable t) {
+ *             t.printStackTrace();
+ *         }
+ *         &#64;Override public void onComplete() {
+ *             System.out.println("Done!");
+ *         }
+ *     });
+ * // ...
+ * d.dispose();
+ * </pre></code>
+ *
  * @param <T> the received value type
  */
 public abstract class DisposableObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/observers/DisposableSingleObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableSingleObserver.java
@@ -22,6 +22,33 @@ import io.reactivex.internal.disposables.DisposableHelper;
 /**
  * An abstract {@link SingleObserver} that allows asynchronous cancellation by implementing Disposable.
  *
+ * <p>All pre-implemented final methods are thread-safe.
+ *
+ * <p>Like all other consumers, {@code DisposableSingleObserver} can be subscribed only once.
+ * Any subsequent attempt to subscribe it to a new source will yield an
+ * {@link IllegalStateException} with message {@code "Disposable already set!"}.
+ *
+ * <p>Implementation of {@link #onStart()}, {@link #onSuccess(Object)} and {@link #onError(Throwable)}
+ * are not allowed to throw any unchecked exceptions.
+ *
+ * <p>Example<code><pre>
+ * Disposable d =
+ *     Single.just(1).delay(1, TimeUnit.SECONDS)
+ *     .subscribeWith(new DisposableSingleObserver&lt;Integer>() {
+ *         &#64;Override public void onStart() {
+ *             System.out.println("Start!");
+ *         }
+ *         &#64;Override public void onSuccess(Integer t) {
+ *             System.out.println(t);
+ *         }
+ *         &#64;Override public void onError(Throwable t) {
+ *             t.printStackTrace();
+ *         }
+ *     });
+ * // ...
+ * d.dispose();
+ * </pre></code>
+ *
  * @param <T> the received value type
  */
 public abstract class DisposableSingleObserver<T> implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/observers/SerializedObserver.java
+++ b/src/main/java/io/reactivex/observers/SerializedObserver.java
@@ -19,12 +19,13 @@ import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
- * Serializes access to the onNext, onError and onComplete methods of another Subscriber.
+ * Serializes access to the onNext, onError and onComplete methods of another Observer.
  *
- * <p>Note that onSubscribe is not serialized in respect of the other methods so
- * make sure the Subscription is set before any of the other methods are called.
+ * <p>Note that {@link #onSubscribe(Disposable)} is not serialized in respect of the other methods so
+ * make sure the {@code onSubscribe()} is called with a non-null {@code Disposable}
+ * before any of the other methods are called.
  *
- * <p>The implementation assumes that the actual Subscriber's methods don't throw.
+ * <p>The implementation assumes that the actual Observer's methods don't throw.
  *
  * @param <T> the value type
  */

--- a/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
@@ -19,12 +19,60 @@ import io.reactivex.FlowableSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 /**
- * Abstract base implementation of a Subscriber with support for requesting via
- * {@link #request(long)}, cancelling via
+ * Abstract base implementation of a {@link org.reactivestreams.Subscriber Subscriber} with
+ * support for requesting via {@link #request(long)}, cancelling via
  * via {@link #cancel()} (both synchronously) and calls {@link #onStart()}
  * when the subscription happens.
  *
+ * <p>All pre-implemented final methods are thread-safe.
+ *
+ * <p>The default {@link #onStart()} requests Long.MAX_VALUE by default. Override
+ * the method to request a custom <em>positive</em> amount.
+ *
+ * <p>Note that calling {@link #request(long)} from {@link #onStart()} may trigger
+ * an immediate, asynchronous emission of data to {@link #onNext(Object)}. Make sure
+ * all initialization happens before the call to {@code request()} in {@code onStart()}.
+ * Calling {@link #request(long)} inside {@link #onNext(Object)} can happen at any time
+ * because by design, {@code onNext} calls from upstream are non-reentrant and non-overlapping.
+ *
+ * <p>Use the protected {@link #cancel()} to cancel the sequence from within an
+ * {@code onNext} implementation.
+ *
+ * <p>Like all other consumers, {@code DefaultSubscriber} can be subscribed only once.
+ * Any subsequent attempt to subscribe it to a new source will yield an
+ * {@link IllegalStateException} with message {@code "Subscription already set!"}.
+ *
+ * <p>Implementation of {@link #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
+ * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
+ * If for some reason this can't be avoided, use {@link io.reactivex.Flowable#safeSubscribe(org.reactivestreams.Subscriber)}
+ * instead of the standard {@code subscribe()} method.
  * @param <T> the value type
+ *
+ * <p>Example<code><pre>
+ * Disposable d =
+ *     Flowable.range(1, 5)
+ *     .subscribeWith(new DefaultSubscriber&lt;Integer>() {
+ *         &#64;Override public void onStart() {
+ *             System.out.println("Start!");
+ *             request(1);
+ *         }
+ *         &#64;Override public void onNext(Integer t) {
+ *             if (t == 3) {
+ *                 cancel();
+ *             }
+ *             System.out.println(t);
+ *             request(1);
+ *         }
+ *         &#64;Override public void onError(Throwable t) {
+ *             t.printStackTrace();
+ *         }
+ *         &#64;Override public void onComplete() {
+ *             System.out.println("Done!");
+ *         }
+ *     });
+ * // ...
+ * d.dispose();
+ * </pre></code>
  */
 public abstract class DefaultSubscriber<T> implements FlowableSubscriber<T> {
     private Subscription s;

--- a/src/main/java/io/reactivex/subscribers/DisposableSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/DisposableSubscriber.java
@@ -22,8 +22,54 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 
 /**
- * An abstract Subscriber that allows asynchronous cancellation by implementing Disposable.
+ * An abstract Subscriber that allows asynchronous, external cancellation by implementing Disposable.
  *
+ * <p>All pre-implemented final methods are thread-safe.
+ *
+ * <p>The default {@link #onStart()} requests Long.MAX_VALUE by default. Override
+ * the method to request a custom <em>positive</em> amount. Use the protected {@link #request(long)}
+ * to request more items and {@link #cancel()} to cancel the sequence from within an
+ * {@code onNext} implementation.
+ *
+ * <p>Note that calling {@link #request(long)} from {@link #onStart()} may trigger
+ * an immediate, asynchronous emission of data to {@link #onNext(Object)}. Make sure
+ * all initialization happens before the call to {@code request()} in {@code onStart()}.
+ * Calling {@link #request(long)} inside {@link #onNext(Object)} can happen at any time
+ * because by design, {@code onNext} calls from upstream are non-reentrant and non-overlapping.
+ *
+ * <p>Like all other consumers, {@code DefaultSubscriber} can be subscribed only once.
+ * Any subsequent attempt to subscribe it to a new source will yield an
+ * {@link IllegalStateException} with message {@code "Subscription already set!"}.
+ *
+ * <p>Implementation of {@link #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
+ * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
+ * If for some reason this can't be avoided, use {@link io.reactivex.Flowable#safeSubscribe(org.reactivestreams.Subscriber)}
+ * instead of the standard {@code subscribe()} method.
+ *
+ * <p>Example<code><pre>
+ * Disposable d =
+ *     Flowable.range(1, 5)
+ *     .subscribeWith(new DisposableSubscriber&lt;Integer>() {
+ *         &#64;Override public void onStart() {
+ *             request(1);
+ *         }
+ *         &#64;Override public void onNext(Integer t) {
+ *             if (t == 3) {
+ *                 cancel();
+ *             }
+ *             System.out.println(t);
+ *             request(1);
+ *         }
+ *         &#64;Override public void onError(Throwable t) {
+ *             t.printStackTrace();
+ *         }
+ *         &#64;Override public void onComplete() {
+ *             System.out.println("Done!");
+ *         }
+ *     });
+ * // ...
+ * d.dispose();
+ * </pre></code>
  * @param <T> the received value type.
  */
 public abstract class DisposableSubscriber<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/subscribers/SerializedSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/SerializedSubscriber.java
@@ -22,8 +22,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Serializes access to the onNext, onError and onComplete methods of another Subscriber.
  *
- * <p>Note that onSubscribe is not serialized in respect of the other methods so
- * make sure the Subscription is set before any of the other methods are called.
+ * <p>Note that {@link #onSubscribe(Subscription)} is not serialized in respect of the other methods so
+ * make sure the {@code onSubscribe} is called with a non-null {@code Subscription}
+ * before any of the other methods are called.
  *
  * <p>The implementation assumes that the actual Subscriber's methods don't throw.
  *


### PR DESCRIPTION
This PR improves the documentation of the abstract consumer classes such as `DisposableSubscriber`, `ResourceSubscriber` and their counterparts for the other base reactive types.

It contains a lot of copy-paste so please read through all of the text in case the text was not properly adapted to the abstract class at hand.

Related: #5148.