### PR TITLE
2.x: small note on Maybe.defaultIfEmpty regarding toSingle

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2193,6 +2193,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Returns a Maybe that emits the item emitted by the source Maybe or a specified default item
      * if the source Maybe is empty.
      * <p>
+     * Note that the result Maybe is semantically equivalent to a {@code Single}, since it's guaranteed
+     * to emit exactly one item or an error. See {@link #toSingle(Object)} for a method with equivalent
+     * behavior which returns a {@code Single}.
+     * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/defaultIfEmpty.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>

--- a/src/test/java/io/reactivex/JavadocWording.java
+++ b/src/test/java/io/reactivex/JavadocWording.java
@@ -148,9 +148,11 @@ public class JavadocWording {
                 for (;;) {
                     int idx = m.javadoc.indexOf("Single", jdx);
                     if (idx >= 0) {
-                        if (!m.signature.contains("Single")) {
+                        int j = m.javadoc.indexOf("#toSingle", jdx);
+                        int k = m.javadoc.indexOf("{@code Single", jdx);
+                        if (!m.signature.contains("Single") && (j + 3 != idx && k + 7 != idx)) {
                             e.append("java.lang.RuntimeException: Maybe doc mentions Single but not in the signature\r\n at io.reactivex.")
-                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            .append("Maybe(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {


### PR DESCRIPTION
Ths PR replaces #5485 regarding the issue of #5480 because our javadoc validation did not allow that type of wording (i.e., mentioning `Single` when the method signature is not related to it).