### PR TITLE
2.x: Gradle to use less memory, missed an export command

### DIFF
--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -8,7 +8,7 @@ if [ "$buildTag" != "" ] && [ "${buildTag:0:3}" != "v2." ]; then
    exit 1
 fi
 
-GRADLE_OPTS=-Xmx832m
+export GRADLE_OPTS=-Xmx1024m
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"


### PR DESCRIPTION
Looks like there was a missing "export" keyword in the build options and thus gradle ate all 3 GB memory dancing on the edge of the OOMKiller.