### PR TITLE
2.x: Try fixing Travis CI lack of java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 jdk:
 - oraclejdk7
+- openjdk7
+- oraclejdk8
+- openjdk8
 
 # force upgrade Java8 as per https://github.com/travis-ci/travis-ci/issues/4042 (fixes compilation issue)
 #addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: java
+# trusty doesn't support jdk 7 apparently
+dist: precise 
 jdk:
 - oraclejdk7
-- openjdk7
-- oraclejdk8
-- openjdk8
 
 # force upgrade Java8 as per https://github.com/travis-ci/travis-ci/issues/4042 (fixes compilation issue)
 #addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
-# trusty doesn't support jdk 7 apparently
-dist: precise 
 jdk:
-- oraclejdk7
+- oraclejdk8
 
 # force upgrade Java8 as per https://github.com/travis-ci/travis-ci/issues/4042 (fixes compilation issue)
 #addons:


### PR DESCRIPTION
Travis CI has replaced the previous Precise image with the Trusty image as part of an ongoing rollout. Unfortunately, the Trusty image fails for `oraclejdk7` because probably it is no longer supported (although I couldn't find anything about it).

This PR tries to identify what's available by trying a matrix of build setups.