### PR TITLE
[2.x] UnicastSubject fail fast support

### DIFF
--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -126,6 +126,7 @@ public final class UnicastSubject<T> extends Subject<T> {
      * @param onTerminate the callback to run when the Subject is terminated or cancelled, null not allowed
      * @param delayError deliver pending onNext events before onError
      * @return an UnicastSubject instance
+     * @since 2.0.8 - experimental
      */
     @CheckReturnValue
     @Experimental
@@ -142,6 +143,7 @@ public final class UnicastSubject<T> extends Subject<T> {
      * @param <T> the value type
      * @param delayError deliver pending onNext events before onError
      * @return an UnicastSubject instance
+     * @since 2.0.8 - experimental
      */
     @CheckReturnValue
     @Experimental
@@ -154,7 +156,7 @@ public final class UnicastSubject<T> extends Subject<T> {
      * Creates an UnicastSubject with the given capacity hint and delay error flag.
      * @param capacityHint the capacity hint for the internal, unbounded queue
      * @param delayError deliver pending onNext events before onError
-     * @since 2.0
+     * @since 2.0.8 - experimental
      */
     UnicastSubject(int capacityHint, boolean delayError) {
         this.queue = new SpscLinkedArrayQueue<T>(ObjectHelper.verifyPositive(capacityHint, "capacityHint"));
@@ -183,7 +185,7 @@ public final class UnicastSubject<T> extends Subject<T> {
      * @param capacityHint the capacity hint for the internal, unbounded queue
      * @param onTerminate the callback to run when the Subject is terminated or cancelled, null not allowed
      * @param delayError deliver pending onNext events before onError
-     * @since 2.0
+     * @since 2.0.8 - experimental
      */
     UnicastSubject(int capacityHint, Runnable onTerminate, boolean delayError) {
         this.queue = new SpscLinkedArrayQueue<T>(ObjectHelper.verifyPositive(capacityHint, "capacityHint"));

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.subjects;
 
+import io.reactivex.annotations.Experimental;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.plugins.RxJavaPlugins;
 import java.util.concurrent.atomic.*;
@@ -82,7 +83,7 @@ public final class UnicastSubject<T> extends Subject<T> {
      */
     @CheckReturnValue
     public static <T> UnicastSubject<T> create() {
-        return new UnicastSubject<T>(bufferSize());
+        return new UnicastSubject<T>(bufferSize(), true);
     }
 
     /**
@@ -93,7 +94,7 @@ public final class UnicastSubject<T> extends Subject<T> {
      */
     @CheckReturnValue
     public static <T> UnicastSubject<T> create(int capacityHint) {
-        return new UnicastSubject<T>(capacityHint);
+        return new UnicastSubject<T>(capacityHint, true);
     }
 
     /**
@@ -127,12 +128,13 @@ public final class UnicastSubject<T> extends Subject<T> {
      * @return an UnicastSubject instance
      */
     @CheckReturnValue
+    @Experimental
     public static <T> UnicastSubject<T> create(int capacityHint, Runnable onTerminate, boolean delayError) {
         return new UnicastSubject<T>(capacityHint, onTerminate, delayError);
     }
 
     /**
-     * Creates an UnicastSubject with an internal buffer capacity hint 16 and given delay error flag
+     * Creates an UnicastSubject with an internal buffer capacity hint 16 and given delay error flag.
      *
      * <p>The callback, if not null, is called exactly once and
      * non-overlapped with any active replay.
@@ -142,6 +144,7 @@ public final class UnicastSubject<T> extends Subject<T> {
      * @return an UnicastSubject instance
      */
     @CheckReturnValue
+    @Experimental
     public static <T> UnicastSubject<T> create(boolean delayError) {
         return new UnicastSubject<T>(bufferSize(), delayError);
     }
@@ -172,15 +175,6 @@ public final class UnicastSubject<T> extends Subject<T> {
      * */
     UnicastSubject(int capacityHint, Runnable onTerminate) {
         this(capacityHint, onTerminate, true);
-    }
-
-    /**
-     * Creates an UnicastSubject with the given capacity hint.
-     * @param capacityHint the capacity hint for the internal, unbounded queue
-     * @since 2.0
-     */
-    UnicastSubject(int capacityHint) {
-        this(capacityHint, true);
     }
 
     /**

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -53,6 +53,9 @@ public final class UnicastSubject<T> extends Subject<T> {
     /** The optional callback when the Subject gets cancelled or terminates. */
     final AtomicReference<Runnable> onTerminate;
 
+    /** deliver onNext events before error event */
+    final boolean delayError;
+
     /** Indicates the single observer has cancelled. */
     volatile boolean disposed;
 
@@ -102,12 +105,73 @@ public final class UnicastSubject<T> extends Subject<T> {
      *
      * @param <T> the value type
      * @param capacityHint the hint to size the internal unbounded buffer
-     * @param onCancelled the non null callback
+     * @param onTerminate the callback to run when the Subject is terminated or cancelled, null not allowed
      * @return an UnicastSubject instance
      */
     @CheckReturnValue
-    public static <T> UnicastSubject<T> create(int capacityHint, Runnable onCancelled) {
-        return new UnicastSubject<T>(capacityHint, onCancelled);
+    public static <T> UnicastSubject<T> create(int capacityHint, Runnable onTerminate) {
+        return new UnicastSubject<T>(capacityHint, onTerminate, true);
+    }
+
+    /**
+     * Creates an UnicastSubject with the given internal buffer capacity hint, delay error flag and
+     * a callback for the case when the single Subscriber cancels its subscription.
+     *
+     * <p>The callback, if not null, is called exactly once and
+     * non-overlapped with any active replay.
+     *
+     * @param <T> the value type
+     * @param capacityHint the hint to size the internal unbounded buffer
+     * @param onTerminate the callback to run when the Subject is terminated or cancelled, null not allowed
+     * @param delayError deliver pending onNext events before onError
+     * @return an UnicastSubject instance
+     */
+    @CheckReturnValue
+    public static <T> UnicastSubject<T> create(int capacityHint, Runnable onTerminate, boolean delayError) {
+        return new UnicastSubject<T>(capacityHint, onTerminate, delayError);
+    }
+
+    /**
+     * Creates an UnicastSubject with an internal buffer capacity hint 16 and given delay error flag
+     *
+     * <p>The callback, if not null, is called exactly once and
+     * non-overlapped with any active replay.
+     *
+     * @param <T> the value type
+     * @param delayError deliver pending onNext events before onError
+     * @return an UnicastSubject instance
+     */
+    @CheckReturnValue
+    public static <T> UnicastSubject<T> create(boolean delayError) {
+        return new UnicastSubject<T>(bufferSize(), delayError);
+    }
+
+
+    /**
+     * Creates an UnicastSubject with the given capacity hint and delay error flag.
+     * @param capacityHint the capacity hint for the internal, unbounded queue
+     * @param delayError deliver pending onNext events before onError
+     * @since 2.0
+     */
+    UnicastSubject(int capacityHint, boolean delayError) {
+        this.queue = new SpscLinkedArrayQueue<T>(ObjectHelper.verifyPositive(capacityHint, "capacityHint"));
+        this.onTerminate = new AtomicReference<Runnable>();
+        this.delayError = delayError;
+        this.actual = new AtomicReference<Observer<? super T>>();
+        this.once = new AtomicBoolean();
+        this.wip = new UnicastQueueDisposable();
+    }
+
+    /**
+     * Creates an UnicastSubject with the given capacity hint and callback
+     * for when the Subject is terminated normally or its single Subscriber cancels.
+     * @param capacityHint the capacity hint for the internal, unbounded queue
+     * @param onTerminate the callback to run when the Subject is terminated or cancelled, null not allowed
+     * @since 2.0
+     *
+     * */
+    UnicastSubject(int capacityHint, Runnable onTerminate) {
+        this(capacityHint, onTerminate, true);
     }
 
     /**
@@ -116,23 +180,21 @@ public final class UnicastSubject<T> extends Subject<T> {
      * @since 2.0
      */
     UnicastSubject(int capacityHint) {
-        this.queue = new SpscLinkedArrayQueue<T>(ObjectHelper.verifyPositive(capacityHint, "capacityHint"));
-        this.onTerminate = new AtomicReference<Runnable>();
-        this.actual = new AtomicReference<Observer<? super T>>();
-        this.once = new AtomicBoolean();
-        this.wip = new UnicastQueueDisposable();
+        this(capacityHint, true);
     }
 
     /**
-     * Creates an UnicastProcessor with the given capacity hint and callback
-     * for when the Processor is terminated normally or its single Subscriber cancels.
+     * Creates an UnicastSubject with the given capacity hint, delay error flag and callback
+     * for when the Subject is terminated normally or its single Subscriber cancels.
      * @param capacityHint the capacity hint for the internal, unbounded queue
-     * @param onTerminate the callback to run when the Processor is terminated or cancelled, null not allowed
+     * @param onTerminate the callback to run when the Subject is terminated or cancelled, null not allowed
+     * @param delayError deliver pending onNext events before onError
      * @since 2.0
      */
-    UnicastSubject(int capacityHint, Runnable onTerminate) {
+    UnicastSubject(int capacityHint, Runnable onTerminate, boolean delayError) {
         this.queue = new SpscLinkedArrayQueue<T>(ObjectHelper.verifyPositive(capacityHint, "capacityHint"));
         this.onTerminate = new AtomicReference<Runnable>(ObjectHelper.requireNonNull(onTerminate, "onTerminate"));
+        this.delayError = delayError;
         this.actual = new AtomicReference<Observer<? super T>>();
         this.once = new AtomicBoolean();
         this.wip = new UnicastQueueDisposable();
@@ -212,6 +274,8 @@ public final class UnicastSubject<T> extends Subject<T> {
     void drainNormal(Observer<? super T> a) {
         int missed = 1;
         SimpleQueue<T> q = queue;
+        boolean failFast = !this.delayError;
+        boolean canBeError = true;
         for (;;) {
             for (;;) {
 
@@ -221,19 +285,23 @@ public final class UnicastSubject<T> extends Subject<T> {
                     return;
                 }
 
-                boolean d = done;
+                boolean d = this.done;
                 T v = queue.poll();
                 boolean empty = v == null;
 
-                if (d && empty) {
-                    actual.lazySet(null);
-                    Throwable ex = error;
-                    if (ex != null) {
-                        a.onError(ex);
-                    } else {
-                        a.onComplete();
+                if (d) {
+                    if (failFast && canBeError) {
+                        if (failedFast(q, a)) {
+                            return;
+                        } else {
+                            canBeError = false;
+                        }
                     }
-                    return;
+
+                    if (empty) {
+                        errorOrComplete(a);
+                        return;
+                    }
                 }
 
                 if (empty) {
@@ -254,6 +322,7 @@ public final class UnicastSubject<T> extends Subject<T> {
         int missed = 1;
 
         final SpscLinkedArrayQueue<T> q = queue;
+        final boolean failFast = !delayError;
 
         for (;;) {
 
@@ -262,20 +331,18 @@ public final class UnicastSubject<T> extends Subject<T> {
                 q.clear();
                 return;
             }
-
             boolean d = done;
+
+            if (failFast && d) {
+                if (failedFast(q, a)) {
+                    return;
+                }
+            }
 
             a.onNext(null);
 
             if (d) {
-                actual.lazySet(null);
-
-                Throwable ex = error;
-                if (ex != null) {
-                    a.onError(ex);
-                } else {
-                    a.onComplete();
-                }
+                errorOrComplete(a);
                 return;
             }
 
@@ -283,6 +350,28 @@ public final class UnicastSubject<T> extends Subject<T> {
             if (missed == 0) {
                 break;
             }
+        }
+    }
+
+    void errorOrComplete(Observer<? super T> a) {
+        actual.lazySet(null);
+        Throwable ex = error;
+        if (ex != null) {
+            a.onError(ex);
+        } else {
+            a.onComplete();
+        }
+    }
+
+    boolean failedFast(final SimpleQueue<T> q, Observer<? super T> a) {
+        Throwable ex = error;
+        if (ex != null) {
+            actual.lazySet(null);
+            q.clear();
+            a.onError(ex);
+            return true;
+        } else {
+            return false;
         }
     }
 

--- a/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
@@ -70,6 +70,32 @@ public class UnicastSubjectTest {
     }
 
     @Test
+    public void failFast() {
+        UnicastSubject<Integer> ap = UnicastSubject.create(false);
+        ap.onNext(1);
+        ap.onError(new RuntimeException());
+        TestObserver<Integer> ts = TestObserver.create();
+        ap.subscribe(ts);
+
+        ts
+                .assertValueCount(0)
+                .assertError(RuntimeException.class);
+    }
+
+    @Test
+    public void fusionOfflineFailFast() {
+        UnicastSubject<Integer> ap = UnicastSubject.create(false);
+        ap.onNext(1);
+        ap.onError(new RuntimeException());
+        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ANY);
+        ap.subscribe(ts);
+
+        ts
+                .assertValueCount(0)
+                .assertError(RuntimeException.class);
+    }
+
+    @Test
     public void onTerminateCalledWhenOnError() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 


### PR DESCRIPTION
This PR adds support for fail-fast behavior to `UnicastSubject` with methods `UnicastSubject<T> create(boolean delayError)`, `UnicastSubject<T> create(int capacityHint, Runnable onTerminated, boolean delayError)`.  Relates to #5165
