### PR TITLE
2.x: fix flatMapIterable appearing to be empty when fused

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
@@ -411,7 +411,10 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
         @Override
         public boolean isEmpty() {
             Iterator<? extends R> it = current;
-            return (it != null && !it.hasNext()) || queue.isEmpty();
+            if (it == null) {
+                return queue.isEmpty();
+            }
+            return !it.hasNext();
         }
 
         @Nullable

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -863,4 +863,55 @@ public class FlowableFlattenIterableTest {
 
         ts.assertResult(1);
     }
+
+    @Test
+    public void doubleShare() {
+        Iterable<Integer> it = Flowable.range(1, 300).blockingIterable();
+            Flowable.just(it, it)
+            .flatMapIterable(Functions.<Iterable<Integer>>identity())
+            .share()
+            .share()
+            .count()
+            .test()
+            .assertResult(600L);
+    }
+
+    @Test
+    public void multiShare() {
+        Iterable<Integer> it = Flowable.range(1, 300).blockingIterable();
+        for (int i = 0; i < 5; i++) {
+            Flowable<Integer> f = Flowable.just(it, it)
+            .flatMapIterable(Functions.<Iterable<Integer>>identity());
+
+            for (int j = 0; j < i; j++) {
+                f = f.share();
+            }
+
+            f
+            .count()
+            .test()
+            .withTag("Share: " + i)
+            .assertResult(600L);
+        }
+    }
+
+    @Test
+    public void multiShareHidden() {
+        Iterable<Integer> it = Flowable.range(1, 300).blockingIterable();
+        for (int i = 0; i < 5; i++) {
+            Flowable<Integer> f = Flowable.just(it, it)
+            .flatMapIterable(Functions.<Iterable<Integer>>identity())
+            .hide();
+
+            for (int j = 0; j < i; j++) {
+                f = f.share();
+            }
+
+            f
+            .count()
+            .test()
+            .withTag("Share: " + i)
+            .assertResult(600L);
+        }
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
@@ -395,7 +395,7 @@ public class FlowableToListTest {
         for (int i = 0; i < 1000; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final TestObserver<List<Integer>> ts = pp.toList().test();
-            
+
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
@@ -408,10 +408,9 @@ public class FlowableToListTest {
                     ts.cancel();
                 }
             };
-            
+
             TestHelper.race(r1, r2);
         }
-        
     }
 
     @Test
@@ -419,7 +418,7 @@ public class FlowableToListTest {
         for (int i = 0; i < 1000; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final TestSubscriber<List<Integer>> ts = pp.toList().toFlowable().test();
-            
+
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
@@ -432,10 +431,10 @@ public class FlowableToListTest {
                     ts.cancel();
                 }
             };
-            
+
             TestHelper.race(r1, r2);
         }
-        
+
     }
 
     @Test
@@ -443,9 +442,9 @@ public class FlowableToListTest {
         for (int i = 0; i < 1000; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final TestSubscriber<List<Integer>> ts = pp.toList().toFlowable().test();
-            
+
             pp.onNext(1);
-            
+
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
@@ -458,14 +457,13 @@ public class FlowableToListTest {
                     ts.cancel();
                 }
             };
-            
+
             TestHelper.race(r1, r2);
-            
+
             if (ts.valueCount() != 0) {
                 ts.assertValue(Arrays.asList(1))
                 .assertNoErrors();
             }
         }
-        
     }
 }


### PR DESCRIPTION
The wrong logical expression in the `isEmpty()` method made `flatMapIterable` complete earlier, even if data was available in the current iterable.

Somewhat related: https://github.com/reactor/reactor-core/issues/508 (different logical bug in the same method).