### PR TITLE
1.x: add link rel=canonical to 1.x javadoc files (semi auto)

### DIFF
--- a/1.x/javadoc/rx/BackpressureOverflow.Strategy.html
+++ b/1.x/javadoc/rx/BackpressureOverflow.Strategy.html
@@ -6,7 +6,7 @@
 <title>BackpressureOverflow.Strategy (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/BackpressureOverflowStrategy.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/BackpressureOverflow.html
+++ b/1.x/javadoc/rx/BackpressureOverflow.html
@@ -6,7 +6,7 @@
 <title>BackpressureOverflow (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/BackpressureOverflowStrategy.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Completable.OnSubscribe.html
+++ b/1.x/javadoc/rx/Completable.OnSubscribe.html
@@ -6,7 +6,7 @@
 <title>Completable.OnSubscribe (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/CompletableOnSubscribe.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Completable.Operator.html
+++ b/1.x/javadoc/rx/Completable.Operator.html
@@ -6,7 +6,7 @@
 <title>Completable.Operator (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/CompletableOperator.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Completable.html
+++ b/1.x/javadoc/rx/Completable.html
@@ -6,7 +6,7 @@
 <title>Completable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Completable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/CompletableSubscriber.html
+++ b/1.x/javadoc/rx/CompletableSubscriber.html
@@ -6,7 +6,7 @@
 <title>CompletableSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/CompletableObserver.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Emitter.BackpressureMode.html
+++ b/1.x/javadoc/rx/Emitter.BackpressureMode.html
@@ -6,7 +6,7 @@
 <title>Emitter.BackpressureMode (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/BackpressureStrategy.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Emitter.html
+++ b/1.x/javadoc/rx/Emitter.html
@@ -6,7 +6,7 @@
 <title>Emitter (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/FlowableEmitter.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Notification.html
+++ b/1.x/javadoc/rx/Notification.html
@@ -6,7 +6,7 @@
 <title>Notification (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Notification.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Observable.OnSubscribe.html
+++ b/1.x/javadoc/rx/Observable.OnSubscribe.html
@@ -6,7 +6,7 @@
 <title>Observable.OnSubscribe (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/FlowableOnSubscribe.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Observable.Operator.html
+++ b/1.x/javadoc/rx/Observable.Operator.html
@@ -6,7 +6,7 @@
 <title>Observable.Operator (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/FlowableOperator.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Observable.html
+++ b/1.x/javadoc/rx/Observable.html
@@ -6,7 +6,7 @@
 <title>Observable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Flowable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Observer.html
+++ b/1.x/javadoc/rx/Observer.html
@@ -6,7 +6,7 @@
 <title>Observer (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Observer.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Producer.html
+++ b/1.x/javadoc/rx/Producer.html
@@ -6,7 +6,7 @@
 <title>Producer (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://www.reactive-streams.org/reactive-streams-1.0.0-javadoc/org/reactivestreams/Subscription.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Scheduler.Worker.html
+++ b/1.x/javadoc/rx/Scheduler.Worker.html
@@ -6,7 +6,7 @@
 <title>Scheduler.Worker (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Scheduler.Worker.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Scheduler.html
+++ b/1.x/javadoc/rx/Scheduler.html
@@ -6,7 +6,7 @@
 <title>Scheduler (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Scheduler.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Single.OnSubscribe.html
+++ b/1.x/javadoc/rx/Single.OnSubscribe.html
@@ -6,7 +6,7 @@
 <title>Single.OnSubscribe (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/SingleOnSubscribe.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Single.html
+++ b/1.x/javadoc/rx/Single.html
@@ -6,7 +6,7 @@
 <title>Single (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Single.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/SingleSubscriber.html
+++ b/1.x/javadoc/rx/SingleSubscriber.html
@@ -6,7 +6,7 @@
 <title>SingleSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/SingleObserver.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Subscriber.html
+++ b/1.x/javadoc/rx/Subscriber.html
@@ -6,7 +6,7 @@
 <title>Subscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/FlowableSubscriber.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/Subscription.html
+++ b/1.x/javadoc/rx/Subscription.html
@@ -6,7 +6,7 @@
 <title>Subscription (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/Disposable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/annotations/Beta.html
+++ b/1.x/javadoc/rx/annotations/Beta.html
@@ -6,7 +6,7 @@
 <title>Beta (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/annotations/Beta.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/annotations/Experimental.html
+++ b/1.x/javadoc/rx/annotations/Experimental.html
@@ -6,7 +6,7 @@
 <title>Experimental (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/annotations/Experimental.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/exceptions/CompositeException.html
+++ b/1.x/javadoc/rx/exceptions/CompositeException.html
@@ -6,7 +6,7 @@
 <title>CompositeException (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/exceptions/CompositeException.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/exceptions/Exceptions.html
+++ b/1.x/javadoc/rx/exceptions/Exceptions.html
@@ -6,7 +6,7 @@
 <title>Exceptions (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/exceptions/Exceptions.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/exceptions/MissingBackpressureException.html
+++ b/1.x/javadoc/rx/exceptions/MissingBackpressureException.html
@@ -6,7 +6,7 @@
 <title>MissingBackpressureException (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/exceptions/MissingBackpressureException.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/exceptions/OnErrorNotImplementedException.html
+++ b/1.x/javadoc/rx/exceptions/OnErrorNotImplementedException.html
@@ -6,7 +6,7 @@
 <title>OnErrorNotImplementedException (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/exceptions/OnErrorNotImplementedException.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Action0.html
+++ b/1.x/javadoc/rx/functions/Action0.html
@@ -6,7 +6,7 @@
 <title>Action0 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Action.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Action1.html
+++ b/1.x/javadoc/rx/functions/Action1.html
@@ -6,7 +6,7 @@
 <title>Action1 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Consumer.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Action2.html
+++ b/1.x/javadoc/rx/functions/Action2.html
@@ -6,7 +6,7 @@
 <title>Action2 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/BiConsumer.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/ActionN.html
+++ b/1.x/javadoc/rx/functions/ActionN.html
@@ -6,7 +6,7 @@
 <title>ActionN (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Consumer.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Cancellable.html
+++ b/1.x/javadoc/rx/functions/Cancellable.html
@@ -6,7 +6,7 @@
 <title>Cancellable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Cancellable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Func0.html
+++ b/1.x/javadoc/rx/functions/Func0.html
@@ -6,7 +6,7 @@
 <title>Func0 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="https://docs.oracle.com/javase/6/docs/api/java/util/concurrent/Callable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Func1.html
+++ b/1.x/javadoc/rx/functions/Func1.html
@@ -6,7 +6,7 @@
 <title>Func1 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Func2.html
+++ b/1.x/javadoc/rx/functions/Func2.html
@@ -6,7 +6,7 @@
 <title>Func2 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/BiFunction.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Func3.html
+++ b/1.x/javadoc/rx/functions/Func3.html
@@ -6,7 +6,7 @@
 <title>Func3 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function3.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Func4.html
+++ b/1.x/javadoc/rx/functions/Func4.html
@@ -6,7 +6,7 @@
 <title>Func4 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function4.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Func5.html
+++ b/1.x/javadoc/rx/functions/Func5.html
@@ -6,7 +6,7 @@
 <title>Func5 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function5.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Func6.html
+++ b/1.x/javadoc/rx/functions/Func6.html
@@ -6,7 +6,7 @@
 <title>Func6 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function6.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Func7.html
+++ b/1.x/javadoc/rx/functions/Func7.html
@@ -6,7 +6,7 @@
 <title>Func7 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function7.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Func8.html
+++ b/1.x/javadoc/rx/functions/Func8.html
@@ -6,7 +6,7 @@
 <title>Func8 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function8.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/Func9.html
+++ b/1.x/javadoc/rx/functions/Func9.html
@@ -6,7 +6,7 @@
 <title>Func9 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function9.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/functions/FuncN.html
+++ b/1.x/javadoc/rx/functions/FuncN.html
@@ -6,7 +6,7 @@
 <title>FuncN (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/observables/BlockingObservable.html
+++ b/1.x/javadoc/rx/observables/BlockingObservable.html
@@ -6,7 +6,7 @@
 <title>BlockingObservable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Flowable.html#blockingIterable%28%29"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/observables/ConnectableObservable.html
+++ b/1.x/javadoc/rx/observables/ConnectableObservable.html
@@ -6,7 +6,7 @@
 <title>ConnectableObservable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/flowables/ConnectableFlowable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/observables/GroupedObservable.html
+++ b/1.x/javadoc/rx/observables/GroupedObservable.html
@@ -6,7 +6,7 @@
 <title>GroupedObservable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/flowables/GroupedFlowable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/observables/SyncOnSubscribe.html
+++ b/1.x/javadoc/rx/observables/SyncOnSubscribe.html
@@ -6,7 +6,7 @@
 <title>SyncOnSubscribe (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/FlowableEmitter.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/observers/AsyncCompletableSubscriber.html
+++ b/1.x/javadoc/rx/observers/AsyncCompletableSubscriber.html
@@ -6,7 +6,7 @@
 <title>AsyncCompletableSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/observers/DisposableCompletableObserver.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/observers/SafeSubscriber.html
+++ b/1.x/javadoc/rx/observers/SafeSubscriber.html
@@ -6,7 +6,7 @@
 <title>SafeSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/subscribers/SafeSubscriber.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/observers/SerializedObserver.html
+++ b/1.x/javadoc/rx/observers/SerializedObserver.html
@@ -6,7 +6,7 @@
 <title>SerializedObserver (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/observers/SerializedObserver.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/observers/SerializedSubscriber.html
+++ b/1.x/javadoc/rx/observers/SerializedSubscriber.html
@@ -6,7 +6,7 @@
 <title>SerializedSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/subscribers/SerializedSubscriber.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/observers/TestObserver.html
+++ b/1.x/javadoc/rx/observers/TestObserver.html
@@ -6,7 +6,7 @@
 <title>TestObserver (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/observers/TestObserver.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/observers/TestSubscriber.html
+++ b/1.x/javadoc/rx/observers/TestSubscriber.html
@@ -6,7 +6,7 @@
 <title>TestSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/subscribers/TestSubscriber.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/plugins/RxJavaCompletableExecutionHook.html
+++ b/1.x/javadoc/rx/plugins/RxJavaCompletableExecutionHook.html
@@ -6,7 +6,7 @@
 <title>RxJavaCompletableExecutionHook (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/plugins/RxJavaHooks.html
+++ b/1.x/javadoc/rx/plugins/RxJavaHooks.html
@@ -6,7 +6,7 @@
 <title>RxJavaHooks (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/plugins/RxJavaObservableExecutionHook.html
+++ b/1.x/javadoc/rx/plugins/RxJavaObservableExecutionHook.html
@@ -6,7 +6,7 @@
 <title>RxJavaObservableExecutionHook (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/plugins/RxJavaPlugins.html
+++ b/1.x/javadoc/rx/plugins/RxJavaPlugins.html
@@ -6,7 +6,7 @@
 <title>RxJavaPlugins (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/plugins/RxJavaSchedulersHook.html
+++ b/1.x/javadoc/rx/plugins/RxJavaSchedulersHook.html
@@ -6,7 +6,7 @@
 <title>RxJavaSchedulersHook (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/plugins/RxJavaSingleExecutionHook.html
+++ b/1.x/javadoc/rx/plugins/RxJavaSingleExecutionHook.html
@@ -6,7 +6,7 @@
 <title>RxJavaSingleExecutionHook (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/singles/BlockingSingle.html
+++ b/1.x/javadoc/rx/singles/BlockingSingle.html
@@ -6,7 +6,7 @@
 <title>BlockingSingle (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Single.html#blockingGet%28%29"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/subjects/AsyncSubject.html
+++ b/1.x/javadoc/rx/subjects/AsyncSubject.html
@@ -6,7 +6,7 @@
 <title>AsyncSubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/AsyncProcessor.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/subjects/BehaviorSubject.html
+++ b/1.x/javadoc/rx/subjects/BehaviorSubject.html
@@ -6,7 +6,7 @@
 <title>BehaviorSubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/BehaviorProcessor.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/subjects/PublishSubject.html
+++ b/1.x/javadoc/rx/subjects/PublishSubject.html
@@ -6,7 +6,7 @@
 <title>PublishSubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/PublishProcessor.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/subjects/ReplaySubject.html
+++ b/1.x/javadoc/rx/subjects/ReplaySubject.html
@@ -6,7 +6,7 @@
 <title>ReplaySubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/ReplayProcessor.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/subjects/SerializedSubject.html
+++ b/1.x/javadoc/rx/subjects/SerializedSubject.html
@@ -6,7 +6,7 @@
 <title>SerializedSubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/FlowableProcessor.html#toSerialized%28%29"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/subjects/UnicastSubject.html
+++ b/1.x/javadoc/rx/subjects/UnicastSubject.html
@@ -6,7 +6,7 @@
 <title>UnicastSubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/UnicastProcessor.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/subscriptions/BooleanSubscription.html
+++ b/1.x/javadoc/rx/subscriptions/BooleanSubscription.html
@@ -6,7 +6,7 @@
 <title>BooleanSubscription (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/Disposables.html#empty%28%29"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/subscriptions/CompositeSubscription.html
+++ b/1.x/javadoc/rx/subscriptions/CompositeSubscription.html
@@ -6,7 +6,7 @@
 <title>CompositeSubscription (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/CompositeDisposable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/subscriptions/MultipleAssignmentSubscription.html
+++ b/1.x/javadoc/rx/subscriptions/MultipleAssignmentSubscription.html
@@ -6,7 +6,7 @@
 <title>MultipleAssignmentSubscription (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/SerialDisposable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/subscriptions/RefCountSubscription.html
+++ b/1.x/javadoc/rx/subscriptions/RefCountSubscription.html
@@ -6,7 +6,7 @@
 <title>RefCountSubscription (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/SerialDisposable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/1.x/javadoc/rx/subscriptions/Subscriptions.html
+++ b/1.x/javadoc/rx/subscriptions/Subscriptions.html
@@ -6,7 +6,7 @@
 <title>Subscriptions (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/Disposables.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/BackpressureOverflow.Strategy.html
+++ b/javadoc/rx/BackpressureOverflow.Strategy.html
@@ -6,7 +6,7 @@
 <title>BackpressureOverflow.Strategy (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/BackpressureOverflowStrategy.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/BackpressureOverflow.html
+++ b/javadoc/rx/BackpressureOverflow.html
@@ -6,7 +6,7 @@
 <title>BackpressureOverflow (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/BackpressureOverflowStrategy.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Completable.OnSubscribe.html
+++ b/javadoc/rx/Completable.OnSubscribe.html
@@ -6,7 +6,7 @@
 <title>Completable.OnSubscribe (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/CompletableOnSubscribe.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Completable.Operator.html
+++ b/javadoc/rx/Completable.Operator.html
@@ -6,7 +6,7 @@
 <title>Completable.Operator (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/CompletableOperator.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Completable.html
+++ b/javadoc/rx/Completable.html
@@ -6,7 +6,7 @@
 <title>Completable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Completable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/CompletableSubscriber.html
+++ b/javadoc/rx/CompletableSubscriber.html
@@ -6,7 +6,7 @@
 <title>CompletableSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/CompletableObserver.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Emitter.BackpressureMode.html
+++ b/javadoc/rx/Emitter.BackpressureMode.html
@@ -6,7 +6,7 @@
 <title>Emitter.BackpressureMode (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/BackpressureStrategy.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Emitter.html
+++ b/javadoc/rx/Emitter.html
@@ -6,7 +6,7 @@
 <title>Emitter (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/FlowableEmitter.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Notification.html
+++ b/javadoc/rx/Notification.html
@@ -6,7 +6,7 @@
 <title>Notification (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Notification.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Observable.OnSubscribe.html
+++ b/javadoc/rx/Observable.OnSubscribe.html
@@ -6,7 +6,7 @@
 <title>Observable.OnSubscribe (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/FlowableOnSubscribe.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Observable.Operator.html
+++ b/javadoc/rx/Observable.Operator.html
@@ -6,7 +6,7 @@
 <title>Observable.Operator (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/FlowableOperator.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Observable.html
+++ b/javadoc/rx/Observable.html
@@ -6,7 +6,7 @@
 <title>Observable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Flowable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Observer.html
+++ b/javadoc/rx/Observer.html
@@ -6,7 +6,7 @@
 <title>Observer (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Observer.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Producer.html
+++ b/javadoc/rx/Producer.html
@@ -6,7 +6,7 @@
 <title>Producer (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://www.reactive-streams.org/reactive-streams-1.0.0-javadoc/org/reactivestreams/Subscription.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Scheduler.Worker.html
+++ b/javadoc/rx/Scheduler.Worker.html
@@ -6,7 +6,7 @@
 <title>Scheduler.Worker (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Scheduler.Worker.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Scheduler.html
+++ b/javadoc/rx/Scheduler.html
@@ -6,7 +6,7 @@
 <title>Scheduler (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Scheduler.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Single.OnSubscribe.html
+++ b/javadoc/rx/Single.OnSubscribe.html
@@ -6,7 +6,7 @@
 <title>Single.OnSubscribe (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/SingleOnSubscribe.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Single.html
+++ b/javadoc/rx/Single.html
@@ -6,7 +6,7 @@
 <title>Single (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Single.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/SingleSubscriber.html
+++ b/javadoc/rx/SingleSubscriber.html
@@ -6,7 +6,7 @@
 <title>SingleSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/SingleObserver.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Subscriber.html
+++ b/javadoc/rx/Subscriber.html
@@ -6,7 +6,7 @@
 <title>Subscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/FlowableSubscriber.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/Subscription.html
+++ b/javadoc/rx/Subscription.html
@@ -6,7 +6,7 @@
 <title>Subscription (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/Disposable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/annotations/Beta.html
+++ b/javadoc/rx/annotations/Beta.html
@@ -6,7 +6,7 @@
 <title>Beta (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/annotations/Beta.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/annotations/Experimental.html
+++ b/javadoc/rx/annotations/Experimental.html
@@ -6,7 +6,7 @@
 <title>Experimental (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/annotations/Experimental.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/exceptions/CompositeException.html
+++ b/javadoc/rx/exceptions/CompositeException.html
@@ -6,7 +6,7 @@
 <title>CompositeException (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/exceptions/CompositeException.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/exceptions/Exceptions.html
+++ b/javadoc/rx/exceptions/Exceptions.html
@@ -6,7 +6,7 @@
 <title>Exceptions (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/exceptions/Exceptions.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/exceptions/MissingBackpressureException.html
+++ b/javadoc/rx/exceptions/MissingBackpressureException.html
@@ -6,7 +6,7 @@
 <title>MissingBackpressureException (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/exceptions/MissingBackpressureException.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/exceptions/OnErrorNotImplementedException.html
+++ b/javadoc/rx/exceptions/OnErrorNotImplementedException.html
@@ -6,7 +6,7 @@
 <title>OnErrorNotImplementedException (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/exceptions/OnErrorNotImplementedException.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Action0.html
+++ b/javadoc/rx/functions/Action0.html
@@ -6,7 +6,7 @@
 <title>Action0 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Action.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Action1.html
+++ b/javadoc/rx/functions/Action1.html
@@ -6,7 +6,7 @@
 <title>Action1 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Consumer.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Action2.html
+++ b/javadoc/rx/functions/Action2.html
@@ -6,7 +6,7 @@
 <title>Action2 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/BiConsumer.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/ActionN.html
+++ b/javadoc/rx/functions/ActionN.html
@@ -6,7 +6,7 @@
 <title>ActionN (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Consumer.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Cancellable.html
+++ b/javadoc/rx/functions/Cancellable.html
@@ -6,7 +6,7 @@
 <title>Cancellable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Cancellable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Func0.html
+++ b/javadoc/rx/functions/Func0.html
@@ -6,7 +6,7 @@
 <title>Func0 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="https://docs.oracle.com/javase/6/docs/api/java/util/concurrent/Callable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Func1.html
+++ b/javadoc/rx/functions/Func1.html
@@ -6,7 +6,7 @@
 <title>Func1 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Func2.html
+++ b/javadoc/rx/functions/Func2.html
@@ -6,7 +6,7 @@
 <title>Func2 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/BiFunction.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Func3.html
+++ b/javadoc/rx/functions/Func3.html
@@ -6,7 +6,7 @@
 <title>Func3 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function3.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Func4.html
+++ b/javadoc/rx/functions/Func4.html
@@ -6,7 +6,7 @@
 <title>Func4 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function4.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Func5.html
+++ b/javadoc/rx/functions/Func5.html
@@ -6,7 +6,7 @@
 <title>Func5 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function5.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Func6.html
+++ b/javadoc/rx/functions/Func6.html
@@ -6,7 +6,7 @@
 <title>Func6 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function6.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Func7.html
+++ b/javadoc/rx/functions/Func7.html
@@ -6,7 +6,7 @@
 <title>Func7 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function7.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Func8.html
+++ b/javadoc/rx/functions/Func8.html
@@ -6,7 +6,7 @@
 <title>Func8 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function8.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/Func9.html
+++ b/javadoc/rx/functions/Func9.html
@@ -6,7 +6,7 @@
 <title>Func9 (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function9.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/functions/FuncN.html
+++ b/javadoc/rx/functions/FuncN.html
@@ -6,7 +6,7 @@
 <title>FuncN (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/functions/Function.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/observables/BlockingObservable.html
+++ b/javadoc/rx/observables/BlockingObservable.html
@@ -6,7 +6,7 @@
 <title>BlockingObservable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Flowable.html#blockingIterable%28%29"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/observables/ConnectableObservable.html
+++ b/javadoc/rx/observables/ConnectableObservable.html
@@ -6,7 +6,7 @@
 <title>ConnectableObservable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/flowables/ConnectableFlowable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/observables/GroupedObservable.html
+++ b/javadoc/rx/observables/GroupedObservable.html
@@ -6,7 +6,7 @@
 <title>GroupedObservable (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/flowables/GroupedFlowable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/observables/SyncOnSubscribe.html
+++ b/javadoc/rx/observables/SyncOnSubscribe.html
@@ -6,7 +6,7 @@
 <title>SyncOnSubscribe (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/FlowableEmitter.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/observers/AsyncCompletableSubscriber.html
+++ b/javadoc/rx/observers/AsyncCompletableSubscriber.html
@@ -6,7 +6,7 @@
 <title>AsyncCompletableSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/observers/DisposableCompletableObserver.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/observers/SafeSubscriber.html
+++ b/javadoc/rx/observers/SafeSubscriber.html
@@ -6,7 +6,7 @@
 <title>SafeSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/subscribers/SafeSubscriber.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/observers/SerializedObserver.html
+++ b/javadoc/rx/observers/SerializedObserver.html
@@ -6,7 +6,7 @@
 <title>SerializedObserver (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/observers/SerializedObserver.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/observers/SerializedSubscriber.html
+++ b/javadoc/rx/observers/SerializedSubscriber.html
@@ -6,7 +6,7 @@
 <title>SerializedSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/subscribers/SerializedSubscriber.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/observers/TestObserver.html
+++ b/javadoc/rx/observers/TestObserver.html
@@ -6,7 +6,7 @@
 <title>TestObserver (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/observers/TestObserver.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/observers/TestSubscriber.html
+++ b/javadoc/rx/observers/TestSubscriber.html
@@ -6,7 +6,7 @@
 <title>TestSubscriber (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/subscribers/TestSubscriber.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/plugins/RxJavaCompletableExecutionHook.html
+++ b/javadoc/rx/plugins/RxJavaCompletableExecutionHook.html
@@ -6,7 +6,7 @@
 <title>RxJavaCompletableExecutionHook (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/plugins/RxJavaHooks.html
+++ b/javadoc/rx/plugins/RxJavaHooks.html
@@ -6,7 +6,7 @@
 <title>RxJavaHooks (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/plugins/RxJavaObservableExecutionHook.html
+++ b/javadoc/rx/plugins/RxJavaObservableExecutionHook.html
@@ -6,7 +6,7 @@
 <title>RxJavaObservableExecutionHook (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/plugins/RxJavaPlugins.html
+++ b/javadoc/rx/plugins/RxJavaPlugins.html
@@ -6,7 +6,7 @@
 <title>RxJavaPlugins (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/plugins/RxJavaSchedulersHook.html
+++ b/javadoc/rx/plugins/RxJavaSchedulersHook.html
@@ -6,7 +6,7 @@
 <title>RxJavaSchedulersHook (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/plugins/RxJavaSingleExecutionHook.html
+++ b/javadoc/rx/plugins/RxJavaSingleExecutionHook.html
@@ -6,7 +6,7 @@
 <title>RxJavaSingleExecutionHook (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/plugins/RxJavaPlugins.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/singles/BlockingSingle.html
+++ b/javadoc/rx/singles/BlockingSingle.html
@@ -6,7 +6,7 @@
 <title>BlockingSingle (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Single.html#blockingGet%28%29"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/subjects/AsyncSubject.html
+++ b/javadoc/rx/subjects/AsyncSubject.html
@@ -6,7 +6,7 @@
 <title>AsyncSubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/AsyncProcessor.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/subjects/BehaviorSubject.html
+++ b/javadoc/rx/subjects/BehaviorSubject.html
@@ -6,7 +6,7 @@
 <title>BehaviorSubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/BehaviorProcessor.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/subjects/PublishSubject.html
+++ b/javadoc/rx/subjects/PublishSubject.html
@@ -6,7 +6,7 @@
 <title>PublishSubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/PublishProcessor.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/subjects/ReplaySubject.html
+++ b/javadoc/rx/subjects/ReplaySubject.html
@@ -6,7 +6,7 @@
 <title>ReplaySubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/ReplayProcessor.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/subjects/SerializedSubject.html
+++ b/javadoc/rx/subjects/SerializedSubject.html
@@ -6,7 +6,7 @@
 <title>SerializedSubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/FlowableProcessor.html#toSerialized%28%29"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/subjects/UnicastSubject.html
+++ b/javadoc/rx/subjects/UnicastSubject.html
@@ -6,7 +6,7 @@
 <title>UnicastSubject (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/processors/UnicastProcessor.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/subscriptions/BooleanSubscription.html
+++ b/javadoc/rx/subscriptions/BooleanSubscription.html
@@ -6,7 +6,7 @@
 <title>BooleanSubscription (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/Disposables.html#empty%28%29"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/subscriptions/CompositeSubscription.html
+++ b/javadoc/rx/subscriptions/CompositeSubscription.html
@@ -6,7 +6,7 @@
 <title>CompositeSubscription (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/CompositeDisposable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/subscriptions/MultipleAssignmentSubscription.html
+++ b/javadoc/rx/subscriptions/MultipleAssignmentSubscription.html
@@ -6,7 +6,7 @@
 <title>MultipleAssignmentSubscription (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/SerialDisposable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/subscriptions/RefCountSubscription.html
+++ b/javadoc/rx/subscriptions/RefCountSubscription.html
@@ -6,7 +6,7 @@
 <title>RefCountSubscription (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/SerialDisposable.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {

--- a/javadoc/rx/subscriptions/Subscriptions.html
+++ b/javadoc/rx/subscriptions/Subscriptions.html
@@ -6,7 +6,7 @@
 <title>Subscriptions (RxJava Javadoc 1.2.7)</title>
 <meta name="date" content="2017-02-24">
 <link rel="stylesheet" type="text/css" href="../../stylesheet.css" title="Style">
-</head>
+<link rel="canonical" href="http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/Disposables.html"/></head>
 <body>
 <script type="text/javascript"><!--
     if (location.href.indexOf('is-external=true') == -1) {


### PR DESCRIPTION
This PR adds `<link rel="canonical" href="..."/>` nodes to the 1.x javadoc via the following program:

https://github.com/akarnokd/akarnokd-misc/blob/master/src/main/java/hu/akarnokd/rxjava/javadoc/AddCanonical.java

How to use it:
- Within a Java 8 project, replace the file directories that point to your checked-out `gh-pages` branch.
- Unpack the rxjava-1.2.x-javadoc.jar into the two places
- Run `AddCanonical`
- Push a PR with the changes.