### PR TITLE
Remove unnecessary generic type parameters for delaySubscription methods in Single

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1752,7 +1752,6 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dd>{@code delaySubscription} does by default subscribe to the current Single
      * on the {@code computation} {@link Scheduler} after the delay.</dd>
      * </dl>
-     * @param <U> the element type of the other source
      * @param time the time amount to wait with the subscription
      * @param unit the time unit of the waiting
      * @return the new Single instance
@@ -1760,7 +1759,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final <U> Single<T> delaySubscription(long time, TimeUnit unit) {
+    public final Single<T> delaySubscription(long time, TimeUnit unit) {
         return delaySubscription(time, unit, Schedulers.computation());
     }
 
@@ -1771,7 +1770,6 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dd>{@code delaySubscription} does by default subscribe to the current Single
      * on the {@link Scheduler} you provided, after the delay.</dd>
      * </dl>
-     * @param <U> the element type of the other source
      * @param time the time amount to wait with the subscription
      * @param unit the time unit of the waiting
      * @param scheduler the scheduler to wait on and subscribe on to the current Single
@@ -1780,7 +1778,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <U> Single<T> delaySubscription(long time, TimeUnit unit, Scheduler scheduler) {
+    public final Single<T> delaySubscription(long time, TimeUnit unit, Scheduler scheduler) {
         return delaySubscription(Observable.timer(time, unit, scheduler));
     }
 


### PR DESCRIPTION
I was running into an issue with using the `delaySubscription(long time, TimeUnit unit)` while testing a `Single` and I saw that the `U` generic type parameter was there unnecessarily. I believe this is only a Kotlin specific issue as I tried playing around in Java and there was no inference error upon compilation. To get it to compile for Kotlin, I would need to specify the generic type parameter and it didn't matter what I set it to as `Any` was a valid option: `.delaySubscription<Any>(5, TimeUnit.SECONDS)`. I also went through `Flowable`, `Observable`, and `Maybe` and saw that the generics were missing for the time-specific `delaySubscription` methods so I believe they should be removed from `Single` as well to help keep things consistent and remove this compilation error for future Kotlin users.

![kotlin_error](https://user-images.githubusercontent.com/1130517/28450952-83ad8468-6db8-11e7-841e-85be4ddf0c26.png)
