### PR TITLE
Defer creation of the TimeoutException when using the Single.timeout() operator

### DIFF
--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -2257,11 +2257,9 @@ public class Single<T> {
             // Use a defer instead of simply   other = Single.error(new TimeoutException())
             // since instantiating an exception will cause the current stack trace to be inspected
             // and we only want to incur that overhead when a timeout actually happens.
-            other = Single.<T>defer(new Func0<Single<T>>()
-            {
+            other = Single.<T>defer(new Func0<Single<T>>() {
                 @Override
-                public Single<T> call()
-                {
+                public Single<T> call() {
                     return Single.<T>error(new TimeoutException());
                 }
             });

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -2254,7 +2254,17 @@ public class Single<T> {
      */
     public final Single<T> timeout(long timeout, TimeUnit timeUnit, Single<? extends T> other, Scheduler scheduler) {
         if (other == null) {
-            other = Single.<T> error(new TimeoutException());
+            // Use a defer instead of simply   other = Single.error(new TimeoutException())
+            // since instantiating an exception will cause the current stack trace to be inspected
+            // and we only want to incur that overhead when a timeout actually happens.
+            other = Single.<T>defer(new Func0<Single<T>>()
+            {
+                @Override
+                public Single<T> call()
+                {
+                    return Single.<T>error(new TimeoutException());
+                }
+            });
         }
         return create(new SingleTimeout<T>(onSubscribe, timeout, timeUnit, scheduler, other.onSubscribe));
     }


### PR DESCRIPTION
Use a defer instead of simply `other = Single.error(new TimeoutException())` since instantiating an exception will cause the current stack trace to be inspected and that overhead should only be incurred when a timeout actually happens.

I caught this problem as I was investigating unusually high CPU usage in one of the systems I operate. When measuring the impact of this change in a real world situation that makes only moderate use of this operator, I observed a *11%* reduction in CPU usage.