### PR TITLE
BoundedReplayBuffer no longer leaks memory

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -739,7 +739,9 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
         /* test */ final void collectValuesInMemory(Collection<? super T> output) {
             Node next = getHead();
             for (;;) {
-                if (next != null) {
+                if (next == null) {
+                    break;
+                } else if (next.value != null) {
                     Object o = next.value;
                     Object v = leaveTransform(o);
                     if (NotificationLite.isComplete(v) || NotificationLite.isError(v)) {
@@ -749,8 +751,6 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
                     if (value != null) {
                         output.add(value);
                     }
-                } else {
-                    break;
                 }
                 next = next.get();
             }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -12,7 +12,6 @@
  */
 
 package io.reactivex.internal.operators.observable;
-
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -766,8 +765,7 @@ public class ObservableReplayTest {
 
         buf.next(3);
         buf.next(4);
-        values.clear();
-        buf.collect(values);
+        collectAndAssertNoLeaks(buf, values);
         Assert.assertEquals(Arrays.asList(3, 4), values);
 
         test.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -809,8 +807,7 @@ public class ObservableReplayTest {
 
         buf.next(3);
         buf.next(4);
-        values.clear();
-        buf.collect(values);
+        collectAndAssertNoLeaks(buf, values);
         Assert.assertEquals(Arrays.asList(3, 4), values);
 
         test.advanceTimeBy(2, TimeUnit.SECONDS);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -748,7 +748,43 @@ public class ObservableReplayTest {
         buf.collect(values);
 
         Assert.assertEquals(Arrays.asList(5, 6), values);
+    }
 
+    @Test
+    public void testBoundedReplayBufferForMemoryLeaks() {
+        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>() {
+            private static final long serialVersionUID = -5182053207244406872L;
+
+            @Override
+            void truncate() {
+            }
+        };
+        buf.addLast(new Node(1));
+        buf.addLast(new Node(2));
+        buf.addLast(new Node(3));
+        buf.addLast(new Node(4));
+        buf.addLast(new Node(5));
+
+        List<Integer> valuesInMemory = new ArrayList<Integer>();
+        buf.collectObjectsInMemory(valuesInMemory);
+
+        Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), valuesInMemory);
+
+        buf.removeFirst();
+        buf.removeFirst();
+        buf.removeFirst();
+        buf.removeFirst();
+        buf.removeFirst();
+
+        valuesInMemory.clear();
+        buf.collectObjectsInMemory(valuesInMemory);
+        Assert.assertTrue(valuesInMemory.isEmpty());
+
+        buf.addLast(new Node(5));
+        buf.addLast(new Node(6));
+        buf.collectObjectsInMemory(valuesInMemory);
+
+        Assert.assertEquals(Arrays.asList(5, 6), valuesInMemory);
     }
 
     @Test


### PR DESCRIPTION
The Issue: When `BoundedReplayBuffer` evicts an item to make room for a new item it still contains a strong reference to the evicted item.

New Test: This diff adds a new unit test to verify this behavior. Given this unit test needs to look under the hood of `BoundedReplayBuffer` in order to ensure no memory leaks exist, writing this test requires a new package private method.

Change: This diff fixes misbehavior.