### PR TITLE
2.x: make withLatestFrom conditional subscriber, test cold consumption

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -726,7 +726,7 @@ public class FlowableWithLatestFromTest {
     }
 
     @Test
-    public void testSingleRequestNotForgottenWhenNoData() {
+    public void singleRequestNotForgottenWhenNoData() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> other = PublishProcessor.create();
 
@@ -749,5 +749,31 @@ public class FlowableWithLatestFromTest {
         source.onNext(2);
 
         ts.assertValue((2 << 8) + 1);
+    }
+
+    @Test
+    public void coldSourceConsumedWithoutOther() {
+        Flowable.range(1, 10).withLatestFrom(Flowable.never(),
+        new BiFunction<Integer, Object, Object>() {
+            @Override
+            public Object apply(Integer a, Object b) throws Exception {
+                return a;
+            }
+        })
+        .test(1)
+        .assertResult();
+    }
+
+    @Test
+    public void coldSourceConsumedWithoutManyOthers() {
+        Flowable.range(1, 10).withLatestFrom(Flowable.never(), Flowable.never(), Flowable.never(),
+        new Function4<Integer, Object, Object, Object, Object>() {
+            @Override
+            public Object apply(Integer a, Object b, Object c, Object d) throws Exception {
+                return a;
+            }
+        })
+        .test(1)
+        .assertResult();
     }
 }


### PR DESCRIPTION
This PR adjusts #5494 by converting the `withLatestFrom` operators into conditional subscribers and adds unit tests that verify a cold source is consumed fully if there is no event(s) from the other source(s).

(Also there was a missing space before the bracked and the new unit test name had the `test` prefix.)