### PR TITLE
2x: Fix wording in Async and Publish processors javadoc.

### DIFF
--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -21,7 +21,8 @@ import io.reactivex.plugins.RxJavaPlugins;
 import org.reactivestreams.*;
 
 /**
- * A Subject that emits the very last value followed by a completion event or the received error to Subscribers.
+ * Processor that emits the very last value followed by a completion event or the received error
+ * to {@link Subscriber}s.
  *
  * <p>The implementation of onXXX methods are technically thread-safe but non-serialized calls
  * to them may lead to undefined state in the currently subscribed Subscribers.

--- a/src/main/java/io/reactivex/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/processors/PublishProcessor.java
@@ -23,14 +23,14 @@ import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
- * A Subject that multicasts events to Subscribers that are currently subscribed to it.
+ * Processor that multicasts all subsequently observed items to its current {@link Subscriber}s.
  *
  * <p>
  * <img width="640" height="405" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/S.PublishSubject.png" alt="">
  *
- * <p>The subject does not coordinate backpressure for its subscribers and implements a weaker onSubscribe which
- * calls requests Long.MAX_VALUE from the incoming Subscriptions. This makes it possible to subscribe the PublishSubject
- * to multiple sources (note on serialization though) unlike the standard contract on Subscriber. Child subscribers, however, are not overflown but receive an
+ * <p>The processor does not coordinate backpressure for its subscribers and implements a weaker onSubscribe which
+ * calls requests Long.MAX_VALUE from the incoming Subscriptions. This makes it possible to subscribe the PublishProcessor
+ * to multiple sources (note on serialization though) unlike the standard Subscriber contract. Child subscribers, however, are not overflown but receive an
  * IllegalStateException in case their requested amount is zero.
  *
  * <p>The implementation of onXXX methods are technically thread-safe but non-serialized calls
@@ -54,7 +54,7 @@ import io.reactivex.plugins.RxJavaPlugins;
   processor.onComplete();
 
   } </pre>
- * @param <T> the value type multicast to Subscribers.
+ * @param <T> the value type multicasted to Subscribers.
  */
 public final class PublishProcessor<T> extends FlowableProcessor<T> {
     /** The terminated indicator for the subscribers array. */


### PR DESCRIPTION
Seams that these are some leftovers from the 1.x -> 2.x refactoring.