### PR TITLE
1.x Use IntelliJ IDE friendly assertion failure message

### DIFF
--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -337,11 +337,11 @@ public class TestSubscriber<T> extends Subscriber<T> {
         if (expected == null) {
             // check for null equality
             if (actual != null) {
-                assertionError("Value at index: " + i + " expected to be [null] but was: [" + actual + "]\n");
+                assertionError("Value at index: " + i + " expected: [null] but was: [" + actual + "]\n");
             }
         } else if (!expected.equals(actual)) {
             assertionError("Value at index: " + i
-                    + " expected to be [" + expected + "] (" + expected.getClass().getSimpleName()
+                    + " expected: [" + expected + "] (" + expected.getClass().getSimpleName()
                     + ") but was: [" + actual + "] (" + (actual != null ? actual.getClass().getSimpleName() : "null") + ")\n");
 
         }

--- a/src/test/java/rx/observers/TestSubscriberTest.java
+++ b/src/test/java/rx/observers/TestSubscriberTest.java
@@ -72,7 +72,7 @@ public class TestSubscriberTest {
         oi.subscribe(o);
 
         thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value at index: 1 expected to be [3] (Integer) but was: [2] (Integer)");
+        thrown.expectMessage("Value at index: 1 expected: [3] (Integer) but was: [2] (Integer)");
 
 
         o.assertReceivedOnNext(Arrays.asList(1, 3));


### PR DESCRIPTION
The `assertItem` failure message pattern in `TestSubscriber` does not match any of the regex patterns defined by IntelliJ to show `<Click to see difference>` link. 
![before](https://cloud.githubusercontent.com/assets/2339109/24586365/9239290c-179f-11e7-8178-38425448d3a1.jpg)

By changing the "_expected to be_" to "_expected:_", the pattern is recognised by IntelliJ and the helpful link is presented.
![after](https://cloud.githubusercontent.com/assets/2339109/24586364/9238f414-179f-11e7-9b12-e6b648318550.jpg)

The original idea from #5249 was to use the "_expected:<> but was:<>_" pattern used in JUnit, but it is not picked up on its own by IntelliJ. The AssertionError must extend from JUnit's ComparisonFailure, to get it recognised. This however requires dependency on JUnit.
![junit](https://cloud.githubusercontent.com/assets/2339109/24586389/fefd6c38-179f-11e7-8841-884bc07db404.jpg)

So in the end, the fix is just a very simple change in the message.
