### PR TITLE
Remove @NonNull annotations in BiConsumer method parameter

### DIFF
--- a/src/main/java/io/reactivex/functions/BiConsumer.java
+++ b/src/main/java/io/reactivex/functions/BiConsumer.java
@@ -13,8 +13,6 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
-
 /**
  * A functional interface (callback) that accepts two values (of possibly different types).
  * @param <T1> the first value type
@@ -28,5 +26,5 @@ public interface BiConsumer<T1, T2> {
      * @param t2 the second value
      * @throws Exception on error
      */
-    void accept(@NonNull T1 t1, @NonNull T2 t2) throws Exception;
+    void accept(T1 t1, T2 t2) throws Exception;
 }


### PR DESCRIPTION
This PR is part of https://github.com/ReactiveX/RxJava/issues/5216

This PR remove @NonNull annotations from ```BiConsumer``` method parameters, there's no sense use these annotations in ```Single``` context because in this case ```BiConsumer``` always brings you a null parameter.
