### PR TITLE
2.x: fix window() with time+size emission problems

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -281,6 +281,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
         final int bufferSize;
         final boolean restartTimerOnMaxSize;
         final long maxSize;
+        final Scheduler.Worker worker;
 
         long count;
 
@@ -289,8 +290,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
         Subscription s;
 
         UnicastProcessor<T> window;
-
-        Scheduler.Worker worker;
 
         volatile boolean terminated;
 
@@ -307,6 +306,11 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             this.bufferSize = bufferSize;
             this.maxSize = maxSize;
             this.restartTimerOnMaxSize = restartTimerOnMaxSize;
+            if (restartTimerOnMaxSize) {
+                worker = scheduler.createWorker();
+            } else {
+                worker = null;
+            }
         }
 
         @Override
@@ -342,10 +346,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                 Disposable d;
                 ConsumerIndexHolder consumerIndexHolder = new ConsumerIndexHolder(producerIndex, this);
                 if (restartTimerOnMaxSize) {
-                    Scheduler.Worker sw = scheduler.createWorker();
-                    worker = sw;
-                    sw.schedulePeriodically(consumerIndexHolder, timespan, timespan, unit);
-                    d = sw;
+                    d = worker.schedulePeriodically(consumerIndexHolder, timespan, timespan, unit);
                 } else {
                     d = scheduler.schedulePeriodicallyDirect(consumerIndexHolder, timespan, timespan, unit);
                 }
@@ -451,6 +452,10 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
         public void dispose() {
             DisposableHelper.dispose(timer);
+            Worker w = worker;
+            if (w != null) {
+                w.dispose();
+            }
         }
 
         void drainLoop() {
@@ -495,9 +500,9 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
                     if (isHolder) {
                         ConsumerIndexHolder consumerIndexHolder = (ConsumerIndexHolder) o;
-                        if (producerIndex == consumerIndexHolder.index) {
+                        if (restartTimerOnMaxSize || producerIndex == consumerIndexHolder.index) {
                             w.onComplete();
-
+                            count = 0;
                             w = UnicastProcessor.<T>create(bufferSize);
                             window = w;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
@@ -254,6 +254,8 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
         final boolean restartTimerOnMaxSize;
         final long maxSize;
 
+        final Scheduler.Worker worker;
+
         long count;
 
         long producerIndex;
@@ -262,7 +264,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
 
         UnicastSubject<T> window;
 
-        Scheduler.Worker worker;
 
         volatile boolean terminated;
 
@@ -279,6 +280,11 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
             this.bufferSize = bufferSize;
             this.maxSize = maxSize;
             this.restartTimerOnMaxSize = restartTimerOnMaxSize;
+            if (restartTimerOnMaxSize) {
+                worker = scheduler.createWorker();
+            } else {
+                worker = null;
+            }
         }
 
         @Override
@@ -302,10 +308,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                 Disposable d;
                 ConsumerIndexHolder consumerIndexHolder = new ConsumerIndexHolder(producerIndex, this);
                 if (restartTimerOnMaxSize) {
-                    Scheduler.Worker sw = scheduler.createWorker();
-                    worker = sw;
-                    sw.schedulePeriodically(consumerIndexHolder, timespan, timespan, unit);
-                    d = sw;
+                    d = worker.schedulePeriodically(consumerIndexHolder, timespan, timespan, unit);
                 } else {
                     d = scheduler.schedulePeriodicallyDirect(consumerIndexHolder, timespan, timespan, unit);
                 }
@@ -394,6 +397,10 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
 
         void disposeTimer() {
             DisposableHelper.dispose(timer);
+            Worker w = worker;
+            if (w != null) {
+                w.dispose();
+            }
         }
 
         void drainLoop() {
@@ -438,9 +445,9 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
 
                     if (isHolder) {
                         ConsumerIndexHolder consumerIndexHolder = (ConsumerIndexHolder) o;
-                        if (producerIndex == consumerIndexHolder.index) {
+                        if (restartTimerOnMaxSize || producerIndex == consumerIndexHolder.index) {
                             w.onComplete();
-
+                            count = 0;
                             w = UnicastSubject.create(bufferSize);
                             window = w;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -704,4 +704,107 @@ public class FlowableWindowWithTimeTest {
 
         ts.values().get(0).test().assertResult();
     }
+
+    @Test
+    public void periodicWindowCompletion() {
+        TestScheduler scheduler = new TestScheduler();
+        FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
+
+        TestSubscriber<Flowable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, Long.MAX_VALUE, false)
+        .test();
+
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+        ts.assertValueCount(21)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+
+    @Test
+    public void periodicWindowCompletionRestartTimer() {
+        TestScheduler scheduler = new TestScheduler();
+        FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
+
+        TestSubscriber<Flowable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, Long.MAX_VALUE, true)
+        .test();
+
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+        ts.assertValueCount(21)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+
+    @Test
+    public void periodicWindowCompletionBounded() {
+        TestScheduler scheduler = new TestScheduler();
+        FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
+
+        TestSubscriber<Flowable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, false)
+        .test();
+
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+        ts.assertValueCount(21)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+
+    @Test
+    public void periodicWindowCompletionRestartTimerBounded() {
+        TestScheduler scheduler = new TestScheduler();
+        FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
+
+        TestSubscriber<Flowable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, true)
+        .test();
+
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+        ts.assertValueCount(21)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+
+    @Test
+    public void periodicWindowCompletionRestartTimerBoundedSomeData() {
+        TestScheduler scheduler = new TestScheduler();
+        FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
+
+        TestSubscriber<Flowable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 2, true)
+        .test();
+
+        ps.onNext(1);
+        ps.onNext(2);
+
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+        ts.assertValueCount(22)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+    @Test
+    public void countRestartsOnTimeTick() {
+        TestScheduler scheduler = new TestScheduler();
+        FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
+
+        TestSubscriber<Flowable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, true)
+        .test();
+
+        // window #1
+        ps.onNext(1);
+        ps.onNext(2);
+
+        scheduler.advanceTimeBy(5, TimeUnit.MILLISECONDS);
+
+        // window #2
+        ps.onNext(3);
+        ps.onNext(4);
+        ps.onNext(5);
+        ps.onNext(6);
+
+        ts.assertValueCount(2)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
 }
+

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -603,4 +603,107 @@ public class ObservableWindowWithTimeTest {
 
         ts.values().get(0).test().assertResult();
     }
+
+    @Test
+    public void periodicWindowCompletion() {
+        TestScheduler scheduler = new TestScheduler();
+        Subject<Integer> ps = PublishSubject.<Integer>create();
+
+        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, Long.MAX_VALUE, false)
+        .test();
+
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+        ts.assertValueCount(21)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+
+    @Test
+    public void periodicWindowCompletionRestartTimer() {
+        TestScheduler scheduler = new TestScheduler();
+        Subject<Integer> ps = PublishSubject.<Integer>create();
+
+        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, Long.MAX_VALUE, true)
+        .test();
+
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+        ts.assertValueCount(21)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+
+    @Test
+    public void periodicWindowCompletionBounded() {
+        TestScheduler scheduler = new TestScheduler();
+        Subject<Integer> ps = PublishSubject.<Integer>create();
+
+        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, false)
+        .test();
+
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+        ts.assertValueCount(21)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+
+    @Test
+    public void periodicWindowCompletionRestartTimerBounded() {
+        TestScheduler scheduler = new TestScheduler();
+        Subject<Integer> ps = PublishSubject.<Integer>create();
+
+        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, true)
+        .test();
+
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+        ts.assertValueCount(21)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+
+    @Test
+    public void periodicWindowCompletionRestartTimerBoundedSomeData() {
+        TestScheduler scheduler = new TestScheduler();
+        Subject<Integer> ps = PublishSubject.<Integer>create();
+
+        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 2, true)
+        .test();
+
+        ps.onNext(1);
+        ps.onNext(2);
+
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+        ts.assertValueCount(22)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
+
+    @Test
+    public void countRestartsOnTimeTick() {
+        TestScheduler scheduler = new TestScheduler();
+        Subject<Integer> ps = PublishSubject.<Integer>create();
+
+        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, true)
+        .test();
+
+        // window #1
+        ps.onNext(1);
+        ps.onNext(2);
+
+        scheduler.advanceTimeBy(5, TimeUnit.MILLISECONDS);
+
+        // window #2
+        ps.onNext(3);
+        ps.onNext(4);
+        ps.onNext(5);
+        ps.onNext(6);
+
+        ts.assertValueCount(2)
+        .assertNoErrors()
+        .assertNotComplete();
+    }
 }


### PR DESCRIPTION
The `window()` operator overload with time and size bound didn't work correctly when some windows were terminated by the timeout and others by the size. This PR fixes:

  - the case when the operator restarts the time windows when the size bound is reached,
  - leaking of the worker,
  - the item counter not reset to zero when the time bound is reached,
  - periodic window bound stopped working after the first window.

Related #5104 (again).