### PR TITLE
2.x: fix SpscLAQ nepotism, FlowableRefCountTest.testRefCountAsync flaky

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -42,7 +42,7 @@ public class FlowableRefCountTest {
     public void testRefCountAsync() {
         final AtomicInteger subscribeCount = new AtomicInteger();
         final AtomicInteger nextCount = new AtomicInteger();
-        Flowable<Long> r = Flowable.interval(0, 5, TimeUnit.MILLISECONDS)
+        Flowable<Long> r = Flowable.interval(0, 20, TimeUnit.MILLISECONDS)
                 .doOnSubscribe(new Consumer<Subscription>() {
                     @Override
                     public void accept(Subscription s) {
@@ -67,11 +67,26 @@ public class FlowableRefCountTest {
 
         Disposable s2 = r.subscribe();
 
-        // give time to emit
         try {
-            Thread.sleep(52);
+            Thread.sleep(10);
         } catch (InterruptedException e) {
         }
+
+        for (;;) {
+            int a = nextCount.get();
+            int b = receivedCount.get();
+            if (a > 10 && a < 20 && a == b) {
+                break;
+            }
+            if (a >= 20) {
+                break;
+            }
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException e) {
+            }
+        }
+        // give time to emit
 
         // now unsubscribe
         s2.dispose(); // unsubscribe s2 first as we're counting in 1 and there can be a race between unsubscribe and one subscriber getting a value but not the other

--- a/src/test/java/io/reactivex/internal/queue/SimpleQueueTest.java
+++ b/src/test/java/io/reactivex/internal/queue/SimpleQueueTest.java
@@ -20,7 +20,7 @@ package io.reactivex.internal.queue;
 
 import static org.junit.Assert.*;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
 
@@ -154,5 +154,24 @@ public class SimpleQueueTest {
 
         t1.join();
         t2.join();
+    }
+
+    @Test
+    public void spscLinkedArrayQueueNoNepotism() {
+        SpscLinkedArrayQueue<Integer> q = new SpscLinkedArrayQueue<Integer>(16);
+
+        AtomicReferenceArray<Object> ara = q.producerBuffer;
+
+        for (int i = 0; i < 20; i++) {
+            q.offer(i);
+        }
+
+        assertNotNull(ara.get(16));
+
+        for (int i = 0; i < 20; i++) {
+            assertEquals(i, q.poll().intValue());
+        }
+
+        assertNull(ara.get(16));
     }
 }


### PR DESCRIPTION
This PR fixes the so-called GC Nepotism (see #3794) in `SpscLinkedArrayQueue` by not nulling out the previous buffer's next pointer upon switching buffers in the `peek()`/`poll()` methods.

In addition, the FlowableRefCountTest.testRefCountAsync has been reworked to be more forgiving towards unexpected delays due to system load (reported in #5506).