### PR TITLE
2.x: make sure interval+trampoline can be stopped

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableInterval.java
@@ -19,9 +19,11 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.schedulers.TrampolineScheduler;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
@@ -43,9 +45,16 @@ public final class FlowableInterval extends Flowable<Long> {
         IntervalSubscriber is = new IntervalSubscriber(s);
         s.onSubscribe(is);
 
-        Disposable d = scheduler.schedulePeriodicallyDirect(is, initialDelay, period, unit);
+        Scheduler sch = scheduler;
 
-        is.setResource(d);
+        if (sch instanceof TrampolineScheduler) {
+            Worker worker = sch.createWorker();
+            is.setResource(worker);
+            worker.schedulePeriodically(is, initialDelay, period, unit);
+        } else {
+            Disposable d = sch.schedulePeriodicallyDirect(is, initialDelay, period, unit);
+            is.setResource(d);
+        }
     }
 
     static final class IntervalSubscriber extends AtomicLong

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIntervalRange.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIntervalRange.java
@@ -19,9 +19,11 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.schedulers.TrampolineScheduler;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 
@@ -47,9 +49,16 @@ public final class FlowableIntervalRange extends Flowable<Long> {
         IntervalRangeSubscriber is = new IntervalRangeSubscriber(s, start, end);
         s.onSubscribe(is);
 
-        Disposable d = scheduler.schedulePeriodicallyDirect(is, initialDelay, period, unit);
+        Scheduler sch = scheduler;
 
-        is.setResource(d);
+        if (sch instanceof TrampolineScheduler) {
+            Worker worker = sch.createWorker();
+            is.setResource(worker);
+            worker.schedulePeriodically(is, initialDelay, period, unit);
+        } else {
+            Disposable d = sch.schedulePeriodicallyDirect(is, initialDelay, period, unit);
+            is.setResource(d);
+        }
     }
 
     static final class IntervalRangeSubscriber extends AtomicLong

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableIntervalRange.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableIntervalRange.java
@@ -17,8 +17,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
+import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.schedulers.TrampolineScheduler;
 
 public final class ObservableIntervalRange extends Observable<Long> {
     final Scheduler scheduler;
@@ -42,9 +44,16 @@ public final class ObservableIntervalRange extends Observable<Long> {
         IntervalRangeObserver is = new IntervalRangeObserver(s, start, end);
         s.onSubscribe(is);
 
-        Disposable d = scheduler.schedulePeriodicallyDirect(is, initialDelay, period, unit);
+        Scheduler sch = scheduler;
 
-        is.setResource(d);
+        if (sch instanceof TrampolineScheduler) {
+            Worker worker = sch.createWorker();
+            is.setResource(worker);
+            worker.schedulePeriodically(is, initialDelay, period, unit);
+        } else {
+            Disposable d = sch.schedulePeriodicallyDirect(is, initialDelay, period, unit);
+            is.setResource(d);
+        }
     }
 
     static final class IntervalRangeObserver

--- a/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
@@ -100,6 +100,10 @@ public final class TrampolineScheduler extends Scheduler {
                 int missed = 1;
                 for (;;) {
                     for (;;) {
+                        if (disposed) {
+                            queue.clear();
+                            return EmptyDisposable.INSTANCE;
+                        }
                         final TimedRunnable polled = queue.poll();
                         if (polled == null) {
                             break;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalRangeTest.java
@@ -109,4 +109,12 @@ public class FlowableIntervalRangeTest {
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1L);
     }
+
+    @Test(timeout = 2000)
+    public void cancel() {
+        Flowable.intervalRange(0, 20, 1, 1, TimeUnit.MILLISECONDS, Schedulers.trampoline())
+        .take(10)
+        .test()
+        .assertResult(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalTest.java
@@ -11,25 +11,20 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.operators.observable;
+package io.reactivex.internal.operators.flowable;
 
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import io.reactivex.*;
-import io.reactivex.schedulers.*;
+import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
 
-public class ObservableIntervalTest {
-
-    @Test
-    public void dispose() {
-        TestHelper.checkDisposed(Observable.interval(1, TimeUnit.MILLISECONDS, new TestScheduler()));
-    }
+public class FlowableIntervalTest {
 
     @Test(timeout = 2000)
     public void cancel() {
-        Observable.interval(1, TimeUnit.MILLISECONDS, Schedulers.trampoline())
+        Flowable.interval(1, TimeUnit.MILLISECONDS, Schedulers.trampoline())
         .take(10)
         .test()
         .assertResult(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableIntervalRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableIntervalRangeTest.java
@@ -76,4 +76,12 @@ public class ObservableIntervalRangeTest {
     public void dispose() {
         TestHelper.checkDisposed(Observable.intervalRange(1, 2, 1, 1, TimeUnit.MILLISECONDS));
     }
+
+    @Test(timeout = 2000)
+    public void cancel() {
+        Observable.intervalRange(0, 20, 1, 1, TimeUnit.MILLISECONDS, Schedulers.trampoline())
+        .take(10)
+        .test()
+        .assertResult(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
+    }
 }


### PR DESCRIPTION
This PR fixes the case where a `trampoline` scheduler is used with the `interval` or `intervalRange` operator, the periodic emissions can't be cancelled properly. The synchronous and blocking nature of the periodic schedule is that the `Disposable` is never connected with the downstream and the `interval` stays in a drain-sleep loop per emission indefinitely.

This PR changes the operators to use the `Worker` of a trampoline scheduler that is available before the drain-sleep loop thus a downstream cancellation can stop the loop. Any other "async" scheduler will still use the direct periodic scheduling facility.

In addition, the trampoline loop has been fixed to check for the worker `disposed` state in the inner loop.
