### PR TITLE
2.x: fix CallbackCompletableObserver calling onError, ResourceX wording

### DIFF
--- a/src/main/java/io/reactivex/internal/observers/CallbackCompletableObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/CallbackCompletableObserver.java
@@ -52,8 +52,7 @@ extends AtomicReference<Disposable> implements CompletableObserver, Disposable, 
             onComplete.run();
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
-            onError(ex);
-            return;
+            RxJavaPlugins.onError(ex);
         }
         lazySet(DisposableHelper.DISPOSED);
     }

--- a/src/main/java/io/reactivex/observers/DisposableObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableObserver.java
@@ -24,7 +24,7 @@ import io.reactivex.internal.disposables.*;
  *
  * <p>All pre-implemented final methods are thread-safe.
  *
- * <p>Use the protected {@link #dispose()} to dispose the sequence from within an
+ * <p>Use the public {@link #dispose()} method to dispose the sequence from within an
  * {@code onNext} implementation.
  *
  * <p>Like all other consumers, {@code DefaultObserver} can be subscribed only once.

--- a/src/main/java/io/reactivex/observers/ResourceCompletableObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceCompletableObserver.java
@@ -29,7 +29,7 @@ import io.reactivex.internal.functions.ObjectHelper;
  * <p>Override the protected {@link #onStart()} to perform initialization when this
  * {@code ResourceCompletableObserver} is subscribed to a source.
  *
- * <p>Use the protected {@link #dispose()} to dispose the sequence externally and release
+ * <p>Use the public {@link #dispose()} method to dispose the sequence externally and release
  * all resources.
  *
  * <p>To release the associated resources, one has to call {@link #dispose()}

--- a/src/main/java/io/reactivex/observers/ResourceMaybeObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceMaybeObserver.java
@@ -33,7 +33,7 @@ import io.reactivex.internal.functions.ObjectHelper;
  * <p>Override the protected {@link #onStart()} to perform initialization when this
  * {@code ResourceMaybeObserver} is subscribed to a source.
  *
- * <p>Use the protected {@link #dispose()} to dispose the sequence externally and release
+ * <p>Use the public {@link #dispose()} method to dispose the sequence externally and release
  * all resources.
  *
  * <p>To release the associated resources, one has to call {@link #dispose()}

--- a/src/main/java/io/reactivex/observers/ResourceSingleObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceSingleObserver.java
@@ -30,7 +30,7 @@ import io.reactivex.internal.functions.ObjectHelper;
  * <p>Override the protected {@link #onStart()} to perform initialization when this
  * {@code ResourceSingleObserver} is subscribed to a source.
  *
- * <p>Use the protected {@link #dispose()} to dispose the sequence externally and release
+ * <p>Use the public {@link #dispose()} method to dispose the sequence externally and release
  * all resources.
  *
  * <p>To release the associated resources, one has to call {@link #dispose()}

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -2566,18 +2566,24 @@ public class CompletableTest {
 
     @Test(timeout = 5000)
     public void subscribeTwoCallbacksCompleteThrows() {
-        final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
-        normal.completable.subscribe(new Action() {
-            @Override
-            public void run() { throw new TestException(); }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) {
-                err.set(e);
-            }
-        });
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
+            normal.completable.subscribe(new Action() {
+                @Override
+                public void run() { throw new TestException(); }
+            }, new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable e) {
+                    err.set(e);
+                }
+            });
 
-        Assert.assertTrue(String.valueOf(err.get()), err.get() instanceof TestException);
+            Assert.assertNull(err.get());
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/io/reactivex/schedulers/TimedTest.java
+++ b/src/test/java/io/reactivex/schedulers/TimedTest.java
@@ -84,7 +84,7 @@ public class TimedTest {
 
         assertEquals("Timed[time=5, unit=SECONDS, value=1]", t1.toString());
     }
-    
+
     @Test(expected = NullPointerException.class)
     public void timeUnitNullFail() throws Exception {
         new Timed<Integer>(1, 5, null);


### PR DESCRIPTION
This PR contains the fix for incorrect call of the `onError` handler within `CallbackCompletableObserver.onComplete()` reported in [5099](https://github.com/ReactiveX/RxJava/issues/5099#issuecomment-289544756) as well as wording fixes to the `ResourceX` javadoc.