### PR TITLE
Add assertValueAt(int, value) to TestObserver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk7
+- oraclejdk8
 
 # force upgrade Java8 as per https://github.com/travis-ci/travis-ci/issues/4042 (fixes compilation issue)
 #addons:

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -17,6 +17,7 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import io.reactivex.Notification;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Predicate;
@@ -335,7 +336,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that this TestObserver/TestSubscriber did not receive an onNext value which is equal to
-     * the given value with respect to Objects.equals.
+     * the given value with respect to null-safe Object.equals.
      *
      * <p>History: 2.0.5 - experimental
      * @param value the value to expect not being received
@@ -403,19 +404,21 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Asserts that this TestObserver/TestSubscriber received an onNext value at the given index
-     * which is equal to the given value with respect to Objects.equals.
+     * which is equal to the given value with respect to null-safe Object.equals.
      * @param index the position to assert on
      * @param value the value to expect
      * @return this
+     * @since 2.1.3 - experimental
      */
     @SuppressWarnings("unchecked")
+    @Experimental
     public final U assertValueAt(int index, T value) {
         int s = values.size();
         if (s == 0) {
             throw fail("No values");
         }
 
-        if (index >= values.size()) {
+        if (index >= s) {
             throw fail("Invalid index: " + index);
         }
 

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -403,6 +403,31 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Asserts that this TestObserver/TestSubscriber received an onNext value at the given index
+     * which is equal to the given value with respect to Objects.equals.
+     * @param index the position to assert on
+     * @param value the value to expect
+     * @return this
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertValueAt(int index, T value) {
+        int s = values.size();
+        if (s == 0) {
+            throw fail("No values");
+        }
+
+        if (index >= values.size()) {
+            throw fail("Invalid index: " + index);
+        }
+
+        T v = values.get(index);
+        if (!ObjectHelper.equals(value, v)) {
+            throw fail("Expected: " + valueAndClass(value) + ", Actual: " + valueAndClass(v));
+        }
+        return (U)this;
+    }
+
+    /**
+     * Asserts that this TestObserver/TestSubscriber received an onNext value at the given index
      * for the provided predicate returns true.
      * @param index the position to assert on
      * @param valuePredicate

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -1390,7 +1390,7 @@ public class TestObserverTest {
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("No values");
-        ts.assertValueAt(0, null);
+        ts.assertValueAt(0, 1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -1390,38 +1390,38 @@ public class TestObserverTest {
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("No values");
-        ts.assertValueAt(0, 1);
+        ts.assertValueAt(0, "a");
     }
 
     @Test
     public void assertValueAtIndexMatch() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<String> ts = new TestObserver<String>();
 
-        Observable.just(1, 2).subscribe(ts);
+        Observable.just("a", "b").subscribe(ts);
 
-        ts.assertValueAt(1, 2);
+        ts.assertValueAt(1, "b");
     }
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<String> ts = new TestObserver<String>();
 
-        Observable.just(1, 2, 3).subscribe(ts);
+        Observable.just("a", "b", "c").subscribe(ts);
 
         thrown.expect(AssertionError.class);
-        thrown.expectMessage("Expected: 2 (class: Integer), Actual: 3 (class: Integer) (latch = 0, values = 3, errors = 0, completions = 1)");
-        ts.assertValueAt(2, 2);
+        thrown.expectMessage("Expected: b (class: String), Actual: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)");
+        ts.assertValueAt(2, "b");
     }
 
     @Test
     public void assertValueAtIndexInvalidIndex() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<String> ts = new TestObserver<String>();
 
-        Observable.just(1, 2).subscribe(ts);
+        Observable.just("a", "b").subscribe(ts);
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)");
-        ts.assertValueAt(2, 1);
+        ts.assertValueAt(2, "c");
     }
 
     @Test

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -1383,6 +1383,48 @@ public class TestObserverTest {
     }
 
     @Test
+    public void assertValueAtIndexEmpty() {
+        TestObserver<Object> ts = new TestObserver<Object>();
+
+        Observable.empty().subscribe(ts);
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("No values");
+        ts.assertValueAt(0, null);
+    }
+
+    @Test
+    public void assertValueAtIndexMatch() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.just(1, 2).subscribe(ts);
+
+        ts.assertValueAt(1, 2);
+    }
+
+    @Test
+    public void assertValueAtIndexNoMatch() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.just(1, 2, 3).subscribe(ts);
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("Expected: 2 (class: Integer), Actual: 3 (class: Integer) (latch = 0, values = 3, errors = 0, completions = 1)");
+        ts.assertValueAt(2, 2);
+    }
+
+    @Test
+    public void assertValueAtIndexInvalidIndex() {
+        TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.just(1, 2).subscribe(ts);
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)");
+        ts.assertValueAt(2, 1);
+    }
+
+    @Test
     public void withTag() {
         try {
             for (int i = 1; i < 3; i++) {


### PR DESCRIPTION
I found myself frequently writing tests that want to check that an observable emitted a certain value second or third, but I don't care what the first or other values one, so `assertValues(Object...))` is more brittle.

This PR implements an `assertValueAt(index, value)` method, similar to `assertValue(value)`. Tests are also added.  