### PR TITLE
1.x fix async single error report (bug #5237)

### DIFF
--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -1819,18 +1819,23 @@ public class Single<T> {
         } catch (Throwable e) {
             // special handling for certain Throwable/Error/Exception types
             Exceptions.throwIfFatal(e);
-            // if an unhandled error occurs executing the onSubscribe we will propagate it
-            try {
-                subscriber.onError(RxJavaHooks.onSingleError(e));
-            } catch (Throwable e2) {
-                Exceptions.throwIfFatal(e2);
-                // if this happens it means the onError itself failed (perhaps an invalid function implementation)
-                // so we are unable to propagate the error correctly and will just throw
-                RuntimeException r = new RuntimeException("Error occurred attempting to subscribe [" + e.getMessage() + "] and then again while trying to pass to onError.", e2);
-                // TODO could the hook be the cause of the error in the on error handling.
-                RxJavaHooks.onSingleError(r);
-                // TODO why aren't we throwing the hook's return value.
-                throw r; // NOPMD
+            // in case the subscriber can't listen to exceptions anymore
+            if (subscriber.isUnsubscribed()) {
+                RxJavaHooks.onError(RxJavaHooks.onSingleError(e));
+            } else {
+                // if an unhandled error occurs executing the onSubscribe we will propagate it
+                try {
+                    subscriber.onError(RxJavaHooks.onSingleError(e));
+                } catch (Throwable e2) {
+                    Exceptions.throwIfFatal(e2);
+                    // if this happens it means the onError itself failed (perhaps an invalid function implementation)
+                    // so we are unable to propagate the error correctly and will just throw
+                    RuntimeException r = new OnErrorFailedException("Error occurred attempting to subscribe [" + e.getMessage() + "] and then again while trying to pass to onError.", e2);
+                    // TODO could the hook be the cause of the error in the on error handling.
+                    RxJavaHooks.onSingleError(r);
+                    // TODO why aren't we throwing the hook's return value.
+                    throw r; // NOPMD
+                }
             }
             return Subscriptions.unsubscribed();
         }
@@ -1968,46 +1973,56 @@ public class Single<T> {
         try {
             RxJavaHooks.onSingleStart(this, onSubscribe).call(subscriber);
             return RxJavaHooks.onSingleReturn(subscriber);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            // if an unhandled error occurs executing the onSubscribe we will propagate it
-            try {
-                subscriber.onError(RxJavaHooks.onSingleError(ex));
-            } catch (Throwable e2) {
-                Exceptions.throwIfFatal(e2);
-                // if this happens it means the onError itself failed (perhaps an invalid function implementation)
-                // so we are unable to propagate the error correctly and will just throw
-                RuntimeException r = new RuntimeException("Error occurred attempting to subscribe [" + ex.getMessage() + "] and then again while trying to pass to onError.", e2);
-                // TODO could the hook be the cause of the error in the on error handling.
-                RxJavaHooks.onSingleError(r);
-                // TODO why aren't we throwing the hook's return value.
-                throw r; // NOPMD
+        } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
+            // in case the subscriber can't listen to exceptions anymore
+            if (subscriber.isUnsubscribed()) {
+                RxJavaHooks.onError(RxJavaHooks.onSingleError(e));
+            } else {
+                // if an unhandled error occurs executing the onSubscribe we will propagate it
+                try {
+                    subscriber.onError(RxJavaHooks.onSingleError(e));
+                } catch (Throwable e2) {
+                    Exceptions.throwIfFatal(e2);
+                    // if this happens it means the onError itself failed (perhaps an invalid function implementation)
+                    // so we are unable to propagate the error correctly and will just throw
+                    RuntimeException r = new OnErrorFailedException("Error occurred attempting to subscribe [" + e.getMessage() + "] and then again while trying to pass to onError.", e2);
+                    // TODO could the hook be the cause of the error in the on error handling.
+                    RxJavaHooks.onSingleError(r);
+                    // TODO why aren't we throwing the hook's return value.
+                    throw r; // NOPMD
+                }
             }
             return Subscriptions.unsubscribed();
         }
     }
 
-    private final Subscription unsafeSubscribe(SingleSubscriber<? super T> subscriber) {
+    private Subscription unsafeSubscribe(SingleSubscriber<? super T> subscriber) {
 
         // The code below is exactly the same an unsafeSubscribe but not used because it would
         // add a significant depth to already huge call stacks.
         try {
             RxJavaHooks.onSingleStart(this, onSubscribe).call(subscriber);
             return RxJavaHooks.onSingleReturn(subscriber);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            // if an unhandled error occurs executing the onSubscribe we will propagate it
-            try {
-                subscriber.onError(RxJavaHooks.onSingleError(ex));
-            } catch (Throwable e2) {
-                Exceptions.throwIfFatal(e2);
-                // if this happens it means the onError itself failed (perhaps an invalid function implementation)
-                // so we are unable to propagate the error correctly and will just throw
-                RuntimeException r = new RuntimeException("Error occurred attempting to subscribe [" + ex.getMessage() + "] and then again while trying to pass to onError.", e2);
-                // TODO could the hook be the cause of the error in the on error handling.
-                RxJavaHooks.onSingleError(r);
-                // TODO why aren't we throwing the hook's return value.
-                throw r; // NOPMD
+        } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
+            // in case the subscriber can't listen to exceptions anymore
+            if (subscriber.isUnsubscribed()) {
+                RxJavaHooks.onError(RxJavaHooks.onSingleError(e));
+            } else {
+                // if an unhandled error occurs executing the onSubscribe we will propagate it
+                try {
+                    subscriber.onError(RxJavaHooks.onSingleError(e));
+                } catch (Throwable e2) {
+                    Exceptions.throwIfFatal(e2);
+                    // if this happens it means the onError itself failed (perhaps an invalid function implementation)
+                    // so we are unable to propagate the error correctly and will just throw
+                    RuntimeException r = new OnErrorFailedException("Error occurred attempting to subscribe [" + e.getMessage() + "] and then again while trying to pass to onError.", e2);
+                    // TODO could the hook be the cause of the error in the on error handling.
+                    RxJavaHooks.onSingleError(r);
+                    // TODO why aren't we throwing the hook's return value.
+                    throw r; // NOPMD
+                }
             }
             return Subscriptions.unsubscribed();
         }

--- a/src/main/java/rx/SingleSubscriber.java
+++ b/src/main/java/rx/SingleSubscriber.java
@@ -35,7 +35,22 @@ import rx.internal.util.SubscriptionList;
  */
 public abstract class SingleSubscriber<T> implements Subscription {
 
-    private final SubscriptionList cs = new SubscriptionList();
+    private final SubscriptionList subscriptions;
+
+    public SingleSubscriber() {
+        this(null);
+    }
+
+    /**
+     * Construct a SingleSubscriber by using another SingleSubscriber. This wrapper will use the
+     * subscription list of the provided SingleSubscriber.
+     *
+     * @param subscriber
+     *              the other Subscriber
+     */
+    public SingleSubscriber(SingleSubscriber<?> subscriber) {
+        this.subscriptions = subscriber != null ? subscriber.subscriptions : new SubscriptionList();
+    }
 
     /**
      * Notifies the SingleSubscriber with a single item and that the {@link Single} has finished sending
@@ -67,12 +82,12 @@ public abstract class SingleSubscriber<T> implements Subscription {
      *            the {@code Subscription} to add
      */
     public final void add(Subscription s) {
-        cs.add(s);
+        subscriptions.add(s);
     }
 
     @Override
     public final void unsubscribe() {
-        cs.unsubscribe();
+        subscriptions.unsubscribe();
     }
 
     /**
@@ -82,6 +97,6 @@ public abstract class SingleSubscriber<T> implements Subscription {
      */
     @Override
     public final boolean isUnsubscribed() {
-        return cs.isUnsubscribed();
+        return subscriptions.isUnsubscribed();
     }
 }

--- a/src/main/java/rx/SingleSubscriber.java
+++ b/src/main/java/rx/SingleSubscriber.java
@@ -26,7 +26,7 @@ import rx.internal.util.SubscriptionList;
  * once or the SingleSubscriber's {@link #onError} method exactly once.
  * <p>
  * Note, that if you want {@link #isUnsubscribed} to return {@code true} after {@link #onSuccess} or {@link #onError}
- * invocation, you need to invoke {@link #unsubscribe} in these methods.
+ * invocation, you need to invoke {@link #unsubscribe} in these methods or use {@link rx.observers.SafeSingleSubscriber}
  *
  * @see <a href="http://reactivex.io/documentation/observable.html">ReactiveX documentation: Observable</a>
  * @param <T>

--- a/src/main/java/rx/internal/util/SingleObserverSubscriber.java
+++ b/src/main/java/rx/internal/util/SingleObserverSubscriber.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.util;
+
+import rx.Observer;
+import rx.SingleSubscriber;
+
+/**
+ * Wraps an Observer and forwards the onXXX method calls to it.
+ * @param <T> the value type
+ */
+public final class SingleObserverSubscriber<T> extends SingleSubscriber<T> {
+    final Observer<? super T> observer;
+
+    public SingleObserverSubscriber(Observer<? super T> observer) {
+        this.observer = observer;
+    }
+
+    @Override
+    public void onSuccess(T t) {
+        observer.onNext(t);
+        observer.onCompleted();
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        observer.onError(e);
+    }
+}

--- a/src/main/java/rx/observers/SafeSingleSubscriber.java
+++ b/src/main/java/rx/observers/SafeSingleSubscriber.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.observers;
+
+import java.util.Arrays;
+
+import rx.SingleSubscriber;
+import rx.Subscriber;
+import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
+import rx.exceptions.OnErrorFailedException;
+import rx.exceptions.OnErrorNotImplementedException;
+import rx.exceptions.UnsubscribeFailedException;
+import rx.plugins.RxJavaHooks;
+
+/**
+ * {@code SafeSingleSubscriber} is a wrapper around {@code SingleSubscriber} that ensures that the {@code SingleSubscriber}
+ * complies with <a href="http://reactivex.io/documentation/single.html">the Single contract</a>.
+ * <p>
+ * <p>
+ * This wrapper does the following:
+ * <ul>
+ * <li>Allows only single execution of either {@code onSuccess} or {@code onError}.</li>
+ * <li>Ensures that once an {@code onCompleted} or {@code onError} is performed, no further calls can be executed</li>
+ * <li>If {@code unsubscribe} is called, the upstream {@code Observable} is notified and the event delivery will be stopped in a
+ * best effort manner (i.e., further onXXX calls may still slip through).</li>
+ * <li>When {@code onError} or {@code onCompleted} occur, unsubscribes from the {@code Observable} (if executing asynchronously).</li>
+ * </ul>
+ * {@code SafeSubscriber} will not synchronize {@code onNext} execution. Use {@link SerializedSubscriber} to do
+ * that.
+ *
+ * @param <T>
+ *            the type of item expected by the {@link Subscriber}
+ */
+public class SafeSingleSubscriber<T> extends SingleSubscriber<T> {
+
+    private final SingleSubscriber<? super T> actual;
+
+    public SafeSingleSubscriber(SingleSubscriber<? super T> actual) {
+        super(actual);
+        this.actual = actual;
+    }
+
+    /**
+     * Notifies the SingleSubscriber that the {@code Single} has received the success notification
+     * <p>
+     * The {@code Single} will not call this method if it calls {@link #onError}.
+     */
+    @Override
+    public void onSuccess(T t) {
+        try {
+            actual.onSuccess(t);
+        } catch (Throwable e) {
+            // we handle here instead of another method so we don't add stacks to the frame
+            // which can prevent it from being able to handle StackOverflow
+            Exceptions.throwOrReport(e, this);
+        } finally {
+            try {
+                // Similarly to onError if failure occurs in unsubscribe then Rx contract is broken
+                // and we throw an UnsubscribeFailureException.
+                unsubscribe();
+            } catch (Throwable e) {
+                RxJavaHooks.onError(e);
+                throw new UnsubscribeFailedException(e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Notifies the Subscriber that the {@code Single} has experienced an error condition.
+     * <p>
+     * If the {@code Single} calls this method, it will not thereafter call
+     * {@link #onSuccess(Object)}.
+     *
+     * @param e
+     *          the exception encountered by the Single
+     */
+    @Override
+    public void onError(Throwable e) {
+        // we handle here instead of another method so we don't add stacks to the frame
+        // which can prevent it from being able to handle StackOverflow
+        Exceptions.throwIfFatal(e);
+        RxJavaHooks.onSingleError(e);
+        try {
+            actual.onError(e);
+        } catch (OnErrorNotImplementedException e2) { // NOPMD
+            /*
+             * onError isn't implemented so throw
+             *
+             * https://github.com/ReactiveX/RxJava/issues/198
+             *
+             * Rx Design Guidelines 5.2
+             *
+             * "when calling the Subscribe method that only has an onNext argument, the OnError behavior
+             * will be to rethrow the exception on the thread that the message comes out from the observable
+             * sequence. The OnCompleted behavior in this case is to do nothing."
+             */
+            try {
+                unsubscribe();
+            } catch (Throwable unsubscribeException) {
+                RxJavaHooks.onSingleError(unsubscribeException);
+                throw new OnErrorNotImplementedException("Observer.onError not implemented and error while unsubscribing.", new CompositeException(Arrays.asList(e, unsubscribeException))); // NOPMD
+            }
+            throw e2;
+        } catch (Throwable e2) {
+            /*
+             * throw since the Rx contract is broken if onError failed
+             *
+             * https://github.com/ReactiveX/RxJava/issues/198
+             */
+            RxJavaHooks.onSingleError(e2);
+            try {
+                unsubscribe();
+            } catch (Throwable unsubscribeException) {
+                RxJavaHooks.onSingleError(unsubscribeException);
+                throw new OnErrorFailedException("Error occurred when trying to propagate error to Observer.onError and during unsubscription.", new CompositeException(Arrays.asList(e, e2, unsubscribeException)));
+            }
+
+            throw new OnErrorFailedException("Error occurred when trying to propagate error to Observer.onError", new CompositeException(Arrays.asList(e, e2)));
+        }
+        // if we did not throw above we will unsubscribe here, if onError failed then unsubscribe happens in the catch
+        try {
+            unsubscribe();
+        } catch (Throwable unsubscribeException) {
+            RxJavaHooks.onSingleError(unsubscribeException);
+            throw new OnErrorFailedException(unsubscribeException);
+        }
+    }
+
+    /**
+     * Returns the {@link SingleSubscriber} underlying this {@code SafeSingleSubscriber}.
+     *
+     * @return the {@link SingleSubscriber} that was used to create this {@code SafeSingleSubscriber}
+     */
+    public SingleSubscriber<? super T> getActual() {
+        return actual;
+    }
+}

--- a/src/test/java/rx/internal/operators/SingleOnSubscribeUsingTest.java
+++ b/src/test/java/rx/internal/operators/SingleOnSubscribeUsingTest.java
@@ -289,7 +289,7 @@ public class SingleOnSubscribeUsingTest {
                 .doOnSuccess(completion);
         observable.subscribe(observer);
 
-        assertEquals(Arrays.asList("disposed", "completed"/*, "unsub"*/), events);
+        assertEquals(Arrays.asList("disposed", "completed", "unsub"), events);
 
     }
 
@@ -314,7 +314,7 @@ public class SingleOnSubscribeUsingTest {
                 .doOnSuccess(completion);
         observable.subscribe(observer);
 
-        assertEquals(Arrays.asList("completed", /* "unsub",*/ "disposed"), events);
+        assertEquals(Arrays.asList("completed",  "unsub", "disposed"), events);
 
     }
 
@@ -341,7 +341,7 @@ public class SingleOnSubscribeUsingTest {
                 .doOnError(onError);
         observable.subscribe(observer);
 
-        assertEquals(Arrays.asList("disposed", "error"/*, "unsub"*/), events);
+        assertEquals(Arrays.asList("disposed", "error", "unsub"), events);
 
     }
 
@@ -366,7 +366,7 @@ public class SingleOnSubscribeUsingTest {
                 .doOnError(onError);
         observable.subscribe(observer);
 
-        assertEquals(Arrays.asList("error", /* "unsub",*/ "disposed"), events);
+        assertEquals(Arrays.asList("error",  "unsub", "disposed"), events);
     }
 
     private static Action0 createUnsubAction(final List<String> events) {


### PR DESCRIPTION
Targets issue #5237 where an `Exception` in `onSuccess` of an async `Single` wasn't forwarded to `onError`. For a sync `Single` it already gets forwarded correctly.

Example:
```java
Single.just("test")
        .delay(1, TimeUnit.MILLISECONDS)
        .subscribe(
        result -> {
            System.out.println("got text: " + result);
            throw new IllegalStateException("single async something is wrong");
            // onError will not be called, hard crash
        },
        e -> {
            // not called
            System.out.println("caught error " + e.getMessage());
            e.printStackTrace();
        });
```

I introduced `SafeSingleSubscriber` analog to `SafeSubscriber` of `Observable`. It makes sure `onError` gets called when `onSuccess` throws.

I had to introduce `private Subscription unsafeSubscribe(SingleSubscriber)` for internal usage of `Single#subscribeOn()` and `Single#unsubscribeOn()` which should *not* be wrapped by `SafeSingleSubscriber`.

Furthermore I added the `subscriber.isUnsubscribed()` case in all three `subscribe` methods analog to `Observable#subscribe`
```java
    // ...
    if (subscriber.isUnsubscribed()) {
        RxJavaHooks.onError(RxJavaHooks.onSingleError(e));
    } else {
        // try forwarding error to subscriber
    }
    // ....
```
as well as `Single#subscribe` now throws `OnErrorFailedException` instead of `RuntimeException` when calling `subscriber.onError(e)` fails.

`Single.using` is now working correctly, I uncommented the missing assertions