### PR TITLE
DefaultSubscriber javadoc sample fix

### DIFF
--- a/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
@@ -52,7 +52,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * <p>Example<code><pre>
  * Disposable d =
  *     Flowable.range(1, 5)
- *     .subscribeWith(new DefaultSubscriber&lt;Integer>() {
+ *     .subscribe(new DefaultSubscriber&lt;Integer>() {
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");
  *             request(1);
@@ -71,8 +71,6 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *             System.out.println("Done!");
  *         }
  *     });
- * // ...
- * d.dispose();
  * </pre></code>
  */
 public abstract class DefaultSubscriber<T> implements FlowableSubscriber<T> {

--- a/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
@@ -50,8 +50,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * @param <T> the value type
  *
  * <p>Example<code><pre>
- * Disposable d =
- *     Flowable.range(1, 5)
+ * Flowable.range(1, 5)
  *     .subscribe(new DefaultSubscriber&lt;Integer>() {
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");


### PR DESCRIPTION
The example in the javadoc of `DefaultSubscriber` is not compiling, `DefaultSubscriber` is not a `Disposable`. 
This PR updates the javadoc to provide a compiling example.

Fix is similar to #5405 for `DefaultObserver`.