### PR TITLE
1.x: TestSubscriber::assertValuesAndClear should reset valueCount

### DIFF
--- a/src/main/java/rx/observers/TestSubscriber.java
+++ b/src/main/java/rx/observers/TestSubscriber.java
@@ -703,5 +703,6 @@ public class TestSubscriber<T> extends Subscriber<T> {
             assertItem(expectedRestValues[i], i + 1);
         }
         values.clear();
+        valueCount = 0;
     }
 }

--- a/src/test/java/rx/observers/AssertableSubscriberTest.java
+++ b/src/test/java/rx/observers/AssertableSubscriberTest.java
@@ -151,7 +151,7 @@ public class AssertableSubscriberTest {
        assertEquals(Thread.currentThread().getName(), ts.getLastSeenThread().getName());
        assertTrue(ts.getOnErrorEvents().isEmpty());
        assertTrue(ts.getOnNextEvents().isEmpty());
-       assertEquals(1, ts.getValueCount());
+       assertEquals(0, ts.getValueCount());
     }
 
     @Test

--- a/src/test/java/rx/observers/TestSubscriberTest.java
+++ b/src/test/java/rx/observers/TestSubscriberTest.java
@@ -815,4 +815,15 @@ public class TestSubscriberTest {
 
         ts.assertNoValues();
     }
+
+    @Test
+    public void assertAndClearResetsValueCount() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        ts.onNext(1);
+        ts.assertValuesAndClear(1);
+
+        ts.assertNoValues();
+        Assert.assertEquals(0, ts.getValueCount());
+    }
 }


### PR DESCRIPTION
During the time between calling `assertValuesAndClear` and providing the next `onNext` event, the `valueCount` is inconsistent with the size of the internal `values` list.