### PR TITLE
2.x: fix doOnNext failure not triggering doOnError when fused

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
@@ -21,6 +21,7 @@ import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscribers.*;
+import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T> {
@@ -149,11 +150,33 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
         @Nullable
         @Override
         public T poll() throws Exception {
-            T v = qs.poll();
+            T v;
+
+            try {
+                v = qs.poll();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                try {
+                    onError.accept(ex);
+                } catch (Throwable exc) {
+                    throw new CompositeException(ex, exc);
+                }
+                throw ExceptionHelper.<Exception>throwIfThrowable(ex);
+            }
 
             if (v != null) {
                 try {
-                    onNext.accept(v);
+                    try {
+                        onNext.accept(v);
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        try {
+                            onError.accept(ex);
+                        } catch (Throwable exc) {
+                            throw new CompositeException(ex, exc);
+                        }
+                        throw ExceptionHelper.<Exception>throwIfThrowable(ex);
+                    }
                 } finally {
                     onAfterTerminate.run();
                 }
@@ -282,11 +305,33 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
         @Nullable
         @Override
         public T poll() throws Exception {
-            T v = qs.poll();
+            T v;
+
+            try {
+                v = qs.poll();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                try {
+                    onError.accept(ex);
+                } catch (Throwable exc) {
+                    throw new CompositeException(ex, exc);
+                }
+                throw ExceptionHelper.<Exception>throwIfThrowable(ex);
+            }
 
             if (v != null) {
                 try {
-                    onNext.accept(v);
+                    try {
+                        onNext.accept(v);
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        try {
+                            onError.accept(ex);
+                        } catch (Throwable exc) {
+                            throw new CompositeException(ex, exc);
+                        }
+                        throw ExceptionHelper.<Exception>throwIfThrowable(ex);
+                    }
                 } finally {
                     onAfterTerminate.run();
                 }

--- a/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
@@ -120,7 +120,7 @@ public final class ExceptionHelper {
         }
         throw (E)e;
     }
-    
+
     static final class Termination extends Throwable {
 
         private static final long serialVersionUID = -4649703670690200604L;

--- a/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
@@ -106,6 +106,21 @@ public final class ExceptionHelper {
         return list;
     }
 
+    /**
+     * Workaround for Java 6 not supporting throwing a final Throwable from a catch block.
+     * @param <E> the generic exception type
+     * @param e the Throwable error to return or throw
+     * @return the Throwable e if it is a subclass of Exception
+     * @throws E the generic exception thrown
+     */
+    @SuppressWarnings("unchecked")
+    public static <E extends Throwable> Exception throwIfThrowable(Throwable e) throws E {
+        if (e instanceof Exception) {
+            return (Exception)e;
+        }
+        throw (E)e;
+    }
+    
     static final class Termination extends Throwable {
 
         private static final long serialVersionUID = -4649703670690200604L;

--- a/src/test/java/io/reactivex/internal/util/ExceptionHelperTest.java
+++ b/src/test/java/io/reactivex/internal/util/ExceptionHelperTest.java
@@ -46,4 +46,9 @@ public class ExceptionHelperTest {
             TestHelper.race(r, r, Schedulers.single());
         }
     }
+
+    @Test(expected = InternalError.class)
+    public void throwIfThrowable() throws Exception {
+        ExceptionHelper.<Exception>throwIfThrowable(new InternalError());
+    }
 }


### PR DESCRIPTION
This PR fixes an issue when in a fused chain of `doOnNext` and `doOnError` the `doOnNext` function fails, the `doOnError` consumer is not called.

Originally reported in Reactor-Core: https://github.com/reactor/reactor-core/issues/664