### PR TITLE
1.x: fix premature cleanup in AsyncOnSubscribe when the last Observable is still running

### DIFF
--- a/src/main/java/rx/observables/AsyncOnSubscribe.java
+++ b/src/main/java/rx/observables/AsyncOnSubscribe.java
@@ -532,8 +532,11 @@ public abstract class AsyncOnSubscribe<S, T> implements OnSubscribe<T> {
                 onNextCalled = false;
                 expectedDelivery = n;
                 nextIteration(n);
-
-                if (hasTerminated || isUnsubscribed()) {
+                
+                //hasTerminated will be true when onCompleted was already emitted from the request callback 
+                //even if the the observer has not seen onCompleted from the requested observable, 
+                //so we should not clean up while there are active subscriptions
+                if (hasTerminated && !subscriptions.hasSubscriptions() || isUnsubscribed()) {
                     cleanup();
                     return true;
                 }


### PR DESCRIPTION
The issue is caused by premature cleanup when onCompleted is emitted from the callback function which may happen while a requested async sequence is still not completed.
The unit test is provided which will fail without the fix.
More cases are provided in the issue https://github.com/ReactiveX/RxJava/issues/5429.