### PR TITLE
2.x: fix Flowable.flatMapMaybe/Single maxConcurrency not requesting more

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -230,6 +230,10 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
                 if (!delayErrors) {
                     s.cancel();
                     set.dispose();
+                } else {
+                    if (maxConcurrency != Integer.MAX_VALUE) {
+                        s.request(1);
+                    }
                 }
                 active.decrementAndGet();
                 drain();
@@ -254,12 +258,19 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
                     }
                     return;
                 }
+
+                if (maxConcurrency != Integer.MAX_VALUE) {
+                    s.request(1);
+                }
                 if (decrementAndGet() == 0) {
                     return;
                 }
                 drainLoop();
             } else {
                 active.decrementAndGet();
+                if (maxConcurrency != Integer.MAX_VALUE) {
+                    s.request(1);
+                }
                 drain();
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -230,6 +230,10 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
                 if (!delayErrors) {
                     s.cancel();
                     set.dispose();
+                } else {
+                    if (maxConcurrency != Integer.MAX_VALUE) {
+                        s.request(1);
+                    }
                 }
                 active.decrementAndGet();
                 drain();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -321,6 +321,36 @@ public class FlowableFlatMapMaybeTest {
     }
 
     @Test
+    public void asyncFlattenNoneMaxConcurrency() {
+        Flowable.range(1, 1000)
+        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(Integer v) throws Exception {
+                return Maybe.<Integer>empty().subscribeOn(Schedulers.computation());
+            }
+        }, false, 128)
+        .take(500)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+
+    @Test
+    public void asyncFlattenErrorMaxConcurrency() {
+        Flowable.range(1, 1000)
+        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(Integer v) throws Exception {
+                return Maybe.<Integer>error(new TestException()).subscribeOn(Schedulers.computation());
+            }
+        }, true, 128)
+        .take(500)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(CompositeException.class);
+    }
+
+    @Test
     public void successError() {
         final PublishProcessor<Integer> ps = PublishProcessor.create();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -490,4 +490,19 @@ public class FlowableFlatMapSingleTest {
             TestHelper.race(r1, r2);
         }
     }
+
+    @Test
+    public void asyncFlattenErrorMaxConcurrency() {
+        Flowable.range(1, 1000)
+        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
+            @Override
+            public MaybeSource<Integer> apply(Integer v) throws Exception {
+                return Maybe.<Integer>error(new TestException()).subscribeOn(Schedulers.computation());
+            }
+        }, true, 128)
+        .take(500)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(CompositeException.class);
+    }
 }


### PR DESCRIPTION
This PR fixes `Flowable.flatMapMaybe` and `Flowable.flatMapSingle` not replenishing from the upstream when they complete/error per inner source.