### PR TITLE
Fix Javadoc for Maybe.toSingle

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3116,7 +3116,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * Converts this Maybe into a Single instance composing cancellation
-     * through and turning an empty Maybe into a signal of NoSuchElementException.
+     * through and turning an empty Maybe into a Single that emits the given
+     * value through onSuccess.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toSingle} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
The Javadoc for the `Maybe.toSingle()` overload that accepts a `defaultValue` incorrectly states that it will convert an empty `Maybe` into a `Single` that signals `NoSuchElementException` (likely copied from the version of `Maybe.toSingle()` that does not accept a default value).

This change updates the Javadoc to indicate that the returned `Single` will emit `defaultValue` if called on an empty `Maybe`.

Relevant existing test: https://github.com/ReactiveX/RxJava/blob/8819cc933e26449751535bc48ba2f10852c9b96d/src/test/java/io/reactivex/maybe/MaybeTest.java#L2730