### PR TITLE
2.x: See if sudo required results in consistent & faster build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
 # prevent travis running gradle assemble; let the build script do it anyway
 install: true
       
-sudo: false
+sudo: required
 # as per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 
 # script for build and release via Travis to Bintray


### PR DESCRIPTION
I asked the Travis support about the slow build times of lately and they suggested I try `sudo:required` to have an isolated build VM instead of the shared container-based one. I'll rerun this PR a couple of times to see the effects.