### PR TITLE
2.x: cleanup based on IntelliJ 2017.1 inspections

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -1880,7 +1880,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * return value of the {@link Future#get} method of that object, by passing the object into the {@code from}
      * method.
      * <p>
-     * <em>Important note:</em> This Publisher is blocking on the thread it gets subscribed on; you cannot unsubscribe from it.
+     * <em>Important note:</em> This Publisher is blocking on the thread it gets subscribed on; you cannot cancel it.
      * <p>
      * Unlike 1.x, cancelling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futurePublisher.doOnCancel(() -> future.cancel(true));}.
@@ -1919,7 +1919,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Unlike 1.x, cancelling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futurePublisher.doOnCancel(() -> future.cancel(true));}.
      * <p>
-     * <em>Important note:</em> This Publisher is blocking on the thread it gets subscribed on; you cannot unsubscribe from it.
+     * <em>Important note:</em> This Publisher is blocking on the thread it gets subscribed on; you cannot cancel it.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
@@ -1960,7 +1960,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Unlike 1.x, cancelling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futurePublisher.doOnCancel(() -> future.cancel(true));}.
      * <p>
-     * <em>Important note:</em> This Publisher is blocking; you cannot unsubscribe from it.
+     * <em>Important note:</em> This Publisher is blocking; you cannot cancel it.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
@@ -3839,7 +3839,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * from the earlier-emitted Publisher and begins emitting items from the new one.
      * <p>
      * The resulting Publisher completes if both the outer Publisher and the last inner Publisher, if any, complete.
-     * If the outer Publisher signals an onError, the inner Publisher is unsubscribed and the error delivered in-sequence.
+     * If the outer Publisher signals an onError, the inner Publisher is cancelled and the error delivered in-sequence.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed in an
@@ -3879,7 +3879,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * from the earlier-emitted Publisher and begins emitting items from the new one.
      * <p>
      * The resulting Publisher completes if both the outer Publisher and the last inner Publisher, if any, complete.
-     * If the outer Publisher signals an onError, the inner Publisher is unsubscribed and the error delivered in-sequence.
+     * If the outer Publisher signals an onError, the inner Publisher is cancelled and the error delivered in-sequence.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed in an
@@ -4160,11 +4160,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * the number of {@code onNext} invocations of the source Publisher that emits the fewest items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4213,11 +4213,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * the number of {@code onNext} invocations of the source Publisher that emits the fewest items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancel the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(just(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4270,11 +4270,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4330,11 +4330,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4392,11 +4392,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4455,11 +4455,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4520,11 +4520,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4590,11 +4590,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4663,11 +4663,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4740,11 +4740,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4822,11 +4822,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4908,11 +4908,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h, i) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4996,11 +4996,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * the number of {@code onNext} invocations of the source Publisher that emits the fewest items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(new Publisher[]{range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)}, (a) -&gt;
      * a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
@@ -5058,11 +5058,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * the number of {@code onNext} invocations of the source Publisher that emits the fewest items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -6355,13 +6355,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="410" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/cache.png" alt="">
      * <p>
      * This is useful when you want a Publisher to cache responses and you can't control the
-     * subscribe/unsubscribe behavior of all the {@link Subscriber}s.
+     * subscribe/cancel behavior of all the {@link Subscriber}s.
      * <p>
      * The operator subscribes only when the first downstream subscriber subscribes and maintains
      * a single subscription towards this Publisher. In contrast, the operator family of {@link #replay()}
      * that return a {@link ConnectableFlowable} require an explicit call to {@link ConnectableFlowable#connect()}.
      * <p>
-     * <em>Note:</em> You sacrifice the ability to unsubscribe from the origin when you use the {@code cache}
+     * <em>Note:</em> You sacrifice the ability to cancel the origin when you use the {@code cache}
      * Subscriber so be careful not to use this Subscriber on Publishers that emit an infinite or very large number
      * of items that will use up memory.
      * A possible workaround is to apply `takeUntil` with a predicate or
@@ -6413,13 +6413,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="410" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/cache.png" alt="">
      * <p>
      * This is useful when you want a Publisher to cache responses and you can't control the
-     * subscribe/unsubscribe behavior of all the {@link Subscriber}s.
+     * subscribe/cancel behavior of all the {@link Subscriber}s.
      * <p>
      * The operator subscribes only when the first downstream subscriber subscribes and maintains
      * a single subscription towards this Publisher. In contrast, the operator family of {@link #replay()}
      * that return a {@link ConnectableFlowable} require an explicit call to {@link ConnectableFlowable#connect()}.
      * <p>
-     * <em>Note:</em> You sacrifice the ability to unsubscribe from the origin when you use the {@code cache}
+     * <em>Note:</em> You sacrifice the ability to cancel the origin when you use the {@code cache}
      * Subscriber so be careful not to use this Subscriber on Publishers that emit an infinite or very large number
      * of items that will use up memory.
      * A possible workaround is to apply `takeUntil` with a predicate or
@@ -7717,12 +7717,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Calls the unsubscribe {@code Action} if the downstream cancels the sequence.
+     * Calls the cancel {@code Action} if the downstream cancels the sequence.
      * <p>
      * The action is shared between subscriptions and thus may be called concurrently from multiple
      * threads; the action must be thread safe.
      * <p>
-     * If the action throws a runtime exception, that exception is rethrown by the {@code unsubscribe()} call,
+     * If the action throws a runtime exception, that exception is rethrown by the {@code onCancel()} call,
      * sometimes as a {@code CompositeException} if there were multiple exceptions along the way.
      * <p>
      * Note that terminal events trigger the action unless the {@code Publisher} is subscribed to via {@code unsafeSubscribe()}.
@@ -7730,7 +7730,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnUnsubscribe.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>{@code doOnUnsubscribe} does not interact with backpressure requests or value delivery; backpressure
+     *  <dd>{@code doOnCancel} does not interact with backpressure requests or value delivery; backpressure
      *  behavior is preserved between its upstream and its downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code doOnCancel} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -9915,7 +9915,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Instructs a Publisher that is emitting items faster than its Subscriber can consume them to buffer up to
      * a given amount of items until they can be emitted. The resulting Publisher will {@code onError} emitting
      * a {@code BufferOverflowException} as soon as the buffer's capacity is exceeded, dropping all undelivered
-     * items, and unsubscribing from the source.
+     * items, and cancelling the source.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
      * <dl>
@@ -9942,7 +9942,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Instructs a Publisher that is emitting items faster than its Subscriber can consume them to buffer up to
      * a given amount of items until they can be emitted. The resulting Publisher will {@code onError} emitting
      * a {@code BufferOverflowException} as soon as the buffer's capacity is exceeded, dropping all undelivered
-     * items, and unsubscribing from the source.
+     * items, and cancelling the source.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
      * <dl>
@@ -9973,7 +9973,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Instructs a Publisher that is emitting items faster than its Subscriber can consume them to buffer up to
      * a given amount of items until they can be emitted. The resulting Publisher will {@code onError} emitting
      * a {@code BufferOverflowException} as soon as the buffer's capacity is exceeded, dropping all undelivered
-     * items, and unsubscribing from the source.
+     * items, and cancelling the source.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
      * <dl>
@@ -10007,7 +10007,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Instructs a Publisher that is emitting items faster than its Subscriber can consume them to buffer up to
      * a given amount of items until they can be emitted. The resulting Publisher will {@code onError} emitting
      * a {@code BufferOverflowException} as soon as the buffer's capacity is exceeded, dropping all undelivered
-     * items, unsubscribing from the source, and notifying the producer with {@code onOverflow}.
+     * items, cancelling the source, and notifying the producer with {@code onOverflow}.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
      * <dl>
@@ -10044,7 +10044,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Instructs a Publisher that is emitting items faster than its Subscriber can consume them to buffer up to
      * a given amount of items until they can be emitted. The resulting Publisher will {@code onError} emitting
      * a {@code BufferOverflowException} as soon as the buffer's capacity is exceeded, dropping all undelivered
-     * items, unsubscribing from the source, and notifying the producer with {@code onOverflow}.
+     * items, cancelling the source, and notifying the producer with {@code onOverflow}.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
      * <dl>
@@ -10075,7 +10075,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * <ul>
      *     <li>{@code BackpressureOverflow.Strategy.ON_OVERFLOW_ERROR} (default) will {@code onError} dropping all undelivered items,
-     *     unsubscribing from the source, and notifying the producer with {@code onOverflow}. </li>
+     *     cancelling the source, and notifying the producer with {@code onOverflow}. </li>
      *     <li>{@code BackpressureOverflow.Strategy.ON_OVERFLOW_DROP_LATEST} will drop any new items emitted by the producer while
      *     the buffer is full, without generating any {@code onError}.  Each drop will however invoke {@code onOverflow}
      *     to signal the overflow to the producer.</li>j
@@ -12124,7 +12124,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Returns a new {@link Publisher} that multicasts (shares) the original {@link Publisher}. As long as
      * there is at least one {@link Subscriber} this {@link Publisher} will be subscribed and emitting data.
-     * When all subscribers have unsubscribed it will unsubscribe from the source {@link Publisher}.
+     * When all subscribers have cancelled it will cancel the source {@link Publisher}.
      * <p>
      * This is an alias for {@link #publish()}.{@link ConnectableFlowable#refCount()}.
      * <p>
@@ -13133,7 +13133,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * of these Publishers.
      * <p>
      * The resulting Publisher completes if both the upstream Publisher and the last inner Publisher, if any, complete.
-     * If the upstream Publisher signals an onError, the inner Publisher is unsubscribed and the error delivered in-sequence.
+     * If the upstream Publisher signals an onError, the inner Publisher is cancelled and the error delivered in-sequence.
      * <p>
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
      * <dl>
@@ -13166,7 +13166,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * of these Publishers.
      * <p>
      * The resulting Publisher completes if both the upstream Publisher and the last inner Publisher, if any, complete.
-     * If the upstream Publisher signals an onError, the inner Publisher is unsubscribed and the error delivered in-sequence.
+     * If the upstream Publisher signals an onError, the inner Publisher is cancelled and the error delivered in-sequence.
      * <p>
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
      * <dl>
@@ -14563,7 +14563,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * calling its {@link #subscribe} method.
      * <p>
      * Be careful not to use this operator on Publishers that emit infinite or very large numbers of items, as
-     * you do not have the option to unsubscribe.
+     * you do not have the option to cancel.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
@@ -14596,7 +14596,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * calling its {@link #subscribe} method.
      * <p>
      * Be careful not to use this operator on Publishers that emit infinite or very large numbers of items, as
-     * you do not have the option to unsubscribe.
+     * you do not have the option to cancel.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
@@ -14632,7 +14632,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * calling its {@link #subscribe} method.
      * <p>
      * Be careful not to use this operator on Publishers that emit infinite or very large numbers of items, as
-     * you do not have the option to unsubscribe.
+     * you do not have the option to cancel.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
@@ -15038,7 +15038,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Modifies the source Publisher so that subscribers will unsubscribe from it on a specified
+     * Modifies the source Publisher so that subscribers will cancel it on a specified
      * {@link Scheduler}.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -16040,11 +16040,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -16088,11 +16088,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -16139,11 +16139,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will cancel B immediately. For example:
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,

--- a/src/main/java/io/reactivex/FlowableEmitter.java
+++ b/src/main/java/io/reactivex/FlowableEmitter.java
@@ -33,14 +33,14 @@ public interface FlowableEmitter<T> extends Emitter<T> {
 
     /**
      * Sets a Disposable on this emitter; any previous Disposable
-     * or Cancellation will be unsubscribed/cancelled.
+     * or Cancellation will be disposed/cancelled.
      * @param s the disposable, null is allowed
      */
     void setDisposable(@Nullable Disposable s);
 
     /**
      * Sets a Cancellable on this emitter; any previous Disposable
-     * or Cancellation will be unsubscribed/cancelled.
+     * or Cancellation will be disposed/cancelled.
      * @param c the cancellable resource, null is allowed
      */
     void setCancellable(@Nullable Cancellable c);

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -660,7 +660,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * return value of the {@link Future#get} method of that object, by passing the object into the {@code from}
      * method.
      * <p>
-     * <em>Important note:</em> This Maybe is blocking; you cannot unsubscribe from it.
+     * <em>Important note:</em> This Maybe is blocking; you cannot dispose it.
      * <p>
      * Unlike 1.x, cancelling the Maybe won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futureMaybe.doOnDispose(() -> future.cancel(true));}.
@@ -696,7 +696,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Unlike 1.x, cancelling the Maybe won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futureMaybe.doOnCancel(() -> future.cancel(true));}.
      * <p>
-     * <em>Important note:</em> This Maybe is blocking on the thread it gets subscribed on; you cannot unsubscribe from it.
+     * <em>Important note:</em> This Maybe is blocking on the thread it gets subscribed on; you cannot dispose it.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2036,7 +2036,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * The operator subscribes only when the first downstream subscriber subscribes and maintains
      * a single subscription towards this Maybe.
      * <p>
-     * <em>Note:</em> You sacrifice the ability to unsubscribe from the origin when you use the {@code cache}.
+     * <em>Note:</em> You sacrifice the ability to dispose the origin when you use the {@code cache}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code cache} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1653,7 +1653,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * return value of the {@link Future#get} method of that object, by passing the object into the {@code from}
      * method.
      * <p>
-     * <em>Important note:</em> This ObservableSource is blocking; you cannot unsubscribe from it.
+     * <em>Important note:</em> This ObservableSource is blocking; you cannot dispose it.
      * <p>
      * Unlike 1.x, cancelling the Observable won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futureObservableSource.doOnCancel(() -> future.cancel(true));}.
@@ -1689,7 +1689,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Unlike 1.x, cancelling the Observable won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futureObservableSource.doOnCancel(() -> future.cancel(true));}.
      * <p>
-     * <em>Important note:</em> This ObservableSource is blocking; you cannot unsubscribe from it.
+     * <em>Important note:</em> This ObservableSource is blocking; you cannot dispose it.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -1727,7 +1727,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Unlike 1.x, cancelling the Observable won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futureObservableSource.doOnCancel(() -> future.cancel(true));}.
      * <p>
-     * <em>Important note:</em> This ObservableSource is blocking; you cannot unsubscribe from it.
+     * <em>Important note:</em> This ObservableSource is blocking; you cannot dispose it.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3431,7 +3431,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * from the earlier-emitted ObservableSource and begins emitting items from the new one.
      * <p>
      * The resulting ObservableSource completes if both the outer ObservableSource and the last inner ObservableSource, if any, complete.
-     * If the outer ObservableSource signals an onError, the inner ObservableSource is unsubscribed and the error delivered in-sequence.
+     * If the outer ObservableSource signals an onError, the inner ObservableSource is disposed and the error delivered in-sequence.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code switchOnNext} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3467,7 +3467,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * from the earlier-emitted ObservableSource and begins emitting items from the new one.
      * <p>
      * The resulting ObservableSource completes if both the outer ObservableSource and the last inner ObservableSource, if any, complete.
-     * If the outer ObservableSource signals an onError, the inner ObservableSource is unsubscribed and the error delivered in-sequence.
+     * If the outer ObservableSource signals an onError, the inner ObservableSource is disposed and the error delivered in-sequence.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code switchOnNext} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3731,11 +3731,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * the number of {@code onNext} invocations of the source ObservableSource that emits the fewest items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -3784,11 +3784,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * the number of {@code onNext} invocations of the source ObservableSource that emits the fewest items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(just(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -3842,11 +3842,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -3897,11 +3897,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -3953,11 +3953,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4011,11 +4011,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4071,11 +4071,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4136,11 +4136,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4204,11 +4204,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4276,11 +4276,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4353,11 +4353,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4434,11 +4434,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h, i) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -4516,11 +4516,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * the number of {@code onNext} invocations of the source ObservableSource that emits the fewest items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(new ObservableSource[]{range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)}, (a) -&gt;
      * a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
@@ -4578,11 +4578,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * the number of {@code onNext} invocations of the source ObservableSource that emits the fewest items.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -5709,13 +5709,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="410" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/cache.png" alt="">
      * <p>
      * This is useful when you want an ObservableSource to cache responses and you can't control the
-     * subscribe/unsubscribe behavior of all the {@link Observer}s.
+     * subscribe/dispose behavior of all the {@link Observer}s.
      * <p>
      * The operator subscribes only when the first downstream subscriber subscribes and maintains
      * a single subscription towards this ObservableSource. In contrast, the operator family of {@link #replay()}
      * that return a {@link ConnectableObservable} require an explicit call to {@link ConnectableObservable#connect()}.
      * <p>
-     * <em>Note:</em> You sacrifice the ability to unsubscribe from the origin when you use the {@code cache}
+     * <em>Note:</em> You sacrifice the ability to dispose the origin when you use the {@code cache}
      * Observer so be careful not to use this Observer on ObservableSources that emit an infinite or very large number
      * of items that will use up memory.
      * A possible workaround is to apply `takeUntil` with a predicate or
@@ -5763,13 +5763,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="410" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/cache.png" alt="">
      * <p>
      * This is useful when you want an ObservableSource to cache responses and you can't control the
-     * subscribe/unsubscribe behavior of all the {@link Observer}s.
+     * subscribe/dispose behavior of all the {@link Observer}s.
      * <p>
      * The operator subscribes only when the first downstream subscriber subscribes and maintains
      * a single subscription towards this ObservableSource. In contrast, the operator family of {@link #replay()}
      * that return a {@link ConnectableObservable} require an explicit call to {@link ConnectableObservable#connect()}.
      * <p>
-     * <em>Note:</em> You sacrifice the ability to unsubscribe from the origin when you use the {@code cache}
+     * <em>Note:</em> You sacrifice the ability to dispose the origin when you use the {@code cache}
      * Observer so be careful not to use this Observer on ObservableSources that emit an infinite or very large number
      * of items that will use up memory.
      * A possible workaround is to apply `takeUntil` with a predicate or
@@ -6885,7 +6885,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Calls the unsubscribe {@code Action} if the downstream disposes the sequence.
+     * Calls the dispose {@code Action} if the downstream disposes the sequence.
      * <p>
      * The action is shared between subscriptions and thus may be called concurrently from multiple
      * threads; the action must be thread safe.
@@ -10143,7 +10143,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Returns a new {@link ObservableSource} that multicasts (shares) the original {@link ObservableSource}. As long as
      * there is at least one {@link Observer} this {@link ObservableSource} will be subscribed and emitting data.
-     * When all subscribers have unsubscribed it will unsubscribe from the source {@link ObservableSource}.
+     * When all subscribers have disposed it will dispose the source {@link ObservableSource}.
      * <p>
      * This is an alias for {@link #publish()}.{@link ConnectableObservable#refCount()}.
      * <p>
@@ -10207,7 +10207,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns a Single that emits the single item emitted by this Observalbe if this Observable
+     * Returns a Single that emits the single item emitted by this Observable if this Observable
      * emits only a single item, otherwise
      * if this Observable completes without emitting any items or emits more than one item a
      * {@link NoSuchElementException} or {@code IllegalArgumentException} will be signalled respectively.
@@ -10946,7 +10946,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * of these ObservableSources.
      * <p>
      * The resulting ObservableSource completes if both the upstream ObservableSource and the last inner ObservableSource, if any, complete.
-     * If the upstream ObservableSource signals an onError, the inner ObservableSource is unsubscribed and the error delivered in-sequence.
+     * If the upstream ObservableSource signals an onError, the inner ObservableSource is disposed and the error delivered in-sequence.
      * <p>
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
      * <dl>
@@ -10973,7 +10973,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * of these ObservableSources.
      * <p>
      * The resulting ObservableSource completes if both the upstream ObservableSource and the last inner ObservableSource, if any, complete.
-     * If the upstream ObservableSource signals an onError, the inner ObservableSource is unsubscribed and the error delivered in-sequence.
+     * If the upstream ObservableSource signals an onError, the inner ObservableSource is disposed and the error delivered in-sequence.
      * <p>
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
      * <dl>
@@ -11012,7 +11012,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * of these SingleSources.
      * <p>
      * The resulting ObservableSource completes if both the upstream ObservableSource and the last inner SingleSource, if any, complete.
-     * If the upstream ObservableSource signals an onError, the inner SingleSource is unsubscribed and the error delivered in-sequence.
+     * If the upstream ObservableSource signals an onError, the inner SingleSource is disposed and the error delivered in-sequence.
      * <p>
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
      * <dl>
@@ -12246,7 +12246,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * calling its {@link #subscribe} method.
      * <p>
      * Be careful not to use this operator on ObservableSources that emit infinite or very large numbers of items, as
-     * you do not have the option to unsubscribe.
+     * you do not have the option to dispose.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toList} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -12275,7 +12275,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * calling its {@link #subscribe} method.
      * <p>
      * Be careful not to use this operator on ObservableSources that emit infinite or very large numbers of items, as
-     * you do not have the option to unsubscribe.
+     * you do not have the option to dispose.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toList} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -12307,7 +12307,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * calling its {@link #subscribe} method.
      * <p>
      * Be careful not to use this operator on ObservableSources that emit infinite or very large numbers of items, as
-     * you do not have the option to unsubscribe.
+     * you do not have the option to dispose.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toList} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -12685,7 +12685,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Modifies the source ObservableSource so that subscribers will unsubscribe from it on a specified
+     * Modifies the source ObservableSource so that subscribers will dispose it on a specified
      * {@link Scheduler}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -13551,11 +13551,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * values, one each from the source ObservableSource and another specified ObservableSource.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -13594,11 +13594,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * values, one each from the source ObservableSource and another specified ObservableSource.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
@@ -13639,11 +13639,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * values, one each from the source ObservableSource and another specified ObservableSource.
      * <p>
      * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while unsubscribing the other sources. Therefore, it
+     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will unsubscribe B immediately. For example:
+     * be sending further values and it will dispose B immediately. For example:
      * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,

--- a/src/main/java/io/reactivex/Scheduler.java
+++ b/src/main/java/io/reactivex/Scheduler.java
@@ -199,7 +199,7 @@ public abstract class Scheduler {
      * size thread pool:
      * 
      * <pre>
-     * Scheduler limitSched = Schedulers.computation().when(workers -> {
+     * Scheduler limitScheduler = Schedulers.computation().when(workers -> {
      *  // use merge max concurrent to limit the number of concurrent
      *  // callbacks two at a time
      *  return Completable.merge(Flowable.merge(workers), 2);
@@ -217,7 +217,7 @@ public abstract class Scheduler {
      * subscription to the second.
      * 
      * <pre>
-     * Scheduler limitSched = Schedulers.computation().when(workers -> {
+     * Scheduler limitScheduler = Schedulers.computation().when(workers -> {
      *  // use merge max concurrent to limit the number of concurrent
      *  // Flowables two at a time
      *  return Completable.merge(Flowable.merge(workers, 2));
@@ -230,7 +230,7 @@ public abstract class Scheduler {
      * bucket algorithm).
      * 
      * <pre>
-     * Scheduler slowSched = Schedulers.computation().when(workers -> {
+     * Scheduler slowScheduler = Schedulers.computation().when(workers -> {
      *  // use concatenate to make each worker happen one at a time.
      *  return Completable.concat(workers.map(actions -> {
      *      // delay the starting of the next worker by 1 second.
@@ -254,7 +254,7 @@ public abstract class Scheduler {
     /**
      * Sequential Scheduler for executing actions on a single thread or event loop.
      * <p>
-     * Unsubscribing the {@link Worker} cancels all outstanding work and allows resource cleanup.
+     * Disposing the {@link Worker} cancels all outstanding work and allows resource cleanup.
      */
     public abstract static class Worker implements Disposable {
         /**

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -457,7 +457,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * value of the {@link Future#get} method of that object, by passing the object into the {@code from}
      * method.
      * <p>
-     * <em>Important note:</em> This Single is blocking; you cannot unsubscribe from it.
+     * <em>Important note:</em> This Single is blocking; you cannot dispose it.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -486,7 +486,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * the return value of the {@link Future#get} method of that object, by passing the object into the
      * {@code from} method.
      * <p>
-     * <em>Important note:</em> This {@code Single} is blocking; you cannot unsubscribe from it.
+     * <em>Important note:</em> This {@code Single} is blocking; you cannot dispose it.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -519,7 +519,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * the return value of the {@link Future#get} method of that object, by passing the object into the
      * {@code from} method.
      * <p>
-     * <em>Important note:</em> This {@code Single} is blocking; you cannot unsubscribe from it.
+     * <em>Important note:</em> This {@code Single} is blocking; you cannot dispose it.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>You specify the {@link Scheduler} where the blocking wait will happen.</dd>

--- a/src/main/java/io/reactivex/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/exceptions/CompositeException.java
@@ -49,7 +49,7 @@ public final class CompositeException extends RuntimeException {
      */
     public CompositeException(Throwable... exceptions) {
         this(exceptions == null ?
-            Arrays.asList(new NullPointerException("exceptions was null")) : Arrays.asList(exceptions));
+                Collections.singletonList(new NullPointerException("exceptions was null")) : Arrays.asList(exceptions));
     }
 
     /**
@@ -129,7 +129,7 @@ public final class CompositeException extends RuntimeException {
                     chain.initCause(e);
                 } catch (Throwable t) { // NOPMD
                     // ignore
-                    // the javadocs say that some Throwables (depending on how they're made) will never
+                    // the JavaDocs say that some Throwables (depending on how they're made) will never
                     // let me call initCause without blowing up even if it returns null
                 }
                 chain = getRootCause(chain);

--- a/src/main/java/io/reactivex/internal/fuseable/SimplePlainQueue.java
+++ b/src/main/java/io/reactivex/internal/fuseable/SimplePlainQueue.java
@@ -18,7 +18,7 @@ import io.reactivex.annotations.Nullable;
 /**
  * Override of the SimpleQueue interface with no throws Exception on poll().
  *
- * @param <T> the value type to enqueue and dequeue, not null
+ * @param <T> the value type to offer and poll, not null
  */
 public interface SimplePlainQueue<T> extends SimpleQueue<T> {
 

--- a/src/main/java/io/reactivex/internal/fuseable/SimpleQueue.java
+++ b/src/main/java/io/reactivex/internal/fuseable/SimpleQueue.java
@@ -18,7 +18,7 @@ import io.reactivex.annotations.*;
 /**
  * A minimalist queue interface without the method bloat of java.util.Collection and java.util.Queue.
  *
- * @param <T> the value type to enqueue and dequeue, not null
+ * @param <T> the value type to offer and poll, not null
  */
 public interface SimpleQueue<T> {
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableAmb.java
@@ -48,7 +48,7 @@ public final class CompletableAmb extends Completable {
                         sources = b;
                     }
                     sources[count++] = element;
-                };
+                }
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 EmptyDisposable.error(e, s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
@@ -167,7 +167,6 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
                 ReplaySubscription<T>[] b;
                 if (n == 1) {
                     b = EMPTY;
-                    return;
                 } else {
                     b = new ReplaySubscription[n - 1];
                     System.arraycopy(a, 0, b, 0, j);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
@@ -129,7 +129,6 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
                     if (decrementAndGet() == 0) {
                         Throwable ex = errors.terminate();
                         actual.onError(ex);
-                        return;
                     } else {
                         if (maxConcurrency != Integer.MAX_VALUE) {
                             s.request(1);
@@ -140,7 +139,6 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
                     if (getAndSet(0) > 0) {
                         Throwable ex = errors.terminate();
                         actual.onError(ex);
-                        return;
                     }
                 }
             } else {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
@@ -136,7 +136,6 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
                     if (decrementAndGet() == 0) {
                         Throwable ex = errors.terminate();
                         actual.onError(ex);
-                        return;
                     } else {
                         if (maxConcurrency != Integer.MAX_VALUE) {
                             s.request(1);
@@ -147,7 +146,6 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
                     if (getAndSet(0) > 0) {
                         Throwable ex = errors.terminate();
                         actual.onError(ex);
-                        return;
                     }
                 }
             } else {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
@@ -270,7 +270,6 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
                             s.cancel();
-                            it = null;
                             ExceptionHelper.addThrowable(error, ex);
                             ex = ExceptionHelper.terminate(error);
                             a.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindow.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindow.java
@@ -72,8 +72,6 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
         UnicastProcessor<T> window;
 
-        boolean done;
-
         WindowExactSubscriber(Subscriber<? super Flowable<T>> actual, long size, int bufferSize) {
             super(1);
             this.actual = actual;
@@ -92,10 +90,6 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
         @Override
         public void onNext(T t) {
-            if (done) {
-                return;
-            }
-
             long i = index;
 
             UnicastProcessor<T> w = window;
@@ -123,10 +117,6 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
         @Override
         public void onError(Throwable t) {
-            if (done) {
-                RxJavaPlugins.onError(t);
-                return;
-            }
             Processor<T, T> w = window;
             if (w != null) {
                 window = null;
@@ -138,10 +128,6 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
         @Override
         public void onComplete() {
-            if (done) {
-                return;
-            }
-
             Processor<T, T> w = window;
             if (w != null) {
                 window = null;
@@ -199,8 +185,6 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
         UnicastProcessor<T> window;
 
-        boolean done;
-
         WindowSkipSubscriber(Subscriber<? super Flowable<T>> actual, long size, long skip, int bufferSize) {
             super(1);
             this.actual = actual;
@@ -221,10 +205,6 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
         @Override
         public void onNext(T t) {
-            if (done) {
-                return;
-            }
-
             long i = index;
 
             UnicastProcessor<T> w = window;
@@ -258,10 +238,6 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
         @Override
         public void onError(Throwable t) {
-            if (done) {
-                RxJavaPlugins.onError(t);
-                return;
-            }
             Processor<T, T> w = window;
             if (w != null) {
                 window = null;
@@ -273,10 +249,6 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
         @Override
         public void onComplete() {
-            if (done) {
-                return;
-            }
-
             Processor<T, T> w = window;
             if (w != null) {
                 window = null;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -788,7 +788,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                                 worker.schedule(new Completion(w), timespan, unit);
                             } else {
                                 a.onError(new MissingBackpressureException("Can't emit window due to lack of requests"));
-                                continue;
                             }
                         } else {
                             ws.remove(work.w);
@@ -796,7 +795,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                             if (ws.isEmpty() && cancelled) {
                                 terminated = true;
                             }
-                            continue;
                         }
                     } else {
                         for (UnicastProcessor<T> w : ws) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableZip.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableZip.java
@@ -98,8 +98,6 @@ public final class FlowableZip<T, R> extends Flowable<R> {
 
         final boolean delayErrors;
 
-        volatile boolean done;
-
         volatile boolean cancelled;
 
         final Object[] current;
@@ -112,7 +110,7 @@ public final class FlowableZip<T, R> extends Flowable<R> {
             @SuppressWarnings("unchecked")
             ZipSubscriber<T, R>[] a = new ZipSubscriber[n];
             for (int i = 0; i < n; i++) {
-                a[i] = new ZipSubscriber<T, R>(this, prefetch, i);
+                a[i] = new ZipSubscriber<T, R>(this, prefetch);
             }
             this.current = new Object[n];
             this.subscribers = a;
@@ -123,7 +121,7 @@ public final class FlowableZip<T, R> extends Flowable<R> {
         void subscribe(Publisher<? extends T>[] sources, int n) {
             ZipSubscriber<T, R>[] a = subscribers;
             for (int i = 0; i < n; i++) {
-                if (done || cancelled || (!delayErrors && errors.get() != null)) {
+                if (cancelled || (!delayErrors && errors.get() != null)) {
                     return;
                 }
                 sources[i].subscribe(a[i]);
@@ -333,8 +331,6 @@ public final class FlowableZip<T, R> extends Flowable<R> {
 
         final int limit;
 
-        final int index;
-
         SimpleQueue<T> queue;
 
         long produced;
@@ -343,10 +339,9 @@ public final class FlowableZip<T, R> extends Flowable<R> {
 
         int sourceMode;
 
-        ZipSubscriber(ZipCoordinator<T, R> parent, int prefetch, int index) {
+        ZipSubscriber(ZipCoordinator<T, R> parent, int prefetch) {
             this.parent = parent;
             this.prefetch = prefetch;
-            this.index = index;
             this.limit = prefetch - (prefetch >> 2);
         }
 

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowable.java
@@ -89,12 +89,12 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
 
         @Override
         public void onSuccess(T value) {
-            Iterator<? extends R> iter;
+            Iterator<? extends R> iterator;
             boolean has;
             try {
-                iter = mapper.apply(value).iterator();
+                iterator = mapper.apply(value).iterator();
 
-                has = iter.hasNext();
+                has = iterator.hasNext();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 actual.onError(ex);
@@ -106,7 +106,7 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
                 return;
             }
 
-            this.it = iter;
+            this.it = iterator;
             drain();
         }
 
@@ -136,7 +136,7 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
             d = DisposableHelper.DISPOSED;
         }
 
-        void fastPath(Subscriber<? super R> a, Iterator<? extends R> iter) {
+        void fastPath(Subscriber<? super R> a, Iterator<? extends R> iterator) {
             for (;;) {
                 if (cancelled) {
                     return;
@@ -145,7 +145,7 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
                 R v;
 
                 try {
-                    v = iter.next();
+                    v = iterator.next();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     a.onError(ex);
@@ -162,7 +162,7 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
                 boolean b;
 
                 try {
-                    b = iter.hasNext();
+                    b = iterator.hasNext();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     a.onError(ex);
@@ -182,9 +182,9 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
             }
 
             Subscriber<? super R> a = actual;
-            Iterator<? extends R> iter = this.it;
+            Iterator<? extends R> iterator = this.it;
 
-            if (outputFused && iter != null) {
+            if (outputFused && iterator != null) {
                 a.onNext(null);
                 a.onComplete();
                 return;
@@ -194,11 +194,11 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
 
             for (;;) {
 
-                if (iter != null) {
+                if (iterator != null) {
                     long r = requested.get();
 
                     if (r == Long.MAX_VALUE) {
-                        fastPath(a, iter);
+                        fastPath(a, iterator);
                         return;
                     }
 
@@ -212,7 +212,7 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
                         R v;
 
                         try {
-                            v = ObjectHelper.requireNonNull(iter.next(), "The iterator returned a null value");
+                            v = ObjectHelper.requireNonNull(iterator.next(), "The iterator returned a null value");
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
                             a.onError(ex);
@@ -230,7 +230,7 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
                         boolean b;
 
                         try {
-                            b = iter.hasNext();
+                            b = iterator.hasNext();
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
                             a.onError(ex);
@@ -253,8 +253,8 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
                     break;
                 }
 
-                if (iter == null) {
-                    iter = it;
+                if (iterator == null) {
+                    iterator = it;
                 }
             }
         }
@@ -281,11 +281,11 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
         @Nullable
         @Override
         public R poll() throws Exception {
-            Iterator<? extends R> iter = it;
+            Iterator<? extends R> iterator = it;
 
-            if (iter != null) {
-                R v = ObjectHelper.requireNonNull(iter.next(), "The iterator returned a null value");
-                if (!iter.hasNext()) {
+            if (iterator != null) {
+                R v = ObjectHelper.requireNonNull(iterator.next(), "The iterator returned a null value");
+                if (!iterator.hasNext()) {
                     it = null;
                 }
                 return v;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservable.java
@@ -82,12 +82,12 @@ public final class MaybeFlatMapIterableObservable<T, R> extends Observable<R> {
         public void onSuccess(T value) {
             Observer<? super R> a = actual;
 
-            Iterator<? extends R> iter;
+            Iterator<? extends R> iterator;
             boolean has;
             try {
-                iter = mapper.apply(value).iterator();
+                iterator = mapper.apply(value).iterator();
 
-                has = iter.hasNext();
+                has = iterator.hasNext();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 a.onError(ex);
@@ -99,7 +99,7 @@ public final class MaybeFlatMapIterableObservable<T, R> extends Observable<R> {
                 return;
             }
 
-            this.it = iter;
+            this.it = iterator;
 
             if (outputFused) {
                 a.onNext(null);
@@ -115,7 +115,7 @@ public final class MaybeFlatMapIterableObservable<T, R> extends Observable<R> {
                 R v;
 
                 try {
-                    v = iter.next();
+                    v = iterator.next();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     a.onError(ex);
@@ -132,7 +132,7 @@ public final class MaybeFlatMapIterableObservable<T, R> extends Observable<R> {
                 boolean b;
 
                 try {
-                    b = iter.hasNext();
+                    b = iterator.hasNext();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     a.onError(ex);
@@ -191,11 +191,11 @@ public final class MaybeFlatMapIterableObservable<T, R> extends Observable<R> {
         @Nullable
         @Override
         public R poll() throws Exception {
-            Iterator<? extends R> iter = it;
+            Iterator<? extends R> iterator = it;
 
-            if (iter != null) {
-                R v = ObjectHelper.requireNonNull(iter.next(), "The iterator returned a null value");
-                if (!iter.hasNext()) {
+            if (iterator != null) {
+                R v = ObjectHelper.requireNonNull(iterator.next(), "The iterator returned a null value");
+                if (!iterator.hasNext()) {
                     it = null;
                 }
                 return v;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapEager.java
@@ -372,7 +372,6 @@ public final class ObservableConcatMapEager<T, R> extends AbstractObservableWith
                             error.addThrowable(ex);
 
                             current = null;
-                            active = null;
                             activeCount--;
                             continue outer;
                         }
@@ -381,7 +380,6 @@ public final class ObservableConcatMapEager<T, R> extends AbstractObservableWith
 
                         if (d && empty) {
                             current = null;
-                            active = null;
                             activeCount--;
                             continue outer;
                         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
@@ -83,7 +83,6 @@ public final class ObservableDistinctUntilChanged<T, K> extends AbstractObservab
             }
 
             actual.onNext(t);
-            return;
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -405,7 +405,6 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                         @SuppressWarnings("unchecked")
                         InnerObserver<T, U> is = (InnerObserver<T, U>)inner[j];
 
-                        U o = null;
                         for (;;) {
                             if (checkTerminate()) {
                                 return;
@@ -414,6 +413,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                             if (q == null) {
                                 break;
                             }
+                            U o;
                             for (;;) {
                                 try {
                                     o = q.poll();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
@@ -111,14 +111,12 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
                     if (decrementAndGet() == 0) {
                         Throwable ex = errors.terminate();
                         actual.onError(ex);
-                        return;
                     }
                 } else {
                     dispose();
                     if (getAndSet(0) > 0) {
                         Throwable ex = errors.terminate();
                         actual.onError(ex);
-                        return;
                     }
                 }
             } else {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
@@ -116,14 +116,12 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
                     if (decrementAndGet() == 0) {
                         Throwable ex = errors.terminate();
                         actual.onError(ex);
-                        return;
                     }
                 } else {
                     dispose();
                     if (getAndSet(0) > 0) {
                         Throwable ex = errors.terminate();
                         actual.onError(ex);
-                        return;
                     }
                 }
             } else {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimed.java
@@ -61,7 +61,6 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
 
         volatile boolean cancelled;
 
-        volatile boolean done;
         Throwable error;
 
         TakeLastTimedObserver(Observer<? super T> actual, long count, long time, TimeUnit unit, Scheduler scheduler, int bufferSize, boolean delayError) {
@@ -107,13 +106,11 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
         @Override
         public void onError(Throwable t) {
             error = t;
-            done = true;
             drain();
         }
 
         @Override
         public void onComplete() {
-            done = true;
             drain();
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowTimed.java
@@ -694,7 +694,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                             if (ws.isEmpty() && cancelled) {
                                 terminated = true;
                             }
-                            continue;
                         }
                     } else {
                         for (UnicastSubject<T> w : ws) {

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelCollect.java
@@ -126,7 +126,6 @@ public final class ParallelCollect<T, C> extends ParallelFlowable<C> {
                 Exceptions.throwIfFatal(ex);
                 cancel();
                 onError(ex);
-                return;
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFilterTry.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFilterTry.java
@@ -249,10 +249,7 @@ public final class ParallelFilterTry<T> extends ParallelFlowable<T> {
                         }
                     }
 
-                    if (b) {
-                        return actual.tryOnNext(t);
-                    }
-                    return false;
+                    return b && actual.tryOnNext(t);
                 }
             }
             return false;

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromPublisher.java
@@ -282,9 +282,9 @@ public final class ParallelFromPublisher<T> extends ParallelFlowable<T> {
                         break;
                     }
 
-                    long ridx = r.get(idx);
-                    long eidx = e[idx];
-                    if (ridx != eidx && r.get(n + idx) == 0) {
+                    long requestAtIndex = r.get(idx);
+                    long emissionAtIndex = e[idx];
+                    if (requestAtIndex != emissionAtIndex && r.get(n + idx) == 0) {
 
                         T v;
 
@@ -305,7 +305,7 @@ public final class ParallelFromPublisher<T> extends ParallelFlowable<T> {
 
                         a[idx].onNext(v);
 
-                        e[idx] = eidx + 1;
+                        e[idx] = emissionAtIndex + 1;
 
                         int c = ++consumed;
                         if (c == limit) {
@@ -370,9 +370,9 @@ public final class ParallelFromPublisher<T> extends ParallelFlowable<T> {
                         return;
                     }
 
-                    long ridx = r.get(idx);
-                    long eidx = e[idx];
-                    if (ridx != eidx && r.get(n + idx) == 0) {
+                    long requestAtIndex = r.get(idx);
+                    long emissionAtIndex = e[idx];
+                    if (requestAtIndex != emissionAtIndex && r.get(n + idx) == 0) {
 
                         T v;
 
@@ -396,7 +396,7 @@ public final class ParallelFromPublisher<T> extends ParallelFlowable<T> {
 
                         a[idx].onNext(v);
 
-                        e[idx] = eidx + 1;
+                        e[idx] = emissionAtIndex + 1;
 
                         notReady = 0;
                     } else {

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelJoin.java
@@ -110,13 +110,15 @@ public final class ParallelJoin<T> extends Flowable<T> {
         }
 
         void cancelAll() {
-            for (JoinInnerSubscriber<T> s : subscribers) {
+            for (int i = 0; i < subscribers.length; i++) {
+                JoinInnerSubscriber<T> s = subscribers[i];
                 s.cancel();
             }
         }
 
         void cleanup() {
-            for (JoinInnerSubscriber<T> s : subscribers) {
+            for (int i = 0; i < subscribers.length; i++) {
+                JoinInnerSubscriber<T> s = subscribers[i];
                 s.queue = null;
             }
         }
@@ -238,7 +240,8 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     boolean empty = true;
 
-                    for (JoinInnerSubscriber<T> inner : s) {
+                    for (int i = 0; i < s.length; i++) {
+                        JoinInnerSubscriber<T> inner = s[i];
                         SimplePlainQueue<T> q = inner.queue;
                         if (q != null) {
                             T v = q.poll();

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelJoin.java
@@ -238,9 +238,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     boolean empty = true;
 
-                    for (int i = 0; i < n; i++) {
-                        JoinInnerSubscriber<T> inner = s[i];
-
+                    for (JoinInnerSubscriber<T> inner : s) {
                         SimplePlainQueue<T> q = inner.queue;
                         if (q != null) {
                             T v = q.poll();

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelPeek.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelPeek.java
@@ -159,7 +159,6 @@ public final class ParallelPeek<T> extends ParallelFlowable<T> {
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     onError(ex);
-                    return;
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowable.java
@@ -89,12 +89,12 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
 
         @Override
         public void onSuccess(T value) {
-            Iterator<? extends R> iter;
+            Iterator<? extends R> iterator;
             boolean has;
             try {
-                iter = mapper.apply(value).iterator();
+                iterator = mapper.apply(value).iterator();
 
-                has = iter.hasNext();
+                has = iterator.hasNext();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 actual.onError(ex);
@@ -106,7 +106,7 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
                 return;
             }
 
-            this.it = iter;
+            this.it = iterator;
             drain();
         }
 
@@ -137,9 +137,9 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
             }
 
             Subscriber<? super R> a = actual;
-            Iterator<? extends R> iter = this.it;
+            Iterator<? extends R> iterator = this.it;
 
-            if (outputFused && iter != null) {
+            if (outputFused && iterator != null) {
                 a.onNext(null);
                 a.onComplete();
                 return;
@@ -149,12 +149,12 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
 
             for (;;) {
 
-                if (iter != null) {
+                if (iterator != null) {
                     long r = requested.get();
                     long e = 0L;
 
                     if (r == Long.MAX_VALUE) {
-                        slowPath(a, iter);
+                        slowPath(a, iterator);
                         return;
                     }
 
@@ -166,7 +166,7 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
                         R v;
 
                         try {
-                            v = ObjectHelper.requireNonNull(iter.next(), "The iterator returned a null value");
+                            v = ObjectHelper.requireNonNull(iterator.next(), "The iterator returned a null value");
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
                             a.onError(ex);
@@ -184,7 +184,7 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
                         boolean b;
 
                         try {
-                            b = iter.hasNext();
+                            b = iterator.hasNext();
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
                             a.onError(ex);
@@ -207,13 +207,13 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
                     break;
                 }
 
-                if (iter == null) {
-                    iter = it;
+                if (iterator == null) {
+                    iterator = it;
                 }
             }
         }
 
-        void slowPath(Subscriber<? super R> a, Iterator<? extends R> iter) {
+        void slowPath(Subscriber<? super R> a, Iterator<? extends R> iterator) {
             for (;;) {
                 if (cancelled) {
                     return;
@@ -222,7 +222,7 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
                 R v;
 
                 try {
-                    v = iter.next();
+                    v = iterator.next();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     a.onError(ex);
@@ -239,7 +239,7 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
                 boolean b;
 
                 try {
-                    b = iter.hasNext();
+                    b = iterator.hasNext();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     a.onError(ex);
@@ -275,11 +275,11 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
         @Nullable
         @Override
         public R poll() throws Exception {
-            Iterator<? extends R> iter = it;
+            Iterator<? extends R> iterator = it;
 
-            if (iter != null) {
-                R v = ObjectHelper.requireNonNull(iter.next(), "The iterator returned a null value");
-                if (!iter.hasNext()) {
+            if (iterator != null) {
+                R v = ObjectHelper.requireNonNull(iterator.next(), "The iterator returned a null value");
+                if (!iterator.hasNext()) {
                     it = null;
                 }
                 return v;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservable.java
@@ -83,12 +83,12 @@ public final class SingleFlatMapIterableObservable<T, R> extends Observable<R> {
         @Override
         public void onSuccess(T value) {
             Observer<? super R> a = actual;
-            Iterator<? extends R> iter;
+            Iterator<? extends R> iterator;
             boolean has;
             try {
-                iter = mapper.apply(value).iterator();
+                iterator = mapper.apply(value).iterator();
 
-                has = iter.hasNext();
+                has = iterator.hasNext();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 actual.onError(ex);
@@ -101,7 +101,7 @@ public final class SingleFlatMapIterableObservable<T, R> extends Observable<R> {
             }
 
             if (outputFused) {
-                it = iter;
+                it = iterator;
                 a.onNext(null);
                 a.onComplete();
             } else {
@@ -113,7 +113,7 @@ public final class SingleFlatMapIterableObservable<T, R> extends Observable<R> {
                     R v;
 
                     try {
-                        v = iter.next();
+                        v = iterator.next();
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
                         a.onError(ex);
@@ -130,7 +130,7 @@ public final class SingleFlatMapIterableObservable<T, R> extends Observable<R> {
                     boolean b;
 
                     try {
-                        b = iter.hasNext();
+                        b = iterator.hasNext();
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
                         a.onError(ex);
@@ -185,11 +185,11 @@ public final class SingleFlatMapIterableObservable<T, R> extends Observable<R> {
         @Nullable
         @Override
         public R poll() throws Exception {
-            Iterator<? extends R> iter = it;
+            Iterator<? extends R> iterator = it;
 
-            if (iter != null) {
-                R v = ObjectHelper.requireNonNull(iter.next(), "The iterator returned a null value");
-                if (!iter.hasNext()) {
+            if (iterator != null) {
+                R v = ObjectHelper.requireNonNull(iterator.next(), "The iterator returned a null value");
+                if (!iterator.hasNext()) {
                     it = null;
                 }
                 return v;

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
@@ -61,7 +61,7 @@ import io.reactivex.processors.UnicastProcessor;
  * thread pool:
  * 
  * <pre>
- * Scheduler limitSched = Schedulers.computation().when(workers -> {
+ * Scheduler limitScheduler = Schedulers.computation().when(workers -> {
  *  // use merge max concurrent to limit the number of concurrent
  *  // callbacks two at a time
  *  return Completable.merge(Observable.merge(workers), 2);
@@ -79,7 +79,7 @@ import io.reactivex.processors.UnicastProcessor;
  * to the second.
  * 
  * <pre>
- * Scheduler limitSched = Schedulers.computation().when(workers -> {
+ * Scheduler limitScheduler = Schedulers.computation().when(workers -> {
  *  // use merge max concurrent to limit the number of concurrent
  *  // Observables two at a time
  *  return Completable.merge(Observable.merge(workers, 2));
@@ -92,7 +92,7 @@ import io.reactivex.processors.UnicastProcessor;
  * algorithm).
  * 
  * <pre>
- * Scheduler slowSched = Schedulers.computation().when(workers -> {
+ * Scheduler slowScheduler = Schedulers.computation().when(workers -> {
  *  // use concatenate to make each worker happen one at a time.
  *  return Completable.concat(workers.map(actions -> {
  *      // delay the starting of the next worker by 1 second.
@@ -245,8 +245,8 @@ public class SchedulerWhen extends Scheduler implements Disposable {
     }
 
     static class OnCompletedAction implements Runnable {
-        private CompletableObserver actionCompletable;
-        private Runnable action;
+        final CompletableObserver actionCompletable;
+        final Runnable action;
 
         OnCompletedAction(Runnable action, CompletableObserver actionCompletable) {
             this.action = action;

--- a/src/main/java/io/reactivex/internal/util/AppendOnlyLinkedArrayList.java
+++ b/src/main/java/io/reactivex/internal/util/AppendOnlyLinkedArrayList.java
@@ -117,7 +117,7 @@ public class AppendOnlyLinkedArrayList<T> {
                 }
 
                 if (NotificationLite.acceptFull(o, subscriber)) {
-                    break;
+                    return true;
                 }
             }
             a = (Object[])a[c];
@@ -145,7 +145,7 @@ public class AppendOnlyLinkedArrayList<T> {
                 }
 
                 if (NotificationLite.acceptFull(o, observer)) {
-                    break;
+                    return true;
                 }
             }
             a = (Object[])a[c];

--- a/src/main/java/io/reactivex/internal/util/MergerBiFunction.java
+++ b/src/main/java/io/reactivex/internal/util/MergerBiFunction.java
@@ -23,7 +23,7 @@ import io.reactivex.functions.BiFunction;
  */
 public final class MergerBiFunction<T> implements BiFunction<List<T>, List<T>, List<T>> {
 
-    Comparator<? super T> comparator;
+    final Comparator<? super T> comparator;
 
     public MergerBiFunction(Comparator<? super T> comparator) {
         this.comparator = comparator;

--- a/src/main/java/io/reactivex/internal/util/SorterFunction.java
+++ b/src/main/java/io/reactivex/internal/util/SorterFunction.java
@@ -19,7 +19,7 @@ import io.reactivex.functions.Function;
 
 public final class SorterFunction<T> implements Function<List<T>, List<T>> {
 
-    Comparator<? super T> comparator;
+    final Comparator<? super T> comparator;
 
     public SorterFunction(Comparator<? super T> comparator) {
         this.comparator = comparator;

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -89,7 +89,7 @@ public abstract class ParallelFlowable<T> {
     }
 
     /**
-     * Take a Publisher and prepare to consume it on parallallism number of 'rails' in a round-robin fashion.
+     * Take a Publisher and prepare to consume it on parallelism number of 'rails' in a round-robin fashion.
      * @param <T> the value type
      * @param source the source Publisher
      * @param parallelism the number of parallel rails
@@ -101,7 +101,7 @@ public abstract class ParallelFlowable<T> {
     }
 
     /**
-     * Take a Publisher and prepare to consume it on parallallism number of 'rails' ,
+     * Take a Publisher and prepare to consume it on parallelism number of 'rails' ,
      * possibly ordered and round-robin fashion and use custom prefetch amount and queue
      * for dealing with the source Publisher's values.
      * @param <T> the value type
@@ -453,7 +453,7 @@ public abstract class ParallelFlowable<T> {
      * This operator requires a finite source ParallelFlowable.
      *
      * @param comparator the comparator to compare elements
-     * @return the new Px instannce
+     * @return the new Flowable instance
      */
     @CheckReturnValue
     public final Flowable<List<T>> toSortedList(@NonNull Comparator<? super T> comparator) {
@@ -466,7 +466,7 @@ public abstract class ParallelFlowable<T> {
      *
      * @param comparator the comparator to compare elements
      * @param capacityHint the expected number of total elements
-     * @return the new Px instannce
+     * @return the new Flowable instance
      */
     @CheckReturnValue
     public final Flowable<List<T>> toSortedList(@NonNull Comparator<? super T> comparator, int capacityHint) {
@@ -695,7 +695,7 @@ public abstract class ParallelFlowable<T> {
      *
      * @param <C> the collection type
      * @param collectionSupplier the supplier of the collection in each rail
-     * @param collector the collector, taking the per-rali collection and the current item
+     * @param collector the collector, taking the per-rail collection and the current item
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -387,7 +387,7 @@ public final class RxJavaPlugins {
      * bug cases that should pass through {@link #onError(Throwable)}
      * as is.
      * @param error the error to check
-     * @return true if the error should pass throug, false if
+     * @return true if the error should pass through, false if
      * it may be wrapped into an UndeliverableException
      */
     static boolean isBug(Throwable error) {
@@ -1166,7 +1166,7 @@ public final class RxJavaPlugins {
     }
 
     /**
-     * Set the handler that is called when an operator attemts a blocking
+     * Set the handler that is called when an operator attempts a blocking
      * await; the handler should return true to prevent the blocking
      * and to signal an IllegalStateException instead.
      * @param handler the handler to set, null resets to the default handler

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -900,7 +900,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
 
                 if (e != 0L) {
                     if (rs.requested.get() != Long.MAX_VALUE) {
-                        r = rs.requested.addAndGet(e);
+                        rs.requested.addAndGet(e);
                     }
                 }
 
@@ -1173,7 +1173,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
 
                 if (e != 0L) {
                     if (rs.requested.get() != Long.MAX_VALUE) {
-                        r = rs.requested.addAndGet(e);
+                        rs.requested.addAndGet(e);
                     }
                 }
 


### PR DESCRIPTION
This PR is the result of running IntelliJ inspections on the code:

  - replace `unsubscribe` with `cancel` and `dispose` in the main classes to better match the 2.x terminology
  - write out a couple of local variables
  - remove unnecessary `return` and `continue` statements
  - remove unnecessary variable writes
  - remove unnecessary and unused fields
  - add `final` to some fields
  - fix typos 