### PR TITLE
1.x: apply API promotions for 1.3

### DIFF
--- a/src/main/java/rx/BackpressureOverflow.java
+++ b/src/main/java/rx/BackpressureOverflow.java
@@ -15,15 +15,13 @@
  */
 package rx;
 
-import rx.annotations.Beta;
 import rx.exceptions.MissingBackpressureException;
 
 /**
  * Generic strategy and default implementations to deal with backpressure buffer overflows.
  * 
- * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+ * @since 1.3
  */
-@Beta
 public final class BackpressureOverflow {
 
     private BackpressureOverflow() {

--- a/src/main/java/rx/Completable.java
+++ b/src/main/java/rx/Completable.java
@@ -20,7 +20,6 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import rx.annotations.*;
 import rx.exceptions.*;
 import rx.functions.*;
 import rx.internal.observers.AssertableSubscriberObservable;
@@ -35,10 +34,9 @@ import rx.subscriptions.*;
  * Represents a deferred computation without any value but only indication for completion or exception.
  *
  * The class follows a similar event pattern as Reactive-Streams: onSubscribe (onError|onComplete)?
- * 
- * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+ *
+ * @since 1.3
  */
-@Beta
 public class Completable {
     /** The actual subscription action. */
     private final OnSubscribe onSubscribe;
@@ -539,9 +537,8 @@ public class Completable {
      * Completable's protocol are held.
      * @param producer the callback invoked for each incoming CompletableSubscriber
      * @return the new Completable instance
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public static Completable fromEmitter(Action1<CompletableEmitter> producer) {
         return create(new CompletableFromEmitter(producer));
     }
@@ -2385,10 +2382,10 @@ public class Completable {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.3 - experimental
      * @return the new AssertableSubscriber instance
-     * @since 1.2.3
+     * @since 1.3
      */
-    @Experimental
     public final AssertableSubscriber<Void> test() {
         AssertableSubscriberObservable<Void> ts = AssertableSubscriberObservable.create(Long.MAX_VALUE);
         subscribe(ts);

--- a/src/main/java/rx/CompletableEmitter.java
+++ b/src/main/java/rx/CompletableEmitter.java
@@ -15,7 +15,6 @@
  */
 package rx;
 
-import rx.annotations.Experimental;
 import rx.functions.Cancellable;
 
 /**
@@ -24,9 +23,8 @@ import rx.functions.Cancellable;
  * <p>
  * All methods are thread-safe; calling onCompleted or onError twice or one after the other has
  * no effect.
- * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+ * @since 1.3
  */
-@Experimental
 public interface CompletableEmitter {
 
     /**

--- a/src/main/java/rx/CompletableSubscriber.java
+++ b/src/main/java/rx/CompletableSubscriber.java
@@ -15,12 +15,10 @@
  */
 package rx;
 
-import rx.annotations.Experimental;
-
 /**
  * Represents the subscription API callbacks when subscribing to a Completable instance.
+ * @since 1.3
  */
-@Experimental
 public interface CompletableSubscriber {
     /**
      * Called once the deferred computation completes normally.

--- a/src/main/java/rx/Emitter.java
+++ b/src/main/java/rx/Emitter.java
@@ -16,7 +16,6 @@
 
 package rx;
 
-import rx.annotations.Experimental;
 import rx.functions.Cancellable;
 
 /**
@@ -29,9 +28,8 @@ import rx.functions.Cancellable;
  * other methods are thread-safe.
  *
  * @param <T> the value type to emit
- * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+ * @since 1.3
  */
-@Experimental
 public interface Emitter<T> extends Observer<T> {
 
     /**

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -400,7 +400,7 @@ public class Observable<T> {
      *         calls onCompleted
      * @see <a href="http://reactivex.io/documentation/completable.html">ReactiveX documentation:
      *      Completable</a>
-     * @since 1
+     * @since 1.3
      */
     public Completable toCompletable() {
         return Completable.fromObservable(this);

--- a/src/main/java/rx/Observable.java
+++ b/src/main/java/rx/Observable.java
@@ -110,7 +110,7 @@ public class Observable<T> {
      * <p>
      * You should call the Emitter's onNext, onError and onCompleted methods in a serialized fashion. The
      * rest of its methods are thread-safe.
-     *
+     * <p>History: 1.2.7 - experimental
      * @param <T> the element type
      * @param emitter the emitter that is called when a Subscriber subscribes to the returned {@code Observable}
      * @param backpressure the backpressure mode to apply if the downstream Subscriber doesn't request (fast) enough
@@ -118,9 +118,8 @@ public class Observable<T> {
      * @see Emitter
      * @see Emitter.BackpressureMode
      * @see rx.functions.Cancellable
-     * @since 1.2.7 - experimental
+     * @since 1.3
      */
-    @Experimental
     public static <T> Observable<T> create(Action1<Emitter<T>> emitter, Emitter.BackpressureMode backpressure) {
         return unsafeCreate(new OnSubscribeCreate<T>(emitter, backpressure));
     }
@@ -148,7 +147,7 @@ public class Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code unsafeCreate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 1.2.7 - experimental
      * @param <T>
      *            the type of the items that this Observable emits
      * @param f
@@ -157,9 +156,8 @@ public class Observable<T> {
      * @return an Observable that, when a {@link Subscriber} subscribes to it, will execute the specified
      *         function
      * @see <a href="http://reactivex.io/documentation/operators/create.html">ReactiveX operators documentation: Create</a>
-     * @since 1.2.7 - experimental
+     * @since 1.3
      */
-    @Experimental
     public static <T> Observable<T> unsafeCreate(OnSubscribe<T> f) {
         return new Observable<T>(RxJavaHooks.onCreate(f));
     }
@@ -243,9 +241,9 @@ public class Observable<T> {
      * @see AsyncOnSubscribe#createStateless(Action2)
      * @see AsyncOnSubscribe#createStateless(Action2, Action0)
      * @see <a href="http://reactivex.io/documentation/operators/create.html">ReactiveX operators documentation: Create</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3 - beta
      */
-    @Experimental
+    @Beta
     public static <S, T> Observable<T> create(AsyncOnSubscribe<S, T> asyncOnSubscribe) {
         return unsafeCreate(asyncOnSubscribe);
     }
@@ -350,8 +348,8 @@ public class Observable<T> {
      * @param <R> the resulting object type
      * @param converter the function that receives the current Observable instance and returns a value
      * @return the value returned by the function
+     * @since 1.3
      */
-    @Experimental
     public final <R> R to(Func1<? super Observable<T>, R> converter) {
         return converter.call(this);
     }
@@ -402,10 +400,8 @@ public class Observable<T> {
      *         calls onCompleted
      * @see <a href="http://reactivex.io/documentation/completable.html">ReactiveX documentation:
      *      Completable</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical
-     *        with the release number)
+     * @since 1
      */
-    @Beta
     public Completable toCompletable() {
         return Completable.fromObservable(this);
     }
@@ -1494,10 +1490,9 @@ public class Observable<T> {
      * @param <T> the common element base type
      * @param sources the Observable sequence of Observables
      * @return the new Observable with the concatenating behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Beta
     public static <T> Observable<T> concatDelayError(Observable<? extends Observable<? extends T>> sources) {
         return sources.concatMapDelayError((Func1)UtilityFunctions.identity());
     }
@@ -1519,9 +1514,8 @@ public class Observable<T> {
      * @param <T> the common element base type
      * @param sources the Iterable sequence of Observables
      * @return the new Observable with the concatenating behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Observable<T> concatDelayError(Iterable<? extends Observable<? extends T>> sources) {
         return concatDelayError(from(sources));
     }
@@ -1546,9 +1540,8 @@ public class Observable<T> {
      * @param t2
      *            an Observable to be concatenated
      * @return an Observable with the concatenating behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2) {
         return concatDelayError(just(t1, t2));
     }
@@ -1575,9 +1568,8 @@ public class Observable<T> {
      * @param t3
      *            an Observable to be concatenated
      * @return an Observable with the concatenating behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2,Observable<? extends T> t3 ) {
         return concatDelayError(just(t1, t2, t3));
     }
@@ -1606,9 +1598,8 @@ public class Observable<T> {
      * @param t4
      *            an Observable to be concatenated
      * @return an Observable with the concatenating behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4) {
         return concatDelayError(just(t1, t2, t3, t4));
     }
@@ -1639,9 +1630,8 @@ public class Observable<T> {
      * @param t5
      *            an Observable to be concatenated
      * @return an Observable with the concatenating behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5) {
         return concatDelayError(just(t1, t2, t3, t4, t5));
     }
@@ -1674,9 +1664,8 @@ public class Observable<T> {
      * @param t6
      *            an Observable to be concatenated
      * @return an Observable with the concatenating behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6) {
         return concatDelayError(just(t1, t2, t3, t4, t5, t6));
     }
@@ -1711,9 +1700,8 @@ public class Observable<T> {
      * @param t7
      *            an Observable to be concatenated
      * @return an Observable with the concatenating behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7) {
         return concatDelayError(just(t1, t2, t3, t4, t5, t6, t7));
     }
@@ -1750,9 +1738,8 @@ public class Observable<T> {
      * @param t8
      *            an Observable to be concatenated
      * @return an Observable with the concatenating behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8) {
         return concatDelayError(just(t1, t2, t3, t4, t5, t6, t7, t8));
     }
@@ -1791,9 +1778,8 @@ public class Observable<T> {
      * @param t9
      *            an Observable to be concatenated
      * @return an Observable with the concatenating behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Observable<T> concatDelayError(Observable<? extends T> t1, Observable<? extends T> t2, Observable<? extends T> t3, Observable<? extends T> t4, Observable<? extends T> t5, Observable<? extends T> t6, Observable<? extends T> t7, Observable<? extends T> t8, Observable<? extends T> t9) {
         return concatDelayError(just(t1, t2, t3, t4, t5, t6, t7, t8, t9));
     }
@@ -2024,54 +2010,6 @@ public class Observable<T> {
             return just(array[0]);
         }
         return unsafeCreate(new OnSubscribeFromArray<T>(array));
-    }
-
-    /**
-     * Provides an API (via a cold Observable) that bridges the reactive world with the callback-style,
-     * generally non-backpressured world.
-     * <p>
-     * Example:
-     * <pre><code>
-     * Observable.&lt;Event&gt;fromEmitter(emitter -&gt; {
-     *     Callback listener = new Callback() {
-     *         &#64;Override
-     *         public void onEvent(Event e) {
-     *             emitter.onNext(e);
-     *             if (e.isLast()) {
-     *                 emitter.onCompleted();
-     *             }
-     *         }
-     *
-     *         &#64;Override
-     *         public void onFailure(Exception e) {
-     *             emitter.onError(e);
-     *         }
-     *     };
-     *
-     *     AutoCloseable c = api.someMethod(listener);
-     *
-     *     emitter.setCancellation(c::close);
-     *
-     * }, BackpressureMode.BUFFER);
-     * </code></pre>
-     * <p>
-     * You should call the Emitter's onNext, onError and onCompleted methods in a serialized fashion. The
-     * rest of its methods are thread-safe.
-     *
-     * @param <T> the element type
-     * @param emitter the emitter that is called when a Subscriber subscribes to the returned {@code Observable}
-     * @param backpressure the backpressure mode to apply if the downstream Subscriber doesn't request (fast) enough
-     * @return the new Observable instance
-     * @see Emitter
-     * @see Emitter.BackpressureMode
-     * @see rx.functions.Cancellable
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
-     * @deprecated 1.2.7 - aliased to {@link #create(Action1, rx.Emitter.BackpressureMode)}, will be removed in 1.3.0
-     */
-    @Experimental
-    @Deprecated
-    public static <T> Observable<T> fromEmitter(Action1<Emitter<T>> emitter, Emitter.BackpressureMode backpressure) {
-        return unsafeCreate(new OnSubscribeCreate<T>(emitter, backpressure));
     }
 
     /**
@@ -3068,9 +3006,8 @@ public class Observable<T> {
      * @return an Observable that emits all of the items emitted by the Observables emitted by the
      *         {@code source} Observable
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Observable<T> mergeDelayError(Observable<? extends Observable<? extends T>> source, int maxConcurrent) {
         return source.lift(OperatorMerge.<T>instance(true, maxConcurrent));
     }
@@ -3684,10 +3621,8 @@ public class Observable<T> {
      * @return an Observable that emits the items emitted by the Observable most recently emitted by the source
      *         Observable
      * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Observable<T> switchOnNextDelayError(Observable<? extends Observable<? extends T>> sequenceOfSequences) {
         return sequenceOfSequences.lift(OperatorSwitch.<T>instance(true));
     }
@@ -3861,10 +3796,8 @@ public class Observable<T> {
      *            a terminal event ({@code onComplete} or {@code onError}).
      * @return the Observable whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T, Resource> Observable<T> using(
             final Func0<Resource> resourceFactory,
             final Func1<? super Resource, ? extends Observable<? extends T>> observableFactory,
@@ -3966,8 +3899,8 @@ public class Observable<T> {
      *            an item that will be emitted by the resulting Observable
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     * @since 1.3
      */
-    @Experimental
     public static <R> Observable<R> zip(Observable<?>[] ws, FuncN<? extends R> zipFunction) {
         return Observable.just(ws).lift(new OperatorZip<R>(zipFunction));
     }
@@ -5192,9 +5125,8 @@ public class Observable<T> {
      * @param <R> the result value type
      * @param func the function that maps the items of this Observable into the inner Observables.
      * @return the new Observable instance with the concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final <R> Observable<R> concatMapDelayError(Func1<? super T, ? extends Observable<?extends R>> func) {
         if (this instanceof ScalarSynchronousObservable) {
             ScalarSynchronousObservable<T> scalar = (ScalarSynchronousObservable<T>) this;
@@ -5692,9 +5624,8 @@ public class Observable<T> {
      *        to this Observable.
      * @return an Observable that delays the subscription to this Observable
      *         until the other Observable emits an element or completes normally.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final <U> Observable<T> delaySubscription(Observable<U> other) {
         if (other == null) {
             throw new NullPointerException();
@@ -5836,10 +5767,8 @@ public class Observable<T> {
      * @return an Observable that emits those items from the source Observable that are distinct from their
      *         immediate predecessors
      * @see <a href="http://reactivex.io/documentation/operators/distinct.html">ReactiveX operators documentation: Distinct</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical
-     *        with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Observable<T> distinctUntilChanged(Func2<? super T, ? super T, Boolean> comparator) {
         return lift(new OperatorDistinctUntilChanged<T, T>(comparator));
     }
@@ -6098,9 +6027,8 @@ public class Observable<T> {
      * @param o1 the first source
      * @param o2 the second source
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings("unchecked")
     public static <T> Observable<T> concatEager(Observable<? extends T> o1, Observable<? extends T> o2) {
         return concatEager(Arrays.asList(o1, o2));
@@ -6124,9 +6052,8 @@ public class Observable<T> {
      * @param o2 the second source
      * @param o3 the third source
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings("unchecked")
     public static <T> Observable<T> concatEager(
             Observable<? extends T> o1, Observable<? extends T> o2,
@@ -6154,9 +6081,8 @@ public class Observable<T> {
      * @param o3 the third source
      * @param o4 the fourth source
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings("unchecked")
     public static <T> Observable<T> concatEager(
             Observable<? extends T> o1, Observable<? extends T> o2,
@@ -6185,9 +6111,8 @@ public class Observable<T> {
      * @param o4 the fourth source
      * @param o5 the fifth source
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings("unchecked")
     public static <T> Observable<T> concatEager(
             Observable<? extends T> o1, Observable<? extends T> o2,
@@ -6218,9 +6143,8 @@ public class Observable<T> {
      * @param o5 the fifth source
      * @param o6 the sixth source
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings("unchecked")
     public static <T> Observable<T> concatEager(
             Observable<? extends T> o1, Observable<? extends T> o2,
@@ -6252,9 +6176,8 @@ public class Observable<T> {
      * @param o6 the sixth source
      * @param o7 the seventh source
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings("unchecked")
     public static <T> Observable<T> concatEager(
             Observable<? extends T> o1, Observable<? extends T> o2,
@@ -6288,9 +6211,8 @@ public class Observable<T> {
      * @param o7 the seventh source
      * @param o8 the eighth source
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings("unchecked")
     public static <T> Observable<T> concatEager(
             Observable<? extends T> o1, Observable<? extends T> o2,
@@ -6325,9 +6247,8 @@ public class Observable<T> {
      * @param o8 the eighth source
      * @param o9 the ninth source
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings("unchecked")
     public static <T> Observable<T> concatEager(
             Observable<? extends T> o1, Observable<? extends T> o2,
@@ -6355,9 +6276,8 @@ public class Observable<T> {
      * @param <T> the value type
      * @param sources a sequence of Observables that need to be eagerly concatenated
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Observable<T> concatEager(Iterable<? extends Observable<? extends T>> sources) {
         return Observable.from(sources).concatMapEager((Func1)UtilityFunctions.identity());
@@ -6380,9 +6300,8 @@ public class Observable<T> {
      * @param sources a sequence of Observables that need to be eagerly concatenated
      * @param capacityHint hints about the number of expected source sequence values
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Observable<T> concatEager(Iterable<? extends Observable<? extends T>> sources, int capacityHint) {
         return Observable.from(sources).concatMapEager((Func1)UtilityFunctions.identity(), capacityHint);
@@ -6404,9 +6323,8 @@ public class Observable<T> {
      * @param <T> the value type
      * @param sources a sequence of Observables that need to be eagerly concatenated
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Observable<T> concatEager(Observable<? extends Observable<? extends T>> sources) {
         return sources.concatMapEager((Func1)UtilityFunctions.identity());
@@ -6429,9 +6347,8 @@ public class Observable<T> {
      * @param sources a sequence of Observables that need to be eagerly concatenated
      * @param capacityHint hints about the number of expected source sequence values
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Observable<T> concatEager(Observable<? extends Observable<? extends T>> sources, int capacityHint) {
         return sources.concatMapEager((Func1)UtilityFunctions.identity(), capacityHint);
@@ -6455,9 +6372,8 @@ public class Observable<T> {
      * @param mapper the function that maps a sequence of values into a sequence of Observables that will be
      *               eagerly concatenated
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final <R> Observable<R> concatMapEager(Func1<? super T, ? extends Observable<? extends R>> mapper) {
         return concatMapEager(mapper, RxRingBuffer.SIZE);
     }
@@ -6481,9 +6397,8 @@ public class Observable<T> {
      *               eagerly concatenated
      * @param capacityHint hints about the number of expected source sequence values
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final <R> Observable<R> concatMapEager(Func1<? super T, ? extends Observable<? extends R>> mapper, int capacityHint) {
         if (capacityHint < 1) {
             throw new IllegalArgumentException("capacityHint > 0 required but it was " + capacityHint);
@@ -6511,9 +6426,8 @@ public class Observable<T> {
      * @param capacityHint hints about the number of expected source sequence values
      * @param maxConcurrent the maximum number of concurrent subscribed observables
      * @return the new Observable instance with the specified concatenation behavior
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final <R> Observable<R> concatMapEager(Func1<? super T, ? extends Observable<? extends R>> mapper, int capacityHint, int maxConcurrent) {
         if (capacityHint < 1) {
             throw new IllegalArgumentException("capacityHint > 0 required but it was " + capacityHint);
@@ -6983,13 +6897,13 @@ public class Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.7 - experimental
      * @param mapper the function that receives an upstream value and turns it into a Completable
      *               to be merged.
      * @return the new Observable instance
      * @see #flatMapCompletable(Func1, boolean, int)
-     * @since 1.2.7 - experimental
+     * @since 1.3
      */
-    @Experimental
     public final Observable<T> flatMapCompletable(Func1<? super T, ? extends Completable> mapper) {
         return flatMapCompletable(mapper, false, Integer.MAX_VALUE);
     }
@@ -7004,15 +6918,15 @@ public class Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.7 - experimental
      * @param mapper the function that receives an upstream value and turns it into a Completable
      *               to be merged.
      * @param delayErrors if true, errors from the upstream and from the inner Completables get delayed till
      *                    the all of them terminate.
      * @return the new Observable instance
-     * @since 1.2.7 - experimental
+     * @since 1.3
      * @see #flatMapCompletable(Func1, boolean, int)
      */
-    @Experimental
     public final Observable<T> flatMapCompletable(Func1<? super T, ? extends Completable> mapper, boolean delayErrors) {
         return flatMapCompletable(mapper, delayErrors, Integer.MAX_VALUE);
     }
@@ -7028,15 +6942,15 @@ public class Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.7 - experimental
      * @param mapper the function that receives an upstream value and turns it into a Completable
      *               to be merged.
      * @param delayErrors if true, errors from the upstream and from the inner Completables get delayed till
      *                    the all of them terminate.
      * @param maxConcurrency the maximum number of inner Completables to run at a time
      * @return the new Observable instance
-     * @since 1.2.7 - experimental
+     * @since 1.3
      */
-    @Experimental
     public final Observable<T> flatMapCompletable(Func1<? super T, ? extends Completable> mapper, boolean delayErrors, int maxConcurrency) {
         return unsafeCreate(new OnSubscribeFlatMapCompletable<T>(this, mapper, delayErrors, maxConcurrency));
     }
@@ -7183,14 +7097,14 @@ public class Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.7 - experimental
      * @param <R> the value type of the inner Singles and the resulting Observable
      * @param mapper the function that receives an upstream value and turns it into a Single
      *               to be merged.
      * @return the new Observable instance
      * @see #flatMapSingle(Func1, boolean, int)
-     * @since 1.2.7 - experimental
+     * @since 1.3
      */
-    @Experimental
     public final <R> Observable<R> flatMapSingle(Func1<? super T, ? extends Single<? extends R>> mapper) {
         return flatMapSingle(mapper, false, Integer.MAX_VALUE);
     }
@@ -7204,16 +7118,16 @@ public class Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.7 - experimental
      * @param <R> the value type of the inner Singles and the resulting Observable
      * @param mapper the function that receives an upstream value and turns it into a Single
      *               to be merged.
      * @param delayErrors if true, errors from the upstream and from the inner Singles get delayed till
      *                    the all of them terminate.
      * @return the new Observable instance
-     * @since 1.2.7 - experimental
+     * @since 1.3
      * @see #flatMapSingle(Func1, boolean, int)
      */
-    @Experimental
     public final <R> Observable<R> flatMapSingle(Func1<? super T, ? extends Single<? extends R>> mapper, boolean delayErrors) {
         return flatMapSingle(mapper, delayErrors, Integer.MAX_VALUE);
     }
@@ -7228,6 +7142,7 @@ public class Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.7 - experimental
      * @param <R> the value type of the inner Singles and the resulting Observable
      * @param mapper the function that receives an upstream value and turns it into a Single
      *               to be merged.
@@ -7235,9 +7150,8 @@ public class Observable<T> {
      *                    the all of them terminate.
      * @param maxConcurrency the maximum number of inner Singles to run at a time
      * @return the new Observable instance
-     * @since 1.2.7 - experimental
+     * @since 1.3
      */
-    @Experimental
     public final <R> Observable<R> flatMapSingle(Func1<? super T, ? extends Single<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
         return unsafeCreate(new OnSubscribeFlatMapSingle<T, R>(this, mapper, delayErrors, maxConcurrency));
     }
@@ -7419,8 +7333,8 @@ public class Observable<T> {
      * @throws NullPointerException
      *             if {@code evictingMapFactory} is null
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
+     * @since 1.3
      */
-    @Experimental
     public final <K, R> Observable<GroupedObservable<K, R>> groupBy(final Func1<? super T, ? extends K> keySelector,
             final Func1<? super T, ? extends R> elementSelector, final Func1<Action1<K>, Map<K, Object>> evictingMapFactory) {
         if (evictingMapFactory == null) {
@@ -8049,9 +7963,8 @@ public class Observable<T> {
      * @param overflowStrategy how should the {@code Observable} react to buffer overflows.  Null is not allowed.
      * @return the source {@code Observable} modified to buffer items up to the given capacity
      * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Observable<T> onBackpressureBuffer(long capacity, Action0 onOverflow, BackpressureOverflow.Strategy overflowStrategy) {
         return lift(new OperatorOnBackpressureBuffer<T>(capacity, onOverflow, overflowStrategy));
     }
@@ -8075,7 +7988,6 @@ public class Observable<T> {
      * @param onDrop the action to invoke for each item dropped. onDrop action should be fast and should never block.
      * @return the source Observable modified to drop {@code onNext} notifications on overflow
      * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
-     * @Experimental The behavior of this can change at any time.
      * @since 1.1.0
      */
     public final Observable<T> onBackpressureDrop(Action1<? super T> onDrop) {
@@ -8306,9 +8218,8 @@ public class Observable<T> {
      * </dl>
      * @return an Observable which out references to the upstream producer and downstream Subscriber if
      * the sequence is terminated or downstream unsubscribes
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final Observable<T> onTerminateDetach() {
         return unsafeCreate(new OnSubscribeDetach<T>(this));
     }
@@ -8381,9 +8292,8 @@ public class Observable<T> {
      *
      * @param n the initial request amount, further request will happen after 75% of this value
      * @return the Observable that rebatches request amounts from downstream
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final Observable<T> rebatchRequests(int n) {
         if (n <= 0) {
             throw new IllegalArgumentException("n > 0 required but it was " + n);
@@ -10511,7 +10421,7 @@ public class Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>you specify which {@link Scheduler} this operator will use</dd>
      * </dl>
-     *
+     * <p>History: 1.2.7 - experimental
      * @param scheduler
      *            the {@link Scheduler} to perform subscription actions on
      * @param requestOn if true, requests are rerouted to the given Scheduler as well (strong pipelining)
@@ -10523,9 +10433,8 @@ public class Observable<T> {
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #observeOn
      * @see #subscribeOn(Scheduler)
-     * @since 1.2.7 - experimental
+     * @since 1.3
      */
-    @Experimental
     public final Observable<T> subscribeOn(Scheduler scheduler, boolean requestOn) {
         if (this instanceof ScalarSynchronousObservable) {
             return ((ScalarSynchronousObservable<T>)this).scalarScheduleOn(scheduler);
@@ -10589,10 +10498,8 @@ public class Observable<T> {
      *            Observable
      * @return an Observable that emits the items emitted by the Observable returned from applying {@code func} to the most recently emitted item emitted by the source Observable
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final <R> Observable<R> switchMapDelayError(Func1<? super T, ? extends Observable<? extends R>> func) {
         return switchOnNextDelayError(map(func));
     }
@@ -11929,9 +11836,8 @@ public class Observable<T> {
      *             if any item emitted by the Observable does not implement {@link Comparable} with respect to
      *             all other items emitted by the Observable
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Observable<List<T>> toSortedList(int initialCapacity) {
         return lift(new OperatorToObservableSortedList<T>(initialCapacity));
     }
@@ -11957,9 +11863,8 @@ public class Observable<T> {
      * @return an Observable that emits a list that contains the items emitted by the source Observable in
      *         sorted order
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Observable<List<T>> toSortedList(Func2<? super T, ? super T, Integer> sortFunction, int initialCapacity) {
         return lift(new OperatorToObservableSortedList<T>(sortFunction, initialCapacity));
     }
@@ -11984,8 +11889,8 @@ public class Observable<T> {
      *             if any item emitted by the Observable does not implement {@link Comparable} with respect to
      *             all other items emitted by the Observable
      * @return an Observable that emits the items emitted by the source Observable in sorted order
+     * @since 1.3
      */
-    @Experimental
     public final Observable<T> sorted() {
         return toSortedList().flatMapIterable(UtilityFunctions.<List<T>>identity());
     }
@@ -12009,8 +11914,8 @@ public class Observable<T> {
      *            a function that compares two items emitted by the source Observable and returns an Integer
      *            that indicates their sort order
      * @return an Observable that emits the items emitted by the source Observable in sorted order
+     * @since 1.3
      */
-    @Experimental
     public final Observable<T> sorted(Func2<? super T, ? super T, Integer> sortFunction) {
         return toSortedList(sortFunction).flatMapIterable(UtilityFunctions.<List<T>>identity());
     }
@@ -12061,11 +11966,9 @@ public class Observable<T> {
      * @return an Observable that merges the specified Observable into this Observable by using the
      *         {@code resultSelector} function only when the source Observable sequence (this instance) emits an
      *         item
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      */
-    @Experimental
     public final <U, R> Observable<R> withLatestFrom(Observable<? extends U> other, Func2<? super T, ? super U, ? extends R> resultSelector) {
         return lift(new OperatorWithLatestFrom<T, U, R>(other, resultSelector));
     }
@@ -12094,10 +11997,8 @@ public class Observable<T> {
      * @param o2 the second other Observable
      * @param combiner the function called with an array of values from each participating observable
      * @return the new Observable instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final <T1, T2, R> Observable<R> withLatestFrom(Observable<T1> o1, Observable<T2> o2, Func3<? super T, ? super T1, ? super T2, R> combiner) {
         return unsafeCreate(new OperatorWithLatestFromMany<T, R>(this, new Observable<?>[] { o1, o2 }, null, Functions.fromFunc(combiner)));
     }
@@ -12128,10 +12029,8 @@ public class Observable<T> {
      * @param o3 the third other Observable
      * @param combiner the function called with an array of values from each participating observable
      * @return the new Observable instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final <T1, T2, T3, R> Observable<R> withLatestFrom(
             Observable<T1> o1, Observable<T2> o2,
             Observable<T3> o3,
@@ -12168,10 +12067,8 @@ public class Observable<T> {
      * @param o4 the fourth other Observable
      * @param combiner the function called with an array of values from each participating observable
      * @return the new Observable instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final <T1, T2, T3, T4, R> Observable<R> withLatestFrom(
             Observable<T1> o1, Observable<T2> o2,
             Observable<T3> o3, Observable<T4> o4,
@@ -12209,10 +12106,8 @@ public class Observable<T> {
      * @param o5 the fifth other Observable
      * @param combiner the function called with an array of values from each participating observable
      * @return the new Observable instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, R> Observable<R> withLatestFrom(
             Observable<T1> o1, Observable<T2> o2,
             Observable<T3> o3, Observable<T4> o4,
@@ -12254,10 +12149,8 @@ public class Observable<T> {
      * @param o6 the sixth other Observable
      * @param combiner the function called with an array of values from each participating observable
      * @return the new Observable instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, T6, R> Observable<R> withLatestFrom(
             Observable<T1> o1, Observable<T2> o2,
             Observable<T3> o3, Observable<T4> o4,
@@ -12301,10 +12194,8 @@ public class Observable<T> {
      * @param o7 the seventh other Observable
      * @param combiner the function called with an array of values from each participating observable
      * @return the new Observable instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> withLatestFrom(
             Observable<T1> o1, Observable<T2> o2,
             Observable<T3> o3, Observable<T4> o4,
@@ -12351,10 +12242,8 @@ public class Observable<T> {
      * @param o8 the eighth other Observable
      * @param combiner the function called with an array of values from each participating observable
      * @return the new Observable instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> withLatestFrom(
             Observable<T1> o1, Observable<T2> o2,
             Observable<T3> o3, Observable<T4> o4,
@@ -12386,10 +12275,8 @@ public class Observable<T> {
      * @param others the array of other sources
      * @param combiner the function called with an array of values from each participating observable
      * @return the new Observable instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final <R> Observable<R> withLatestFrom(Observable<?>[] others, FuncN<R> combiner) {
         return unsafeCreate(new OperatorWithLatestFromMany<T, R>(this, others, null, combiner));
     }
@@ -12415,10 +12302,8 @@ public class Observable<T> {
      * @param others the iterable of other sources
      * @param combiner the function called with an array of values from each participating observable
      * @return the new Observable instance
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final <R> Observable<R> withLatestFrom(Iterable<Observable<?>> others, FuncN<R> combiner) {
         return unsafeCreate(new OperatorWithLatestFromMany<T, R>(this, null, others, combiner));
     }
@@ -12899,10 +12784,10 @@ public class Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.3 - experimental
      * @return the new AssertableSubscriber instance
-     * @since 1.2.3
+     * @since 1.3
      */
-    @Experimental
     public final AssertableSubscriber<T> test() {
         AssertableSubscriber<T> ts = AssertableSubscriberObservable.create(Long.MAX_VALUE);
         subscribe(ts);
@@ -12918,11 +12803,11 @@ public class Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.3 - experimental
      * @return the new AssertableSubscriber instance
      * @param initialRequestAmount the amount to request from upstream upfront, non-negative (not verified)
-     * @since 1.2.3
+     * @since 1.3
      */
-    @Experimental
     public final AssertableSubscriber<T> test(long initialRequestAmount) {
         AssertableSubscriber<T> ts = AssertableSubscriberObservable.create(initialRequestAmount);
         subscribe(ts);

--- a/src/main/java/rx/Scheduler.java
+++ b/src/main/java/rx/Scheduler.java
@@ -17,7 +17,6 @@ package rx;
 
 import java.util.concurrent.TimeUnit;
 
-import rx.annotations.Experimental;
 import rx.functions.*;
 import rx.internal.schedulers.*;
 import rx.schedulers.Schedulers;
@@ -203,9 +202,9 @@ public abstract class Scheduler {
      * @param combine the function that takes a two-level nested Observable sequence of a Completable and returns
      * the Completable that will be subscribed to and should trigger the execution of the scheduled Actions.
      * @return the Scheduler with the customized execution behavior
+     * @since 1.3
      */
     @SuppressWarnings("unchecked")
-    @Experimental
     public <S extends Scheduler & Subscription> S when(Func1<Observable<Observable<Completable>>, Completable> combine) {
         return (S) new SchedulerWhen(combine, this);
     }

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -145,8 +145,8 @@ public class Single<T> {
      *            the Operator that implements the Single-operating function to be applied to the source Single
      * @return a Single that is the result of applying the lifted Operator to the source Single
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
+     * @since 1.3
      */
-    @Beta
     public final <R> Single<R> lift(final Operator<? extends R, ? super T> lift) {
         return create(new SingleLiftObservableOperator<T, R>(this.onSubscribe, lift));
     }
@@ -602,12 +602,12 @@ public class Single<T> {
      * </code></pre>
      * <p>All of the SingleEmitter's methods are thread-safe and ensure the
      * Single's protocol are held.
+     * <p>History: 1.2.3 - experimental
      * @param <T> the success value type
      * @param producer the callback invoked for each incoming SingleSubscriber
      * @return the new Single instance
-     * @since 1.2.3 - experimental (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public static <T> Single<T> fromEmitter(Action1<SingleEmitter<T>> producer) {
         if (producer == null) { throw new NullPointerException("producer is null"); }
         return create(new SingleFromEmitter<T>(producer));
@@ -939,15 +939,15 @@ public class Single<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.7 - experimental
      * @param <T> the value type of the inner Singles and the resulting Observable
      * @param sources the Observable that emits Singles to be merged
      * @return the new Observable instance
      * @see #merge(Observable, int)
      * @see #mergeDelayError(Observable)
      * @see #mergeDelayError(Observable, int)
-     * @since 1.2.7 - experimental
+     * @since 1.3
      */
-    @Experimental
     public static <T> Observable<T> merge(Observable<? extends Single<? extends T>> sources) {
         return merge(sources, Integer.MAX_VALUE);
     }
@@ -963,14 +963,14 @@ public class Single<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.7 - experimental
      * @param <T> the value type of the inner Singles and the resulting Observable
      * @param sources the Observable that emits Singles to be merged
      * @param maxConcurrency the maximum number of inner Singles to run at a time
      * @return the new Observable instance
-     * @since 1.2.7 - experimental
+     * @since 1.3
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    @Experimental
     public static <T> Observable<T> merge(Observable<? extends Single<? extends T>> sources, int maxConcurrency) {
         return sources.flatMapSingle((Func1)UtilityFunctions.identity(), false, maxConcurrency);
     }
@@ -985,15 +985,15 @@ public class Single<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.7 - experimental
      * @param <T> the value type of the inner Singles and the resulting Observable
      * @param sources the Observable that emits Singles to be merged
      * @return the new Observable instance
      * @see #mergeDelayError(Observable, int)
      * @see #merge(Observable)
      * @see #merge(Observable, int)
-     * @since 1.2.7 - experimental
+     * @since 1.3
      */
-    @Experimental
     public static <T> Observable<T> mergeDelayError(Observable<? extends Single<? extends T>> sources) {
         return merge(sources, Integer.MAX_VALUE);
     }
@@ -1009,14 +1009,14 @@ public class Single<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.7 - experimental
      * @param <T> the value type of the inner Singles and the resulting Observable
      * @param sources the Observable that emits Singles to be merged
      * @param maxConcurrency the maximum number of inner Singles to run at a time
      * @return the new Observable instance
-     * @since 1.2.7 - experimental
+     * @since 1.3
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    @Experimental
     public static <T> Observable<T> mergeDelayError(Observable<? extends Single<? extends T>> sources, int maxConcurrency) {
         return sources.flatMapSingle((Func1)UtilityFunctions.identity(), true, maxConcurrency);
     }
@@ -1452,8 +1452,8 @@ public class Single<T> {
      * @return a Single that, when first subscribed to, caches its response for the
      *         benefit of subsequent subscribers
      * @see <a href="http://reactivex.io/documentation/operators/replay.html">ReactiveX operators documentation: Replay</a>
+     * @since 1.3
      */
-    @Experimental
     public final Single<T> cache() {
         return toObservable().cacheWithInitialCapacity(1).toSingle();
     }
@@ -1537,9 +1537,8 @@ public class Single<T> {
      *            Completable
      * @return the Completable returned from {@code func} when applied to the item emitted by the source Single
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Completable flatMapCompletable(final Func1<? super T, ? extends Completable> func) {
         return Completable.create(new CompletableFlatMapSingleToCompletable<T>(this, func));
     }
@@ -1669,10 +1668,8 @@ public class Single<T> {
      * @param resumeSingleInCaseOfError a Single that will take control if source Single encounters an error.
      * @return the original Single, with appropriately modified behavior.
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Single<T> onErrorResumeNext(Single<? extends T> resumeSingleInCaseOfError) {
         return new Single<T>(SingleOperatorOnErrorResumeNext.withOther(this, resumeSingleInCaseOfError));
     }
@@ -1703,10 +1700,8 @@ public class Single<T> {
      * @param resumeFunctionInCaseOfError a function that returns a Single that will take control if source Single encounters an error.
      * @return the original Single, with appropriately modified behavior.
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Single<T> onErrorResumeNext(final Func1<Throwable, ? extends Single<? extends T>> resumeFunctionInCaseOfError) {
         return new Single<T>(SingleOperatorOnErrorResumeNext.withFunction(this, resumeFunctionInCaseOfError));
     }
@@ -2117,8 +2112,8 @@ public class Single<T> {
      * @param <R> the resulting object type
      * @param converter the function that receives the current Single instance and returns a value
      * @return the value returned by the function
+     * @since 1.3
      */
-    @Experimental
     public final <R> R to(Func1<? super Single<T>, R> converter) {
         return converter.call(this);
     }
@@ -2150,10 +2145,8 @@ public class Single<T> {
      * @return a {@link Completable} that calls {@code onCompleted} on it's subscriber when the source {@link Single}
      *         calls {@code onSuccess}.
      * @see <a href="http://reactivex.io/documentation/completable.html">ReactiveX documentation: Completable</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical
-     *        with the release number).
+     * @since 1.3
      */
-    @Beta
     public final Completable toCompletable() {
         return Completable.fromSingle(this);
     }
@@ -2276,8 +2269,8 @@ public class Single<T> {
      *
      * @return a {@code BlockingSingle} version of this Single.
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
+     * @since 1.3
      */
-    @Beta
     public final BlockingSingle<T> toBlocking() {
         return BlockingSingle.from(this);
     }
@@ -2326,9 +2319,8 @@ public class Single<T> {
      *            the action to invoke if the source {@link Single} calls {@code onError}
      * @return the source {@link Single} with the side-effecting behavior applied
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Single<T> doOnError(final Action1<Throwable> onError) {
         if (onError == null) {
             throw new IllegalArgumentException("onError is null");
@@ -2355,9 +2347,8 @@ public class Single<T> {
      *            the action to invoke when the source {@link Single} calls {@code onSuccess} or {@code onError}.
      * @return the source {@link Single} with the side-effecting behavior applied
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final Single<T> doOnEach(final Action1<Notification<? extends T>> onNotification) {
         if (onNotification == null) {
             throw new IllegalArgumentException("onNotification is null");
@@ -2389,9 +2380,8 @@ public class Single<T> {
      *            the action to invoke when the source {@link Single} calls {@code onSuccess}
      * @return the source {@link Single} with the side-effecting behavior applied
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final Single<T> doOnSuccess(final Action1<? super T> onSuccess) {
         if (onSuccess == null) {
             throw new IllegalArgumentException("onSuccess is null");
@@ -2417,9 +2407,8 @@ public class Single<T> {
      *            the action that gets called when an observer subscribes to this {@code Single}
      * @return the source {@code Single} modified so as to call this Action when appropriate
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Single<T> doOnSubscribe(final Action0 subscribe) {
         return create(new SingleDoOnSubscribe<T>(onSubscribe, subscribe));
     }
@@ -2442,9 +2431,8 @@ public class Single<T> {
      *            the {@link Scheduler} to use for delaying
      * @return the source Single shifted in time by the specified delay
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Single<T> delay(long delay, TimeUnit unit, Scheduler scheduler) {
         return create(new SingleDelay<T>(onSubscribe, delay, unit, scheduler));
     }
@@ -2465,9 +2453,8 @@ public class Single<T> {
      *            the {@link TimeUnit} in which {@code period} is defined
      * @return the source Single shifted in time by the specified delay
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Single<T> delay(long delay, TimeUnit unit) {
         return delay(delay, unit, Schedulers.computation());
     }
@@ -2495,9 +2482,8 @@ public class Single<T> {
      * @return a {@link Single} whose {@link Observer}s' subscriptions trigger an invocation of the given
      *         {@link Single} factory function.
      * @see <a href="http://reactivex.io/documentation/operators/defer.html">ReactiveX operators documentation: Defer</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T> Single<T> defer(final Callable<Single<T>> singleFactory) {
         return create(new OnSubscribe<T>() {
             @Override
@@ -2531,9 +2517,8 @@ public class Single<T> {
      *            the action that gets called when this {@link Single} is unsubscribed.
      * @return the source {@link Single} modified so as to call this Action when appropriate.
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Single<T> doOnUnsubscribe(final Action0 action) {
         return create(new SingleDoOnUnsubscribe<T>(onSubscribe, action));
     }
@@ -2553,9 +2538,8 @@ public class Single<T> {
      * @return a {@link Single} that emits the same item or error as the source {@link Single}, then invokes the
      *         {@link Action0}
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Single<T> doAfterTerminate(Action0 action) {
         return create(new SingleDoAfterTerminate<T>(this, action));
     }
@@ -2735,8 +2719,8 @@ public class Single<T> {
      *            the function that will dispose of the resource
      * @return the Single whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
+     * @since 1.3
      */
-    @Beta
     public static <T, Resource> Single<T> using(
             final Func0<Resource> resourceFactory,
             final Func1<? super Resource, ? extends Single<? extends T>> singleFactory,
@@ -2770,10 +2754,8 @@ public class Single<T> {
      *            a terminal event ({@code onComplete} or {@code onError}).
      * @return the Single whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
-     * @Experimental The behavior of this can change at any time.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static <T, Resource> Single<T> using(
             final Func0<Resource> resourceFactory,
             final Func1<? super Resource, ? extends Single<? extends T>> singleFactory,
@@ -2806,9 +2788,8 @@ public class Single<T> {
      *        to this Single.
      * @return a Single that delays the subscription to this Single
      *         until the Observable emits an element or completes normally.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public final Single<T> delaySubscription(Observable<?> other) {
         if (other == null) {
             throw new NullPointerException();
@@ -2874,10 +2855,10 @@ public class Single<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 1.2.3 - experimental
      * @return the new AssertableSubscriber instance
-     * @since 1.2.3
+     * @since 1.3
      */
-    @Experimental
     public final AssertableSubscriber<T> test() {
         AssertableSubscriberObservable<T> ts = AssertableSubscriberObservable.create(Long.MAX_VALUE);
         subscribe(ts);

--- a/src/main/java/rx/SingleEmitter.java
+++ b/src/main/java/rx/SingleEmitter.java
@@ -23,7 +23,7 @@ import rx.functions.Cancellable;
  * <p>
  * All methods are thread-safe; calling onSuccess or onError twice or one after the other has
  * no effect.
- * <p>History: 1.2.3 -experimental 
+ * <p>History: 1.2.3 - experimental 
  * @param <T> the success value type
  * @since 1.3
  */

--- a/src/main/java/rx/SingleEmitter.java
+++ b/src/main/java/rx/SingleEmitter.java
@@ -15,7 +15,6 @@
  */
 package rx;
 
-import rx.annotations.Experimental;
 import rx.functions.Cancellable;
 
 /**
@@ -24,11 +23,10 @@ import rx.functions.Cancellable;
  * <p>
  * All methods are thread-safe; calling onSuccess or onError twice or one after the other has
  * no effect.
- * @since 1.2.3 - experimental (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
- * 
+ * <p>History: 1.2.3 -experimental 
  * @param <T> the success value type
+ * @since 1.3
  */
-@Experimental
 public interface SingleEmitter<T> {
 
     /**

--- a/src/main/java/rx/exceptions/AssemblyStackTraceException.java
+++ b/src/main/java/rx/exceptions/AssemblyStackTraceException.java
@@ -17,14 +17,13 @@ package rx.exceptions;
 
 import java.util.*;
 
-import rx.annotations.Experimental;
 import rx.plugins.RxJavaHooks;
 
 /**
  * A RuntimeException that is stackless but holds onto a textual
  * stacktrace from tracking the assembly location of operators.
+ * @since 1.3
  */
-@Experimental
 public final class AssemblyStackTraceException extends RuntimeException {
 
     /** */

--- a/src/main/java/rx/exceptions/CompositeException.java
+++ b/src/main/java/rx/exceptions/CompositeException.java
@@ -18,8 +18,6 @@ package rx.exceptions;
 import java.io.*;
 import java.util.*;
 
-import rx.annotations.Beta;
-
 /**
  * Represents an exception that is a composite of one or more other exceptions. A {@code CompositeException}
  * does not modify the structure of any exception it wraps, but at print-time it iterates through the list of
@@ -85,8 +83,8 @@ public final class CompositeException extends RuntimeException {
     /**
      * Constructs a CompositeException instance with the supplied initial Throwables.
      * @param errors the array of Throwables
+     * @since 1.3
      */
-    @Beta
     public CompositeException(Throwable... errors) {
         Set<Throwable> deDupedExceptions = new LinkedHashSet<Throwable>();
         List<Throwable> localExceptions = new ArrayList<Throwable>();

--- a/src/main/java/rx/exceptions/Exceptions.java
+++ b/src/main/java/rx/exceptions/Exceptions.java
@@ -19,7 +19,6 @@ import java.util.*;
 
 import rx.Observer;
 import rx.SingleSubscriber;
-import rx.annotations.Beta;
 
 /**
  * Utility class with methods to wrap checked exceptions and
@@ -182,9 +181,8 @@ public final class Exceptions {
      * @param t the exception
      * @param o the observer to report to
      * @param value the value that caused the exception
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static void throwOrReport(Throwable t, Observer<?> o, Object value) {
         Exceptions.throwIfFatal(t);
         o.onError(OnErrorThrowable.addValueAsLastCause(t, value));
@@ -196,9 +194,8 @@ public final class Exceptions {
      * @param t the exception
      * @param o the observer to report to
      * @param value the value that caused the exception
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static void throwOrReport(Throwable t, SingleSubscriber<?> o, Object value) {
         Exceptions.throwIfFatal(t);
         o.onError(OnErrorThrowable.addValueAsLastCause(t, value));
@@ -208,9 +205,8 @@ public final class Exceptions {
      * Forwards a fatal exception or reports it to the given Observer.
      * @param t the exception
      * @param o the observer to report to
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public static void throwOrReport(Throwable t, Observer<?> o) {
         Exceptions.throwIfFatal(t);
         o.onError(t);
@@ -221,9 +217,8 @@ public final class Exceptions {
      *
      * @param throwable the exception.
      * @param subscriber the subscriber to report to.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number).
+     * @since 1.3
      */
-    @Beta
     public static void throwOrReport(Throwable throwable, SingleSubscriber<?> subscriber) {
         Exceptions.throwIfFatal(throwable);
         subscriber.onError(throwable);

--- a/src/main/java/rx/functions/Cancellable.java
+++ b/src/main/java/rx/functions/Cancellable.java
@@ -16,12 +16,10 @@
 
 package rx.functions;
 
-import rx.annotations.Experimental;
-
 /**
  * A functional interface that has a single close method that can throw.
+ * @since 1.3
  */
-@Experimental
 public interface Cancellable {
 
     /**

--- a/src/main/java/rx/internal/observers/AssertableSubscriberObservable.java
+++ b/src/main/java/rx/internal/observers/AssertableSubscriberObservable.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 
 import rx.Producer;
 import rx.Subscriber;
-import rx.annotations.Experimental;
 import rx.functions.Action0;
 import rx.observers.TestSubscriber;
 import rx.observers.AssertableSubscriber;
@@ -33,8 +32,8 @@ import rx.observers.AssertableSubscriber;
  * 
  * @param <T>
  *            the value type
+ * @since 1.3
  */
-@Experimental
 public class AssertableSubscriberObservable<T> extends Subscriber<T> implements AssertableSubscriber<T> {
 
     private final TestSubscriber<T> ts;

--- a/src/main/java/rx/internal/operators/OnSubscribeFlatMapCompletable.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFlatMapCompletable.java
@@ -27,8 +27,9 @@ import rx.subscriptions.CompositeSubscription;
 /**
  * Maps upstream values to Completables and merges them, up to a given
  * number of them concurrently, optionally delaying errors.
+ * <p>History: 1.2.7 - experimental
  * @param <T> the upstream value type
- * @since 1.2.7 - experimental
+ * @since 1.3
  */
 public final class OnSubscribeFlatMapCompletable<T> implements Observable.OnSubscribe<T> {
 

--- a/src/main/java/rx/internal/operators/OnSubscribeFlatMapSingle.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeFlatMapSingle.java
@@ -31,9 +31,10 @@ import rx.subscriptions.CompositeSubscription;
 /**
  * Maps upstream values to Singles and merges them, up to a given
  * number of them concurrently, optionally delaying errors.
+ * <p>History: 1.2.7 - experimental
  * @param <T> the upstream value type
  * @param <R> the inner Singles and result value type
- * @since 1.2.7 - experimental
+ * @since 1.3
  */
 public final class OnSubscribeFlatMapSingle<T, R> implements Observable.OnSubscribe<R> {
 

--- a/src/main/java/rx/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/rx/internal/schedulers/SchedulerWhen.java
@@ -26,7 +26,6 @@ import rx.Observable;
 import rx.Observer;
 import rx.Scheduler;
 import rx.Subscription;
-import rx.annotations.Experimental;
 import rx.functions.Action0;
 import rx.functions.Func1;
 import rx.internal.operators.BufferUntilSubscriber;
@@ -101,8 +100,8 @@ import rx.subscriptions.Subscriptions;
  *     }));
  * });
  * </pre>
+ * @since 1.3
  */
-@Experimental
 public class SchedulerWhen extends Scheduler implements Subscription {
     private final Scheduler actualScheduler;
     private final Observer<Observable<Completable>> workerObserver;

--- a/src/main/java/rx/internal/util/BackpressureDrainManager.java
+++ b/src/main/java/rx/internal/util/BackpressureDrainManager.java
@@ -18,16 +18,14 @@ package rx.internal.util;
 import java.util.concurrent.atomic.AtomicLong;
 
 import rx.Producer;
-import rx.annotations.Experimental;
 
 /**
  * Manages the producer-backpressure-consumer interplay by
  * matching up available elements with requested elements and/or
  * terminal events.
- *
- * @since 1.1.0
+ * <p>History: 1.1.0 - experimental
+ * @since 1.3
  */
-@Experimental
 public final class BackpressureDrainManager extends AtomicLong implements Producer {
     /** */
     private static final long serialVersionUID = 2826241102729529449L;

--- a/src/main/java/rx/internal/util/BlockingUtils.java
+++ b/src/main/java/rx/internal/util/BlockingUtils.java
@@ -17,7 +17,6 @@
 package rx.internal.util;
 
 import rx.Subscription;
-import rx.annotations.Experimental;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -25,8 +24,8 @@ import java.util.concurrent.CountDownLatch;
  * Utility functions relating to blocking types.
  * <p/>
  * Not intended to be part of the public API.
+ * @since 1.3
  */
-@Experimental
 public final class BlockingUtils {
 
     private BlockingUtils() { }
@@ -37,7 +36,6 @@ public final class BlockingUtils {
      * @param latch        a CountDownLatch
      * @param subscription the Subscription to wait on.
      */
-    @Experimental
     public static void awaitForComplete(CountDownLatch latch, Subscription subscription) {
         if (latch.getCount() == 0) {
             // Synchronous observable completes before awaiting for it.

--- a/src/main/java/rx/observables/AsyncOnSubscribe.java
+++ b/src/main/java/rx/observables/AsyncOnSubscribe.java
@@ -23,7 +23,7 @@ import rx.*;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
-import rx.annotations.Experimental;
+import rx.annotations.Beta;
 import rx.functions.*;
 import rx.internal.operators.BufferUntilSubscriber;
 import rx.observers.SerializedObserver;
@@ -43,8 +43,9 @@ import rx.subscriptions.CompositeSubscription;
  *            {@link #onUnsubscribe(Object) onUnsubscribe(S)}.
  * @param <T>
  *            the type of {@code Subscribers} that will be compatible with {@code this}.
+ * @since 1.3 - beta
  */
-@Experimental
+@Beta
 public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
 
     /**
@@ -110,7 +111,6 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      *            {@link #next(Object, long, Observer) next(S, long, Observer)})
      * @return an AsyncOnSubscribe that emits data in a protocol compatible with back-pressure.
      */
-    @Experimental
     public static <S, T> AsyncOnSubscribe<S, T> createSingleState(Func0<? extends S> generator,
             final Action3<? super S, Long, ? super Observer<Observable<? extends T>>> next) {
         Func3<S, Long, ? super Observer<Observable<? extends T>>, S> nextFunc =
@@ -141,7 +141,6 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * @return an AsyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
      */
-    @Experimental
     public static <S, T> AsyncOnSubscribe<S, T> createSingleState(Func0<? extends S> generator,
             final Action3<? super S, Long, ? super Observer<Observable<? extends T>>> next,
             final Action1<? super S> onUnsubscribe) {
@@ -171,7 +170,6 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * @return an AsyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
      */
-    @Experimental
     public static <S, T> AsyncOnSubscribe<S, T> createStateful(Func0<? extends S> generator,
             Func3<? super S, Long, ? super Observer<Observable<? extends T>>, ? extends S> next,
             Action1<? super S> onUnsubscribe) {
@@ -192,7 +190,6 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * @return an AsyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
      */
-    @Experimental
     public static <S, T> AsyncOnSubscribe<S, T> createStateful(Func0<? extends S> generator,
             Func3<? super S, Long, ? super Observer<Observable<? extends T>>, ? extends S> next) {
         return new AsyncOnSubscribeImpl<S, T>(generator, next);
@@ -212,7 +209,6 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * @return an AsyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
      */
-    @Experimental
     public static <T> AsyncOnSubscribe<Void, T> createStateless(final Action2<Long, ? super Observer<Observable<? extends T>>> next) {
         Func3<Void, Long, Observer<Observable<? extends T>>, Void> nextFunc =
                 new Func3<Void, Long, Observer<Observable<? extends T>>, Void>() {
@@ -240,7 +236,6 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
      * @return an AsyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
      */
-    @Experimental
     public static <T> AsyncOnSubscribe<Void, T> createStateless(final Action2<Long, ? super Observer<Observable<? extends T>>> next,
             final Action0 onUnsubscribe) {
         Func3<Void, Long, Observer<Observable<? extends T>>, Void> nextFunc =

--- a/src/main/java/rx/observables/BlockingObservable.java
+++ b/src/main/java/rx/observables/BlockingObservable.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import rx.*;
 import rx.Observable;
 import rx.Observer;
-import rx.annotations.Beta;
 import rx.exceptions.*;
 import rx.functions.*;
 import rx.internal.operators.*;
@@ -469,9 +468,8 @@ public final class BlockingObservable<T> {
 
     /**
      * Runs the source observable to a terminal event, ignoring any values and rethrowing any exception.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public void subscribe() {
         final CountDownLatch cdl = new CountDownLatch(1);
         final Throwable[] error = { null };
@@ -503,9 +501,8 @@ public final class BlockingObservable<T> {
     /**
      * Subscribes to the source and calls back the Observer methods on the current thread.
      * @param observer the observer to call event methods on
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public void subscribe(Observer<? super T> observer) {
         final BlockingQueue<Object> queue = new LinkedBlockingQueue<Object>();
 
@@ -548,10 +545,9 @@ public final class BlockingObservable<T> {
      * <p>
      * The unsubscription and backpressure is composed through.
      * @param subscriber the subscriber to forward events and calls to in the current thread
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
     @SuppressWarnings("unchecked")
-    @Beta
     public void subscribe(Subscriber<? super T> subscriber) {
         final BlockingQueue<Object> queue = new LinkedBlockingQueue<Object>();
         final Producer[] theProducer = { null };
@@ -631,9 +627,8 @@ public final class BlockingObservable<T> {
      *
      * @param onNext the callback action for each source value
      * @see #forEach(Action1)
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public void subscribe(final Action1<? super T> onNext) {
         subscribe(onNext, new Action1<Throwable>() {
             @Override
@@ -647,9 +642,8 @@ public final class BlockingObservable<T> {
      * Subscribes to the source and calls the given actions on the current thread.
      * @param onNext the callback action for each source value
      * @param onError the callback action for an error event
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public void subscribe(final Action1<? super T> onNext, final Action1<? super Throwable> onError) {
         subscribe(onNext, onError, Actions.empty());
     }
@@ -659,9 +653,8 @@ public final class BlockingObservable<T> {
      * @param onNext the callback action for each source value
      * @param onError the callback action for an error event
      * @param onCompleted the callback action for the completion event.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Beta
     public void subscribe(final Action1<? super T> onNext, final Action1<? super Throwable> onError, final Action0 onCompleted) {
         subscribe(new Observer<T>() {
             @Override

--- a/src/main/java/rx/observables/SyncOnSubscribe.java
+++ b/src/main/java/rx/observables/SyncOnSubscribe.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import rx.*;
 import rx.Observable.OnSubscribe;
-import rx.annotations.Beta;
 import rx.exceptions.Exceptions;
 import rx.functions.*;
 import rx.internal.operators.BackpressureUtils;
@@ -120,8 +119,8 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      *            produces data to the downstream subscriber (see {@link #next(Object, Observer)
      *            next(S, Subscriber)})
      * @return a SyncOnSubscribe that emits data in a protocol compatible with back-pressure.
+     * @since 1.3
      */
-    @Beta
     public static <S, T> SyncOnSubscribe<S, T> createSingleState(Func0<? extends S> generator,
             final Action2<? super S, ? super Observer<? super T>> next) {
         Func2<S, ? super Observer<? super T>, S> nextFunc = new Func2<S, Observer<? super T>, S>() {
@@ -151,8 +150,8 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      *            clean up behavior (see {@link #onUnsubscribe(Object) onUnsubscribe(S)})
      * @return a SyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
+     * @since 1.3
      */
-    @Beta
     public static <S, T> SyncOnSubscribe<S, T> createSingleState(Func0<? extends S> generator,
             final Action2<? super S, ? super Observer<? super T>> next,
             final Action1<? super S> onUnsubscribe) {
@@ -181,8 +180,8 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      *            clean up behavior (see {@link #onUnsubscribe(Object) onUnsubscribe(S)})
      * @return a SyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
+     * @since 1.3
      */
-    @Beta
     public static <S, T> SyncOnSubscribe<S, T> createStateful(Func0<? extends S> generator,
             Func2<? super S, ? super Observer<? super T>, ? extends S> next,
             Action1<? super S> onUnsubscribe) {
@@ -202,8 +201,8 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      *            next(S, Subscriber)})
      * @return a SyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
+     * @since 1.3
      */
-    @Beta
     public static <S, T> SyncOnSubscribe<S, T> createStateful(Func0<? extends S> generator,
             Func2<? super S, ? super Observer<? super T>, ? extends S> next) {
         return new SyncOnSubscribeImpl<S, T>(generator, next);
@@ -222,8 +221,8 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      *            next(S, Subscriber)})
      * @return a SyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
+     * @since 1.3
      */
-    @Beta
     public static <T> SyncOnSubscribe<Void, T> createStateless(final Action1<? super Observer<? super T>> next) {
         Func2<Void, Observer<? super T>, Void> nextFunc = new Func2<Void, Observer<? super T>, Void>() {
             @Override
@@ -250,8 +249,8 @@ public abstract class SyncOnSubscribe<S, T> implements OnSubscribe<T> {
      *            clean up behavior (see {@link #onUnsubscribe(Object) onUnsubscribe(S)})
      * @return a SyncOnSubscribe that emits data downstream in a protocol compatible with
      *         back-pressure.
+     * @since 1.3
      */
-    @Beta
     public static <T> SyncOnSubscribe<Void, T> createStateless(final Action1<? super Observer<? super T>> next,
             final Action0 onUnsubscribe) {
         Func2<Void, Observer<? super T>, Void> nextFunc = new Func2<Void, Observer<? super T>, Void>() {

--- a/src/main/java/rx/observers/AssertableSubscriber.java
+++ b/src/main/java/rx/observers/AssertableSubscriber.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import rx.*;
-import rx.annotations.Experimental;
 import rx.functions.Action0;
 
 /**
@@ -30,10 +29,10 @@ import rx.functions.Action0;
  * <p>
  * This interface extends {@link Observer} and allows injecting onXXX signals into
  * the testing process.
+ * <p>History: 1.2.3 - experimental
  * @param <T> the value type consumed by this Observer
- * @since 1.2.3
+ * @since 1.3
  */
-@Experimental
 public interface AssertableSubscriber<T> extends Observer<T>, Subscription {
 
     /**

--- a/src/main/java/rx/observers/AsyncCompletableSubscriber.java
+++ b/src/main/java/rx/observers/AsyncCompletableSubscriber.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import rx.CompletableSubscriber;
 import rx.Subscription;
-import rx.annotations.Experimental;
 import rx.plugins.RxJavaHooks;
 
 /**
@@ -54,9 +53,8 @@ import rx.plugins.RxJavaHooks;
  *     }
  * }
  * </code></pre>
- * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+ * @since 1.3
  */
-@Experimental
 public abstract class AsyncCompletableSubscriber implements CompletableSubscriber, Subscription {
     /**
      * Indicates the unsubscribed state.

--- a/src/main/java/rx/observers/SafeCompletableSubscriber.java
+++ b/src/main/java/rx/observers/SafeCompletableSubscriber.java
@@ -17,7 +17,6 @@ package rx.observers;
 
 import rx.CompletableSubscriber;
 import rx.Subscription;
-import rx.annotations.Experimental;
 import rx.exceptions.*;
 import rx.plugins.RxJavaHooks;
 
@@ -25,9 +24,8 @@ import rx.plugins.RxJavaHooks;
  * Wraps another CompletableSubscriber and handles exceptions thrown
  * from onError and onCompleted.
  *
- * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+ * @since 1.3
  */
-@Experimental
 public final class SafeCompletableSubscriber implements CompletableSubscriber, Subscription {
     final CompletableSubscriber actual;
 

--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -20,7 +20,6 @@ import java.util.concurrent.*;
 
 import rx.*;
 import rx.Observer;
-import rx.annotations.Experimental;
 import rx.exceptions.CompositeException;
 
 /**
@@ -225,9 +224,8 @@ public class TestSubscriber<T> extends Subscriber<T> {
     /**
      * Returns the number of times onCompleted was called on this TestSubscriber.
      * @return the number of times onCompleted was called on this TestSubscriber.
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final int getCompletions() {
         return completions;
     }
@@ -356,9 +354,8 @@ public class TestSubscriber<T> extends Subscriber<T> {
      * @param unit the time unit of waiting
      * @return true if the expected number of onNext events happened
      * @throws RuntimeException if the sleep is interrupted
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final boolean awaitValueCount(int expected, long timeout, TimeUnit unit) {
         while (timeout != 0 && valueCount < expected) {
             try {
@@ -696,9 +693,8 @@ public class TestSubscriber<T> extends Subscriber<T> {
      * </pre></code>
      * @param expectedFirstValue the expected first value
      * @param expectedRestValues the optional rest values
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public final void assertValuesAndClear(T expectedFirstValue, T... expectedRestValues) {
         int n = 1 + expectedRestValues.length;
         assertValueCount(n);

--- a/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
+++ b/src/main/java/rx/plugins/RxJavaCompletableExecutionHook.java
@@ -16,7 +16,6 @@
 package rx.plugins;
 
 import rx.*;
-import rx.annotations.Experimental;
 import rx.functions.Func1;
 
 /**
@@ -35,9 +34,8 @@ import rx.functions.Func1;
  * should be fast. If anything time-consuming is to be done it should be spawned asynchronously onto separate
  * worker threads.
  *
- * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+ * @since 1.3
  */
-@Experimental
 public abstract class RxJavaCompletableExecutionHook { // NOPMD
     /**
      * Invoked during the construction by {@link Completable#create(Completable.OnSubscribe)}

--- a/src/main/java/rx/plugins/RxJavaErrorHandler.java
+++ b/src/main/java/rx/plugins/RxJavaErrorHandler.java
@@ -16,7 +16,6 @@
 package rx.plugins;
 
 import rx.*;
-import rx.annotations.Beta;
 import rx.exceptions.Exceptions;
 
 /**
@@ -64,10 +63,8 @@ public abstract class RxJavaErrorHandler { // NOPMD
      *             {@code OnErrorThrowable.OnNextValue}
      * @return a short {@link String} representation of the item if one is known for its type, or null for
      *         default
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the
-     *        release number)
+     * @since 1.3
      */
-    @Beta
     public final String handleOnNextValueRendering(Object item) {
 
         try {
@@ -95,10 +92,8 @@ public abstract class RxJavaErrorHandler { // NOPMD
      * @return a short {@link String} representation of the item if one is known for its type, or null for
      *         default
      * @throws InterruptedException if the rendering thread is interrupted
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the
-     *        release number)
+     * @since 1.3
      */
-    @Beta
     protected String render (Object item) throws InterruptedException {
         //do nothing by default
         return null;

--- a/src/main/java/rx/plugins/RxJavaHooks.java
+++ b/src/main/java/rx/plugins/RxJavaHooks.java
@@ -19,7 +19,6 @@ import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.concurrent.ScheduledExecutorService;
 
 import rx.*;
-import rx.annotations.Experimental;
 import rx.functions.*;
 import rx.internal.operators.*;
 
@@ -29,8 +28,8 @@ import rx.internal.operators.*;
  * <p>
  * The class features a lockdown state, see {@link #lockdown()} and {@link #isLockdown()}, to
  * prevent further changes to the hooks.
+ * @since 1.3
  */
-@Experimental
 public final class RxJavaHooks {
     /**
      * Prevents changing the hook callbacks when set to true.

--- a/src/main/java/rx/plugins/RxJavaPlugins.java
+++ b/src/main/java/rx/plugins/RxJavaPlugins.java
@@ -17,7 +17,6 @@ package rx.plugins;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
-import rx.annotations.Experimental;
 
 /**
  * Registry for plugin implementations that allows global override and handles the retrieval of correct
@@ -84,9 +83,9 @@ public class RxJavaPlugins {
      * during application runtime and also bad code could invoke it in
      * the middle of an application life-cycle and really break applications
      * if not used cautiously. For more detailed discussions:
-     * * @see <a href="https://github.com/ReactiveX/RxJava/issues/2297">Make RxJavaPlugins.reset() public</a>
+     * @see <a href="https://github.com/ReactiveX/RxJava/issues/2297">Make RxJavaPlugins.reset() public</a>
+     * @since 1.3
      */
-    @Experimental
     public void reset() {
         INSTANCE.errorHandler.set(null);
         INSTANCE.observableExecutionHook.set(null);
@@ -228,9 +227,8 @@ public class RxJavaPlugins {
      * full class name to load.
      *
      * @return {@link RxJavaCompletableExecutionHook} implementation to use
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public RxJavaCompletableExecutionHook getCompletableExecutionHook() {
         if (completableExecutionHook.get() == null) {
             // check for an implementation from System.getProperty first
@@ -256,9 +254,8 @@ public class RxJavaPlugins {
      * @throws IllegalStateException
      *             if called more than once or after the default was initialized (if usage occurs before trying
      *             to register)
-     * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+     * @since 1.3
      */
-    @Experimental
     public void registerCompletableExecutionHook(RxJavaCompletableExecutionHook impl) {
         if (!completableExecutionHook.compareAndSet(null, impl)) {
             throw new IllegalStateException("Another strategy was already registered: " + singleExecutionHook.get());

--- a/src/main/java/rx/plugins/RxJavaSchedulersHook.java
+++ b/src/main/java/rx/plugins/RxJavaSchedulersHook.java
@@ -18,7 +18,6 @@ package rx.plugins;
 
 import java.util.concurrent.ThreadFactory;
 import rx.Scheduler;
-import rx.annotations.Experimental;
 import rx.functions.Action0;
 import rx.internal.schedulers.CachedThreadScheduler;
 import rx.internal.schedulers.EventLoopsScheduler;
@@ -47,8 +46,8 @@ public class RxJavaSchedulersHook {
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#computation()}.
      * @return the created Scheduler instance
+     * @since 1.3
      */
-    @Experimental
     public static Scheduler createComputationScheduler() {
         return createComputationScheduler(new RxThreadFactory("RxComputationScheduler-"));
     }
@@ -58,8 +57,8 @@ public class RxJavaSchedulersHook {
      * except using {@code threadFactory} for thread creation.
      * @param threadFactory the factory to use for each worker thread
      * @return the created Scheduler instance
+     * @since 1.3
      */
-    @Experimental
     public static Scheduler createComputationScheduler(ThreadFactory threadFactory) {
         if (threadFactory == null) {
             throw new NullPointerException("threadFactory == null");
@@ -70,8 +69,8 @@ public class RxJavaSchedulersHook {
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}.
      * @return the created Scheduler instance
+     * @since 1.3
      */
-    @Experimental
     public static Scheduler createIoScheduler() {
         return createIoScheduler(new RxThreadFactory("RxIoScheduler-"));
     }
@@ -81,8 +80,8 @@ public class RxJavaSchedulersHook {
      * except using {@code threadFactory} for thread creation.
      * @param threadFactory the factory to use for each worker thread
      * @return the created Scheduler instance
+     * @since 1.3
      */
-    @Experimental
     public static Scheduler createIoScheduler(ThreadFactory threadFactory) {
         if (threadFactory == null) {
             throw new NullPointerException("threadFactory == null");
@@ -93,8 +92,8 @@ public class RxJavaSchedulersHook {
     /**
      * Create an instance of the default {@link Scheduler} used for {@link Schedulers#newThread()}.
      * @return the created Scheduler instance
+     * @since 1.3
      */
-    @Experimental
     public static Scheduler createNewThreadScheduler() {
         return createNewThreadScheduler(new RxThreadFactory("RxNewThreadScheduler-"));
     }
@@ -104,8 +103,8 @@ public class RxJavaSchedulersHook {
      * except using {@code threadFactory} for thread creation.
      * @param threadFactory the factory to use for each worker thread
      * @return the created Scheduler instance
+     * @since 1.3
      */
-    @Experimental
     public static Scheduler createNewThreadScheduler(ThreadFactory threadFactory) {
         if (threadFactory == null) {
             throw new NullPointerException("threadFactory == null");

--- a/src/main/java/rx/schedulers/Schedulers.java
+++ b/src/main/java/rx/schedulers/Schedulers.java
@@ -19,7 +19,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
 import rx.Scheduler;
-import rx.annotations.Experimental;
 import rx.internal.schedulers.*;
 import rx.plugins.*;
 
@@ -185,8 +184,8 @@ public final class Schedulers {
      * Resets the current {@link Schedulers} instance.
      * This will re-init the cached schedulers on the next usage,
      * which can be useful in testing.
+     * @since 1.3
      */
-    @Experimental
     public static void reset() {
         Schedulers s = INSTANCE.getAndSet(null);
         if (s != null) {

--- a/src/main/java/rx/singles/BlockingSingle.java
+++ b/src/main/java/rx/singles/BlockingSingle.java
@@ -20,7 +20,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import rx.*;
-import rx.annotations.*;
 import rx.exceptions.Exceptions;
 import rx.internal.operators.BlockingOperatorToFuture;
 import rx.internal.util.BlockingUtils;
@@ -33,9 +32,8 @@ import rx.internal.util.BlockingUtils;
  * or {@link Single#toBlocking()}.
  *
  * @param <T> the value type of the sequence
- * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+ * @since 1.3
  */
-@Beta
 public final class BlockingSingle<T> {
     private final Single<? extends T> single;
 

--- a/src/main/java/rx/subjects/UnicastSubject.java
+++ b/src/main/java/rx/subjects/UnicastSubject.java
@@ -19,7 +19,6 @@ import java.util.Queue;
 import java.util.concurrent.atomic.*;
 
 import rx.*;
-import rx.annotations.Experimental;
 import rx.exceptions.*;
 import rx.functions.Action0;
 import rx.internal.operators.*;
@@ -35,8 +34,8 @@ import rx.internal.util.unsafe.*;
  * <p>
  * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/UnicastSubject.v1.png" alt="">
  * @param <T> the input and output value type
+ * @since 1.3
  */
-@Experimental
 public final class UnicastSubject<T> extends Subject<T, T> {
 
     final State<T> state;


### PR DESCRIPTION
This PR applies the API promotions of #5201.

Note that `Single.unsubscribeOn` remainded experimental and `Observable.fromEmitter` was removed.

Where the experimental version was available, it was moved up as `<p>History: 1.x.y - experimental` similar to how 2.x versioning/promotions happen.

Suggested review strategy:

- verify `@Experimental` and `@Beta` annotations are removed from the method and from Javadoc
- verify `@since 1.3` is present