### PR TITLE
Switch to JSR305 nullability annotations.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,26 @@ apply plugin: 'nebula.rxjava-project'
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 
+configurations {
+    provided
+}
+
+sourceSets {
+    main {
+        compileClasspath += configurations.provided
+        runtimeClasspath += configurations.provided
+    }
+    test {
+        compileClasspath += configurations.provided
+        runtimeClasspath += configurations.provided
+    }
+}
+
 dependencies {
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 
     compile 'org.reactivestreams:reactive-streams:1.0.0'
+    provided 'com.google.code.findbugs:jsr305:3.0.2'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -21,27 +21,14 @@ apply plugin: 'nebula.rxjava-project'
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 
-configurations {
-    provided
-}
-
-sourceSets {
-    main {
-        compileClasspath += configurations.provided
-        runtimeClasspath += configurations.provided
-    }
-    test {
-        compileClasspath += configurations.provided
-        runtimeClasspath += configurations.provided
-    }
-}
-
 dependencies {
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 
     compile 'org.reactivestreams:reactive-streams:1.0.0'
-    provided 'com.google.code.findbugs:jsr305:3.0.2'
 
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+    testCompileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+    
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.1.0'
 

--- a/src/main/java/io/reactivex/CompletableEmitter.java
+++ b/src/main/java/io/reactivex/CompletableEmitter.java
@@ -36,7 +36,7 @@ public interface CompletableEmitter {
      * Signal an exception.
      * @param t the exception, not null
      */
-    void onError(@NonNull Throwable t);
+    void onError(Throwable t);
 
     /**
      * Sets a Disposable on this emitter; any previous Disposable
@@ -71,5 +71,5 @@ public interface CompletableEmitter {
      * @since 2.1.1 - experimental
      */
     @Experimental
-    boolean tryOnError(@NonNull Throwable t);
+    boolean tryOnError(Throwable t);
 }

--- a/src/main/java/io/reactivex/CompletableEmitter.java
+++ b/src/main/java/io/reactivex/CompletableEmitter.java
@@ -13,9 +13,10 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
+import javax.annotation.Nullable;
 
 /**
  * Abstraction over an RxJava {@link CompletableObserver} that allows associating

--- a/src/main/java/io/reactivex/CompletableObserver.java
+++ b/src/main/java/io/reactivex/CompletableObserver.java
@@ -13,7 +13,6 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 
 /**
@@ -25,7 +24,7 @@ public interface CompletableObserver {
      * then can be used to cancel the subscription at any time.
      * @param d the Disposable instance to call dispose on for cancellation, not null
      */
-    void onSubscribe(@NonNull Disposable d);
+    void onSubscribe(Disposable d);
 
     /**
      * Called once the deferred computation completes normally.
@@ -36,5 +35,5 @@ public interface CompletableObserver {
      * Called once if the deferred computation 'throws' an exception.
      * @param e the exception, not null.
      */
-    void onError(@NonNull Throwable e);
+    void onError(Throwable e);
 }

--- a/src/main/java/io/reactivex/CompletableOnSubscribe.java
+++ b/src/main/java/io/reactivex/CompletableOnSubscribe.java
@@ -26,6 +26,6 @@ public interface CompletableOnSubscribe {
      * @param e the safe emitter instance, never null
      * @throws Exception on error
      */
-    void subscribe(@NonNull CompletableEmitter e) throws Exception;
+    void subscribe(CompletableEmitter e) throws Exception;
 }
 

--- a/src/main/java/io/reactivex/CompletableOperator.java
+++ b/src/main/java/io/reactivex/CompletableOperator.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import javax.annotation.Nonnull;
 
 /**
  * Interface to map/wrap a downstream observer to an upstream observer.
@@ -25,6 +25,6 @@ public interface CompletableOperator {
      * @return the parent CompletableObserver instance
      * @throws Exception on failure
      */
-    @NonNull
+    @Nonnull
     CompletableObserver apply(CompletableObserver observer) throws Exception;
 }

--- a/src/main/java/io/reactivex/CompletableOperator.java
+++ b/src/main/java/io/reactivex/CompletableOperator.java
@@ -26,5 +26,5 @@ public interface CompletableOperator {
      * @throws Exception on failure
      */
     @NonNull
-    CompletableObserver apply(@NonNull CompletableObserver observer) throws Exception;
+    CompletableObserver apply(CompletableObserver observer) throws Exception;
 }

--- a/src/main/java/io/reactivex/CompletableSource.java
+++ b/src/main/java/io/reactivex/CompletableSource.java
@@ -27,5 +27,5 @@ public interface CompletableSource {
      * @param cs the CompletableObserver, not null
      * @throws NullPointerException if {@code cs} is null
      */
-    void subscribe(@NonNull CompletableObserver cs);
+    void subscribe(CompletableObserver cs);
 }

--- a/src/main/java/io/reactivex/CompletableTransformer.java
+++ b/src/main/java/io/reactivex/CompletableTransformer.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import javax.annotation.Nonnull;
 
 /**
  * Convenience interface and callback used by the compose operator to turn a Completable into another
@@ -25,6 +25,6 @@ public interface CompletableTransformer {
      * @param upstream the upstream Completable instance
      * @return the transformed CompletableSource instance
      */
-    @NonNull
+    @Nonnull
     CompletableSource apply(Completable upstream);
 }

--- a/src/main/java/io/reactivex/CompletableTransformer.java
+++ b/src/main/java/io/reactivex/CompletableTransformer.java
@@ -26,5 +26,5 @@ public interface CompletableTransformer {
      * @return the transformed CompletableSource instance
      */
     @NonNull
-    CompletableSource apply(@NonNull Completable upstream);
+    CompletableSource apply(Completable upstream);
 }

--- a/src/main/java/io/reactivex/Emitter.java
+++ b/src/main/java/io/reactivex/Emitter.java
@@ -12,8 +12,6 @@
  */
 package io.reactivex;
 
-import io.reactivex.annotations.NonNull;
-
 /**
  * Base interface for emitting signals in a push-fashion in various generator-like source
  * operators (create, generate).
@@ -26,13 +24,13 @@ public interface Emitter<T> {
      * Signal a normal value.
      * @param value the value to signal, not null
      */
-    void onNext(@NonNull T value);
+    void onNext(T value);
 
     /**
      * Signal a Throwable exception.
      * @param error the Throwable to signal, not null
      */
-    void onError(@NonNull Throwable error);
+    void onError(Throwable error);
 
     /**
      * Signal a completion.

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -13079,7 +13079,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> subscribeOn(@NonNull Scheduler scheduler) {
+    public final Flowable<T> subscribeOn(Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return subscribeOn(scheduler, !(this instanceof FlowableCreate));
     }
@@ -13117,7 +13117,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @Experimental
-    public final Flowable<T> subscribeOn(@NonNull Scheduler scheduler, boolean requestOn) {
+    public final Flowable<T> subscribeOn(Scheduler scheduler, boolean requestOn) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new FlowableSubscribeOn<T>(this, scheduler, requestOn));
     }

--- a/src/main/java/io/reactivex/FlowableEmitter.java
+++ b/src/main/java/io/reactivex/FlowableEmitter.java
@@ -79,5 +79,5 @@ public interface FlowableEmitter<T> extends Emitter<T> {
      * @since 2.1.1 - experimental
      */
     @Experimental
-    boolean tryOnError(@NonNull Throwable t);
+    boolean tryOnError(Throwable t);
 }

--- a/src/main/java/io/reactivex/FlowableEmitter.java
+++ b/src/main/java/io/reactivex/FlowableEmitter.java
@@ -16,6 +16,7 @@ package io.reactivex;
 import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
+import javax.annotation.Nonnull;
 
 /**
  * Abstraction over a Reactive Streams {@link org.reactivestreams.Subscriber} that allows associating
@@ -63,7 +64,7 @@ public interface FlowableEmitter<T> extends Emitter<T> {
      * Ensures that calls to onNext, onError and onComplete are properly serialized.
      * @return the serialized FlowableEmitter
      */
-    @NonNull
+    @Nonnull
     FlowableEmitter<T> serialize();
 
     /**

--- a/src/main/java/io/reactivex/FlowableEmitter.java
+++ b/src/main/java/io/reactivex/FlowableEmitter.java
@@ -13,10 +13,10 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
-import javax.annotation.Nonnull;
+import javax.annotation.*;
 
 /**
  * Abstraction over a Reactive Streams {@link org.reactivestreams.Subscriber} that allows associating

--- a/src/main/java/io/reactivex/FlowableOnSubscribe.java
+++ b/src/main/java/io/reactivex/FlowableOnSubscribe.java
@@ -28,6 +28,6 @@ public interface FlowableOnSubscribe<T> {
      * @param e the safe emitter instance, never null
      * @throws Exception on error
      */
-    void subscribe(@NonNull FlowableEmitter<T> e) throws Exception;
+    void subscribe(FlowableEmitter<T> e) throws Exception;
 }
 

--- a/src/main/java/io/reactivex/FlowableOperator.java
+++ b/src/main/java/io/reactivex/FlowableOperator.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import javax.annotation.Nonnull;
 import org.reactivestreams.Subscriber;
 
 /**
@@ -29,6 +29,6 @@ public interface FlowableOperator<Downstream, Upstream> {
      * @return the parent Subscriber instance
      * @throws Exception on failure
      */
-    @NonNull
+    @Nonnull
     Subscriber<? super Upstream> apply(Subscriber<? super Downstream> observer) throws Exception;
 }

--- a/src/main/java/io/reactivex/FlowableOperator.java
+++ b/src/main/java/io/reactivex/FlowableOperator.java
@@ -30,5 +30,5 @@ public interface FlowableOperator<Downstream, Upstream> {
      * @throws Exception on failure
      */
     @NonNull
-    Subscriber<? super Upstream> apply(@NonNull Subscriber<? super Downstream> observer) throws Exception;
+    Subscriber<? super Upstream> apply(Subscriber<? super Downstream> observer) throws Exception;
 }

--- a/src/main/java/io/reactivex/FlowableSubscriber.java
+++ b/src/main/java/io/reactivex/FlowableSubscriber.java
@@ -37,5 +37,5 @@ public interface FlowableSubscriber<T> extends Subscriber<T> {
      * {@inheritDoc}
      */
     @Override
-    void onSubscribe(@NonNull Subscription s);
+    void onSubscribe(Subscription s);
 }

--- a/src/main/java/io/reactivex/FlowableTransformer.java
+++ b/src/main/java/io/reactivex/FlowableTransformer.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import javax.annotation.Nonnull;
 import org.reactivestreams.Publisher;
 
 /**
@@ -29,6 +29,6 @@ public interface FlowableTransformer<Upstream, Downstream> {
      * @param upstream the upstream Flowable instance
      * @return the transformed Publisher instance
      */
-    @NonNull
+    @Nonnull
     Publisher<Downstream> apply(Flowable<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/FlowableTransformer.java
+++ b/src/main/java/io/reactivex/FlowableTransformer.java
@@ -30,5 +30,5 @@ public interface FlowableTransformer<Upstream, Downstream> {
      * @return the transformed Publisher instance
      */
     @NonNull
-    Publisher<Downstream> apply(@NonNull Flowable<Upstream> upstream);
+    Publisher<Downstream> apply(Flowable<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/MaybeEmitter.java
+++ b/src/main/java/io/reactivex/MaybeEmitter.java
@@ -13,9 +13,10 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
+import javax.annotation.Nullable;
 
 /**
  * Abstraction over an RxJava {@link MaybeObserver} that allows associating

--- a/src/main/java/io/reactivex/MaybeEmitter.java
+++ b/src/main/java/io/reactivex/MaybeEmitter.java
@@ -33,13 +33,13 @@ public interface MaybeEmitter<T> {
      * Signal a success value.
      * @param t the value, not null
      */
-    void onSuccess(@NonNull T t);
+    void onSuccess(T t);
 
     /**
      * Signal an exception.
      * @param t the exception, not null
      */
-    void onError(@NonNull Throwable t);
+    void onError(Throwable t);
 
     /**
      * Signal the completion.
@@ -79,5 +79,5 @@ public interface MaybeEmitter<T> {
      * @since 2.1.1 - experimental
      */
     @Experimental
-    boolean tryOnError(@NonNull Throwable t);
+    boolean tryOnError(Throwable t);
 }

--- a/src/main/java/io/reactivex/MaybeObserver.java
+++ b/src/main/java/io/reactivex/MaybeObserver.java
@@ -39,7 +39,7 @@ public interface MaybeObserver<T> {
      * @param d the Disposable instance whose {@link Disposable#dispose()} can
      * be called anytime to cancel the connection
      */
-    void onSubscribe(@NonNull Disposable d);
+    void onSubscribe(Disposable d);
 
     /**
      * Notifies the MaybeObserver with one item and that the {@link Maybe} has finished sending
@@ -50,7 +50,7 @@ public interface MaybeObserver<T> {
      * @param t
      *          the item emitted by the Maybe
      */
-    void onSuccess(@NonNull T t);
+    void onSuccess(T t);
 
     /**
      * Notifies the MaybeObserver that the {@link Maybe} has experienced an error condition.
@@ -60,7 +60,7 @@ public interface MaybeObserver<T> {
      * @param e
      *          the exception encountered by the Maybe
      */
-    void onError(@NonNull Throwable e);
+    void onError(Throwable e);
 
     /**
      * Called once the deferred computation completes normally.

--- a/src/main/java/io/reactivex/MaybeOnSubscribe.java
+++ b/src/main/java/io/reactivex/MaybeOnSubscribe.java
@@ -28,6 +28,6 @@ public interface MaybeOnSubscribe<T> {
      * @param e the safe emitter instance, never null
      * @throws Exception on error
      */
-    void subscribe(@NonNull MaybeEmitter<T> e) throws Exception;
+    void subscribe(MaybeEmitter<T> e) throws Exception;
 }
 

--- a/src/main/java/io/reactivex/MaybeOperator.java
+++ b/src/main/java/io/reactivex/MaybeOperator.java
@@ -28,5 +28,5 @@ public interface MaybeOperator<Downstream, Upstream> {
      * @throws Exception on failure
      */
     @NonNull
-    MaybeObserver<? super Upstream> apply(@NonNull MaybeObserver<? super Downstream> observer) throws Exception;
+    MaybeObserver<? super Upstream> apply(MaybeObserver<? super Downstream> observer) throws Exception;
 }

--- a/src/main/java/io/reactivex/MaybeOperator.java
+++ b/src/main/java/io/reactivex/MaybeOperator.java
@@ -12,7 +12,7 @@
  */
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import javax.annotation.Nonnull;
 
 /**
  * Interface to map/wrap a downstream observer to an upstream observer.
@@ -27,6 +27,6 @@ public interface MaybeOperator<Downstream, Upstream> {
      * @return the parent MaybeObserver instance
      * @throws Exception on failure
      */
-    @NonNull
+    @Nonnull
     MaybeObserver<? super Upstream> apply(MaybeObserver<? super Downstream> observer) throws Exception;
 }

--- a/src/main/java/io/reactivex/MaybeSource.java
+++ b/src/main/java/io/reactivex/MaybeSource.java
@@ -31,5 +31,5 @@ public interface MaybeSource<T> {
      * @param observer the MaybeObserver, not null
      * @throws NullPointerException if {@code observer} is null
      */
-    void subscribe(@NonNull MaybeObserver<? super T> observer);
+    void subscribe(MaybeObserver<? super T> observer);
 }

--- a/src/main/java/io/reactivex/MaybeTransformer.java
+++ b/src/main/java/io/reactivex/MaybeTransformer.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import javax.annotation.Nonnull;
 
 /**
  * Interface to compose Maybes.
@@ -28,6 +28,6 @@ public interface MaybeTransformer<Upstream, Downstream> {
      * @param upstream the upstream Maybe instance
      * @return the transformed MaybeSource instance
      */
-    @NonNull
+    @Nonnull
     MaybeSource<Downstream> apply(Maybe<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/MaybeTransformer.java
+++ b/src/main/java/io/reactivex/MaybeTransformer.java
@@ -29,5 +29,5 @@ public interface MaybeTransformer<Upstream, Downstream> {
      * @return the transformed MaybeSource instance
      */
     @NonNull
-    MaybeSource<Downstream> apply(@NonNull Maybe<Upstream> upstream);
+    MaybeSource<Downstream> apply(Maybe<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/Notification.java
+++ b/src/main/java/io/reactivex/Notification.java
@@ -16,6 +16,7 @@ package io.reactivex;
 import io.reactivex.annotations.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.NotificationLite;
+import javax.annotation.Nonnull;
 
 /**
  * Represents the reactive signal types: onNext, onError and onComplete and
@@ -125,7 +126,7 @@ public final class Notification<T> {
      * @return the new Notification instance
      * @throws NullPointerException if value is null
      */
-    @NonNull
+    @Nonnull
     public static <T> Notification<T> createOnNext(T value) {
         ObjectHelper.requireNonNull(value, "value is null");
         return new Notification<T>(value);
@@ -138,7 +139,7 @@ public final class Notification<T> {
      * @return the new Notification instance
      * @throws NullPointerException if error is null
      */
-    @NonNull
+    @Nonnull
     public static <T> Notification<T> createOnError(Throwable error) {
         ObjectHelper.requireNonNull(error, "error is null");
         return new Notification<T>(NotificationLite.error(error));
@@ -151,7 +152,7 @@ public final class Notification<T> {
      * @return the shared Notification instance representing an onComplete signal
      */
     @SuppressWarnings("unchecked")
-    @NonNull
+    @Nonnull
     public static <T> Notification<T> createOnComplete() {
         return (Notification<T>)COMPLETE;
     }

--- a/src/main/java/io/reactivex/Notification.java
+++ b/src/main/java/io/reactivex/Notification.java
@@ -126,7 +126,7 @@ public final class Notification<T> {
      * @throws NullPointerException if value is null
      */
     @NonNull
-    public static <T> Notification<T> createOnNext(@NonNull T value) {
+    public static <T> Notification<T> createOnNext(T value) {
         ObjectHelper.requireNonNull(value, "value is null");
         return new Notification<T>(value);
     }
@@ -139,7 +139,7 @@ public final class Notification<T> {
      * @throws NullPointerException if error is null
      */
     @NonNull
-    public static <T> Notification<T> createOnError(@NonNull Throwable error) {
+    public static <T> Notification<T> createOnError(Throwable error) {
         ObjectHelper.requireNonNull(error, "error is null");
         return new Notification<T>(NotificationLite.error(error));
     }

--- a/src/main/java/io/reactivex/Notification.java
+++ b/src/main/java/io/reactivex/Notification.java
@@ -13,10 +13,9 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.NotificationLite;
-import javax.annotation.Nonnull;
+import javax.annotation.*;
 
 /**
  * Represents the reactive signal types: onNext, onError and onComplete and

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -13,11 +13,6 @@
 
 package io.reactivex;
 
-import java.util.*;
-import java.util.concurrent.*;
-
-import org.reactivestreams.Publisher;
-
 import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
@@ -32,6 +27,10 @@ import io.reactivex.observables.*;
 import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.*;
+import java.util.*;
+import java.util.concurrent.*;
+import javax.annotation.Nonnull;
+import org.reactivestreams.Publisher;
 
 /**
  * The Observable class is the non-backpressured, optionally multi-valued base reactive class that
@@ -11093,7 +11092,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
+    @Nonnull
     public final <R> Observable<R> switchMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return ObservableInternalHelper.switchMapSingle(this, mapper);
     }
@@ -11124,7 +11123,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
+    @Nonnull
     public final <R> Observable<R> switchMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return ObservableInternalHelper.switchMapSingleDelayError(this, mapper);
     }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -11094,7 +11094,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <R> Observable<R> switchMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    public final <R> Observable<R> switchMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return ObservableInternalHelper.switchMapSingle(this, mapper);
     }
 
@@ -11125,7 +11125,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <R> Observable<R> switchMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    public final <R> Observable<R> switchMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return ObservableInternalHelper.switchMapSingleDelayError(this, mapper);
     }
 

--- a/src/main/java/io/reactivex/ObservableEmitter.java
+++ b/src/main/java/io/reactivex/ObservableEmitter.java
@@ -70,5 +70,5 @@ public interface ObservableEmitter<T> extends Emitter<T> {
      * @since 2.1.1 - experimental
      */
     @Experimental
-    boolean tryOnError(@NonNull Throwable t);
+    boolean tryOnError(Throwable t);
 }

--- a/src/main/java/io/reactivex/ObservableEmitter.java
+++ b/src/main/java/io/reactivex/ObservableEmitter.java
@@ -16,6 +16,7 @@ package io.reactivex;
 import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
+import javax.annotation.Nonnull;
 
 /**
  * Abstraction over an RxJava {@link Observer} that allows associating
@@ -54,7 +55,7 @@ public interface ObservableEmitter<T> extends Emitter<T> {
      * Ensures that calls to onNext, onError and onComplete are properly serialized.
      * @return the serialized ObservableEmitter
      */
-    @NonNull
+    @Nonnull
     ObservableEmitter<T> serialize();
 
     /**

--- a/src/main/java/io/reactivex/ObservableEmitter.java
+++ b/src/main/java/io/reactivex/ObservableEmitter.java
@@ -13,10 +13,10 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
-import javax.annotation.Nonnull;
+import javax.annotation.*;
 
 /**
  * Abstraction over an RxJava {@link Observer} that allows associating

--- a/src/main/java/io/reactivex/ObservableOnSubscribe.java
+++ b/src/main/java/io/reactivex/ObservableOnSubscribe.java
@@ -28,6 +28,6 @@ public interface ObservableOnSubscribe<T> {
      * @param e the safe emitter instance, never null
      * @throws Exception on error
      */
-    void subscribe(@NonNull ObservableEmitter<T> e) throws Exception;
+    void subscribe(ObservableEmitter<T> e) throws Exception;
 }
 

--- a/src/main/java/io/reactivex/ObservableOperator.java
+++ b/src/main/java/io/reactivex/ObservableOperator.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import javax.annotation.Nonnull;
 
 /**
  * Interface to map/wrap a downstream observer to an upstream observer.
@@ -28,6 +28,6 @@ public interface ObservableOperator<Downstream, Upstream> {
      * @return the parent Observer instance
      * @throws Exception on failure
      */
-    @NonNull
+    @Nonnull
     Observer<? super Upstream> apply(Observer<? super Downstream> observer) throws Exception;
 }

--- a/src/main/java/io/reactivex/ObservableOperator.java
+++ b/src/main/java/io/reactivex/ObservableOperator.java
@@ -29,5 +29,5 @@ public interface ObservableOperator<Downstream, Upstream> {
      * @throws Exception on failure
      */
     @NonNull
-    Observer<? super Upstream> apply(@NonNull Observer<? super Downstream> observer) throws Exception;
+    Observer<? super Upstream> apply(Observer<? super Downstream> observer) throws Exception;
 }

--- a/src/main/java/io/reactivex/ObservableSource.java
+++ b/src/main/java/io/reactivex/ObservableSource.java
@@ -28,5 +28,5 @@ public interface ObservableSource<T> {
      * @param observer the Observer, not null
      * @throws NullPointerException if {@code observer} is null
      */
-    void subscribe(@NonNull Observer<? super T> observer);
+    void subscribe(Observer<? super T> observer);
 }

--- a/src/main/java/io/reactivex/ObservableTransformer.java
+++ b/src/main/java/io/reactivex/ObservableTransformer.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import javax.annotation.Nonnull;
 
 /**
  * Interface to compose Observables.
@@ -28,6 +28,6 @@ public interface ObservableTransformer<Upstream, Downstream> {
      * @param upstream the upstream Observable instance
      * @return the transformed ObservableSource instance
      */
-    @NonNull
+    @Nonnull
     ObservableSource<Downstream> apply(Observable<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/ObservableTransformer.java
+++ b/src/main/java/io/reactivex/ObservableTransformer.java
@@ -29,5 +29,5 @@ public interface ObservableTransformer<Upstream, Downstream> {
      * @return the transformed ObservableSource instance
      */
     @NonNull
-    ObservableSource<Downstream> apply(@NonNull Observable<Upstream> upstream);
+    ObservableSource<Downstream> apply(Observable<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/Observer.java
+++ b/src/main/java/io/reactivex/Observer.java
@@ -13,7 +13,6 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 
 /**
@@ -41,7 +40,7 @@ public interface Observer<T> {
      * be called anytime to cancel the connection
      * @since 2.0
      */
-    void onSubscribe(@NonNull Disposable d);
+    void onSubscribe(Disposable d);
 
     /**
      * Provides the Observer with a new item to observe.
@@ -54,7 +53,7 @@ public interface Observer<T> {
      * @param t
      *          the item emitted by the Observable
      */
-    void onNext(@NonNull T t);
+    void onNext(T t);
 
     /**
      * Notifies the Observer that the {@link Observable} has experienced an error condition.
@@ -65,7 +64,7 @@ public interface Observer<T> {
      * @param e
      *          the exception encountered by the Observable
      */
-    void onError(@NonNull Throwable e);
+    void onError(Throwable e);
 
     /**
      * Notifies the Observer that the {@link Observable} has finished sending push-based notifications.

--- a/src/main/java/io/reactivex/Scheduler.java
+++ b/src/main/java/io/reactivex/Scheduler.java
@@ -13,18 +13,15 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.EmptyDisposable;
-import io.reactivex.internal.disposables.SequentialDisposable;
-import io.reactivex.internal.schedulers.NewThreadWorker;
-import io.reactivex.internal.schedulers.SchedulerWhen;
+import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.schedulers.*;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
-
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 /**
  * A {@code Scheduler} is an object that specifies an API for scheduling
@@ -63,7 +60,7 @@ public abstract class Scheduler {
      *
      * @return a Worker representing a serial queue of actions to be executed
      */
-    @NonNull
+    @Nonnull
     public abstract Worker createWorker();
 
     /**
@@ -108,7 +105,7 @@ public abstract class Scheduler {
      * @return the Disposable instance that let's one cancel this particular task.
      * @since 2.0
      */
-    @NonNull
+    @Nonnull
     public Disposable scheduleDirect(Runnable run) {
         return scheduleDirect(run, 0L, TimeUnit.NANOSECONDS);
     }
@@ -126,7 +123,7 @@ public abstract class Scheduler {
      * @return the Disposable that let's one cancel this particular delayed task.
      * @since 2.0
      */
-    @NonNull
+    @Nonnull
     public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
         final Worker w = createWorker();
 
@@ -157,7 +154,7 @@ public abstract class Scheduler {
      * @return the Disposable that let's one cancel this particular delayed task.
      * @since 2.0
      */
-    @NonNull
+    @Nonnull
     public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
         final Worker w = createWorker();
 
@@ -249,7 +246,7 @@ public abstract class Scheduler {
      * @since 2.1
      */
     @SuppressWarnings("unchecked")
-    @NonNull
+    @Nonnull
     public <S extends Scheduler & Disposable> S when(Function<Flowable<Flowable<Completable>>, Completable> combine) {
         return (S) new SchedulerWhen(combine, this);
     }
@@ -269,7 +266,7 @@ public abstract class Scheduler {
          *            Runnable to schedule
          * @return a Disposable to be able to unsubscribe the action (cancel it if not executed)
          */
-        @NonNull
+        @Nonnull
         public Disposable schedule(Runnable run) {
             return schedule(run, 0L, TimeUnit.NANOSECONDS);
         }
@@ -289,7 +286,7 @@ public abstract class Scheduler {
          *            the time unit of {@code delayTime}
          * @return a Disposable to be able to unsubscribe the action (cancel it if not executed)
          */
-        @NonNull
+        @Nonnull
         public abstract Disposable schedule(Runnable run, long delay, TimeUnit unit);
 
         /**
@@ -312,7 +309,7 @@ public abstract class Scheduler {
          *            the time unit of {@code period}
          * @return a Disposable to be able to unsubscribe the action (cancel it if not executed)
          */
-        @NonNull
+        @Nonnull
         public Disposable schedulePeriodically(Runnable run, final long initialDelay, final long period, final TimeUnit unit) {
             final SequentialDisposable first = new SequentialDisposable();
 
@@ -350,9 +347,9 @@ public abstract class Scheduler {
          * of this task has to happen (accounting for clock drifts).
          */
         final class PeriodicTask implements Runnable {
-            @NonNull
+            @Nonnull
             final Runnable decoratedRun;
-            @NonNull
+            @Nonnull
             final SequentialDisposable sd;
             final long periodInNanoseconds;
             long count;
@@ -401,9 +398,9 @@ public abstract class Scheduler {
     static class PeriodicDirectTask
     implements Runnable, Disposable {
         final Runnable run;
-        @NonNull
+        @Nonnull
         final Worker worker;
-        @NonNull
+        @Nonnull
         volatile boolean disposed;
 
         PeriodicDirectTask(Runnable run, Worker worker) {

--- a/src/main/java/io/reactivex/Scheduler.java
+++ b/src/main/java/io/reactivex/Scheduler.java
@@ -13,16 +13,18 @@
 
 package io.reactivex;
 
-import java.util.concurrent.TimeUnit;
-
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.*;
-import io.reactivex.internal.schedulers.*;
+import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.disposables.SequentialDisposable;
+import io.reactivex.internal.schedulers.NewThreadWorker;
+import io.reactivex.internal.schedulers.SchedulerWhen;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * A {@code Scheduler} is an object that specifies an API for scheduling
@@ -70,7 +72,7 @@ public abstract class Scheduler {
      * @return the 'current time'
      * @since 2.0
      */
-    public long now(@NonNull TimeUnit unit) {
+    public long now(TimeUnit unit) {
         return unit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
     }
 
@@ -107,7 +109,7 @@ public abstract class Scheduler {
      * @since 2.0
      */
     @NonNull
-    public Disposable scheduleDirect(@NonNull Runnable run) {
+    public Disposable scheduleDirect(Runnable run) {
         return scheduleDirect(run, 0L, TimeUnit.NANOSECONDS);
     }
 
@@ -125,7 +127,7 @@ public abstract class Scheduler {
      * @since 2.0
      */
     @NonNull
-    public Disposable scheduleDirect(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
+    public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
         final Worker w = createWorker();
 
         final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
@@ -156,7 +158,7 @@ public abstract class Scheduler {
      * @since 2.0
      */
     @NonNull
-    public Disposable schedulePeriodicallyDirect(@NonNull Runnable run, long initialDelay, long period, @NonNull TimeUnit unit) {
+    public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
         final Worker w = createWorker();
 
         final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
@@ -248,7 +250,7 @@ public abstract class Scheduler {
      */
     @SuppressWarnings("unchecked")
     @NonNull
-    public <S extends Scheduler & Disposable> S when(@NonNull Function<Flowable<Flowable<Completable>>, Completable> combine) {
+    public <S extends Scheduler & Disposable> S when(Function<Flowable<Flowable<Completable>>, Completable> combine) {
         return (S) new SchedulerWhen(combine, this);
     }
 
@@ -268,7 +270,7 @@ public abstract class Scheduler {
          * @return a Disposable to be able to unsubscribe the action (cancel it if not executed)
          */
         @NonNull
-        public Disposable schedule(@NonNull Runnable run) {
+        public Disposable schedule(Runnable run) {
             return schedule(run, 0L, TimeUnit.NANOSECONDS);
         }
 
@@ -288,7 +290,7 @@ public abstract class Scheduler {
          * @return a Disposable to be able to unsubscribe the action (cancel it if not executed)
          */
         @NonNull
-        public abstract Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit);
+        public abstract Disposable schedule(Runnable run, long delay, TimeUnit unit);
 
         /**
          * Schedules a cancelable action to be executed periodically. This default implementation schedules
@@ -311,7 +313,7 @@ public abstract class Scheduler {
          * @return a Disposable to be able to unsubscribe the action (cancel it if not executed)
          */
         @NonNull
-        public Disposable schedulePeriodically(@NonNull Runnable run, final long initialDelay, final long period, @NonNull final TimeUnit unit) {
+        public Disposable schedulePeriodically(Runnable run, final long initialDelay, final long period, final TimeUnit unit) {
             final SequentialDisposable first = new SequentialDisposable();
 
             final SequentialDisposable sd = new SequentialDisposable(first);
@@ -339,7 +341,7 @@ public abstract class Scheduler {
          * @return the 'current time'
          * @since 2.0
          */
-        public long now(@NonNull TimeUnit unit) {
+        public long now(TimeUnit unit) {
             return unit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
         }
 
@@ -357,8 +359,8 @@ public abstract class Scheduler {
             long lastNowNanoseconds;
             long startInNanoseconds;
 
-            PeriodicTask(long firstStartInNanoseconds, @NonNull Runnable decoratedRun,
-                    long firstNowNanoseconds, @NonNull SequentialDisposable sd, long periodInNanoseconds) {
+            PeriodicTask(long firstStartInNanoseconds, Runnable decoratedRun,
+                    long firstNowNanoseconds, SequentialDisposable sd, long periodInNanoseconds) {
                 this.decoratedRun = decoratedRun;
                 this.sd = sd;
                 this.periodInNanoseconds = periodInNanoseconds;
@@ -404,7 +406,7 @@ public abstract class Scheduler {
         @NonNull
         volatile boolean disposed;
 
-        PeriodicDirectTask(@NonNull Runnable run, @NonNull Worker worker) {
+        PeriodicDirectTask(Runnable run, Worker worker) {
             this.run = run;
             this.worker = worker;
         }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2712,7 +2712,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Override this method in subclasses to handle the incoming SingleObservers.
      * @param observer the SingleObserver to handle, not null
      */
-    protected abstract void subscribeActual(@NonNull SingleObserver<? super T> observer);
+    protected abstract void subscribeActual(SingleObserver<? super T> observer);
 
     /**
      * Subscribes a given SingleObserver (subclass) to this Single and returns the given

--- a/src/main/java/io/reactivex/SingleEmitter.java
+++ b/src/main/java/io/reactivex/SingleEmitter.java
@@ -33,13 +33,13 @@ public interface SingleEmitter<T> {
      * Signal a success value.
      * @param t the value, not null
      */
-    void onSuccess(@NonNull T t);
+    void onSuccess(T t);
 
     /**
      * Signal an exception.
      * @param t the exception, not null
      */
-    void onError(@NonNull Throwable t);
+    void onError(Throwable t);
 
     /**
      * Sets a Disposable on this emitter; any previous Disposable
@@ -74,5 +74,5 @@ public interface SingleEmitter<T> {
      * @since 2.1.1 - experimental
      */
     @Experimental
-    boolean tryOnError(@NonNull Throwable t);
+    boolean tryOnError(Throwable t);
 }

--- a/src/main/java/io/reactivex/SingleEmitter.java
+++ b/src/main/java/io/reactivex/SingleEmitter.java
@@ -13,9 +13,10 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
+import javax.annotation.Nullable;
 
 /**
  * Abstraction over an RxJava {@link SingleObserver} that allows associating

--- a/src/main/java/io/reactivex/SingleObserver.java
+++ b/src/main/java/io/reactivex/SingleObserver.java
@@ -40,7 +40,7 @@ public interface SingleObserver<T> {
      * be called anytime to cancel the connection
      * @since 2.0
      */
-    void onSubscribe(@NonNull Disposable d);
+    void onSubscribe(Disposable d);
 
     /**
      * Notifies the SingleObserver with a single item and that the {@link Single} has finished sending
@@ -51,7 +51,7 @@ public interface SingleObserver<T> {
      * @param t
      *          the item emitted by the Single
      */
-    void onSuccess(@NonNull T t);
+    void onSuccess(T t);
 
     /**
      * Notifies the SingleObserver that the {@link Single} has experienced an error condition.
@@ -61,5 +61,5 @@ public interface SingleObserver<T> {
      * @param e
      *          the exception encountered by the Single
      */
-    void onError(@NonNull Throwable e);
+    void onError(Throwable e);
 }

--- a/src/main/java/io/reactivex/SingleOnSubscribe.java
+++ b/src/main/java/io/reactivex/SingleOnSubscribe.java
@@ -28,6 +28,6 @@ public interface SingleOnSubscribe<T> {
      * @param e the safe emitter instance, never null
      * @throws Exception on error
      */
-    void subscribe(@NonNull SingleEmitter<T> e) throws Exception;
+    void subscribe(SingleEmitter<T> e) throws Exception;
 }
 

--- a/src/main/java/io/reactivex/SingleOperator.java
+++ b/src/main/java/io/reactivex/SingleOperator.java
@@ -29,5 +29,5 @@ public interface SingleOperator<Downstream, Upstream> {
      * @throws Exception on failure
      */
     @NonNull
-    SingleObserver<? super Upstream> apply(@NonNull SingleObserver<? super Downstream> observer) throws Exception;
+    SingleObserver<? super Upstream> apply(SingleObserver<? super Downstream> observer) throws Exception;
 }

--- a/src/main/java/io/reactivex/SingleOperator.java
+++ b/src/main/java/io/reactivex/SingleOperator.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import javax.annotation.Nonnull;
 
 /**
  * Interface to map/wrap a downstream observer to an upstream observer.
@@ -28,6 +28,6 @@ public interface SingleOperator<Downstream, Upstream> {
      * @return the parent SingleObserver instance
      * @throws Exception on failure
      */
-    @NonNull
+    @Nonnull
     SingleObserver<? super Upstream> apply(SingleObserver<? super Downstream> observer) throws Exception;
 }

--- a/src/main/java/io/reactivex/SingleSource.java
+++ b/src/main/java/io/reactivex/SingleSource.java
@@ -31,5 +31,5 @@ public interface SingleSource<T> {
      * @param observer the SingleObserver, not null
      * @throws NullPointerException if {@code observer} is null
      */
-    void subscribe(@NonNull SingleObserver<? super T> observer);
+    void subscribe(SingleObserver<? super T> observer);
 }

--- a/src/main/java/io/reactivex/SingleTransformer.java
+++ b/src/main/java/io/reactivex/SingleTransformer.java
@@ -29,5 +29,5 @@ public interface SingleTransformer<Upstream, Downstream> {
      * @return the transformed SingleSource instance
      */
     @NonNull
-    SingleSource<Downstream> apply(@NonNull Single<Upstream> upstream);
+    SingleSource<Downstream> apply(Single<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/SingleTransformer.java
+++ b/src/main/java/io/reactivex/SingleTransformer.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.*;
+import javax.annotation.Nonnull;
 
 /**
  * Interface to compose Singles.
@@ -28,6 +28,6 @@ public interface SingleTransformer<Upstream, Downstream> {
      * @param upstream the upstream Single instance
      * @return the transformed SingleSource instance
      */
-    @NonNull
+    @Nonnull
     SingleSource<Downstream> apply(Single<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/annotations/package-info.java
+++ b/src/main/java/io/reactivex/annotations/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Annotations for indicating experimental and beta operators, classes, methods, types or fields.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.annotations;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/disposables/ActionDisposable.java
+++ b/src/main/java/io/reactivex/disposables/ActionDisposable.java
@@ -12,7 +12,6 @@
  */
 package io.reactivex.disposables;
 
-import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Action;
 import io.reactivex.internal.util.ExceptionHelper;
 
@@ -25,7 +24,7 @@ final class ActionDisposable extends ReferenceDisposable<Action> {
     }
 
     @Override
-    protected void onDisposed(@NonNull Action value) {
+    protected void onDisposed(Action value) {
         try {
             value.run();
         } catch (Throwable ex) {

--- a/src/main/java/io/reactivex/disposables/CompositeDisposable.java
+++ b/src/main/java/io/reactivex/disposables/CompositeDisposable.java
@@ -12,13 +12,12 @@
  */
 package io.reactivex.disposables;
 
-import java.util.*;
-
-import io.reactivex.annotations.NonNull;
 import io.reactivex.exceptions.*;
 import io.reactivex.internal.disposables.DisposableContainer;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.*;
+
+import java.util.*;
 
 /**
  * A disposable container that can hold onto multiple other disposables and
@@ -40,7 +39,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      * Creates a CompositeDisposables with the given array of initial elements.
      * @param resources the array of Disposables to start with
      */
-    public CompositeDisposable(@NonNull Disposable... resources) {
+    public CompositeDisposable(Disposable... resources) {
         ObjectHelper.requireNonNull(resources, "resources is null");
         this.resources = new OpenHashSet<Disposable>(resources.length + 1);
         for (Disposable d : resources) {
@@ -53,7 +52,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      * Creates a CompositeDisposables with the given Iterable sequence of initial elements.
      * @param resources the Iterable sequence of Disposables to start with
      */
-    public CompositeDisposable(@NonNull Iterable<? extends Disposable> resources) {
+    public CompositeDisposable(Iterable<? extends Disposable> resources) {
         ObjectHelper.requireNonNull(resources, "resources is null");
         this.resources = new OpenHashSet<Disposable>();
         for (Disposable d : resources) {
@@ -86,7 +85,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
     }
 
     @Override
-    public boolean add(@NonNull Disposable d) {
+    public boolean add(Disposable d) {
         ObjectHelper.requireNonNull(d, "d is null");
         if (!disposed) {
             synchronized (this) {
@@ -111,7 +110,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      * @param ds the array of Disposables
      * @return true if the operation was successful, false if the container has been disposed
      */
-    public boolean addAll(@NonNull Disposable... ds) {
+    public boolean addAll(Disposable... ds) {
         ObjectHelper.requireNonNull(ds, "ds is null");
         if (!disposed) {
             synchronized (this) {
@@ -136,7 +135,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
     }
 
     @Override
-    public boolean remove(@NonNull Disposable d) {
+    public boolean remove(Disposable d) {
         if (delete(d)) {
             d.dispose();
             return true;
@@ -145,7 +144,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
     }
 
     @Override
-    public boolean delete(@NonNull Disposable d) {
+    public boolean delete(Disposable d) {
         ObjectHelper.requireNonNull(d, "Disposable item is null");
         if (disposed) {
             return false;

--- a/src/main/java/io/reactivex/disposables/Disposables.java
+++ b/src/main/java/io/reactivex/disposables/Disposables.java
@@ -13,13 +13,13 @@
 
 package io.reactivex.disposables;
 
-import java.util.concurrent.Future;
-
 import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Action;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.*;
 import org.reactivestreams.Subscription;
+
+import java.util.concurrent.Future;
 
 /**
  * Utility class to help create disposables by wrapping
@@ -39,7 +39,7 @@ public final class Disposables {
      * @return the new Disposable instance
      */
     @NonNull
-    public static Disposable fromRunnable(@NonNull Runnable run) {
+    public static Disposable fromRunnable(Runnable run) {
         ObjectHelper.requireNonNull(run, "run is null");
         return new RunnableDisposable(run);
     }
@@ -51,7 +51,7 @@ public final class Disposables {
      * @return the new Disposable instance
      */
     @NonNull
-    public static Disposable fromAction(@NonNull Action run) {
+    public static Disposable fromAction(Action run) {
         ObjectHelper.requireNonNull(run, "run is null");
         return new ActionDisposable(run);
     }
@@ -63,7 +63,7 @@ public final class Disposables {
      * @return the new Disposable instance
      */
     @NonNull
-    public static Disposable fromFuture(@NonNull Future<?> future) {
+    public static Disposable fromFuture(Future<?> future) {
         ObjectHelper.requireNonNull(future, "future is null");
         return fromFuture(future, true);
     }
@@ -76,7 +76,7 @@ public final class Disposables {
      * @return the new Disposable instance
      */
     @NonNull
-    public static Disposable fromFuture(@NonNull Future<?> future, boolean allowInterrupt) {
+    public static Disposable fromFuture(Future<?> future, boolean allowInterrupt) {
         ObjectHelper.requireNonNull(future, "future is null");
         return new FutureDisposable(future, allowInterrupt);
     }
@@ -88,7 +88,7 @@ public final class Disposables {
      * @return the new Disposable instance
      */
     @NonNull
-    public static Disposable fromSubscription(@NonNull Subscription subscription) {
+    public static Disposable fromSubscription(Subscription subscription) {
         ObjectHelper.requireNonNull(subscription, "subscription is null");
         return new SubscriptionDisposable(subscription);
     }

--- a/src/main/java/io/reactivex/disposables/Disposables.java
+++ b/src/main/java/io/reactivex/disposables/Disposables.java
@@ -13,13 +13,12 @@
 
 package io.reactivex.disposables;
 
-import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Action;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.*;
-import org.reactivestreams.Subscription;
-
 import java.util.concurrent.Future;
+import javax.annotation.Nonnull;
+import org.reactivestreams.Subscription;
 
 /**
  * Utility class to help create disposables by wrapping
@@ -38,7 +37,7 @@ public final class Disposables {
      * @param run the Runnable to wrap
      * @return the new Disposable instance
      */
-    @NonNull
+    @Nonnull
     public static Disposable fromRunnable(Runnable run) {
         ObjectHelper.requireNonNull(run, "run is null");
         return new RunnableDisposable(run);
@@ -50,7 +49,7 @@ public final class Disposables {
      * @param run the Action to wrap
      * @return the new Disposable instance
      */
-    @NonNull
+    @Nonnull
     public static Disposable fromAction(Action run) {
         ObjectHelper.requireNonNull(run, "run is null");
         return new ActionDisposable(run);
@@ -62,7 +61,7 @@ public final class Disposables {
      * @param future the Future to wrap
      * @return the new Disposable instance
      */
-    @NonNull
+    @Nonnull
     public static Disposable fromFuture(Future<?> future) {
         ObjectHelper.requireNonNull(future, "future is null");
         return fromFuture(future, true);
@@ -75,7 +74,7 @@ public final class Disposables {
      * @param allowInterrupt if true, the future cancel happens via Future.cancel(true)
      * @return the new Disposable instance
      */
-    @NonNull
+    @Nonnull
     public static Disposable fromFuture(Future<?> future, boolean allowInterrupt) {
         ObjectHelper.requireNonNull(future, "future is null");
         return new FutureDisposable(future, allowInterrupt);
@@ -87,7 +86,7 @@ public final class Disposables {
      * @param subscription the Runnable to wrap
      * @return the new Disposable instance
      */
-    @NonNull
+    @Nonnull
     public static Disposable fromSubscription(Subscription subscription) {
         ObjectHelper.requireNonNull(subscription, "subscription is null");
         return new SubscriptionDisposable(subscription);
@@ -97,7 +96,7 @@ public final class Disposables {
      * Returns a new, non-disposed Disposable instance.
      * @return a new, non-disposed Disposable instance
      */
-    @NonNull
+    @Nonnull
     public static Disposable empty() {
         return fromRunnable(Functions.EMPTY_RUNNABLE);
     }
@@ -106,7 +105,7 @@ public final class Disposables {
      * Returns a disposed Disposable instance.
      * @return a disposed Disposable instance
      */
-    @NonNull
+    @Nonnull
     public static Disposable disposed() {
         return EmptyDisposable.INSTANCE;
     }

--- a/src/main/java/io/reactivex/disposables/ReferenceDisposable.java
+++ b/src/main/java/io/reactivex/disposables/ReferenceDisposable.java
@@ -32,7 +32,7 @@ abstract class ReferenceDisposable<T> extends AtomicReference<T> implements Disp
         super(ObjectHelper.requireNonNull(value, "value is null"));
     }
 
-    protected abstract void onDisposed(@NonNull T value);
+    protected abstract void onDisposed(T value);
 
     @Override
     public final void dispose() {

--- a/src/main/java/io/reactivex/disposables/ReferenceDisposable.java
+++ b/src/main/java/io/reactivex/disposables/ReferenceDisposable.java
@@ -14,8 +14,6 @@
 package io.reactivex.disposables;
 
 import java.util.concurrent.atomic.AtomicReference;
-
-import io.reactivex.annotations.NonNull;
 import io.reactivex.internal.functions.ObjectHelper;
 
 /**

--- a/src/main/java/io/reactivex/disposables/RunnableDisposable.java
+++ b/src/main/java/io/reactivex/disposables/RunnableDisposable.java
@@ -26,7 +26,7 @@ final class RunnableDisposable extends ReferenceDisposable<Runnable> {
     }
 
     @Override
-    protected void onDisposed(@NonNull Runnable value) {
+    protected void onDisposed(Runnable value) {
         value.run();
     }
 

--- a/src/main/java/io/reactivex/disposables/RunnableDisposable.java
+++ b/src/main/java/io/reactivex/disposables/RunnableDisposable.java
@@ -12,8 +12,6 @@
  */
 package io.reactivex.disposables;
 
-import io.reactivex.annotations.NonNull;
-
 /**
  * A disposable container that manages a Runnable instance.
  */

--- a/src/main/java/io/reactivex/disposables/SerialDisposable.java
+++ b/src/main/java/io/reactivex/disposables/SerialDisposable.java
@@ -15,7 +15,7 @@ package io.reactivex.disposables;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
 /**

--- a/src/main/java/io/reactivex/disposables/SubscriptionDisposable.java
+++ b/src/main/java/io/reactivex/disposables/SubscriptionDisposable.java
@@ -12,7 +12,6 @@
  */
 package io.reactivex.disposables;
 
-import io.reactivex.annotations.NonNull;
 import org.reactivestreams.Subscription;
 
 /**

--- a/src/main/java/io/reactivex/disposables/SubscriptionDisposable.java
+++ b/src/main/java/io/reactivex/disposables/SubscriptionDisposable.java
@@ -27,7 +27,7 @@ final class SubscriptionDisposable extends ReferenceDisposable<Subscription> {
     }
 
     @Override
-    protected void onDisposed(@NonNull Subscription value) {
+    protected void onDisposed(Subscription value) {
         value.cancel();
     }
 }

--- a/src/main/java/io/reactivex/disposables/package-info.java
+++ b/src/main/java/io/reactivex/disposables/package-info.java
@@ -19,4 +19,7 @@
  * (Disposable container types) and utility classes to construct
  * Disposables from callbacks and other types.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.disposables;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/exceptions/CompositeException.java
@@ -49,7 +49,7 @@ public final class CompositeException extends RuntimeException {
      *
      * @throws IllegalArgumentException if <code>exceptions</code> is empty.
      */
-    public CompositeException(@NonNull Throwable... exceptions) {
+    public CompositeException(Throwable... exceptions) {
         this(exceptions == null ?
                 Collections.singletonList(new NullPointerException("exceptions was null")) : Arrays.asList(exceptions));
     }
@@ -61,7 +61,7 @@ public final class CompositeException extends RuntimeException {
      *
      * @throws IllegalArgumentException if <code>errors</code> is empty.
      */
-    public CompositeException(@NonNull Iterable<? extends Throwable> errors) {
+    public CompositeException(Iterable<? extends Throwable> errors) {
         Set<Throwable> deDupedExceptions = new LinkedHashSet<Throwable>();
         List<Throwable> localExceptions = new ArrayList<Throwable>();
         if (errors != null) {

--- a/src/main/java/io/reactivex/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/exceptions/CompositeException.java
@@ -17,8 +17,7 @@ package io.reactivex.exceptions;
 
 import java.io.*;
 import java.util.*;
-
-import io.reactivex.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 /**
  * Represents an exception that is a composite of one or more other exceptions. A {@code CompositeException}
@@ -91,19 +90,19 @@ public final class CompositeException extends RuntimeException {
      *
      * @return the exceptions that make up the {@code CompositeException}, as a {@link List} of {@link Throwable}s
      */
-    @NonNull
+    @Nonnull
     public List<Throwable> getExceptions() {
         return exceptions;
     }
 
     @Override
-    @NonNull
+    @Nonnull
     public String getMessage() {
         return message;
     }
 
     @Override
-    @NonNull
+    @Nonnull
     public synchronized Throwable getCause() { // NOPMD
         if (cause == null) {
             // we lazily generate this causal chain if this is called

--- a/src/main/java/io/reactivex/exceptions/Exceptions.java
+++ b/src/main/java/io/reactivex/exceptions/Exceptions.java
@@ -34,7 +34,7 @@ public final class Exceptions {
      *         value; {@code propagate} does not actually return anything
      */
     @NonNull
-    public static RuntimeException propagate(@NonNull Throwable t) {
+    public static RuntimeException propagate(Throwable t) {
         /*
          * The return type of RuntimeException is a trick for code to be like this:
          *
@@ -63,7 +63,7 @@ public final class Exceptions {
      *         the {@code Throwable} to test and perhaps throw
      * @see <a href="https://github.com/ReactiveX/RxJava/issues/748#issuecomment-32471495">RxJava: StackOverflowError is swallowed (Issue #748)</a>
      */
-    public static void throwIfFatal(@NonNull Throwable t) {
+    public static void throwIfFatal(Throwable t) {
         // values here derived from https://github.com/ReactiveX/RxJava/issues/748#issuecomment-32471495
         if (t instanceof VirtualMachineError) {
             throw (VirtualMachineError) t;

--- a/src/main/java/io/reactivex/exceptions/Exceptions.java
+++ b/src/main/java/io/reactivex/exceptions/Exceptions.java
@@ -13,8 +13,8 @@
 
 package io.reactivex.exceptions;
 
-import io.reactivex.annotations.*;
 import io.reactivex.internal.util.ExceptionHelper;
+import javax.annotation.Nonnull;
 
 /**
  * Utility class to help propagate checked exceptions and rethrow exceptions
@@ -33,7 +33,7 @@ public final class Exceptions {
      * @return because {@code propagate} itself throws an exception or error, this is a sort of phantom return
      *         value; {@code propagate} does not actually return anything
      */
-    @NonNull
+    @Nonnull
     public static RuntimeException propagate(Throwable t) {
         /*
          * The return type of RuntimeException is a trick for code to be like this:

--- a/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
@@ -36,7 +36,7 @@ public final class OnErrorNotImplementedException extends RuntimeException {
      * @param e
      *          the {@code Throwable} to signal; if null, a NullPointerException is constructed
      */
-    public OnErrorNotImplementedException(String message, @NonNull Throwable e) {
+    public OnErrorNotImplementedException(String message, Throwable e) {
         super(message, e != null ? e : new NullPointerException());
     }
 
@@ -48,7 +48,7 @@ public final class OnErrorNotImplementedException extends RuntimeException {
      * @param e
      *          the {@code Throwable} to signal; if null, a NullPointerException is constructed
      */
-    public OnErrorNotImplementedException(@NonNull Throwable e) {
+    public OnErrorNotImplementedException(Throwable e) {
         super(e != null ? e.getMessage() : null, e != null ? e : new NullPointerException());
     }
 }

--- a/src/main/java/io/reactivex/exceptions/package-info.java
+++ b/src/main/java/io/reactivex/exceptions/package-info.java
@@ -18,4 +18,7 @@
  * Exception handling utilities, safe subscriber exception classes,
  * lifecycle exception classes.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.exceptions;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
+++ b/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
@@ -48,7 +48,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      *          allowing the caller to synchronously disconnect a synchronous source
      * @see <a href="http://reactivex.io/documentation/operators/connect.html">ReactiveX documentation: Connect</a>
      */
-    public abstract void connect(@NonNull Consumer<? super Disposable> connection);
+    public abstract void connect(Consumer<? super Disposable> connection);
 
     /**
      * Instructs the {@code ConnectableObservable} to begin emitting the items from its underlying
@@ -118,7 +118,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      *         specified callback with the Subscription associated with the established connection
      */
     @NonNull
-    public Flowable<T> autoConnect(int numberOfSubscribers, @NonNull Consumer<? super Disposable> connection) {
+    public Flowable<T> autoConnect(int numberOfSubscribers, Consumer<? super Disposable> connection) {
         if (numberOfSubscribers <= 0) {
             this.connect(connection);
             return RxJavaPlugins.onAssembly(this);

--- a/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
+++ b/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
@@ -13,9 +13,6 @@
 
 package io.reactivex.flowables;
 
-import io.reactivex.annotations.NonNull;
-import org.reactivestreams.Subscriber;
-
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
@@ -23,6 +20,8 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.util.ConnectConsumer;
 import io.reactivex.plugins.RxJavaPlugins;
+import javax.annotation.Nonnull;
+import org.reactivestreams.Subscriber;
 
 /**
  * A {@code ConnectableObservable} resembles an ordinary {@link Flowable}, except that it does not begin
@@ -72,7 +71,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * @return a {@link Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/refcount.html">ReactiveX documentation: RefCount</a>
      */
-    @NonNull
+    @Nonnull
     public Flowable<T> refCount() {
         return RxJavaPlugins.onAssembly(new FlowableRefCount<T>(this));
     }
@@ -84,7 +83,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * @return an Observable that automatically connects to this ConnectableObservable
      *         when the first Subscriber subscribes
      */
-    @NonNull
+    @Nonnull
     public Flowable<T> autoConnect() {
         return autoConnect(1);
     }
@@ -98,7 +97,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * @return an Observable that automatically connects to this ConnectableObservable
      *         when the specified number of Subscribers subscribe to it
      */
-    @NonNull
+    @Nonnull
     public Flowable<T> autoConnect(int numberOfSubscribers) {
         return autoConnect(numberOfSubscribers, Functions.emptyConsumer());
     }
@@ -117,7 +116,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      *         when the specified number of Subscribers subscribe to it and calls the
      *         specified callback with the Subscription associated with the established connection
      */
-    @NonNull
+    @Nonnull
     public Flowable<T> autoConnect(int numberOfSubscribers, Consumer<? super Disposable> connection) {
         if (numberOfSubscribers <= 0) {
             this.connect(connection);

--- a/src/main/java/io/reactivex/flowables/GroupedFlowable.java
+++ b/src/main/java/io/reactivex/flowables/GroupedFlowable.java
@@ -13,7 +13,7 @@
 package io.reactivex.flowables;
 
 import io.reactivex.Flowable;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 
 /**
  * A {@link Flowable} that has been grouped by key, the value of which can be obtained with {@link #getKey()}.

--- a/src/main/java/io/reactivex/flowables/package-info.java
+++ b/src/main/java/io/reactivex/flowables/package-info.java
@@ -18,4 +18,7 @@
  * Classes supporting the Flowable base reactive class: connectable and grouped
  * flowables.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.flowables;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/functions/BiFunction.java
+++ b/src/main/java/io/reactivex/functions/BiFunction.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
@@ -30,6 +30,6 @@ public interface BiFunction<T1, T2, R> {
      * @return the result value
      * @throws Exception on error
      */
-    @NonNull
+    @Nonnull
     R apply(T1 t1, T2 t2) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/BiFunction.java
+++ b/src/main/java/io/reactivex/functions/BiFunction.java
@@ -31,5 +31,5 @@ public interface BiFunction<T1, T2, R> {
      * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2) throws Exception;
+    R apply(T1 t1, T2 t2) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/BiPredicate.java
+++ b/src/main/java/io/reactivex/functions/BiPredicate.java
@@ -29,5 +29,5 @@ public interface BiPredicate<T1, T2> {
      * @return the boolean result
      * @throws Exception on error
      */
-    boolean test(@NonNull T1 t1, @NonNull T2 t2) throws Exception;
+    boolean test(T1 t1, T2 t2) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/BiPredicate.java
+++ b/src/main/java/io/reactivex/functions/BiPredicate.java
@@ -13,8 +13,6 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
-
 /**
  * A functional interface (callback) that returns true or false for the given input values.
  * @param <T1> the first value

--- a/src/main/java/io/reactivex/functions/Function.java
+++ b/src/main/java/io/reactivex/functions/Function.java
@@ -13,8 +13,6 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
-
 /**
  * A functional interface that takes a value and returns another value, possibly with a
  * different type and allows throwing a checked exception.

--- a/src/main/java/io/reactivex/functions/Function.java
+++ b/src/main/java/io/reactivex/functions/Function.java
@@ -29,5 +29,5 @@ public interface Function<T, R> {
      * @return the output value
      * @throws Exception on error
      */
-    R apply(@NonNull T t) throws Exception;
+    R apply(T t) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function3.java
+++ b/src/main/java/io/reactivex/functions/Function3.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
@@ -31,6 +31,6 @@ public interface Function3<T1, T2, T3, R> {
      * @return the result value
      * @throws Exception on error
      */
-    @NonNull
+    @Nonnull
     R apply(T1 t1, T2 t2, T3 t3) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function3.java
+++ b/src/main/java/io/reactivex/functions/Function3.java
@@ -32,5 +32,5 @@ public interface Function3<T1, T2, T3, R> {
      * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3) throws Exception;
+    R apply(T1 t1, T2 t2, T3 t3) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function4.java
+++ b/src/main/java/io/reactivex/functions/Function4.java
@@ -34,5 +34,5 @@ public interface Function4<T1, T2, T3, T4, R> {
      * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4) throws Exception;
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function4.java
+++ b/src/main/java/io/reactivex/functions/Function4.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
@@ -33,6 +33,6 @@ public interface Function4<T1, T2, T3, T4, R> {
      * @return the result value
      * @throws Exception on error
      */
-    @NonNull
+    @Nonnull
     R apply(T1 t1, T2 t2, T3 t3, T4 t4) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function5.java
+++ b/src/main/java/io/reactivex/functions/Function5.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
@@ -35,6 +35,6 @@ public interface Function5<T1, T2, T3, T4, T5, R> {
      * @return the result value
      * @throws Exception on error
      */
-    @NonNull
+    @Nonnull
     R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function5.java
+++ b/src/main/java/io/reactivex/functions/Function5.java
@@ -36,5 +36,5 @@ public interface Function5<T1, T2, T3, T4, T5, R> {
      * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5) throws Exception;
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function6.java
+++ b/src/main/java/io/reactivex/functions/Function6.java
@@ -38,5 +38,5 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> {
      * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6) throws Exception;
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function6.java
+++ b/src/main/java/io/reactivex/functions/Function6.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
@@ -37,6 +37,6 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> {
      * @return the result value
      * @throws Exception on error
      */
-    @NonNull
+    @Nonnull
     R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function7.java
+++ b/src/main/java/io/reactivex/functions/Function7.java
@@ -40,5 +40,5 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> {
      * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6, @NonNull T7 t7) throws Exception;
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function7.java
+++ b/src/main/java/io/reactivex/functions/Function7.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
@@ -39,6 +39,6 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> {
      * @return the result value
      * @throws Exception on error
      */
-    @NonNull
+    @Nonnull
     R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function8.java
+++ b/src/main/java/io/reactivex/functions/Function8.java
@@ -42,5 +42,5 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> {
      * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6, @NonNull T7 t7, @NonNull T8 t8) throws Exception;
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function8.java
+++ b/src/main/java/io/reactivex/functions/Function8.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
@@ -41,6 +41,6 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> {
      * @return the result value
      * @throws Exception on error
      */
-    @NonNull
+    @Nonnull
     R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function9.java
+++ b/src/main/java/io/reactivex/functions/Function9.java
@@ -44,5 +44,5 @@ public interface Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> {
      * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6, @NonNull T7 t7, @NonNull T8 t8, @NonNull T9 t9) throws Exception;
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Function9.java
+++ b/src/main/java/io/reactivex/functions/Function9.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 /**
  * A functional interface (callback) that computes a value based on multiple input values.
@@ -43,6 +43,6 @@ public interface Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> {
      * @return the result value
      * @throws Exception on error
      */
-    @NonNull
+    @Nonnull
     R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/IntFunction.java
+++ b/src/main/java/io/reactivex/functions/IntFunction.java
@@ -12,7 +12,7 @@
  */
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
+import javax.annotation.Nonnull;
 
 /**
  * A functional interface (callback) that takes a primitive value and return value of type T.
@@ -25,6 +25,6 @@ public interface IntFunction<T> {
      * @return the result Object
      * @throws Exception on error
      */
-    @NonNull
+    @Nonnull
     T apply(int i) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/Predicate.java
+++ b/src/main/java/io/reactivex/functions/Predicate.java
@@ -13,8 +13,6 @@
 
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
-
 /**
  * A functional interface (callback) that returns true or false for the given input value.
  * @param <T> the first value

--- a/src/main/java/io/reactivex/functions/Predicate.java
+++ b/src/main/java/io/reactivex/functions/Predicate.java
@@ -26,5 +26,5 @@ public interface Predicate<T> {
      * @return the boolean result
      * @throws Exception on error
      */
-    boolean test(@NonNull T t) throws Exception;
+    boolean test(T t) throws Exception;
 }

--- a/src/main/java/io/reactivex/functions/package-info.java
+++ b/src/main/java/io/reactivex/functions/package-info.java
@@ -18,4 +18,7 @@
  * Functional interfaces of functions and actions of arity 0 to 9 and related
  * utility classes.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.functions;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/disposables/EmptyDisposable.java
+++ b/src/main/java/io/reactivex/internal/disposables/EmptyDisposable.java
@@ -14,7 +14,7 @@
 package io.reactivex.internal.disposables;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.fuseable.QueueDisposable;
 
 /**

--- a/src/main/java/io/reactivex/internal/disposables/package-info.java
+++ b/src/main/java/io/reactivex/internal/disposables/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.disposables;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/functions/package-info.java
+++ b/src/main/java/io/reactivex/internal/functions/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.functions;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/fuseable/SimplePlainQueue.java
+++ b/src/main/java/io/reactivex/internal/fuseable/SimplePlainQueue.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.fuseable;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 
 /**
  * Override of the SimpleQueue interface with no throws Exception on poll().

--- a/src/main/java/io/reactivex/internal/fuseable/SimpleQueue.java
+++ b/src/main/java/io/reactivex/internal/fuseable/SimpleQueue.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.fuseable;
 
-import io.reactivex.annotations.*;
+import javax.annotation.Nullable;
 
 /**
  * A minimalist queue interface without the method bloat of java.util.Collection and java.util.Queue.

--- a/src/main/java/io/reactivex/internal/fuseable/SimpleQueue.java
+++ b/src/main/java/io/reactivex/internal/fuseable/SimpleQueue.java
@@ -28,7 +28,7 @@ public interface SimpleQueue<T> {
      * @return true if successful, false if the value was not enqueued
      * likely due to reaching the queue capacity)
      */
-    boolean offer(@NonNull T value);
+    boolean offer(T value);
 
     /**
      * Atomically enqueue two values.
@@ -37,7 +37,7 @@ public interface SimpleQueue<T> {
      * @return true if successful, false if the value was not enqueued
      * likely due to reaching the queue capacity)
      */
-    boolean offer(@NonNull T v1, @NonNull T v2);
+    boolean offer(T v1, T v2);
 
     /**
      * Tries to dequeue a value (non-null) or returns null if

--- a/src/main/java/io/reactivex/internal/fuseable/package-info.java
+++ b/src/main/java/io/reactivex/internal/fuseable/package-info.java
@@ -14,4 +14,7 @@
 /**
  * Base interfaces and types for supporting operator-fusion.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.internal.fuseable;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/observers/DeferredScalarDisposable.java
+++ b/src/main/java/io/reactivex/internal/observers/DeferredScalarDisposable.java
@@ -14,7 +14,7 @@
 package io.reactivex.internal.observers;
 
 import io.reactivex.Observer;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**

--- a/src/main/java/io/reactivex/internal/observers/package-info.java
+++ b/src/main/java/io/reactivex/internal/observers/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.observers;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/operators/completable/package-info.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.operators.completable;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -13,21 +13,23 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.Iterator;
-import java.util.concurrent.atomic.*;
-
-import org.reactivestreams.*;
-
-import io.reactivex.*;
-import io.reactivex.annotations.*;
+import io.reactivex.Flowable;
+import io.reactivex.FlowableSubscriber;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.operators.flowable.FlowableMap.MapSubscriber;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.*;
-import io.reactivex.internal.util.*;
+import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
+import org.reactivestreams.*;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Combines the latest values from multiple sources through a function.
@@ -50,8 +52,8 @@ extends Flowable<R> {
 
     final boolean delayErrors;
 
-    public FlowableCombineLatest(@NonNull Publisher<? extends T>[] array,
-                    @NonNull Function<? super Object[], ? extends R> combiner,
+    public FlowableCombineLatest(Publisher<? extends T>[] array,
+                    Function<? super Object[], ? extends R> combiner,
                     int bufferSize, boolean delayErrors) {
         this.array = array;
         this.iterable = null;
@@ -60,8 +62,8 @@ extends Flowable<R> {
         this.delayErrors = delayErrors;
     }
 
-    public FlowableCombineLatest(@NonNull Iterable<? extends Publisher<? extends T>> iterable,
-                    @NonNull Function<? super Object[], ? extends R> combiner,
+    public FlowableCombineLatest(Iterable<? extends Publisher<? extends T>> iterable,
+                    Function<? super Object[], ? extends R> combiner,
                     int bufferSize, boolean delayErrors) {
         this.array = null;
         this.iterable = iterable;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import io.reactivex.Flowable;
 import io.reactivex.FlowableSubscriber;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -19,7 +19,7 @@ import java.util.concurrent.Callable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscribers.*;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
@@ -13,13 +13,13 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import org.reactivestreams.Subscriber;
-
 import io.reactivex.Flowable;
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscribers.*;
+import javax.annotation.Nullable;
+import org.reactivestreams.Subscriber;
 
 /**
  * Calls a consumer after pushing the current item to the downstream.

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoFinally.java
@@ -13,15 +13,15 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import org.reactivestreams.*;
-
 import io.reactivex.*;
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
+import javax.annotation.Nullable;
+import org.reactivestreams.*;
 
 /**
  * Execute an action after an onError, onComplete or a cancel event.

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscribers.*;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.*;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
@@ -18,7 +18,7 @@ import java.util.Iterator;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.flowables.GroupedFlowable;
 import io.reactivex.functions.Function;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElements.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElements.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
@@ -17,7 +17,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
@@ -19,7 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.exceptions.*;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscArrayQueue;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Action;
 import io.reactivex.internal.fuseable.SimplePlainQueue;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRangeLong.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRangeLong.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -12,13 +12,7 @@
  */
 package io.reactivex.internal.operators.flowable;
 
-import java.util.Arrays;
-import java.util.concurrent.atomic.*;
-
-import org.reactivestreams.*;
-
 import io.reactivex.*;
-import io.reactivex.annotations.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
@@ -26,6 +20,10 @@ import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
+import java.util.Arrays;
+import java.util.concurrent.atomic.*;
+import javax.annotation.Nullable;
+import org.reactivestreams.*;
 
 /**
  * Combines a main sequence of values with the latest from multiple other sequences via

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -43,14 +43,14 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
 
     final Function<? super Object[], R> combiner;
 
-    public FlowableWithLatestFromMany(@NonNull Flowable<T> source, @NonNull Publisher<?>[] otherArray, Function<? super Object[], R> combiner) {
+    public FlowableWithLatestFromMany(Flowable<T> source, Publisher<?>[] otherArray, Function<? super Object[], R> combiner) {
         super(source);
         this.otherArray = otherArray;
         this.otherIterable = null;
         this.combiner = combiner;
     }
 
-    public FlowableWithLatestFromMany(@NonNull Flowable<T> source, @NonNull Iterable<? extends Publisher<?>> otherIterable, @NonNull Function<? super Object[], R> combiner) {
+    public FlowableWithLatestFromMany(Flowable<T> source, Iterable<? extends Publisher<?>> otherIterable, Function<? super Object[], R> combiner) {
         super(source);
         this.otherArray = null;
         this.otherIterable = otherIterable;

--- a/src/main/java/io/reactivex/internal/operators/flowable/package-info.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.operators.flowable;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowable.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.maybe;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservable.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.maybe;
 import java.util.Iterator;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeMergeArray.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeMergeArray.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.maybe;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;

--- a/src/main/java/io/reactivex/internal/operators/maybe/package-info.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.operators.maybe;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.EmptyDisposable;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
@@ -14,7 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.observers.BasicFuseableObserver;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.annotations.Experimental;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.observers.BasicFuseableObserver;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
 import io.reactivex.annotations.Experimental;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
@@ -14,7 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.observers.BasicFuseableObserver;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletable.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.observable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
@@ -14,7 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.observers.BasicQueueDisposable;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.observable;
 import java.util.Iterator;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMap.java
@@ -15,7 +15,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.observers.BasicFuseableObserver;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableObserveOn.java
@@ -14,7 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.disposables.DisposableHelper;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRange.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRange.java
@@ -13,7 +13,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.observers.BasicIntQueueDisposable;
 
 /**

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRangeLong.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRangeLong.java
@@ -13,7 +13,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.observers.BasicIntQueueDisposable;
 
 public final class ObservableRangeLong extends Observable<Long> {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
@@ -17,7 +17,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.EmptyDisposable;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
@@ -13,7 +13,7 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
@@ -12,11 +12,7 @@
  */
 package io.reactivex.internal.operators.observable;
 
-import java.util.Arrays;
-import java.util.concurrent.atomic.*;
-
 import io.reactivex.*;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
@@ -25,6 +21,9 @@ import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
+import java.util.Arrays;
+import java.util.concurrent.atomic.*;
+import javax.annotation.Nonnull;
 
 /**
  * Combines a main sequence of values with the latest from multiple other sequences via
@@ -41,7 +40,7 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
     @Nullable
     final Iterable<? extends ObservableSource<?>> otherIterable;
 
-    @NonNull
+    @Nonnull
     final Function<? super Object[], R> combiner;
 
     public ObservableWithLatestFromMany(ObservableSource<T> source, ObservableSource<?>[] otherArray, Function<? super Object[], R> combiner) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
@@ -44,14 +44,14 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
     @NonNull
     final Function<? super Object[], R> combiner;
 
-    public ObservableWithLatestFromMany(@NonNull ObservableSource<T> source, @NonNull ObservableSource<?>[] otherArray, @NonNull Function<? super Object[], R> combiner) {
+    public ObservableWithLatestFromMany(ObservableSource<T> source, ObservableSource<?>[] otherArray, Function<? super Object[], R> combiner) {
         super(source);
         this.otherArray = otherArray;
         this.otherIterable = null;
         this.combiner = combiner;
     }
 
-    public ObservableWithLatestFromMany(@NonNull ObservableSource<T> source, @NonNull Iterable<? extends ObservableSource<?>> otherIterable, @NonNull Function<? super Object[], R> combiner) {
+    public ObservableWithLatestFromMany(ObservableSource<T> source, Iterable<? extends ObservableSource<?>> otherIterable, Function<? super Object[], R> combiner) {
         super(source);
         this.otherArray = null;
         this.otherIterable = otherIterable;

--- a/src/main/java/io/reactivex/internal/operators/observable/package-info.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.operators.observable;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/operators/package-info.java
+++ b/src/main/java/io/reactivex/internal/operators/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.operators;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/operators/parallel/package-info.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.operators.parallel;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowable.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.single;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservable.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.operators.single;
 import java.util.Iterator;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;

--- a/src/main/java/io/reactivex/internal/operators/single/package-info.java
+++ b/src/main/java/io/reactivex/internal/operators/single/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.operators.single;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/package-info.java
+++ b/src/main/java/io/reactivex/internal/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/MpscLinkedQueue.java
@@ -20,7 +20,7 @@ package io.reactivex.internal.queue;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.fuseable.SimplePlainQueue;
 
 /**

--- a/src/main/java/io/reactivex/internal/queue/SpscArrayQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/SpscArrayQueue.java
@@ -20,7 +20,7 @@ package io.reactivex.internal.queue;
 
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.fuseable.SimplePlainQueue;
 import io.reactivex.internal.util.Pow2;
 

--- a/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
@@ -20,7 +20,7 @@ package io.reactivex.internal.queue;
 
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.internal.fuseable.SimplePlainQueue;
 import io.reactivex.internal.util.Pow2;
 

--- a/src/main/java/io/reactivex/internal/queue/package-info.java
+++ b/src/main/java/io/reactivex/internal/queue/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.queue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
@@ -127,14 +127,14 @@ public final class ComputationScheduler extends Scheduler {
 
     @NonNull
     @Override
-    public Disposable scheduleDirect(@NonNull Runnable run, long delay, TimeUnit unit) {
+    public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
         PoolWorker w = pool.get().getEventLoop();
         return w.scheduleDirect(run, delay, unit);
     }
 
     @NonNull
     @Override
-    public Disposable schedulePeriodicallyDirect(@NonNull Runnable run, long initialDelay, long period, TimeUnit unit) {
+    public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
         PoolWorker w = pool.get().getEventLoop();
         return w.schedulePeriodicallyDirect(run, initialDelay, period, unit);
     }
@@ -194,7 +194,7 @@ public final class ComputationScheduler extends Scheduler {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable action) {
+        public Disposable schedule(Runnable action) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }
@@ -203,7 +203,7 @@ public final class ComputationScheduler extends Scheduler {
         }
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
+        public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }

--- a/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
@@ -16,12 +16,11 @@
 package io.reactivex.internal.schedulers;
 
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.*;
-
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
 
 /**
  * Holds a fixed pool of worker threads and assigns them
@@ -119,20 +118,20 @@ public final class ComputationScheduler extends Scheduler {
         start();
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Worker createWorker() {
         return new EventLoopWorker(pool.get().getEventLoop());
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
         PoolWorker w = pool.get().getEventLoop();
         return w.scheduleDirect(run, delay, unit);
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
         PoolWorker w = pool.get().getEventLoop();
@@ -192,7 +191,7 @@ public final class ComputationScheduler extends Scheduler {
             return disposed;
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable action) {
             if (disposed) {
@@ -201,7 +200,7 @@ public final class ComputationScheduler extends Scheduler {
 
             return poolWorker.scheduleActual(action, 0, TimeUnit.MILLISECONDS, serial);
         }
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
             if (disposed) {

--- a/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
@@ -13,24 +13,23 @@
 
 package io.reactivex.internal.schedulers;
 
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
-
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.schedulers.ExecutorScheduler.ExecutorWorker.BooleanRunnable;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import javax.annotation.Nonnull;
 
 /**
  * Wraps an Executor and provides the Scheduler API over it.
  */
 public final class ExecutorScheduler extends Scheduler {
 
-    @NonNull
+    @Nonnull
     final Executor executor;
 
     static final Scheduler HELPER = Schedulers.single();
@@ -39,13 +38,13 @@ public final class ExecutorScheduler extends Scheduler {
         this.executor = executor;
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Worker createWorker() {
         return new ExecutorWorker(executor);
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable scheduleDirect(Runnable run) {
         Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
@@ -66,7 +65,7 @@ public final class ExecutorScheduler extends Scheduler {
         }
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable scheduleDirect(Runnable run, final long delay, final TimeUnit unit) {
         final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
@@ -91,7 +90,7 @@ public final class ExecutorScheduler extends Scheduler {
         return dr;
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
         if (executor instanceof ScheduledExecutorService) {
@@ -125,7 +124,7 @@ public final class ExecutorScheduler extends Scheduler {
             this.queue = new MpscLinkedQueue<Runnable>();
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable run) {
             if (disposed) {
@@ -151,7 +150,7 @@ public final class ExecutorScheduler extends Scheduler {
             return br;
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
             if (delay <= 0) {

--- a/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
@@ -35,7 +35,7 @@ public final class ExecutorScheduler extends Scheduler {
 
     static final Scheduler HELPER = Schedulers.single();
 
-    public ExecutorScheduler(@NonNull Executor executor) {
+    public ExecutorScheduler(Executor executor) {
         this.executor = executor;
     }
 
@@ -47,7 +47,7 @@ public final class ExecutorScheduler extends Scheduler {
 
     @NonNull
     @Override
-    public Disposable scheduleDirect(@NonNull Runnable run) {
+    public Disposable scheduleDirect(Runnable run) {
         Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
         try {
             if (executor instanceof ExecutorService) {
@@ -68,7 +68,7 @@ public final class ExecutorScheduler extends Scheduler {
 
     @NonNull
     @Override
-    public Disposable scheduleDirect(@NonNull Runnable run, final long delay, final TimeUnit unit) {
+    public Disposable scheduleDirect(Runnable run, final long delay, final TimeUnit unit) {
         final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
         if (executor instanceof ScheduledExecutorService) {
             try {
@@ -93,7 +93,7 @@ public final class ExecutorScheduler extends Scheduler {
 
     @NonNull
     @Override
-    public Disposable schedulePeriodicallyDirect(@NonNull Runnable run, long initialDelay, long period, TimeUnit unit) {
+    public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
         if (executor instanceof ScheduledExecutorService) {
             Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
             try {
@@ -127,7 +127,7 @@ public final class ExecutorScheduler extends Scheduler {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable run) {
+        public Disposable schedule(Runnable run) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }
@@ -153,7 +153,7 @@ public final class ExecutorScheduler extends Scheduler {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
+        public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
             if (delay <= 0) {
                 return schedule(run);
             }

--- a/src/main/java/io/reactivex/internal/schedulers/ImmediateThinScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ImmediateThinScheduler.java
@@ -13,11 +13,10 @@
 
 package io.reactivex.internal.schedulers;
 
-import java.util.concurrent.TimeUnit;
-
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 /**
  * A Scheduler partially implementing the API by allowing only non-delayed, non-periodic
@@ -46,26 +45,26 @@ public final class ImmediateThinScheduler extends Scheduler {
         // singleton class
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable scheduleDirect(Runnable run) {
         run.run();
         return DISPOSED;
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
         throw new UnsupportedOperationException("This scheduler doesn't support delayed execution");
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
         throw new UnsupportedOperationException("This scheduler doesn't support periodic execution");
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Worker createWorker() {
         return WORKER;
@@ -83,20 +82,20 @@ public final class ImmediateThinScheduler extends Scheduler {
             return false; // dispose() has no effect
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable run) {
             run.run();
             return DISPOSED;
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
             throw new UnsupportedOperationException("This scheduler doesn't support delayed execution");
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedulePeriodically(Runnable run, long initialDelay, long period, TimeUnit unit) {
             throw new UnsupportedOperationException("This scheduler doesn't support periodic execution");

--- a/src/main/java/io/reactivex/internal/schedulers/ImmediateThinScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ImmediateThinScheduler.java
@@ -48,20 +48,20 @@ public final class ImmediateThinScheduler extends Scheduler {
 
     @NonNull
     @Override
-    public Disposable scheduleDirect(@NonNull Runnable run) {
+    public Disposable scheduleDirect(Runnable run) {
         run.run();
         return DISPOSED;
     }
 
     @NonNull
     @Override
-    public Disposable scheduleDirect(@NonNull Runnable run, long delay, TimeUnit unit) {
+    public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
         throw new UnsupportedOperationException("This scheduler doesn't support delayed execution");
     }
 
     @NonNull
     @Override
-    public Disposable schedulePeriodicallyDirect(@NonNull Runnable run, long initialDelay, long period, TimeUnit unit) {
+    public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
         throw new UnsupportedOperationException("This scheduler doesn't support periodic execution");
     }
 
@@ -85,20 +85,20 @@ public final class ImmediateThinScheduler extends Scheduler {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable run) {
+        public Disposable schedule(Runnable run) {
             run.run();
             return DISPOSED;
         }
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
+        public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
             throw new UnsupportedOperationException("This scheduler doesn't support delayed execution");
         }
 
         @NonNull
         @Override
-        public Disposable schedulePeriodically(@NonNull Runnable run, long initialDelay, long period, TimeUnit unit) {
+        public Disposable schedulePeriodically(Runnable run, long initialDelay, long period, TimeUnit unit) {
             throw new UnsupportedOperationException("This scheduler doesn't support periodic execution");
         }
     }

--- a/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
@@ -17,12 +17,11 @@
 package io.reactivex.internal.schedulers;
 
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
-
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
+import javax.annotation.Nonnull;
 
 /**
  * Scheduler that creates and caches a set of thread pools and reuses them if possible.
@@ -181,7 +180,7 @@ public final class IoScheduler extends Scheduler {
         }
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Worker createWorker() {
         return new EventLoopWorker(pool.get());
@@ -219,7 +218,7 @@ public final class IoScheduler extends Scheduler {
             return once.get();
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
             if (tasks.isDisposed()) {

--- a/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
@@ -221,7 +221,7 @@ public final class IoScheduler extends Scheduler {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
+        public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
             if (tasks.isDisposed()) {
                 // don't schedule, we are unsubscribed
                 return EmptyDisposable.INSTANCE;

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadScheduler.java
@@ -17,9 +17,8 @@
 package io.reactivex.internal.schedulers;
 
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.NonNull;
-
 import java.util.concurrent.ThreadFactory;
+import javax.annotation.Nonnull;
 
 /**
  * Schedules work on a new thread.
@@ -49,7 +48,7 @@ public final class NewThreadScheduler extends Scheduler {
         this.threadFactory = threadFactory;
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Worker createWorker() {
         return new NewThreadWorker(threadFactory);

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
@@ -13,14 +13,13 @@
 
 package io.reactivex.internal.schedulers;
 
-import java.util.concurrent.*;
-
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.annotations.Nullable;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
+import java.util.concurrent.*;
+import javax.annotation.Nonnull;
 
 /**
  * Base class that manages a single-threaded ScheduledExecutorService as a
@@ -36,13 +35,13 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
         executor = SchedulerPoolFactory.create(threadFactory);
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable schedule(final Runnable run) {
         return schedule(run, 0, null);
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable schedule(final Runnable action, long delayTime, TimeUnit unit) {
         if (disposed) {
@@ -128,7 +127,7 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
      * @param parent the optional tracker parent to add the created ScheduledRunnable instance to before it gets scheduled
      * @return the ScheduledRunnable instance
      */
-    @NonNull
+    @Nonnull
     public ScheduledRunnable scheduleActual(final Runnable run, long delayTime, TimeUnit unit, @Nullable DisposableContainer parent) {
         Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
 

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
@@ -38,13 +38,13 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
 
     @NonNull
     @Override
-    public Disposable schedule(@NonNull final Runnable run) {
+    public Disposable schedule(final Runnable run) {
         return schedule(run, 0, null);
     }
 
     @NonNull
     @Override
-    public Disposable schedule(@NonNull final Runnable action, long delayTime, @NonNull TimeUnit unit) {
+    public Disposable schedule(final Runnable action, long delayTime, TimeUnit unit) {
         if (disposed) {
             return EmptyDisposable.INSTANCE;
         }
@@ -129,7 +129,7 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
      * @return the ScheduledRunnable instance
      */
     @NonNull
-    public ScheduledRunnable scheduleActual(final Runnable run, long delayTime, @NonNull TimeUnit unit, @Nullable DisposableContainer parent) {
+    public ScheduledRunnable scheduleActual(final Runnable run, long delayTime, TimeUnit unit, @Nullable DisposableContainer parent) {
         Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
 
         ScheduledRunnable sr = new ScheduledRunnable(decoratedRun, parent);

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
@@ -14,7 +14,7 @@
 package io.reactivex.internal.schedulers;
 
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
@@ -318,7 +318,7 @@ public class SchedulerWhen extends Scheduler implements Disposable {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull final Runnable action, final long delayTime, @NonNull final TimeUnit unit) {
+        public Disposable schedule(final Runnable action, final long delayTime, final TimeUnit unit) {
             // send a scheduled action to the actionQueue
             DelayedAction delayedAction = new DelayedAction(action, delayTime, unit);
             actionProcessor.onNext(delayedAction);
@@ -327,7 +327,7 @@ public class SchedulerWhen extends Scheduler implements Disposable {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull final Runnable action) {
+        public Disposable schedule(final Runnable action) {
             // send a scheduled action to the actionQueue
             ImmediateAction immediateAction = new ImmediateAction(action);
             actionProcessor.onNext(immediateAction);

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
@@ -15,23 +15,15 @@
  */
 package io.reactivex.internal.schedulers;
 
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-
-import io.reactivex.Completable;
-import io.reactivex.CompletableObserver;
-import io.reactivex.Flowable;
-import io.reactivex.Observable;
-import io.reactivex.Scheduler;
+import io.reactivex.*;
 import io.reactivex.annotations.Experimental;
-import io.reactivex.annotations.NonNull;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.disposables.Disposables;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.processors.FlowableProcessor;
-import io.reactivex.processors.UnicastProcessor;
+import io.reactivex.processors.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.*;
+import javax.annotation.Nonnull;
 
 /**
  * Allows the use of operators for controlling the timing around when actions
@@ -130,7 +122,7 @@ public class SchedulerWhen extends Scheduler implements Disposable {
         return disposable.isDisposed();
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Worker createWorker() {
         final Worker actualWorker = actualScheduler.createWorker();
@@ -316,7 +308,7 @@ public class SchedulerWhen extends Scheduler implements Disposable {
             return unsubscribed.get();
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(final Runnable action, final long delayTime, final TimeUnit unit) {
             // send a scheduled action to the actionQueue
@@ -325,7 +317,7 @@ public class SchedulerWhen extends Scheduler implements Disposable {
             return delayedAction;
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(final Runnable action) {
             // send a scheduled action to the actionQueue

--- a/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
@@ -13,13 +13,12 @@
 package io.reactivex.internal.schedulers;
 
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
-
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
 
 /**
  * A scheduler with a shared, single threaded underlying ScheduledExecutorService.
@@ -97,13 +96,13 @@ public final class SingleScheduler extends Scheduler {
         }
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Worker createWorker() {
         return new ScheduledWorker(executor.get());
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
         ScheduledDirectTask task = new ScheduledDirectTask(RxJavaPlugins.onSchedule(run));
@@ -122,7 +121,7 @@ public final class SingleScheduler extends Scheduler {
         }
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
         final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
@@ -170,7 +169,7 @@ public final class SingleScheduler extends Scheduler {
             this.tasks = new CompositeDisposable();
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
             if (disposed) {

--- a/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SingleScheduler.java
@@ -105,7 +105,7 @@ public final class SingleScheduler extends Scheduler {
 
     @NonNull
     @Override
-    public Disposable scheduleDirect(@NonNull Runnable run, long delay, TimeUnit unit) {
+    public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
         ScheduledDirectTask task = new ScheduledDirectTask(RxJavaPlugins.onSchedule(run));
         try {
             Future<?> f;
@@ -124,7 +124,7 @@ public final class SingleScheduler extends Scheduler {
 
     @NonNull
     @Override
-    public Disposable schedulePeriodicallyDirect(@NonNull Runnable run, long initialDelay, long period, TimeUnit unit) {
+    public Disposable schedulePeriodicallyDirect(Runnable run, long initialDelay, long period, TimeUnit unit) {
         final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
         if (period <= 0L) {
 
@@ -172,7 +172,7 @@ public final class SingleScheduler extends Scheduler {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
+        public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }

--- a/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
@@ -16,15 +16,14 @@
 
 package io.reactivex.internal.schedulers;
 
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
 
 /**
  * Schedules work on the current thread but does not execute immediately. Work is put in a queue and executed
@@ -37,7 +36,7 @@ public final class TrampolineScheduler extends Scheduler {
         return INSTANCE;
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Worker createWorker() {
         return new TrampolineWorker();
@@ -46,14 +45,14 @@ public final class TrampolineScheduler extends Scheduler {
     /* package accessible for unit tests */TrampolineScheduler() {
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable scheduleDirect(Runnable run) {
         run.run();
         return EmptyDisposable.INSTANCE;
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
         try {
@@ -75,13 +74,13 @@ public final class TrampolineScheduler extends Scheduler {
 
         volatile boolean disposed;
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable action) {
             return enqueue(action, now(TimeUnit.MILLISECONDS));
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
             long execTime = now(TimeUnit.MILLISECONDS) + unit.toMillis(delayTime);

--- a/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
@@ -48,14 +48,14 @@ public final class TrampolineScheduler extends Scheduler {
 
     @NonNull
     @Override
-    public Disposable scheduleDirect(@NonNull Runnable run) {
+    public Disposable scheduleDirect(Runnable run) {
         run.run();
         return EmptyDisposable.INSTANCE;
     }
 
     @NonNull
     @Override
-    public Disposable scheduleDirect(@NonNull Runnable run, long delay, TimeUnit unit) {
+    public Disposable scheduleDirect(Runnable run, long delay, TimeUnit unit) {
         try {
             unit.sleep(delay);
             run.run();
@@ -77,13 +77,13 @@ public final class TrampolineScheduler extends Scheduler {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable action) {
+        public Disposable schedule(Runnable action) {
             return enqueue(action, now(TimeUnit.MILLISECONDS));
         }
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
+        public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
             long execTime = now(TimeUnit.MILLISECONDS) + unit.toMillis(delayTime);
 
             return enqueue(new SleepingRunnable(action, this, execTime), execTime);

--- a/src/main/java/io/reactivex/internal/schedulers/package-info.java
+++ b/src/main/java/io/reactivex/internal/schedulers/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.schedulers;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/subscribers/package-info.java
+++ b/src/main/java/io/reactivex/internal/subscribers/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.subscribers;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/DeferredScalarSubscription.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.subscriptions;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.reactivestreams.Subscriber;
 
 /**

--- a/src/main/java/io/reactivex/internal/subscriptions/EmptySubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/EmptySubscription.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.subscriptions;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.internal.fuseable.QueueSubscription;

--- a/src/main/java/io/reactivex/internal/subscriptions/ScalarSubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/ScalarSubscription.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.subscriptions;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.internal.fuseable.QueueSubscription;

--- a/src/main/java/io/reactivex/internal/subscriptions/package-info.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.subscriptions;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/internal/util/package-info.java
+++ b/src/main/java/io/reactivex/internal/util/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.reactivex.internal.util;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/observables/ConnectableObservable.java
+++ b/src/main/java/io/reactivex/observables/ConnectableObservable.java
@@ -47,7 +47,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *          allowing the caller to synchronously disconnect a synchronous source
      * @see <a href="http://reactivex.io/documentation/operators/connect.html">ReactiveX documentation: Connect</a>
      */
-    public abstract void connect(@NonNull Consumer<? super Disposable> connection);
+    public abstract void connect(Consumer<? super Disposable> connection);
 
     /**
      * Instructs the {@code ConnectableObservable} to begin emitting the items from its underlying
@@ -118,7 +118,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *         specified callback with the Subscription associated with the established connection
      */
     @NonNull
-    public Observable<T> autoConnect(int numberOfSubscribers, @NonNull Consumer<? super Disposable> connection) {
+    public Observable<T> autoConnect(int numberOfSubscribers, Consumer<? super Disposable> connection) {
         if (numberOfSubscribers <= 0) {
             this.connect(connection);
             return RxJavaPlugins.onAssembly(this);

--- a/src/main/java/io/reactivex/observables/ConnectableObservable.java
+++ b/src/main/java/io/reactivex/observables/ConnectableObservable.java
@@ -13,8 +13,6 @@
 
 package io.reactivex.observables;
 
-import io.reactivex.annotations.NonNull;
-
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
@@ -22,6 +20,7 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.observable.*;
 import io.reactivex.internal.util.ConnectConsumer;
 import io.reactivex.plugins.RxJavaPlugins;
+import javax.annotation.Nonnull;
 
 /**
  * A {@code ConnectableObservable} resembles an ordinary {@link Observable}, except that it does not begin
@@ -71,7 +70,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      * @return an {@link Observable}
      * @see <a href="http://reactivex.io/documentation/operators/refcount.html">ReactiveX documentation: RefCount</a>
      */
-    @NonNull
+    @Nonnull
     public Observable<T> refCount() {
         return RxJavaPlugins.onAssembly(new ObservableRefCount<T>(this));
     }
@@ -83,7 +82,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      * @return an Observable that automatically connects to this ConnectableObservable
      *         when the first Observer subscribes
      */
-    @NonNull
+    @Nonnull
     public Observable<T> autoConnect() {
         return autoConnect(1);
     }
@@ -98,7 +97,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      * @return an Observable that automatically connects to this ConnectableObservable
      *         when the specified number of Subscribers subscribe to it
      */
-    @NonNull
+    @Nonnull
     public Observable<T> autoConnect(int numberOfSubscribers) {
         return autoConnect(numberOfSubscribers, Functions.emptyConsumer());
     }
@@ -117,7 +116,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *         when the specified number of Subscribers subscribe to it and calls the
      *         specified callback with the Subscription associated with the established connection
      */
-    @NonNull
+    @Nonnull
     public Observable<T> autoConnect(int numberOfSubscribers, Consumer<? super Disposable> connection) {
         if (numberOfSubscribers <= 0) {
             this.connect(connection);

--- a/src/main/java/io/reactivex/observables/GroupedObservable.java
+++ b/src/main/java/io/reactivex/observables/GroupedObservable.java
@@ -13,7 +13,7 @@
 package io.reactivex.observables;
 
 import io.reactivex.Observable;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 
 /**
  * An {@link Observable} that has been grouped by key, the value of which can be obtained with {@link #getKey()}.

--- a/src/main/java/io/reactivex/observables/package-info.java
+++ b/src/main/java/io/reactivex/observables/package-info.java
@@ -18,4 +18,7 @@
  * Classes supporting the Observable base reactive class: connectable and grouped
  * observables.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.observables;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/observers/DefaultObserver.java
+++ b/src/main/java/io/reactivex/observers/DefaultObserver.java
@@ -14,7 +14,6 @@
 package io.reactivex.observers;
 
 import io.reactivex.Observer;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.util.EndConsumerHelper;

--- a/src/main/java/io/reactivex/observers/DefaultObserver.java
+++ b/src/main/java/io/reactivex/observers/DefaultObserver.java
@@ -64,7 +64,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
 public abstract class DefaultObserver<T> implements Observer<T> {
     private Disposable s;
     @Override
-    public final void onSubscribe(@NonNull Disposable s) {
+    public final void onSubscribe(Disposable s) {
         if (EndConsumerHelper.validate(this.s, s, getClass())) {
             this.s = s;
             onStart();

--- a/src/main/java/io/reactivex/observers/DisposableCompletableObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableCompletableObserver.java
@@ -55,7 +55,7 @@ public abstract class DisposableCompletableObserver implements CompletableObserv
     final AtomicReference<Disposable> s = new AtomicReference<Disposable>();
 
     @Override
-    public final void onSubscribe(@NonNull Disposable s) {
+    public final void onSubscribe(Disposable s) {
         if (EndConsumerHelper.setOnce(this.s, s, getClass())) {
             onStart();
         }

--- a/src/main/java/io/reactivex/observers/DisposableCompletableObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableCompletableObserver.java
@@ -16,7 +16,6 @@ package io.reactivex.observers;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.CompletableObserver;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.util.EndConsumerHelper;

--- a/src/main/java/io/reactivex/observers/DisposableMaybeObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableMaybeObserver.java
@@ -16,7 +16,6 @@ package io.reactivex.observers;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.MaybeObserver;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.util.EndConsumerHelper;

--- a/src/main/java/io/reactivex/observers/DisposableMaybeObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableMaybeObserver.java
@@ -65,7 +65,7 @@ public abstract class DisposableMaybeObserver<T> implements MaybeObserver<T>, Di
     final AtomicReference<Disposable> s = new AtomicReference<Disposable>();
 
     @Override
-    public final void onSubscribe(@NonNull Disposable s) {
+    public final void onSubscribe(Disposable s) {
         if (EndConsumerHelper.setOnce(this.s, s, getClass())) {
             onStart();
         }

--- a/src/main/java/io/reactivex/observers/DisposableObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableObserver.java
@@ -69,7 +69,7 @@ public abstract class DisposableObserver<T> implements Observer<T>, Disposable {
     final AtomicReference<Disposable> s = new AtomicReference<Disposable>();
 
     @Override
-    public final void onSubscribe(@NonNull Disposable s) {
+    public final void onSubscribe(Disposable s) {
         if (EndConsumerHelper.setOnce(this.s, s, getClass())) {
             onStart();
         }

--- a/src/main/java/io/reactivex/observers/DisposableObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableObserver.java
@@ -16,7 +16,6 @@ package io.reactivex.observers;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.Observer;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.util.EndConsumerHelper;

--- a/src/main/java/io/reactivex/observers/DisposableSingleObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableSingleObserver.java
@@ -16,7 +16,6 @@ package io.reactivex.observers;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.SingleObserver;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.util.EndConsumerHelper;

--- a/src/main/java/io/reactivex/observers/DisposableSingleObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableSingleObserver.java
@@ -58,7 +58,7 @@ public abstract class DisposableSingleObserver<T> implements SingleObserver<T>, 
     final AtomicReference<Disposable> s = new AtomicReference<Disposable>();
 
     @Override
-    public final void onSubscribe(@NonNull Disposable s) {
+    public final void onSubscribe(Disposable s) {
         if (EndConsumerHelper.setOnce(this.s, s, getClass())) {
             onStart();
         }

--- a/src/main/java/io/reactivex/observers/ResourceCompletableObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceCompletableObserver.java
@@ -16,7 +16,6 @@ package io.reactivex.observers;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.CompletableObserver;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.ObjectHelper;

--- a/src/main/java/io/reactivex/observers/ResourceCompletableObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceCompletableObserver.java
@@ -86,13 +86,13 @@ public abstract class ResourceCompletableObserver implements CompletableObserver
      *
      * @throws NullPointerException if resource is null
      */
-    public final void add(@NonNull Disposable resource) {
+    public final void add(Disposable resource) {
         ObjectHelper.requireNonNull(resource, "resource is null");
         resources.add(resource);
     }
 
     @Override
-    public final void onSubscribe(@NonNull Disposable s) {
+    public final void onSubscribe(Disposable s) {
         if (EndConsumerHelper.setOnce(this.s, s, getClass())) {
             onStart();
         }

--- a/src/main/java/io/reactivex/observers/ResourceMaybeObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceMaybeObserver.java
@@ -96,13 +96,13 @@ public abstract class ResourceMaybeObserver<T> implements MaybeObserver<T>, Disp
      *
      * @throws NullPointerException if resource is null
      */
-    public final void add(@NonNull Disposable resource) {
+    public final void add(Disposable resource) {
         ObjectHelper.requireNonNull(resource, "resource is null");
         resources.add(resource);
     }
 
     @Override
-    public final void onSubscribe(@NonNull Disposable s) {
+    public final void onSubscribe(Disposable s) {
         if (EndConsumerHelper.setOnce(this.s, s, getClass())) {
             onStart();
         }

--- a/src/main/java/io/reactivex/observers/ResourceMaybeObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceMaybeObserver.java
@@ -16,7 +16,6 @@ package io.reactivex.observers;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.MaybeObserver;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.ObjectHelper;

--- a/src/main/java/io/reactivex/observers/ResourceObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceObserver.java
@@ -94,7 +94,7 @@ public abstract class ResourceObserver<T> implements Observer<T>, Disposable {
      *
      * @throws NullPointerException if resource is null
      */
-    public final void add(@NonNull Disposable resource) {
+    public final void add(Disposable resource) {
         ObjectHelper.requireNonNull(resource, "resource is null");
         resources.add(resource);
     }

--- a/src/main/java/io/reactivex/observers/ResourceObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceObserver.java
@@ -16,7 +16,6 @@ package io.reactivex.observers;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.Observer;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.ObjectHelper;

--- a/src/main/java/io/reactivex/observers/ResourceSingleObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceSingleObserver.java
@@ -89,13 +89,13 @@ public abstract class ResourceSingleObserver<T> implements SingleObserver<T>, Di
      *
      * @throws NullPointerException if resource is null
      */
-    public final void add(@NonNull Disposable resource) {
+    public final void add(Disposable resource) {
         ObjectHelper.requireNonNull(resource, "resource is null");
         resources.add(resource);
     }
 
     @Override
-    public final void onSubscribe(@NonNull Disposable s) {
+    public final void onSubscribe(Disposable s) {
         if (EndConsumerHelper.setOnce(this.s, s, getClass())) {
             onStart();
         }

--- a/src/main/java/io/reactivex/observers/ResourceSingleObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceSingleObserver.java
@@ -16,7 +16,6 @@ package io.reactivex.observers;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.SingleObserver;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.ObjectHelper;

--- a/src/main/java/io/reactivex/observers/SafeObserver.java
+++ b/src/main/java/io/reactivex/observers/SafeObserver.java
@@ -37,12 +37,12 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
      * Constructs a SafeObserver by wrapping the given actual Observer.
      * @param actual the actual Observer to wrap, not null (not validated)
      */
-    public SafeObserver(@NonNull Observer<? super T> actual) {
+    public SafeObserver(Observer<? super T> actual) {
         this.actual = actual;
     }
 
     @Override
-    public void onSubscribe(@NonNull Disposable s) {
+    public void onSubscribe(Disposable s) {
         if (DisposableHelper.validate(this.s, s)) {
             this.s = s;
             try {
@@ -75,7 +75,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
     }
 
     @Override
-    public void onNext(@NonNull T t) {
+    public void onNext(T t) {
         if (done) {
             return;
         }
@@ -135,7 +135,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
     }
 
     @Override
-    public void onError(@NonNull Throwable t) {
+    public void onError(Throwable t) {
         if (done) {
             RxJavaPlugins.onError(t);
             return;

--- a/src/main/java/io/reactivex/observers/SerializedObserver.java
+++ b/src/main/java/io/reactivex/observers/SerializedObserver.java
@@ -47,7 +47,7 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
      * Construct a SerializedObserver by wrapping the given actual Observer.
      * @param actual the actual Observer, not null (not verified)
      */
-    public SerializedObserver(@NonNull Observer<? super T> actual) {
+    public SerializedObserver(Observer<? super T> actual) {
         this(actual, false);
     }
 
@@ -58,13 +58,13 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
      * @param actual the actual Observer, not null (not verified)
      * @param delayError if true, errors are emitted after regular values have been emitted
      */
-    public SerializedObserver(@NonNull Observer<? super T> actual, boolean delayError) {
+    public SerializedObserver(Observer<? super T> actual, boolean delayError) {
         this.actual = actual;
         this.delayError = delayError;
     }
 
     @Override
-    public void onSubscribe(@NonNull Disposable s) {
+    public void onSubscribe(Disposable s) {
         if (DisposableHelper.validate(this.s, s)) {
             this.s = s;
 
@@ -85,7 +85,7 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
 
 
     @Override
-    public void onNext(@NonNull T t) {
+    public void onNext(T t) {
         if (done) {
             return;
         }
@@ -116,7 +116,7 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
     }
 
     @Override
-    public void onError(@NonNull Throwable t) {
+    public void onError(Throwable t) {
         if (done) {
             RxJavaPlugins.onError(t);
             return;

--- a/src/main/java/io/reactivex/observers/package-info.java
+++ b/src/main/java/io/reactivex/observers/package-info.java
@@ -18,4 +18,7 @@
  * Default wrappers and implementations for Observer-based consumer classes and interfaces;
  * utility classes for creating them from callbacks.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.observers;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/package-info.java
+++ b/src/main/java/io/reactivex/package-info.java
@@ -48,5 +48,7 @@
  * and receive events.</p>
  * <p>Usage examples can be found on the {@link io.reactivex.Flowable}/{@link io.reactivex.Observable} and {@link org.reactivestreams.Subscriber} classes.</p>
  */
+@ParametersAreNonnullByDefault
 package io.reactivex;
 
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -13,22 +13,19 @@
 
 package io.reactivex.parallel;
 
-import io.reactivex.Flowable;
-import io.reactivex.Scheduler;
+import io.reactivex.*;
 import io.reactivex.annotations.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
-import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.functions.*;
 import io.reactivex.internal.operators.parallel.*;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import org.reactivestreams.*;
-
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.Callable;
+import javax.annotation.Nonnull;
+import org.reactivestreams.*;
 
 /**
  * Abstract base class for Parallel publishers that take an array of Subscribers.
@@ -115,7 +112,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public static <T> ParallelFlowable<T> from(Publisher<? extends T> source,
             int parallelism, int prefetch) {
         ObjectHelper.requireNonNull(source, "source");
@@ -134,7 +131,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> map(Function<? super T, ? extends R> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper");
         return RxJavaPlugins.onAssembly(new ParallelMap<T, R>(this, mapper));
@@ -154,7 +151,7 @@ public abstract class ParallelFlowable<T> {
      */
     @CheckReturnValue
     @Experimental
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> map(Function<? super T, ? extends R> mapper, ParallelFailureHandling errorHandler) {
         ObjectHelper.requireNonNull(mapper, "mapper");
         ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
@@ -176,7 +173,7 @@ public abstract class ParallelFlowable<T> {
      */
     @CheckReturnValue
     @Experimental
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> map(Function<? super T, ? extends R> mapper, BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
         ObjectHelper.requireNonNull(mapper, "mapper");
         ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
@@ -256,7 +253,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> runOn(Scheduler scheduler) {
         return runOn(scheduler, Flowable.bufferSize());
     }
@@ -283,7 +280,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> runOn(Scheduler scheduler, int prefetch) {
         ObjectHelper.requireNonNull(scheduler, "scheduler");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -299,7 +296,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new Flowable instance emitting the reduced value or empty if the ParallelFlowable was empty
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final Flowable<T> reduce(BiFunction<T, T, T> reducer) {
         ObjectHelper.requireNonNull(reducer, "reducer");
         return RxJavaPlugins.onAssembly(new ParallelReduceFull<T>(this, reducer));
@@ -317,7 +314,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> reduce(Callable<R> initialSupplier, BiFunction<R, ? super T, R> reducer) {
         ObjectHelper.requireNonNull(initialSupplier, "initialSupplier");
         ObjectHelper.requireNonNull(reducer, "reducer");
@@ -367,7 +364,7 @@ public abstract class ParallelFlowable<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final Flowable<T> sequential(int prefetch) {
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new ParallelJoin<T>(this, prefetch, false));
@@ -395,7 +392,7 @@ public abstract class ParallelFlowable<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
     @Experimental
-    @NonNull
+    @Nonnull
     public final Flowable<T> sequentialDelayError() {
         return sequentialDelayError(Flowable.bufferSize());
     }
@@ -420,7 +417,7 @@ public abstract class ParallelFlowable<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final Flowable<T> sequentialDelayError(int prefetch) {
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new ParallelJoin<T>(this, prefetch, true));
@@ -436,7 +433,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new Flowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final Flowable<T> sorted(Comparator<? super T> comparator) {
         return sorted(comparator, 16);
     }
@@ -452,7 +449,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new Flowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final Flowable<T> sorted(Comparator<? super T> comparator, int capacityHint) {
         ObjectHelper.requireNonNull(comparator, "comparator is null");
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
@@ -472,7 +469,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new Flowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final Flowable<List<T>> toSortedList(Comparator<? super T> comparator) {
         return toSortedList(comparator, 16);
     }
@@ -486,7 +483,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new Flowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final Flowable<List<T>> toSortedList(Comparator<? super T> comparator, int capacityHint) {
         ObjectHelper.requireNonNull(comparator, "comparator is null");
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
@@ -507,7 +504,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> doOnNext(Consumer<? super T> onNext) {
         ObjectHelper.requireNonNull(onNext, "onNext is null");
         return RxJavaPlugins.onAssembly(new ParallelPeek<T>(this,
@@ -535,7 +532,7 @@ public abstract class ParallelFlowable<T> {
      */
     @CheckReturnValue
     @Experimental
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> doOnNext(Consumer<? super T> onNext, ParallelFailureHandling errorHandler) {
         ObjectHelper.requireNonNull(onNext, "onNext is null");
         ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
@@ -555,7 +552,7 @@ public abstract class ParallelFlowable<T> {
      */
     @CheckReturnValue
     @Experimental
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> doOnNext(Consumer<? super T> onNext, BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
         ObjectHelper.requireNonNull(onNext, "onNext is null");
         ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
@@ -570,7 +567,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> doAfterNext(Consumer<? super T> onAfterNext) {
         ObjectHelper.requireNonNull(onAfterNext, "onAfterNext is null");
         return RxJavaPlugins.onAssembly(new ParallelPeek<T>(this,
@@ -592,7 +589,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> doOnError(Consumer<Throwable> onError) {
         ObjectHelper.requireNonNull(onError, "onError is null");
         return RxJavaPlugins.onAssembly(new ParallelPeek<T>(this,
@@ -614,7 +611,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> doOnComplete(Action onComplete) {
         ObjectHelper.requireNonNull(onComplete, "onComplete is null");
         return RxJavaPlugins.onAssembly(new ParallelPeek<T>(this,
@@ -636,7 +633,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> doAfterTerminated(Action onAfterTerminate) {
         ObjectHelper.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
         return RxJavaPlugins.onAssembly(new ParallelPeek<T>(this,
@@ -658,7 +655,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> doOnSubscribe(Consumer<? super Subscription> onSubscribe) {
         ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
         return RxJavaPlugins.onAssembly(new ParallelPeek<T>(this,
@@ -680,7 +677,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> doOnRequest(LongConsumer onRequest) {
         ObjectHelper.requireNonNull(onRequest, "onRequest is null");
         return RxJavaPlugins.onAssembly(new ParallelPeek<T>(this,
@@ -702,7 +699,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final ParallelFlowable<T> doOnCancel(Action onCancel) {
         ObjectHelper.requireNonNull(onCancel, "onCancel is null");
         return RxJavaPlugins.onAssembly(new ParallelPeek<T>(this,
@@ -727,7 +724,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <C> ParallelFlowable<C> collect(Callable<? extends C> collectionSupplier, BiConsumer<? super C, ? super T> collector) {
         ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
         ObjectHelper.requireNonNull(collector, "collector is null");
@@ -743,7 +740,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public static <T> ParallelFlowable<T> fromArray(Publisher<T>... publishers) {
         if (publishers.length == 0) {
             throw new IllegalArgumentException("Zero publishers not supported");
@@ -760,7 +757,7 @@ public abstract class ParallelFlowable<T> {
      * @return the value returned by the converter function
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <U> U to(Function<? super ParallelFlowable<T>, U> converter) {
         try {
             return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
@@ -779,7 +776,7 @@ public abstract class ParallelFlowable<T> {
      * @return the ParallelFlowable returned by the function
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <U> ParallelFlowable<U> compose(ParallelTransformer<T, U> composer) {
         return RxJavaPlugins.onAssembly(ObjectHelper.requireNonNull(composer, "composer is null").apply(this));
     }
@@ -794,7 +791,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return flatMap(mapper, false, Integer.MAX_VALUE, Flowable.bufferSize());
     }
@@ -810,7 +807,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> flatMap(
             Function<? super T, ? extends Publisher<? extends R>> mapper, boolean delayError) {
         return flatMap(mapper, delayError, Integer.MAX_VALUE, Flowable.bufferSize());
@@ -829,7 +826,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> flatMap(
             Function<? super T, ? extends Publisher<? extends R>> mapper, boolean delayError, int maxConcurrency) {
         return flatMap(mapper, delayError, maxConcurrency, Flowable.bufferSize());
@@ -848,7 +845,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> flatMap(
             Function<? super T, ? extends Publisher<? extends R>> mapper,
             boolean delayError, int maxConcurrency, int prefetch) {
@@ -868,7 +865,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> concatMap(
             Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return concatMap(mapper, 2);
@@ -885,7 +882,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> concatMap(
             Function<? super T, ? extends Publisher<? extends R>> mapper,
                     int prefetch) {
@@ -906,7 +903,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> concatMapDelayError(
             Function<? super T, ? extends Publisher<? extends R>> mapper,
                     boolean tillTheEnd) {
@@ -925,7 +922,7 @@ public abstract class ParallelFlowable<T> {
      * @return the new ParallelFlowable instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public final <R> ParallelFlowable<R> concatMapDelayError(
             Function<? super T, ? extends Publisher<? extends R>> mapper,
                     int prefetch, boolean tillTheEnd) {

--- a/src/main/java/io/reactivex/parallel/ParallelTransformer.java
+++ b/src/main/java/io/reactivex/parallel/ParallelTransformer.java
@@ -32,5 +32,5 @@ public interface ParallelTransformer<Upstream, Downstream> {
      * @return the transformed ParallelFlowable instance
      */
     @NonNull
-    ParallelFlowable<Downstream> apply(@NonNull ParallelFlowable<Upstream> upstream);
+    ParallelFlowable<Downstream> apply(ParallelFlowable<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/parallel/ParallelTransformer.java
+++ b/src/main/java/io/reactivex/parallel/ParallelTransformer.java
@@ -13,7 +13,8 @@
 
 package io.reactivex.parallel;
 
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.Experimental;
+import javax.annotation.Nonnull;
 
 /**
  * Interface to compose ParallelFlowable.
@@ -31,6 +32,6 @@ public interface ParallelTransformer<Upstream, Downstream> {
      * @param upstream the upstream ParallelFlowable instance
      * @return the transformed ParallelFlowable instance
      */
-    @NonNull
+    @Nonnull
     ParallelFlowable<Downstream> apply(ParallelFlowable<Upstream> upstream);
 }

--- a/src/main/java/io/reactivex/parallel/package-info.java
+++ b/src/main/java/io/reactivex/parallel/package-info.java
@@ -18,4 +18,7 @@
  * Base type for the parallel type offering a sub-DSL for working with Flowable items
  * in parallel.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.parallel;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -23,11 +23,10 @@ import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.schedulers.Schedulers;
-import org.reactivestreams.Subscriber;
-
 import java.lang.Thread.UncaughtExceptionHandler;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.*;
+import javax.annotation.Nonnull;
+import org.reactivestreams.Subscriber;
 /**
  * Utility class to inject handlers to certain standard RxJava operations.
  */
@@ -263,7 +262,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    @NonNull
+    @Nonnull
     public static Scheduler initComputationScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitComputationHandler;
@@ -279,7 +278,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    @NonNull
+    @Nonnull
     public static Scheduler initIoScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitIoHandler;
@@ -295,7 +294,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    @NonNull
+    @Nonnull
     public static Scheduler initNewThreadScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitNewThreadHandler;
@@ -311,7 +310,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook, not null
      * @throws NullPointerException if the callable parameter or its result are null
      */
-    @NonNull
+    @Nonnull
     public static Scheduler initSingleScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitSingleHandler;
@@ -326,7 +325,7 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    @NonNull
+    @Nonnull
     public static Scheduler onComputationScheduler(Scheduler defaultScheduler) {
         Function<? super Scheduler, ? extends Scheduler> f = onComputationHandler;
         if (f == null) {
@@ -416,7 +415,7 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    @NonNull
+    @Nonnull
     public static Scheduler onIoScheduler(Scheduler defaultScheduler) {
         Function<? super Scheduler, ? extends Scheduler> f = onIoHandler;
         if (f == null) {
@@ -430,7 +429,7 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    @NonNull
+    @Nonnull
     public static Scheduler onNewThreadScheduler(Scheduler defaultScheduler) {
         Function<? super Scheduler, ? extends Scheduler> f = onNewThreadHandler;
         if (f == null) {
@@ -444,7 +443,7 @@ public final class RxJavaPlugins {
      * @param run the runnable instance
      * @return the replacement runnable
      */
-    @NonNull
+    @Nonnull
     public static Runnable onSchedule(Runnable run) {
         Function<? super Runnable, ? extends Runnable> f = onScheduleHandler;
         if (f == null) {
@@ -458,7 +457,7 @@ public final class RxJavaPlugins {
      * @param defaultScheduler the hook's input value
      * @return the value returned by the hook
      */
-    @NonNull
+    @Nonnull
     public static Scheduler onSingleScheduler(Scheduler defaultScheduler) {
         Function<? super Scheduler, ? extends Scheduler> f = onSingleHandler;
         if (f == null) {
@@ -897,7 +896,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @NonNull
+    @Nonnull
     public static <T> Subscriber<? super T> onSubscribe(Flowable<T> source, Subscriber<? super T> subscriber) {
         BiFunction<? super Flowable, ? super Subscriber, ? extends Subscriber> f = onFlowableSubscribe;
         if (f != null) {
@@ -914,7 +913,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @NonNull
+    @Nonnull
     public static <T> Observer<? super T> onSubscribe(Observable<T> source, Observer<? super T> observer) {
         BiFunction<? super Observable, ? super Observer, ? extends Observer> f = onObservableSubscribe;
         if (f != null) {
@@ -931,7 +930,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @NonNull
+    @Nonnull
     public static <T> SingleObserver<? super T> onSubscribe(Single<T> source, SingleObserver<? super T> observer) {
         BiFunction<? super Single, ? super SingleObserver, ? extends SingleObserver> f = onSingleSubscribe;
         if (f != null) {
@@ -946,7 +945,7 @@ public final class RxJavaPlugins {
      * @param observer the observer
      * @return the value returned by the hook
      */
-    @NonNull
+    @Nonnull
     public static CompletableObserver onSubscribe(Completable source, CompletableObserver observer) {
         BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> f = onCompletableSubscribe;
         if (f != null) {
@@ -963,7 +962,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @NonNull
+    @Nonnull
     public static <T> MaybeObserver<? super T> onSubscribe(Maybe<T> source, MaybeObserver<? super T> subscriber) {
         BiFunction<? super Maybe, ? super MaybeObserver, ? extends MaybeObserver> f = onMaybeSubscribe;
         if (f != null) {
@@ -979,7 +978,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @NonNull
+    @Nonnull
     public static <T> Maybe<T> onAssembly(Maybe<T> source) {
         Function<? super Maybe, ? extends Maybe> f = onMaybeAssembly;
         if (f != null) {
@@ -995,7 +994,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @NonNull
+    @Nonnull
     public static <T> Flowable<T> onAssembly(Flowable<T> source) {
         Function<? super Flowable, ? extends Flowable> f = onFlowableAssembly;
         if (f != null) {
@@ -1011,7 +1010,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @NonNull
+    @Nonnull
     public static <T> ConnectableFlowable<T> onAssembly(ConnectableFlowable<T> source) {
         Function<? super ConnectableFlowable, ? extends ConnectableFlowable> f = onConnectableFlowableAssembly;
         if (f != null) {
@@ -1027,7 +1026,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @NonNull
+    @Nonnull
     public static <T> Observable<T> onAssembly(Observable<T> source) {
         Function<? super Observable, ? extends Observable> f = onObservableAssembly;
         if (f != null) {
@@ -1043,7 +1042,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @NonNull
+    @Nonnull
     public static <T> ConnectableObservable<T> onAssembly(ConnectableObservable<T> source) {
         Function<? super ConnectableObservable, ? extends ConnectableObservable> f = onConnectableObservableAssembly;
         if (f != null) {
@@ -1059,7 +1058,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @NonNull
+    @Nonnull
     public static <T> Single<T> onAssembly(Single<T> source) {
         Function<? super Single, ? extends Single> f = onSingleAssembly;
         if (f != null) {
@@ -1073,7 +1072,7 @@ public final class RxJavaPlugins {
      * @param source the hook's input value
      * @return the value returned by the hook
      */
-    @NonNull
+    @Nonnull
     public static Completable onAssembly(Completable source) {
         Function<? super Completable, ? extends Completable> f = onCompletableAssembly;
         if (f != null) {
@@ -1120,7 +1119,7 @@ public final class RxJavaPlugins {
      */
     @Beta
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @NonNull
+    @Nonnull
     public static <T> ParallelFlowable<T> onAssembly(ParallelFlowable<T> source) {
         Function<? super ParallelFlowable, ? extends ParallelFlowable> f = onParallelAssembly;
         if (f != null) {
@@ -1189,7 +1188,7 @@ public final class RxJavaPlugins {
      * @return the created Scheduler instance
      * @since 2.1
      */
-    @NonNull
+    @Nonnull
     public static Scheduler createComputationScheduler(ThreadFactory threadFactory) {
         return new ComputationScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
@@ -1203,7 +1202,7 @@ public final class RxJavaPlugins {
      * @return the created Scheduler instance
      * @since 2.1
      */
-    @NonNull
+    @Nonnull
     public static Scheduler createIoScheduler(ThreadFactory threadFactory) {
         return new IoScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
@@ -1217,7 +1216,7 @@ public final class RxJavaPlugins {
      * @return the created Scheduler instance
      * @since 2.1
      */
-    @NonNull
+    @Nonnull
     public static Scheduler createNewThreadScheduler(ThreadFactory threadFactory) {
         return new NewThreadScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
@@ -1231,7 +1230,7 @@ public final class RxJavaPlugins {
      * @return the created Scheduler instance
      * @since 2.1
      */
-    @NonNull
+    @Nonnull
     public static Scheduler createSingleScheduler(ThreadFactory threadFactory) {
         return new SingleScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
@@ -1245,7 +1244,7 @@ public final class RxJavaPlugins {
      * @param t the parameter value to the function
      * @return the result of the function call
      */
-    @NonNull
+    @Nonnull
     static <T, R> R apply(Function<T, R> f, T t) {
         try {
             return f.apply(t);
@@ -1265,7 +1264,7 @@ public final class RxJavaPlugins {
      * @param u the second parameter value to the function
      * @return the result of the function call
      */
-    @NonNull
+    @Nonnull
     static <T, U, R> R apply(BiFunction<T, U, R> f, T t, U u) {
         try {
             return f.apply(t, u);
@@ -1281,7 +1280,7 @@ public final class RxJavaPlugins {
      * @return the result of the callable call, not null
      * @throws NullPointerException if the callable parameter returns null
      */
-    @NonNull
+    @Nonnull
     static Scheduler callRequireNonNull(Callable<Scheduler> s) {
         try {
             return ObjectHelper.requireNonNull(s.call(), "Scheduler Callable result can't be null");
@@ -1298,7 +1297,7 @@ public final class RxJavaPlugins {
      * @return the result of the function call, not null
      * @throws NullPointerException if the function parameter returns null
      */
-    @NonNull
+    @Nonnull
     static Scheduler applyRequireNonNull(Function<? super Callable<Scheduler>, ? extends Scheduler> f, Callable<Scheduler> s) {
         return ObjectHelper.requireNonNull(apply(f, s), "Scheduler Callable result can't be null");
     }

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -12,11 +12,6 @@
  */
 package io.reactivex.plugins;
 
-import java.lang.Thread.UncaughtExceptionHandler;
-import java.util.concurrent.*;
-
-import org.reactivestreams.Subscriber;
-
 import io.reactivex.*;
 import io.reactivex.annotations.*;
 import io.reactivex.exceptions.*;
@@ -28,6 +23,11 @@ import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.schedulers.Schedulers;
+import org.reactivestreams.Subscriber;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadFactory;
 /**
  * Utility class to inject handlers to certain standard RxJava operations.
  */
@@ -264,7 +264,7 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the callable parameter or its result are null
      */
     @NonNull
-    public static Scheduler initComputationScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
+    public static Scheduler initComputationScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitComputationHandler;
         if (f == null) {
@@ -280,7 +280,7 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the callable parameter or its result are null
      */
     @NonNull
-    public static Scheduler initIoScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
+    public static Scheduler initIoScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitIoHandler;
         if (f == null) {
@@ -296,7 +296,7 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the callable parameter or its result are null
      */
     @NonNull
-    public static Scheduler initNewThreadScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
+    public static Scheduler initNewThreadScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitNewThreadHandler;
         if (f == null) {
@@ -312,7 +312,7 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the callable parameter or its result are null
      */
     @NonNull
-    public static Scheduler initSingleScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
+    public static Scheduler initSingleScheduler(Callable<Scheduler> defaultScheduler) {
         ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
         Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitSingleHandler;
         if (f == null) {
@@ -327,7 +327,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @NonNull
-    public static Scheduler onComputationScheduler(@NonNull Scheduler defaultScheduler) {
+    public static Scheduler onComputationScheduler(Scheduler defaultScheduler) {
         Function<? super Scheduler, ? extends Scheduler> f = onComputationHandler;
         if (f == null) {
             return defaultScheduler;
@@ -339,7 +339,7 @@ public final class RxJavaPlugins {
      * Called when an undeliverable error occurs.
      * @param error the error to report
      */
-    public static void onError(@NonNull Throwable error) {
+    public static void onError(Throwable error) {
         Consumer<? super Throwable> f = errorHandler;
 
         if (error == null) {
@@ -405,7 +405,7 @@ public final class RxJavaPlugins {
         return false;
     }
 
-    static void uncaught(@NonNull Throwable error) {
+    static void uncaught(Throwable error) {
         Thread currentThread = Thread.currentThread();
         UncaughtExceptionHandler handler = currentThread.getUncaughtExceptionHandler();
         handler.uncaughtException(currentThread, error);
@@ -417,7 +417,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @NonNull
-    public static Scheduler onIoScheduler(@NonNull Scheduler defaultScheduler) {
+    public static Scheduler onIoScheduler(Scheduler defaultScheduler) {
         Function<? super Scheduler, ? extends Scheduler> f = onIoHandler;
         if (f == null) {
             return defaultScheduler;
@@ -431,7 +431,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @NonNull
-    public static Scheduler onNewThreadScheduler(@NonNull Scheduler defaultScheduler) {
+    public static Scheduler onNewThreadScheduler(Scheduler defaultScheduler) {
         Function<? super Scheduler, ? extends Scheduler> f = onNewThreadHandler;
         if (f == null) {
             return defaultScheduler;
@@ -445,7 +445,7 @@ public final class RxJavaPlugins {
      * @return the replacement runnable
      */
     @NonNull
-    public static Runnable onSchedule(@NonNull Runnable run) {
+    public static Runnable onSchedule(Runnable run) {
         Function<? super Runnable, ? extends Runnable> f = onScheduleHandler;
         if (f == null) {
             return run;
@@ -459,7 +459,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @NonNull
-    public static Scheduler onSingleScheduler(@NonNull Scheduler defaultScheduler) {
+    public static Scheduler onSingleScheduler(Scheduler defaultScheduler) {
         Function<? super Scheduler, ? extends Scheduler> f = onSingleHandler;
         if (f == null) {
             return defaultScheduler;
@@ -898,7 +898,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> Subscriber<? super T> onSubscribe(@NonNull Flowable<T> source, @NonNull Subscriber<? super T> subscriber) {
+    public static <T> Subscriber<? super T> onSubscribe(Flowable<T> source, Subscriber<? super T> subscriber) {
         BiFunction<? super Flowable, ? super Subscriber, ? extends Subscriber> f = onFlowableSubscribe;
         if (f != null) {
             return apply(f, source, subscriber);
@@ -915,7 +915,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> Observer<? super T> onSubscribe(@NonNull Observable<T> source, @NonNull Observer<? super T> observer) {
+    public static <T> Observer<? super T> onSubscribe(Observable<T> source, Observer<? super T> observer) {
         BiFunction<? super Observable, ? super Observer, ? extends Observer> f = onObservableSubscribe;
         if (f != null) {
             return apply(f, source, observer);
@@ -932,7 +932,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> SingleObserver<? super T> onSubscribe(@NonNull Single<T> source, @NonNull SingleObserver<? super T> observer) {
+    public static <T> SingleObserver<? super T> onSubscribe(Single<T> source, SingleObserver<? super T> observer) {
         BiFunction<? super Single, ? super SingleObserver, ? extends SingleObserver> f = onSingleSubscribe;
         if (f != null) {
             return apply(f, source, observer);
@@ -947,7 +947,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @NonNull
-    public static CompletableObserver onSubscribe(@NonNull Completable source, @NonNull CompletableObserver observer) {
+    public static CompletableObserver onSubscribe(Completable source, CompletableObserver observer) {
         BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> f = onCompletableSubscribe;
         if (f != null) {
             return apply(f, source, observer);
@@ -964,7 +964,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> MaybeObserver<? super T> onSubscribe(@NonNull Maybe<T> source, @NonNull MaybeObserver<? super T> subscriber) {
+    public static <T> MaybeObserver<? super T> onSubscribe(Maybe<T> source, MaybeObserver<? super T> subscriber) {
         BiFunction<? super Maybe, ? super MaybeObserver, ? extends MaybeObserver> f = onMaybeSubscribe;
         if (f != null) {
             return apply(f, source, subscriber);
@@ -980,7 +980,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> Maybe<T> onAssembly(@NonNull Maybe<T> source) {
+    public static <T> Maybe<T> onAssembly(Maybe<T> source) {
         Function<? super Maybe, ? extends Maybe> f = onMaybeAssembly;
         if (f != null) {
             return apply(f, source);
@@ -996,7 +996,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> Flowable<T> onAssembly(@NonNull Flowable<T> source) {
+    public static <T> Flowable<T> onAssembly(Flowable<T> source) {
         Function<? super Flowable, ? extends Flowable> f = onFlowableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1012,7 +1012,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> ConnectableFlowable<T> onAssembly(@NonNull ConnectableFlowable<T> source) {
+    public static <T> ConnectableFlowable<T> onAssembly(ConnectableFlowable<T> source) {
         Function<? super ConnectableFlowable, ? extends ConnectableFlowable> f = onConnectableFlowableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1028,7 +1028,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> Observable<T> onAssembly(@NonNull Observable<T> source) {
+    public static <T> Observable<T> onAssembly(Observable<T> source) {
         Function<? super Observable, ? extends Observable> f = onObservableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1044,7 +1044,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> ConnectableObservable<T> onAssembly(@NonNull ConnectableObservable<T> source) {
+    public static <T> ConnectableObservable<T> onAssembly(ConnectableObservable<T> source) {
         Function<? super ConnectableObservable, ? extends ConnectableObservable> f = onConnectableObservableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1060,7 +1060,7 @@ public final class RxJavaPlugins {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> Single<T> onAssembly(@NonNull Single<T> source) {
+    public static <T> Single<T> onAssembly(Single<T> source) {
         Function<? super Single, ? extends Single> f = onSingleAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1074,7 +1074,7 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @NonNull
-    public static Completable onAssembly(@NonNull Completable source) {
+    public static Completable onAssembly(Completable source) {
         Function<? super Completable, ? extends Completable> f = onCompletableAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1121,7 +1121,7 @@ public final class RxJavaPlugins {
     @Beta
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> ParallelFlowable<T> onAssembly(@NonNull ParallelFlowable<T> source) {
+    public static <T> ParallelFlowable<T> onAssembly(ParallelFlowable<T> source) {
         Function<? super ParallelFlowable, ? extends ParallelFlowable> f = onParallelAssembly;
         if (f != null) {
             return apply(f, source);
@@ -1190,7 +1190,7 @@ public final class RxJavaPlugins {
      * @since 2.1
      */
     @NonNull
-    public static Scheduler createComputationScheduler(@NonNull ThreadFactory threadFactory) {
+    public static Scheduler createComputationScheduler(ThreadFactory threadFactory) {
         return new ComputationScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1204,7 +1204,7 @@ public final class RxJavaPlugins {
      * @since 2.1
      */
     @NonNull
-    public static Scheduler createIoScheduler(@NonNull ThreadFactory threadFactory) {
+    public static Scheduler createIoScheduler(ThreadFactory threadFactory) {
         return new IoScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1218,7 +1218,7 @@ public final class RxJavaPlugins {
      * @since 2.1
      */
     @NonNull
-    public static Scheduler createNewThreadScheduler(@NonNull ThreadFactory threadFactory) {
+    public static Scheduler createNewThreadScheduler(ThreadFactory threadFactory) {
         return new NewThreadScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1232,7 +1232,7 @@ public final class RxJavaPlugins {
      * @since 2.1
      */
     @NonNull
-    public static Scheduler createSingleScheduler(@NonNull ThreadFactory threadFactory) {
+    public static Scheduler createSingleScheduler(ThreadFactory threadFactory) {
         return new SingleScheduler(ObjectHelper.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
@@ -1246,7 +1246,7 @@ public final class RxJavaPlugins {
      * @return the result of the function call
      */
     @NonNull
-    static <T, R> R apply(@NonNull Function<T, R> f, @NonNull T t) {
+    static <T, R> R apply(Function<T, R> f, T t) {
         try {
             return f.apply(t);
         } catch (Throwable ex) {
@@ -1266,7 +1266,7 @@ public final class RxJavaPlugins {
      * @return the result of the function call
      */
     @NonNull
-    static <T, U, R> R apply(@NonNull BiFunction<T, U, R> f, @NonNull T t, @NonNull U u) {
+    static <T, U, R> R apply(BiFunction<T, U, R> f, T t, U u) {
         try {
             return f.apply(t, u);
         } catch (Throwable ex) {
@@ -1282,7 +1282,7 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the callable parameter returns null
      */
     @NonNull
-    static Scheduler callRequireNonNull(@NonNull Callable<Scheduler> s) {
+    static Scheduler callRequireNonNull(Callable<Scheduler> s) {
         try {
             return ObjectHelper.requireNonNull(s.call(), "Scheduler Callable result can't be null");
         } catch (Throwable ex) {
@@ -1299,7 +1299,7 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the function parameter returns null
      */
     @NonNull
-    static Scheduler applyRequireNonNull(@NonNull Function<? super Callable<Scheduler>, ? extends Scheduler> f, Callable<Scheduler> s) {
+    static Scheduler applyRequireNonNull(Function<? super Callable<Scheduler>, ? extends Scheduler> f, Callable<Scheduler> s) {
         return ObjectHelper.requireNonNull(apply(f, s), "Scheduler Callable result can't be null");
     }
 

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -13,7 +13,7 @@
 package io.reactivex.plugins;
 
 import io.reactivex.*;
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.Beta;
 import io.reactivex.exceptions.*;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
@@ -25,7 +25,7 @@ import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.schedulers.Schedulers;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.concurrent.*;
-import javax.annotation.Nonnull;
+import javax.annotation.*;
 import org.reactivestreams.Subscriber;
 /**
  * Utility class to inject handlers to certain standard RxJava operations.

--- a/src/main/java/io/reactivex/plugins/package-info.java
+++ b/src/main/java/io/reactivex/plugins/package-info.java
@@ -18,4 +18,7 @@
  * Callback types and a central plugin handler class to hook into the lifecycle
  * of the base reactive types and schedulers.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.plugins;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -12,12 +12,12 @@
  */
 package io.reactivex.processors;
 
-import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicReference;
-
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.internal.subscriptions.DeferredScalarSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
 import org.reactivestreams.*;
 
 /**
@@ -51,7 +51,7 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
      * @return the new AsyncProcessor instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public static <T> AsyncProcessor<T> create() {
         return new AsyncProcessor<T>();
     }

--- a/src/main/java/io/reactivex/processors/FlowableProcessor.java
+++ b/src/main/java/io/reactivex/processors/FlowableProcessor.java
@@ -14,7 +14,7 @@
 package io.reactivex.processors;
 
 import io.reactivex.*;
-import io.reactivex.annotations.NonNull;
+import javax.annotation.Nonnull;
 import org.reactivestreams.Processor;
 
 /**
@@ -66,7 +66,7 @@ public abstract class FlowableProcessor<T> extends Flowable<T> implements Proces
      * <p>The method is thread-safe.
      * @return the wrapped and serialized subject
      */
-    @NonNull
+    @Nonnull
     public final FlowableProcessor<T> toSerialized() {
         if (this instanceof SerializedProcessor) {
             return this;

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -17,7 +17,7 @@ import io.reactivex.annotations.CheckReturnValue;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.annotations.Experimental;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.internal.functions.ObjectHelper;

--- a/src/main/java/io/reactivex/processors/package-info.java
+++ b/src/main/java/io/reactivex/processors/package-info.java
@@ -18,4 +18,7 @@
  * Classes extending the Flowable base reactive class and implementing
  * the Subscriber interface at the same time (aka hot Flowables).
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.processors;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -14,11 +14,10 @@
 package io.reactivex.schedulers;
 
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.internal.schedulers.*;
 import io.reactivex.plugins.RxJavaPlugins;
-
 import java.util.concurrent.*;
+import javax.annotation.Nonnull;
 
 /**
  * Static factory methods for returning standard Scheduler instances.
@@ -39,19 +38,19 @@ import java.util.concurrent.*;
  * </ul>
  */
 public final class Schedulers {
-    @NonNull
+    @Nonnull
     static final Scheduler SINGLE;
 
-    @NonNull
+    @Nonnull
     static final Scheduler COMPUTATION;
 
-    @NonNull
+    @Nonnull
     static final Scheduler IO;
 
-    @NonNull
+    @Nonnull
     static final Scheduler TRAMPOLINE;
 
-    @NonNull
+    @Nonnull
     static final Scheduler NEW_THREAD;
 
     static final class SingleHolder {
@@ -130,7 +129,7 @@ public final class Schedulers {
      * annotation.
      * @return a {@link Scheduler} meant for computation-bound work
      */
-    @NonNull
+    @Nonnull
     public static Scheduler computation() {
         return RxJavaPlugins.onComputationScheduler(COMPUTATION);
     }
@@ -174,7 +173,7 @@ public final class Schedulers {
      * annotation.
      * @return a {@link Scheduler} meant for IO-bound work
      */
-    @NonNull
+    @Nonnull
     public static Scheduler io() {
         return RxJavaPlugins.onIoScheduler(IO);
     }
@@ -193,7 +192,7 @@ public final class Schedulers {
      * This scheduler can't be overridden via an {@link RxJavaPlugins} method.
      * @return a {@link Scheduler} that queues work on the current thread
      */
-    @NonNull
+    @Nonnull
     public static Scheduler trampoline() {
         return TRAMPOLINE;
     }
@@ -232,7 +231,7 @@ public final class Schedulers {
      * annotation.
      * @return a {@link Scheduler} that creates new threads
      */
-    @NonNull
+    @Nonnull
     public static Scheduler newThread() {
         return RxJavaPlugins.onNewThreadScheduler(NEW_THREAD);
     }
@@ -282,7 +281,7 @@ public final class Schedulers {
      * @return a {@link Scheduler} that shares a single backing thread.
      * @since 2.0
      */
-    @NonNull
+    @Nonnull
     public static Scheduler single() {
         return RxJavaPlugins.onSingleScheduler(SINGLE);
     }
@@ -336,7 +335,7 @@ public final class Schedulers {
      *          the executor to wrap
      * @return the new Scheduler wrapping the Executor
      */
-    @NonNull
+    @Nonnull
     public static Scheduler from(Executor executor) {
         return new ExecutorScheduler(executor);
     }

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -337,7 +337,7 @@ public final class Schedulers {
      * @return the new Scheduler wrapping the Executor
      */
     @NonNull
-    public static Scheduler from(@NonNull Executor executor) {
+    public static Scheduler from(Executor executor) {
         return new ExecutorScheduler(executor);
     }
 

--- a/src/main/java/io/reactivex/schedulers/TestScheduler.java
+++ b/src/main/java/io/reactivex/schedulers/TestScheduler.java
@@ -64,7 +64,7 @@ public final class TestScheduler extends Scheduler {
     }
 
     @Override
-    public long now(@NonNull TimeUnit unit) {
+    public long now(TimeUnit unit) {
         return unit.convert(time, TimeUnit.NANOSECONDS);
     }
 
@@ -141,7 +141,7 @@ public final class TestScheduler extends Scheduler {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable run, long delayTime, @NonNull TimeUnit unit) {
+        public Disposable schedule(Runnable run, long delayTime, TimeUnit unit) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }
@@ -153,7 +153,7 @@ public final class TestScheduler extends Scheduler {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable run) {
+        public Disposable schedule(Runnable run) {
             if (disposed) {
                 return EmptyDisposable.INSTANCE;
             }
@@ -163,7 +163,7 @@ public final class TestScheduler extends Scheduler {
         }
 
         @Override
-        public long now(@NonNull TimeUnit unit) {
+        public long now(TimeUnit unit) {
             return TestScheduler.this.now(unit);
         }
 

--- a/src/main/java/io/reactivex/schedulers/TestScheduler.java
+++ b/src/main/java/io/reactivex/schedulers/TestScheduler.java
@@ -13,14 +13,13 @@
 
 package io.reactivex.schedulers;
 
-import java.util.Queue;
-import java.util.concurrent.*;
-
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
+import java.util.Queue;
+import java.util.concurrent.*;
+import javax.annotation.Nonnull;
 
 /**
  * A special, non thread-safe scheduler for testing operators that require
@@ -119,7 +118,7 @@ public final class TestScheduler extends Scheduler {
         time = targetTimeInNanoseconds;
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public Worker createWorker() {
         return new TestWorker();
@@ -139,7 +138,7 @@ public final class TestScheduler extends Scheduler {
             return disposed;
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable run, long delayTime, TimeUnit unit) {
             if (disposed) {
@@ -151,7 +150,7 @@ public final class TestScheduler extends Scheduler {
             return Disposables.fromRunnable(new QueueRemove(timedAction));
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable run) {
             if (disposed) {

--- a/src/main/java/io/reactivex/schedulers/Timed.java
+++ b/src/main/java/io/reactivex/schedulers/Timed.java
@@ -35,7 +35,7 @@ public final class Timed<T> {
      * @param unit the time unit, not null
      * @throws NullPointerException if unit is null
      */
-    public Timed(@NonNull T value, long time, @NonNull TimeUnit unit) {
+    public Timed(T value, long time, TimeUnit unit) {
         this.value = value;
         this.time = time;
         this.unit = ObjectHelper.requireNonNull(unit, "unit is null");
@@ -72,7 +72,7 @@ public final class Timed<T> {
      * @param unit the time unt
      * @return the converted time
      */
-    public long time(@NonNull TimeUnit unit) {
+    public long time(TimeUnit unit) {
         return unit.convert(time, this.unit);
     }
 

--- a/src/main/java/io/reactivex/schedulers/Timed.java
+++ b/src/main/java/io/reactivex/schedulers/Timed.java
@@ -13,10 +13,9 @@
 
 package io.reactivex.schedulers;
 
-import java.util.concurrent.TimeUnit;
-
-import io.reactivex.annotations.NonNull;
 import io.reactivex.internal.functions.ObjectHelper;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 /**
  * Holds onto a value along with time information.
@@ -45,7 +44,7 @@ public final class Timed<T> {
      * Returns the contained value.
      * @return the contained value
      */
-    @NonNull
+    @Nonnull
     public T value() {
         return value;
     }
@@ -54,7 +53,7 @@ public final class Timed<T> {
      * Returns the time unit of the contained time.
      * @return the time unit of the contained time
      */
-    @NonNull
+    @Nonnull
     public TimeUnit unit() {
         return unit;
     }

--- a/src/main/java/io/reactivex/schedulers/package-info.java
+++ b/src/main/java/io/reactivex/schedulers/package-info.java
@@ -17,4 +17,7 @@
  * Scheduler implementations, value+time record class and the standard factory class to
  * return standard RxJava schedulers or wrap any Executor-based (thread pool) instances.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.schedulers;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/subjects/SingleSubject.java
+++ b/src/main/java/io/reactivex/subjects/SingleSubject.java
@@ -14,11 +14,10 @@
 package io.reactivex.subjects;
 
 import io.reactivex.*;
-import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.plugins.RxJavaPlugins;
 import java.util.concurrent.atomic.*;
-import javax.annotation.Nonnull;
+import javax.annotation.*;
 
 /**
  * Represents a hot Single-like source and consumer of events similar to Subjects.

--- a/src/main/java/io/reactivex/subjects/SingleSubject.java
+++ b/src/main/java/io/reactivex/subjects/SingleSubject.java
@@ -13,12 +13,12 @@
 
 package io.reactivex.subjects;
 
-import java.util.concurrent.atomic.*;
-
 import io.reactivex.*;
 import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.plugins.RxJavaPlugins;
+import java.util.concurrent.atomic.*;
+import javax.annotation.Nonnull;
 
 /**
  * Represents a hot Single-like source and consumer of events similar to Subjects.
@@ -53,7 +53,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
      * @return the new SingleSubject instance
      */
     @CheckReturnValue
-    @NonNull
+    @Nonnull
     public static <T> SingleSubject<T> create() {
         return new SingleSubject<T>();
     }

--- a/src/main/java/io/reactivex/subjects/SingleSubject.java
+++ b/src/main/java/io/reactivex/subjects/SingleSubject.java
@@ -65,7 +65,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
     }
 
     @Override
-    public void onSubscribe(@NonNull Disposable d) {
+    public void onSubscribe(Disposable d) {
         if (observers.get() == TERMINATED) {
             d.dispose();
         }
@@ -73,7 +73,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
 
     @SuppressWarnings("unchecked")
     @Override
-    public void onSuccess(@NonNull T value) {
+    public void onSuccess(T value) {
         if (value == null) {
             onError(new NullPointerException("Null values are not allowed in 2.x"));
             return;
@@ -88,7 +88,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
 
     @SuppressWarnings("unchecked")
     @Override
-    public void onError(@NonNull Throwable e) {
+    public void onError(Throwable e) {
         if (e == null) {
             e = new NullPointerException("Null errors are not allowed in 2.x");
         }
@@ -103,7 +103,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
     }
 
     @Override
-    protected void subscribeActual(@NonNull SingleObserver<? super T> observer) {
+    protected void subscribeActual(SingleObserver<? super T> observer) {
         SingleDisposable<T> md = new SingleDisposable<T>(observer, this);
         observer.onSubscribe(md);
         if (add(md)) {
@@ -120,7 +120,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
         }
     }
 
-    boolean add(@NonNull SingleDisposable<T> inner) {
+    boolean add(SingleDisposable<T> inner) {
         for (;;) {
             SingleDisposable<T>[] a = observers.get();
             if (a == TERMINATED) {
@@ -139,7 +139,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
     }
 
     @SuppressWarnings("unchecked")
-    void remove(@NonNull SingleDisposable<T> inner) {
+    void remove(SingleDisposable<T> inner) {
         for (;;) {
             SingleDisposable<T>[] a = observers.get();
             int n = a.length;

--- a/src/main/java/io/reactivex/subjects/Subject.java
+++ b/src/main/java/io/reactivex/subjects/Subject.java
@@ -14,7 +14,7 @@
 package io.reactivex.subjects;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 
 /**

--- a/src/main/java/io/reactivex/subjects/Subject.java
+++ b/src/main/java/io/reactivex/subjects/Subject.java
@@ -14,7 +14,8 @@
 package io.reactivex.subjects;
 
 import io.reactivex.*;
-import io.reactivex.annotations.*;
+import io.reactivex.annotations.Nullable;
+import javax.annotation.Nonnull;
 
 /**
  * Represents an Observer and an Observable at the same time, allowing
@@ -65,7 +66,7 @@ public abstract class Subject<T> extends Observable<T> implements Observer<T> {
      * <p>The method is thread-safe.
      * @return the wrapped and serialized subject
      */
-    @NonNull
+    @Nonnull
     public final Subject<T> toSerialized() {
         if (this instanceof SerializedSubject) {
             return this;

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -14,7 +14,7 @@
 package io.reactivex.subjects;
 
 import io.reactivex.annotations.Experimental;
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import io.reactivex.plugins.RxJavaPlugins;
 import java.util.concurrent.atomic.*;
 

--- a/src/main/java/io/reactivex/subjects/package-info.java
+++ b/src/main/java/io/reactivex/subjects/package-info.java
@@ -18,4 +18,7 @@
  * Classes extending the Observable base reactive class and implementing
  * the Observer interface at the same time (aka hot Observables).
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.subjects;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/reactivex/subscribers/package-info.java
+++ b/src/main/java/io/reactivex/subscribers/package-info.java
@@ -18,4 +18,7 @@
  * Default wrappers and implementations for Subscriber-based consumer classes and interfaces;
  * utility classes for creating them from callbacks.
  */
+@ParametersAreNonnullByDefault
 package io.reactivex.subscribers;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/java/io/reactivex/internal/observers/BasicFuseableObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/BasicFuseableObserverTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.observers;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.junit.Test;
 
 import io.reactivex.disposables.Disposables;

--- a/src/test/java/io/reactivex/internal/observers/BasicQueueDisposableTest.java
+++ b/src/test/java/io/reactivex/internal/observers/BasicQueueDisposableTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.observers;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.junit.Test;
 
 public class BasicQueueDisposableTest {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.reactivestreams.*;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -13,19 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
-
-import io.reactivex.annotations.NonNull;
-import org.junit.*;
-import org.mockito.InOrder;
-import org.reactivestreams.*;
-
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
@@ -40,6 +27,19 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import javax.annotation.Nonnull;
+import org.junit.*;
+import org.mockito.InOrder;
+import org.reactivestreams.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
 
 public class FlowableReplayTest {
     @Test
@@ -705,14 +705,14 @@ public class FlowableReplayTest {
             this.mockDisposable = mockDisposable;
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable action) {
             action.run();
             return mockDisposable; // this subscription is returned but discarded
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
             action.run();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -707,14 +707,14 @@ public class FlowableReplayTest {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable action) {
+        public Disposable schedule(Runnable action) {
             action.run();
             return mockDisposable; // this subscription is returned but discarded
         }
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
+        public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
             action.run();
             return mockDisposable;
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -149,13 +149,13 @@ public class FlowableSubscribeOnTest {
 
             @NonNull
             @Override
-            public Disposable schedule(@NonNull final Runnable action) {
+            public Disposable schedule(final Runnable action) {
                 return actualInner.schedule(action, delay, unit);
             }
 
             @NonNull
             @Override
-            public Disposable schedule(@NonNull final Runnable action, final long delayTime, @NonNull final TimeUnit delayUnit) {
+            public Disposable schedule(final Runnable action, final long delayTime, final TimeUnit delayUnit) {
                 TimeUnit common = delayUnit.compareTo(unit) < 0 ? delayUnit : unit;
                 long t = common.convert(delayTime, delayUnit) + common.convert(delay, unit);
                 return actualInner.schedule(action, t, common);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -13,15 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import static org.junit.Assert.*;
-
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
-
-import io.reactivex.annotations.NonNull;
-import org.junit.*;
-import org.reactivestreams.*;
-
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
@@ -30,6 +21,13 @@ import io.reactivex.internal.operators.flowable.FlowableSubscribeOn.SubscribeOnS
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import javax.annotation.Nonnull;
+import org.junit.*;
+import org.reactivestreams.*;
+
+import static org.junit.Assert.*;
 
 public class FlowableSubscribeOnTest {
 
@@ -123,7 +121,7 @@ public class FlowableSubscribeOnTest {
             this.unit = unit;
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Worker createWorker() {
             return new SlowInner(actual.createWorker());
@@ -147,13 +145,13 @@ public class FlowableSubscribeOnTest {
                 return actualInner.isDisposed();
             }
 
-            @NonNull
+            @Nonnull
             @Override
             public Disposable schedule(final Runnable action) {
                 return actualInner.schedule(action, delay, unit);
             }
 
-            @NonNull
+            @Nonnull
             @Override
             public Disposable schedule(final Runnable action, final long delayTime, final TimeUnit delayUnit) {
                 TimeUnit common = delayUnit.compareTo(unit) < 0 ? delayUnit : unit;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
@@ -13,16 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import static org.junit.Assert.*;
-
-import java.util.List;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicReference;
-
-import io.reactivex.annotations.NonNull;
-import org.junit.Test;
-import org.reactivestreams.*;
-
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Action;
@@ -30,6 +20,14 @@ import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import static org.junit.Assert.*;
 
 public class FlowableUnsubscribeOnTest {
 
@@ -178,7 +176,7 @@ public class FlowableUnsubscribeOnTest {
             }
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Worker createWorker() {
             return eventLoop.createWorker();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.mockito.InOrder;
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -692,14 +692,14 @@ public class ObservableReplayTest {
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable action) {
+        public Disposable schedule(Runnable action) {
             action.run();
             return mockDisposable; // this subscription is returned but discarded
         }
 
         @NonNull
         @Override
-        public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
+        public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
             action.run();
             return mockDisposable;
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -13,22 +13,10 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.*;
-import org.mockito.InOrder;
-
-import io.reactivex.*;
 import io.reactivex.Observable;
+import io.reactivex.*;
 import io.reactivex.Observer;
 import io.reactivex.Scheduler.Worker;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
@@ -40,6 +28,18 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import org.junit.*;
+import org.mockito.InOrder;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
 
 public class ObservableReplayTest {
     @Test
@@ -690,14 +690,14 @@ public class ObservableReplayTest {
             this.mockDisposable = mockDisposable;
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable action) {
             action.run();
             return mockDisposable; // this subscription is returned but discarded
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
             action.run();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
@@ -13,18 +13,16 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import io.reactivex.annotations.NonNull;
-import org.junit.*;
-
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import org.junit.*;
+
+import static org.junit.Assert.assertEquals;
 
 public class ObservableSubscribeOnTest {
 
@@ -118,7 +116,7 @@ public class ObservableSubscribeOnTest {
             this.unit = unit;
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Worker createWorker() {
             return new SlowInner(actual.createWorker());
@@ -142,13 +140,13 @@ public class ObservableSubscribeOnTest {
                 return actualInner.isDisposed();
             }
 
-            @NonNull
+            @Nonnull
             @Override
             public Disposable schedule(final Runnable action) {
                 return actualInner.schedule(action, delay, unit);
             }
 
-            @NonNull
+            @Nonnull
             @Override
             public Disposable schedule(final Runnable action, final long delayTime, final TimeUnit delayUnit) {
                 TimeUnit common = delayUnit.compareTo(unit) < 0 ? delayUnit : unit;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
@@ -144,13 +144,13 @@ public class ObservableSubscribeOnTest {
 
             @NonNull
             @Override
-            public Disposable schedule(@NonNull final Runnable action) {
+            public Disposable schedule(final Runnable action) {
                 return actualInner.schedule(action, delay, unit);
             }
 
             @NonNull
             @Override
-            public Disposable schedule(@NonNull final Runnable action, final long delayTime, @NonNull final TimeUnit delayUnit) {
+            public Disposable schedule(final Runnable action, final long delayTime, final TimeUnit delayUnit) {
                 TimeUnit common = delayUnit.compareTo(unit) < 0 ? delayUnit : unit;
                 long t = common.convert(delayTime, delayUnit) + common.convert(delay, unit);
                 return actualInner.schedule(action, t, common);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOnTest.java
@@ -13,15 +13,6 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.*;
-
-import java.util.List;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
-
-import io.reactivex.annotations.NonNull;
-import org.junit.Test;
-
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
@@ -29,6 +20,13 @@ import io.reactivex.functions.Action;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import javax.annotation.Nonnull;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class ObservableUnsubscribeOnTest {
 
@@ -180,7 +178,7 @@ public class ObservableUnsubscribeOnTest {
             }
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public Worker createWorker() {
             return eventLoop.createWorker();

--- a/src/test/java/io/reactivex/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.subscribers;
 
 import static org.junit.Assert.*;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 

--- a/src/test/java/io/reactivex/internal/subscribers/BasicFuseableSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/BasicFuseableSubscriberTest.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.subscribers;
 
 import static org.junit.Assert.*;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.junit.Test;
 
 import io.reactivex.TestHelper;

--- a/src/test/java/io/reactivex/internal/subscriptions/QueueSubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/QueueSubscriptionTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.subscriptions;
 
-import io.reactivex.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.junit.Test;
 
 import static org.junit.Assert.*;

--- a/src/test/java/io/reactivex/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerTest.java
@@ -255,7 +255,7 @@ public class SchedulerTest {
                 return new Worker() {
                     @NonNull
                     @Override
-                    public Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
+                    public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
                         return EmptyDisposable.INSTANCE;
                     }
 

--- a/src/test/java/io/reactivex/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerTest.java
@@ -13,14 +13,6 @@
 
 package io.reactivex.schedulers;
 
-import static org.junit.Assert.*;
-
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import io.reactivex.annotations.NonNull;
-import org.junit.Test;
-
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
@@ -28,6 +20,12 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.plugins.RxJavaPlugins;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class SchedulerTest {
 
@@ -249,11 +247,11 @@ public class SchedulerTest {
     @Test
     public void defaultSchedulePeriodicallyDirectRejects() {
         Scheduler s = new Scheduler() {
-            @NonNull
+            @Nonnull
             @Override
             public Worker createWorker() {
                 return new Worker() {
-                    @NonNull
+                    @Nonnull
                     @Override
                     public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
                         return EmptyDisposable.INSTANCE;

--- a/src/test/java/io/reactivex/schedulers/SchedulerWorkerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerWorkerTest.java
@@ -13,22 +13,20 @@
 
 package io.reactivex.schedulers;
 
-import static org.junit.Assert.*;
-
-import java.util.*;
-import java.util.concurrent.TimeUnit;
-
-import io.reactivex.annotations.NonNull;
-import org.junit.Test;
-
 import io.reactivex.Scheduler;
 import io.reactivex.disposables.Disposable;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 public class SchedulerWorkerTest {
 
     static final class CustomDriftScheduler extends Scheduler {
         public volatile long drift;
-        @NonNull
+        @Nonnull
         @Override
         public Worker createWorker() {
             final Worker w = Schedulers.computation().createWorker();
@@ -44,13 +42,13 @@ public class SchedulerWorkerTest {
                     return w.isDisposed();
                 }
 
-                @NonNull
+                @Nonnull
                 @Override
                 public Disposable schedule(Runnable action) {
                     return w.schedule(action);
                 }
 
-                @NonNull
+                @Nonnull
                 @Override
                 public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
                     return w.schedule(action, delayTime, unit);

--- a/src/test/java/io/reactivex/schedulers/SchedulerWorkerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerWorkerTest.java
@@ -46,13 +46,13 @@ public class SchedulerWorkerTest {
 
                 @NonNull
                 @Override
-                public Disposable schedule(@NonNull Runnable action) {
+                public Disposable schedule(Runnable action) {
                     return w.schedule(action);
                 }
 
                 @NonNull
                 @Override
-                public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {
+                public Disposable schedule(Runnable action, long delayTime, TimeUnit unit) {
                     return w.schedule(action, delayTime, unit);
                 }
 
@@ -64,7 +64,7 @@ public class SchedulerWorkerTest {
         }
 
         @Override
-        public long now(@NonNull TimeUnit unit) {
+        public long now(TimeUnit unit) {
             return super.now(unit) + unit.convert(drift, TimeUnit.NANOSECONDS);
         }
     }


### PR DESCRIPTION
This PR implements proposal #5341.

Since `@ParametersAreNonnullByDefault` only covers function parameters, I've left `@Nonnull` for return results in existing usage places. 

@hzsweers suggested creating `@EverythingIsNonNullByDefault` but I'm not sure how tooling will recognise it.

@akarnokd we can also change RxJava's `@CheckReturnValue` with `javax.annotation.@CheckReturnValue` in a separate PR if this one gets merged. 

P.S. I've tried to minimize imports regrouping, but some files were written in different code styles regarding imports, so you might find few minor regroupings, sorry.