### PR TITLE
2.x: safeguard against building with v1 tags

### DIFF
--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # This script will build the project.
 
+buildTag="$TRAVIS_TAG"
+
+if [ "$buildTag" != "" ] && [ "${buildTag:0:3}" != "v2." ]; then
+   echo -e "Wrong tag on the 2.x brach: $buildTag : build stopped"
+   exit 1
+fi
+
 GRADLE_OPTS=-Xmx832m
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then


### PR DESCRIPTION
This PR adds the same version guard that 1.x has: stop the build when the version tag doesn't start with "v2." to prevent releasing a 2.x version under the 1.x numbering.

This almost happened with today's botched 1.2.8 release where I forgot to set the target tag to 1.x, but noticed the mistake and stopped the build.

Since tags can't be deleted or retargeted, the fix can't prevent the wrong target tag mistake on itself. A small workaround is to mark bad tagged releases as pre-release.

Either way, the 2.x snapshots have a fixed `2.0.0-DP0-SNAPSHOT` and don't draw a custom version number from the latest release tag on their branch, unlike 1.x.