### PR TITLE
2.x: FlowableTimeoutTimed - replace AtomicReference with mutable field

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -68,7 +68,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
 
         final FullArbiter<T> arbiter;
 
-        final AtomicReference<Disposable> timer = new AtomicReference<Disposable>();
+        Disposable timer;
 
         volatile long index;
 
@@ -110,16 +110,11 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
         }
 
         void scheduleTimeout(final long idx) {
-            Disposable d = timer.get();
-            if (d != null) {
-                d.dispose();
+            if (timer != null) {
+                timer.dispose();
             }
 
-            if (timer.compareAndSet(d, NEW_TIMER)) {
-                d = worker.schedule(new TimeoutTask(idx), timeout, unit);
-
-                DisposableHelper.replace(timer, d);
-            }
+            timer = worker.schedule(new TimeoutTask(idx), timeout, unit);
         }
 
         void subscribeNext() {
@@ -170,11 +165,10 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
                 if (idx == index) {
                     done = true;
                     s.cancel();
-                    DisposableHelper.dispose(timer);
+                    worker.dispose();
 
                     subscribeNext();
 
-                    worker.dispose();
                 }
             }
         }
@@ -188,7 +182,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
 
         Subscription s;
 
-        final AtomicReference<Disposable> timer = new AtomicReference<Disposable>();
+        Disposable timer;
 
         volatile long index;
 
@@ -224,16 +218,11 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
         }
 
         void scheduleTimeout(final long idx) {
-            Disposable d = timer.get();
-            if (d != null) {
-                d.dispose();
+            if (timer != null) {
+                timer.dispose();
             }
 
-            if (timer.compareAndSet(d, NEW_TIMER)) {
-                d = worker.schedule(new TimeoutTask(idx), timeout, unit);
-
-                DisposableHelper.replace(timer, d);
-            }
+            timer = worker.schedule(new TimeoutTask(idx), timeout, unit);
         }
 
         @Override


### PR DESCRIPTION
As per discussion in #5461. The timer fields in the Subscriber classes in [FlowableTimeoutTimed](https://github.com/ReactiveX/RxJava/blob/4c22f969927a98bc35458645d373bcb94b7df622/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java) are `AtomicReference`s but this is not required as the fields are accessed synchronously.

The `timer` field in `TimeoutTimedOtherSubscriber` did require an `AtomicReference` because of the dispose call [here](https://github.com/ReactiveX/RxJava/blob/4c22f969927a98bc35458645d373bcb94b7df622/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java#L173) but this call is not required if we just call `worker.dispose()`.

No unit test additions.

P.S. 9321 unit tests in RxJava 2.x! An outrageous amount of work, thanks @akarnokd (and other contributors)!