### PR TITLE
2.x: upgrade to Reactive-Streams 1.0.1-x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 dependencies {
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 
-    compile 'org.reactivestreams:reactive-streams:1.0.0'
+    compile 'org.reactivestreams:reactive-streams:1.0.1-RC1'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.1.0'
@@ -32,7 +32,7 @@ dependencies {
     perfCompile 'org.openjdk.jmh:jmh-core:1.16'
     perfCompile 'org.openjdk.jmh:jmh-generator-annprocess:1.16'
 
-    testCompile 'org.reactivestreams:reactive-streams-tck:1.0.0'
+    testCompile 'org.reactivestreams:reactive-streams-tck:1.0.1-RC1'
     testCompile group: 'org.testng', name: 'testng', version: '6.9.10'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,13 @@ apply plugin: 'nebula.rxjava-project'
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 
+def rsVersion = '1.0.1-RC2'
+
 dependencies {
+    repositories { maven { url "https://oss.sonatype.org/content/repositories/orgreactivestreams-1031" } }
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 
-    compile 'org.reactivestreams:reactive-streams:1.0.1-RC1'
+    compile "org.reactivestreams:reactive-streams:$rsVersion"
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.1.0'
@@ -32,7 +35,7 @@ dependencies {
     perfCompile 'org.openjdk.jmh:jmh-core:1.16'
     perfCompile 'org.openjdk.jmh:jmh-generator-annprocess:1.16'
 
-    testCompile 'org.reactivestreams:reactive-streams-tck:1.0.1-RC1'
+    testCompile "org.reactivestreams:reactive-streams-tck:$rsVersion"
     testCompile group: 'org.testng', name: 'testng', version: '6.9.10'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ targetCompatibility = JavaVersion.VERSION_1_6
 def rsVersion = '1.0.1-RC2'
 
 dependencies {
-    repositories { maven { url "https://oss.sonatype.org/content/repositories/orgreactivestreams-1031" } }
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 
     compile "org.reactivestreams:reactive-streams:$rsVersion"


### PR DESCRIPTION
The Reactive-Streams initiative has updated their specification, API and TCK to 1.0.1 and short testing phase started with RC1. The binary RS API has not changed but the Test Compatibility Kit has received several bugfixes and some extensions. Depending on the time it will take the RC to become stable, RxJava 2.1.2 may not release with an RC dependency (i.e., doing some gradle version overriding to have the most recent TCK but still have 1.0.0 as the API dependency).