### PR TITLE
2.x: more eager cancellation in flatMapX

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
@@ -72,6 +72,8 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
 
         Subscription s;
 
+        volatile boolean cancelled;
+
         FlatMapCompletableMainSubscriber(Subscriber<? super T> observer,
                 Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors,
                 int maxConcurrency) {
@@ -117,7 +119,7 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
 
             InnerConsumer inner = new InnerConsumer();
 
-            if (set.add(inner)) {
+            if (!cancelled && set.add(inner)) {
                 cs.subscribe(inner);
             }
         }
@@ -164,6 +166,7 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
 
         @Override
         public void cancel() {
+            cancelled = true;
             s.cancel();
             set.dispose();
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
@@ -79,6 +79,8 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
 
         Subscription s;
 
+        volatile boolean disposed;
+
         FlatMapCompletableMainSubscriber(CompletableObserver observer,
                 Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors,
                 int maxConcurrency) {
@@ -124,7 +126,7 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
 
             InnerObserver inner = new InnerObserver();
 
-            if (set.add(inner)) {
+            if (!disposed && set.add(inner)) {
                 cs.subscribe(inner);
             }
         }
@@ -171,6 +173,7 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
 
         @Override
         public void dispose() {
+            disposed = true;
             s.cancel();
             set.dispose();
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -128,7 +128,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
 
             InnerObserver inner = new InnerObserver();
 
-            if (set.add(inner)) {
+            if (!cancelled && set.add(inner)) {
                 ms.subscribe(inner);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -128,7 +128,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
 
             InnerObserver inner = new InnerObserver();
 
-            if (set.add(inner)) {
+            if (!cancelled && set.add(inner)) {
                 ms.subscribe(inner);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
@@ -64,6 +64,8 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
 
         Disposable d;
 
+        volatile boolean disposed;
+
         FlatMapCompletableMainObserver(Observer<? super T> observer, Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors) {
             this.actual = observer;
             this.mapper = mapper;
@@ -99,7 +101,7 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
 
             InnerObserver inner = new InnerObserver();
 
-            if (set.add(inner)) {
+            if (!disposed && set.add(inner)) {
                 cs.subscribe(inner);
             }
         }
@@ -138,6 +140,7 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
 
         @Override
         public void dispose() {
+            disposed = true;
             d.dispose();
             set.dispose();
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
@@ -69,6 +69,8 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
 
         Disposable d;
 
+        volatile boolean disposed;
+
         FlatMapCompletableMainObserver(CompletableObserver observer, Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors) {
             this.actual = observer;
             this.mapper = mapper;
@@ -104,7 +106,7 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
 
             InnerObserver inner = new InnerObserver();
 
-            if (set.add(inner)) {
+            if (!disposed && set.add(inner)) {
                 cs.subscribe(inner);
             }
         }
@@ -143,6 +145,7 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
 
         @Override
         public void dispose() {
+            disposed = true;
             d.dispose();
             set.dispose();
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
@@ -109,7 +109,7 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
 
             InnerObserver inner = new InnerObserver();
 
-            if (set.add(inner)) {
+            if (!cancelled && set.add(inner)) {
                 ms.subscribe(inner);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
@@ -109,7 +109,7 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
 
             InnerObserver inner = new InnerObserver();
 
-            if (set.add(inner)) {
+            if (!cancelled && set.add(inner)) {
                 ms.subscribe(inner);
             }
         }


### PR DESCRIPTION
The FlatMapX tests kept failing because there was a race between the cancellation and the disposing of their inner set: the cancel may have interrupted the test wait and ended up in the inner subscribe before `set.isDisposed()` would become true in the `dispose()` call of the operator that run on the main thread. The change adds/uses a boolean field that gets set first and is checked before the inner are subscribed.