### PR TITLE
Add the cast operator to Single.

### DIFF
--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -211,6 +211,21 @@ public class Single<T> {
      */
 
     /**
+     * Casts the success value of the current Single into the target type or signals a
+     * ClassCastException if not compatible.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code cast} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <R> the target type
+     * @param klass the type token to use for casting the success result from the current Single
+     * @return the new Single instance
+     */
+    public final <R> Single<R> cast(final Class<R> klass) {
+        return lift(new OperatorCast<T, R>(klass));
+    }
+
+    /**
      * Returns an Observable that emits the items emitted by two Singles, one after the other.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concat.png" alt="">

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -220,6 +220,7 @@ public class Single<T> {
      * @param <R> the target type
      * @param klass the type token to use for casting the success result from the current Single
      * @return the new Single instance
+     * @since 1.3.1 - experimental
      */
     public final <R> Single<R> cast(final Class<R> klass) {
         return map(new SingleOperatorCast<T, R>(klass));

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -222,7 +222,7 @@ public class Single<T> {
      * @return the new Single instance
      */
     public final <R> Single<R> cast(final Class<R> klass) {
-        return lift(new OperatorCast<T, R>(klass));
+        return map(new SingleOperatorCast<T, R>(klass));
     }
 
     /**

--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -222,6 +222,7 @@ public class Single<T> {
      * @return the new Single instance
      * @since 1.3.1 - experimental
      */
+    @Experimental
     public final <R> Single<R> cast(final Class<R> klass) {
         return map(new SingleOperatorCast<T, R>(klass));
     }

--- a/src/main/java/rx/internal/operators/SingleOperatorCast.java
+++ b/src/main/java/rx/internal/operators/SingleOperatorCast.java
@@ -1,0 +1,27 @@
+/*
+ * This is the confidential unpublished intellectual property of EMC Corporation,
+ * and includes without limitation exclusive copyright and trade secret rights
+ * of EMC throughout the world.
+ */
+package rx.internal.operators;
+
+import rx.functions.Func1;
+
+/**
+ * Converts the element of a Single to the specified type.
+ * @param <T> the input value type
+ * @param <R> the output value type
+ */
+public class SingleOperatorCast<T, R> implements Func1<T, R> {
+
+  final Class<R> castClass;
+
+  public SingleOperatorCast(Class<R> castClass) {
+    this.castClass = castClass;
+  }
+
+  @Override
+  public R call(T t) {
+    return castClass.cast(t);
+  }
+}

--- a/src/main/java/rx/internal/operators/SingleOperatorCast.java
+++ b/src/main/java/rx/internal/operators/SingleOperatorCast.java
@@ -14,14 +14,14 @@ import rx.functions.Func1;
  */
 public class SingleOperatorCast<T, R> implements Func1<T, R> {
 
-  final Class<R> castClass;
+    final Class<R> castClass;
 
-  public SingleOperatorCast(Class<R> castClass) {
-    this.castClass = castClass;
-  }
+    public SingleOperatorCast(Class<R> castClass) {
+        this.castClass = castClass;
+    }
 
-  @Override
-  public R call(T t) {
-    return castClass.cast(t);
-  }
+    @Override
+    public R call(T t) {
+        return castClass.cast(t);
+    }
 }

--- a/src/main/java/rx/internal/operators/SingleOperatorCast.java
+++ b/src/main/java/rx/internal/operators/SingleOperatorCast.java
@@ -1,7 +1,17 @@
-/*
- * This is the confidential unpublished intellectual property of EMC Corporation,
- * and includes without limitation exclusive copyright and trade secret rights
- * of EMC throughout the world.
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package rx.internal.operators;
 

--- a/src/test/java/rx/internal/operators/OperatorCastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorCastTest.java
@@ -69,31 +69,4 @@ public class OperatorCastTest {
 
         ts.assertError(ClassCastException.class);
     }
-
-    @Test
-    public void testSingleCast() {
-        Single<?> source = Single.just(1);
-        Single<Integer> single = source.cast(Integer.class);
-
-        @SuppressWarnings("unchecked")
-        Observer<Integer> observer = mock(Observer.class);
-        single.subscribe(observer);
-        verify(observer, times(1)).onNext(1);
-        verify(observer, times(1)).onNext(1);
-        verify(observer, never()).onError(
-            org.mockito.Matchers.any(Throwable.class));
-        verify(observer, times(1)).onCompleted();
-    }
-
-    @Test
-    public void testSingleCastWithWrongType() {
-        Single<?> source = Single.just(1);
-        Single<Boolean> single = source.cast(Boolean.class);
-
-        @SuppressWarnings("unchecked")
-        Observer<Boolean> observer = mock(Observer.class);
-        single.subscribe(observer);
-        verify(observer, times(1)).onError(
-            org.mockito.Matchers.any(ClassCastException.class));
-    }
 }

--- a/src/test/java/rx/internal/operators/OperatorCastTest.java
+++ b/src/test/java/rx/internal/operators/OperatorCastTest.java
@@ -69,4 +69,31 @@ public class OperatorCastTest {
 
         ts.assertError(ClassCastException.class);
     }
+
+    @Test
+    public void testSingleCast() {
+        Single<?> source = Single.just(1);
+        Single<Integer> single = source.cast(Integer.class);
+
+        @SuppressWarnings("unchecked")
+        Observer<Integer> observer = mock(Observer.class);
+        single.subscribe(observer);
+        verify(observer, times(1)).onNext(1);
+        verify(observer, times(1)).onNext(1);
+        verify(observer, never()).onError(
+            org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onCompleted();
+    }
+
+    @Test
+    public void testSingleCastWithWrongType() {
+        Single<?> source = Single.just(1);
+        Single<Boolean> single = source.cast(Boolean.class);
+
+        @SuppressWarnings("unchecked")
+        Observer<Boolean> observer = mock(Observer.class);
+        single.subscribe(observer);
+        verify(observer, times(1)).onError(
+            org.mockito.Matchers.any(ClassCastException.class));
+    }
 }

--- a/src/test/java/rx/internal/operators/SingleOperatorCastTest.java
+++ b/src/test/java/rx/internal/operators/SingleOperatorCastTest.java
@@ -1,7 +1,17 @@
-/*
- * This is the confidential unpublished intellectual property of EMC Corporation,
- * and includes without limitation exclusive copyright and trade secret rights
- * of EMC throughout the world.
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package rx.internal.operators;
 ;

--- a/src/test/java/rx/internal/operators/SingleOperatorCastTest.java
+++ b/src/test/java/rx/internal/operators/SingleOperatorCastTest.java
@@ -32,7 +32,6 @@ public class SingleOperatorCastTest {
         Observer<Integer> observer = mock(Observer.class);
         single.subscribe(observer);
         verify(observer, times(1)).onNext(1);
-        verify(observer, times(1)).onNext(1);
         verify(observer, never()).onError(
             org.mockito.Matchers.any(Throwable.class));
         verify(observer, times(1)).onCompleted();

--- a/src/test/java/rx/internal/operators/SingleOperatorCastTest.java
+++ b/src/test/java/rx/internal/operators/SingleOperatorCastTest.java
@@ -1,0 +1,42 @@
+/*
+ * This is the confidential unpublished intellectual property of EMC Corporation,
+ * and includes without limitation exclusive copyright and trade secret rights
+ * of EMC throughout the world.
+ */
+package rx.internal.operators;
+;
+import org.junit.Test;
+import rx.Observer;
+import rx.Single;
+
+import static org.mockito.Mockito.*;
+
+public class SingleOperatorCastTest {
+
+    @Test
+    public void testSingleCast() {
+        Single<?> source = Single.just(1);
+        Single<Integer> single = source.cast(Integer.class);
+
+        @SuppressWarnings("unchecked")
+        Observer<Integer> observer = mock(Observer.class);
+        single.subscribe(observer);
+        verify(observer, times(1)).onNext(1);
+        verify(observer, times(1)).onNext(1);
+        verify(observer, never()).onError(
+            org.mockito.Matchers.any(Throwable.class));
+        verify(observer, times(1)).onCompleted();
+    }
+
+    @Test
+    public void testSingleCastWithWrongType() {
+        Single<?> source = Single.just(1);
+        Single<Boolean> single = source.cast(Boolean.class);
+
+        @SuppressWarnings("unchecked")
+        Observer<Boolean> observer = mock(Observer.class);
+        single.subscribe(observer);
+        verify(observer, times(1)).onError(
+            org.mockito.Matchers.any(ClassCastException.class));
+    }
+}


### PR DESCRIPTION
Adding the cast operator to Single.  This exists in the 2.x branch but not in the 1.x branch, so callers have had to do unnatural operations like `.map(SomeClass.class:cast)` to get around this.  Added tests similar to those for Observable.cast. 

Signed-off-by: Mike Burns <burnsm523@gmail.com>