### PR TITLE
DefaultObserver javadoc example fix

### DIFF
--- a/src/main/java/io/reactivex/observers/DefaultObserver.java
+++ b/src/main/java/io/reactivex/observers/DefaultObserver.java
@@ -39,9 +39,8 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * instead of the standard {@code subscribe()} method.
  *
  * <p>Example<code><pre>
- * Disposable d =
- *     Observable.range(1, 5)
- *     .subscribeWith(new DefaultObserver&lt;Integer>() {
+ * Observable.range(1, 5)
+ *     .subscribe(new DefaultObserver&lt;Integer>() {
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");
  *         }
@@ -58,8 +57,6 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *             System.out.println("Done!");
  *         }
  *     });
- * // ...
- * d.dispose();
  * </pre></code>
  *
  * @param <T> the value type


### PR DESCRIPTION
The example in the javadoc of `DefaultObserver` is not compiling, `DefaultObserver` is not a `Disposable`. 
This PR updates the javadoc to provide a compiling example.