### PR TITLE
2.x: Flowable.combineLatest combiner should not return null

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -167,7 +167,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param sources
      *            the collection of source Publishers
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -208,7 +208,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param sources
      *            the collection of source Publishers
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -249,7 +249,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param sources
      *            the collection of source Publishers
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @param bufferSize
      *            the internal buffer size and prefetch amount applied to every source Flowable
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
@@ -298,7 +298,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param sources
      *            the collection of source Publishers
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -340,7 +340,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param sources
      *            the collection of source Publishers
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @param bufferSize
      *            the internal buffer size and prefetch amount applied to every source Flowable
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
@@ -387,7 +387,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param sources
      *            the collection of source Publishers
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -430,7 +430,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param sources
      *            the collection of source Publishers
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -473,7 +473,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param sources
      *            the collection of source Publishers
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @param bufferSize
      *            the internal buffer size and prefetch amount applied to every source Publisher
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
@@ -518,7 +518,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param sources
      *            the collection of source Publishers
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @param bufferSize
      *            the internal buffer size and prefetch amount applied to every source Flowable
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
@@ -569,7 +569,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param sources
      *            the collection of source Publishers
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -612,7 +612,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param sources
      *            the collection of source Publishers
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @param bufferSize
      *            the internal buffer size and prefetch amount applied to every source Flowable
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
@@ -657,7 +657,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param source2
      *            the second source Publisher
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -705,7 +705,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param source3
      *            the third source Publisher
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -757,7 +757,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param source4
      *            the fourth source Publisher
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -813,7 +813,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param source5
      *            the fifth source Publisher
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -874,7 +874,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param source6
      *            the sixth source Publisher
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -939,7 +939,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param source7
      *            the seventh source Publisher
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -1009,7 +1009,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param source8
      *            the eighth source Publisher
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
@@ -1083,7 +1083,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param source9
      *            the ninth source Publisher
      * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
+     *            the aggregation function used to combine the items emitted by the source Publishers. Should not return null.
      * @return a Flowable that emits items that are the result of combining the items emitted by the source
      *         Publishers by means of the given aggregation function
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -474,7 +474,7 @@ extends Flowable<R> {
                 return null;
             }
             T[] a = (T[])queue.poll();
-            R r = combiner.apply(a);
+            R r = ObjectHelper.requireNonNull(combiner.apply(a), "combiner should not return null");
             ((CombineLatestInnerSubscriber<T>)e).requestOne();
             return r;
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -60,6 +60,29 @@ public class FlowableCombineLatestTest {
         verify(w, never()).onComplete();
         verify(w, times(1)).onError(Mockito.<RuntimeException> any());
     }
+    
+    @Test
+    public void testCombineLatestWithFunctionThatReturnsNullShouldEmitNPE() {
+        Subscriber<String> w = TestHelper.mockSubscriber();
+
+        PublishProcessor<String> w1 = PublishProcessor.create();
+        PublishProcessor<String> w2 = PublishProcessor.create();
+
+        Flowable<String> combined = Flowable.combineLatest(w1, w2, new BiFunction<String, String, String>() {
+            @Override
+            public String apply(String v1, String v2) {
+                return null;
+            }
+        });
+        combined.subscribe(w);
+
+        w1.onNext("first value of w1");
+        w2.onNext("first value of w2");
+
+        verify(w, never()).onNext(anyString());
+        verify(w, never()).onComplete();
+        verify(w, times(1)).onError(Mockito.any(NullPointerException.class));
+    }
 
     @Test
     public void testCombineLatestDifferentLengthFlowableSequences1() {


### PR DESCRIPTION
As per #5376 the combiner should not return null when applied.

* added unit test that failed on original code 
* mentioned constraint in javadoc

I'll look for some others as well.