### PR TITLE
2.x: Remove commented out code in IoScheduler

### DIFF
--- a/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
@@ -210,12 +210,6 @@ public final class IoScheduler extends Scheduler {
                 tasks.dispose();
 
                 // releasing the pool should be the last action
-                // should prevent pool reuse in case there is a blocking
-                // action not responding to cancellation
-//                threadWorker.scheduleDirect(() -> {
-//                    pool.release(threadWorker);
-//                }, 0, TimeUnit.MILLISECONDS);
-
                 pool.release(threadWorker);
             }
         }


### PR DESCRIPTION
Removes some code that was commented out in `IoScheduler`. Those lines were last edited in 2 years ago, so I assume they should be safe to delete.