### PR TITLE
2.x: fix buffer(time, maxSize) duplicating buffers on time-size race

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -460,12 +460,12 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
                 if (b.size() < maxSize) {
                     return;
                 }
+
+                buffer = null;
+                producerIndex++;
             }
 
             if (restartTimerOnMaxSize) {
-                buffer = null;
-                producerIndex++;
-
                 timer.dispose();
             }
 
@@ -480,17 +480,12 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
                 return;
             }
 
+            synchronized (this) {
+                buffer = b;
+                consumerIndex++;
+            }
             if (restartTimerOnMaxSize) {
-                synchronized (this) {
-                    buffer = b;
-                    consumerIndex++;
-                }
-
                 timer = w.schedulePeriodically(this, timespan, timespan, unit);
-            } else {
-                synchronized (this) {
-                    buffer = b;
-                }
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -458,12 +458,11 @@ extends AbstractObservableWithUpstream<T, U> {
                 if (b.size() < maxSize) {
                     return;
                 }
+                buffer = null;
+                producerIndex++;
             }
 
             if (restartTimerOnMaxSize) {
-                buffer = null;
-                producerIndex++;
-
                 timer.dispose();
             }
 
@@ -478,17 +477,12 @@ extends AbstractObservableWithUpstream<T, U> {
                 return;
             }
 
+            synchronized (this) {
+                buffer = b;
+                consumerIndex++;
+            }
             if (restartTimerOnMaxSize) {
-                synchronized (this) {
-                    buffer = b;
-                    consumerIndex++;
-                }
-
                 timer = w.schedulePeriodically(this, timespan, timespan, unit);
-            } else {
-                synchronized (this) {
-                    buffer = b;
-                }
             }
         }
 


### PR DESCRIPTION
The PR fixes both the time+maxSize bound `buffer` operators of `Flowable` and `Observable`. The logic didn't properly mutually exclude the timer action and the `onNext` action, resulting in probabilistic emission of the same buffer twice.

Reported in #5426.