### PR TITLE
1.x: remove semicolon that Eclipse thinks is compile error

### DIFF
--- a/src/test/java/rx/internal/operators/SingleOperatorCastTest.java
+++ b/src/test/java/rx/internal/operators/SingleOperatorCastTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 package rx.internal.operators;
-;
+
 import org.junit.Test;
 import rx.Observer;
 import rx.Single;


### PR DESCRIPTION
as per title, gradle build works fine but Eclipse doesn't like it.