### PR TITLE
2.x: Removing commented code from tests

### DIFF
--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -1026,17 +1026,6 @@ public class FlowableTests {
         Flowable.just(1).ambWith(Flowable.just(2)).subscribe(ts);
         ts.assertValue(1);
     }
-// FIXME Subscribers can't throw
-//    @Test(expected = OnErrorNotImplementedException.class)
-//    public void testSubscribeWithoutOnError() {
-//        Observable<String> o = Observable.just("a", "b").flatMap(new Func1<String, Observable<String>>() {
-//            @Override
-//            public Observable<String> call(String s) {
-//                return Observable.error(new Exception("test"));
-//            }
-//        });
-//        o.subscribe();
-//    }
 
     @Test
     public void testTakeWhileToList() {
@@ -1112,28 +1101,6 @@ public class FlowableTests {
         verify(w, never()).onNext(any(Integer.class));
         verify(w, never()).onError(any(Throwable.class));
     }
-
-// FIXME this test doesn't make sense
-//    @Test // cf. https://github.com/ReactiveX/RxJava/issues/2599
-//    public void testSubscribingSubscriberAsObserverMaintainsSubscriptionChain() {
-//        TestSubscriber<Object> subscriber = new TestSubscriber<T>();
-//        Subscription subscription = Observable.just("event").subscribe((Observer<Object>) subscriber);
-//        subscription.unsubscribe();
-//
-//        subscriber.assertUnsubscribed();
-//    }
-
-// FIXME subscribers can't throw
-//    @Test(expected=OnErrorNotImplementedException.class)
-//    public void testForEachWithError() {
-//        Observable.error(new Exception("boo"))
-//        //
-//        .forEach(new Action1<Object>() {
-//            @Override
-//            public void call(Object t) {
-//                //do nothing
-//            }});
-//    }
 
     @Test(expected = NullPointerException.class)
     public void testForEachWithNull() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -151,7 +151,6 @@ public class FlowableCacheTest {
         ts.assertNoErrors();
         ts.assertComplete();
         ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-//        ts.assertUnsubscribed(); // FIXME no longer valid
         assertFalse(cached.hasSubscribers());
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnUnsubscribeTest.java
@@ -80,8 +80,6 @@ public class FlowableDoOnUnsubscribeTest {
         for (int i = 0; i < subCount; ++i) {
             subscriptions.get(i).dispose();
             // Test that unsubscribe() method is not affected in any way
-            // FIXME no longer valid
-//            subscribers.get(i).assertUnsubscribed();
         }
 
         upperLatch.await();
@@ -143,8 +141,6 @@ public class FlowableDoOnUnsubscribeTest {
         for (int i = 0; i < subCount; ++i) {
             subscriptions.get(i).dispose();
             // Test that unsubscribe() method is not affected in any way
-            // FIXME no longer valid
-//            subscribers.get(i).assertUnsubscribed();
         }
 
         upperLatch.await();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -65,8 +65,6 @@ public class FlowableIgnoreElementsTest {
         ts.assertNoErrors();
         ts.assertNoValues();
         ts.assertTerminated();
-        // FIXME no longer testable
-//        ts.assertUnsubscribed();
     }
 
     @Test
@@ -76,8 +74,6 @@ public class FlowableIgnoreElementsTest {
         Flowable.error(ex).ignoreElements().toFlowable().subscribe(ts);
         ts.assertNoValues();
         ts.assertTerminated();
-        // FIXME no longer testable
-//        ts.assertUnsubscribed();
         ts.assertError(TestException.class);
         ts.assertErrorMessage("boo");
     }
@@ -183,8 +179,6 @@ public class FlowableIgnoreElementsTest {
         ts.assertNoErrors();
         ts.assertNoValues();
         ts.assertTerminated();
-        // FIXME no longer testable
-//        ts.assertUnsubscribed();
     }
 
     @Test
@@ -194,8 +188,6 @@ public class FlowableIgnoreElementsTest {
         Flowable.error(ex).ignoreElements().subscribe(ts);
         ts.assertNoValues();
         ts.assertTerminated();
-        // FIXME no longer testable
-//        ts.assertUnsubscribed();
         ts.assertError(TestException.class);
         ts.assertErrorMessage("boo");
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
@@ -256,59 +256,6 @@ public class FlowableMapTest {
         }).blockingGet();
     }
 
-    // FIXME RS subscribers can't throw
-//    @Test(expected = OnErrorNotImplementedException.class)
-//    public void verifyExceptionIsThrownIfThereIsNoExceptionHandler() {
-//
-//        Publisher<Object> creator = new Publisher<Object>() {
-//
-//            @Override
-//            public void subscribe(Subscriber<? super Object> observer) {
-//                observer.onSubscribe(EmptySubscription.INSTANCE);
-//                observer.onNext("a");
-//                observer.onNext("b");
-//                observer.onNext("c");
-//                observer.onComplete();
-//            }
-//        };
-//
-//        Function<Object, Flowable<Object>> manyMapper = new Function<Object, Flowable<Object>>() {
-//
-//            @Override
-//            public Flowable<Object> apply(Object object) {
-//                return Flowable.just(object);
-//            }
-//        };
-//
-//        Function<Object, Object> mapper = new Function<Object, Object>() {
-//            private int count = 0;
-//
-//            @Override
-//            public Object apply(Object object) {
-//                ++count;
-//                if (count > 2) {
-//                    throw new RuntimeException();
-//                }
-//                return object;
-//            }
-//        };
-//
-//        Consumer<Object> onNext = new Consumer<Object>() {
-//
-//            @Override
-//            public void accept(Object object) {
-//                System.out.println(object.toString());
-//            }
-//        };
-//
-//        try {
-//            Flowable.create(creator).flatMap(manyMapper).map(mapper).subscribe(onNext);
-//        } catch (RuntimeException e) {
-//            e.printStackTrace();
-//            throw e;
-//        }
-//    }
-
     private static Map<String, String> getMap(String prefix) {
         Map<String, String> m = new HashMap<String, String>();
         m.put("firstName", prefix + "First");

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
@@ -197,8 +197,6 @@ public class FlowableMaterializeTest {
         ts.dispose();
         ts.request(1);
         ts.assertNoValues();
-        // FIXME no longer assertable
-//        ts.assertUnsubscribed();
     }
 
     private static class TestNotificationSubscriber extends DefaultSubscriber<Notification<String>> {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -506,8 +506,6 @@ public class FlowableMergeTest {
             assertTrue(os2.get());
 
             ts.assertValues(0L, 1L, 2L, 0L, 1L);
-            // FIXME not happening anymore
-//            ts.assertUnsubscribed();
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -144,8 +144,6 @@ public class FlowableOnBackpressureBufferTest {
         int size = ts.values().size();
         assertTrue(size <= 150);  // will get up to 50 more
         assertTrue(ts.values().get(size - 1) == size - 1);
-        // FIXME no longer assertable
-//        assertTrue(s.isUnsubscribed());
     }
 
     static final Flowable<Long> infinite = Flowable.unsafeCreate(new Publisher<Long>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -601,8 +601,6 @@ public class FlowableReplayTest {
         verifyObserverMock(mockObserverBeforeConnect, 2, 6);
         verifyObserverMock(mockObserverAfterConnect, 2, 6);
 
-        // FIXME not supported
-//        verify(spiedWorker, times(1)).isUnsubscribed();
         // FIXME publish calls cancel too
         verify(spiedWorker, times(1)).dispose();
         verify(sourceUnsubscribed, never()).run();
@@ -667,8 +665,6 @@ public class FlowableReplayTest {
         verifyObserver(mockObserverBeforeConnect, 2, 2, illegalArgumentException);
         verifyObserver(mockObserverAfterConnect, 2, 2, illegalArgumentException);
 
-        // FIXME no longer supported
-//        verify(spiedWorker, times(1)).isUnsubscribed();
         // FIXME publish also calls cancel
         verify(spiedWorker, times(1)).dispose();
         verify(sourceUnsubscribed, never()).run();
@@ -973,8 +969,6 @@ public class FlowableReplayTest {
         ts.assertNoErrors();
         ts.assertTerminated();
         ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        // FIXME no longer assertable
-//        ts.assertUnsubscribed();
     }
 
     @Test

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -1044,17 +1044,6 @@ public class ObservableTest {
         Observable.just(1).ambWith(Observable.just(2)).subscribe(ts);
         ts.assertValue(1);
     }
-// FIXME Subscribers can't throw
-//    @Test(expected = OnErrorNotImplementedException.class)
-//    public void testSubscribeWithoutOnError() {
-//        Observable<String> o = Observable.just("a", "b").flatMap(new Func1<String, Observable<String>>() {
-//            @Override
-//            public Observable<String> call(String s) {
-//                return Observable.error(new Exception("test"));
-//            }
-//        });
-//        o.subscribe();
-//    }
 
     @Test
     public void testTakeWhileToList() {


### PR DESCRIPTION
Hi,

In this PR I'm removing commented code from tests as it's generally considered as bad practice.
Part of this code is even not available in the current RxJava API. It does not resolve all of the issues like that, but only part of them. I didn't want to create PR with more changes because it will be harder to review. Rest of the similar issues could be resolved in the future PRs.

Regards,
Piotr
