### PR TITLE
2.x: add missing null check to fused Observable.fromCallable

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromCallable.java
@@ -54,6 +54,6 @@ public final class ObservableFromCallable<T> extends Observable<T> implements Ca
 
     @Override
     public T call() throws Exception {
-        return callable.call();
+        return ObjectHelper.requireNonNull(callable.call(), "The callable returned a null value");
     }
 }


### PR DESCRIPTION
There was a missing null check on the fusion path in `ObservableFromCallable` which meant the consumer considered the source to be empty. (The `FlowableFromCallable` was okay.)

Discovered on StackOverflow: https://stackoverflow.com/questions/45304226/null-handling-in-rx-java2-flatmap

Unit test mirrored and updated to verify both `Flowable` and `Observable` versions.