### PR TITLE
fix #5468: eager hooks onError call

### DIFF
--- a/src/main/java/rx/observers/SafeCompletableSubscriber.java
+++ b/src/main/java/rx/observers/SafeCompletableSubscriber.java
@@ -54,7 +54,6 @@ public final class SafeCompletableSubscriber implements CompletableSubscriber, S
 
     @Override
     public void onError(Throwable e) {
-        RxJavaHooks.onError(e);
         if (done) {
             return;
         }
@@ -63,6 +62,7 @@ public final class SafeCompletableSubscriber implements CompletableSubscriber, S
             actual.onError(e);
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
+            RxJavaHooks.onError(e);
 
             throw new OnErrorFailedException(new CompositeException(e, ex));
         }

--- a/src/main/java/rx/observers/SafeCompletableSubscriber.java
+++ b/src/main/java/rx/observers/SafeCompletableSubscriber.java
@@ -55,6 +55,7 @@ public final class SafeCompletableSubscriber implements CompletableSubscriber, S
     @Override
     public void onError(Throwable e) {
         if (done) {
+            RxJavaHooks.onError(e);
             return;
         }
         done = true;
@@ -62,7 +63,6 @@ public final class SafeCompletableSubscriber implements CompletableSubscriber, S
             actual.onError(e);
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
-            RxJavaHooks.onError(e);
 
             throw new OnErrorFailedException(new CompositeException(e, ex));
         }


### PR DESCRIPTION
Move the call to RxJavaHooks into the catch block, so we only report and it if the underlying subscriber throws in its onError method.

This brings its behaviour in line with that of SafeSubscriber


