### PR TITLE
2.x: enable link to external JDK, fix Schedulers style

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ javadoc {
     options.addStringOption('top').value = ''
     options.addStringOption('doctitle').value = ''
     options.addStringOption('header').value = ''
+    options.links("http://docs.oracle.com/javase/7/docs/api/")
     if (JavaVersion.current().isJava7()) {
         // "./gradle/stylesheet.css" only supports Java 7
         options.addStringOption('stylesheetfile', rootProject.file('./gradle/stylesheet.css').toString())

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -108,7 +108,7 @@ public final class Schedulers {
      * <p>
      * You can control certain properties of this standard scheduler via system properties that have to be set
      * before the {@link Schedulers} class is referenced in your code.
-     * <br><strong>Supported system properties ({@code System.getProperty()}):</strong>
+     * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
      * <li>{@code rx2.computation-threads} (int): sets the number of threads in the {@link #computation()} Scheduler, default is the number of available CPUs</li>
      * <li>{@code rx2.computation-priority} (int): sets the thread priority of the {@link #computation()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
@@ -153,7 +153,7 @@ public final class Schedulers {
      * <p>
      * You can control certain properties of this standard scheduler via system properties that have to be set
      * before the {@link Schedulers} class is referenced in your code.
-     * <br><strong>Supported system properties ({@code System.getProperty()}):</strong>
+     * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
      * <li>{@code rx2.io-priority} (int): sets the thread priority of the {@link #io()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
      * </ul>
@@ -211,7 +211,7 @@ public final class Schedulers {
      * <p>
      * You can control certain properties of this standard scheduler via system properties that have to be set
      * before the {@link Schedulers} class is referenced in your code.
-     * <br><strong>Supported system properties ({@code System.getProperty()}):</strong>
+     * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
      * <li>{@code rx2.newthread-priority} (int): sets the thread priority of the {@link #newThread()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
      * </ul>
@@ -260,7 +260,7 @@ public final class Schedulers {
      * <p>
      * You can control certain properties of this standard scheduler via system properties that have to be set
      * before the {@link Schedulers} class is referenced in your code.
-     * <br><strong>Supported system properties ({@code System.getProperty()}):</strong>
+     * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
      * <li>{@code rx2.single-priority} (int): sets the thread priority of the {@link #single()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
      * </ul>


### PR DESCRIPTION
This PR enables the generated Javadoc to `{@link }` to JDK classes properly (current 2.0.8 doc [shows them](http://reactivex.io/RxJava/2.x/javadoc/2.0.8/io/reactivex/schedulers/Schedulers.html#io()) as plain text). I'm linking to the v7 docs because v6 is ugly.

In addition, I've fixed the style of the `Schedulers` documentation by separating the **Supported system properties** properly into a new paragraph.