### PR TITLE
2.x: add subscribeOn overload to avoid same-pool deadlock with create

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOn.java
@@ -65,13 +65,13 @@ public final class FlowableSubscribeOn<T> extends AbstractFlowableWithUpstream<T
 
         Publisher<T> source;
 
-        SubscribeOnSubscriber(Subscriber<? super T> actual, Scheduler.Worker worker, Publisher<T> source, boolean nonScheduledRequests) {
+        SubscribeOnSubscriber(Subscriber<? super T> actual, Scheduler.Worker worker, Publisher<T> source, boolean requestOn) {
             this.actual = actual;
             this.worker = worker;
             this.source = source;
             this.s = new AtomicReference<Subscription>();
             this.requested = new AtomicLong();
-            this.nonScheduledRequests = nonScheduledRequests;
+            this.nonScheduledRequests = !requestOn;
         }
 
         @Override


### PR DESCRIPTION
This PR adds an overload to `subscribeOn` that exposes the existing feature to optionally request on the same scheduler where the subscription happened. This is necessary to avoid same-pool deadlock when the upstream contains `create` logic that blocks the emission thread, preventing any scheduled request to get through and leading to excess buffering or dropping data excessively. By not scheduling the request, it can directly update the emitter's request tracking and let the emitter continue.

Formerly, the existing `subscribeOn` automatically disabled scheduling the requests if the immediate upstream was a `FlowableCreate`. However, if there were operators between `create` and `subscribeOn` (as often happening on Android with composing the schedulers at the end of the chain), the `subscribeOn` operator run in scheduled request mode by default. 

This change allows specifying this behavior through the new overload and thus distance between the `create` and `subscribeOn` operators no longer matters.

(Note that 1.x already has this overload.)