### PR TITLE
Update Maybe#defaultIfEmpty javadoc (#5480)

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2192,6 +2192,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Returns a Maybe that emits the item emitted by the source Maybe or a specified default item
      * if the source Maybe is empty.
+     * <p>Note that the result Maybe is semantically equivalent to a Single, since it's guaranteed to emit exactly one item or an error. 
+     * See {@link #toSingle(Object)} for a method with equivalent behavior which returns a Single.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/defaultIfEmpty.png" alt="">
      * <dl>


### PR DESCRIPTION
Adds a link to Javadoc for `Maybe#defaultIfEmpty` method which has a surprising return type (#5480, #5417).