### PR TITLE
2.x: Fix flaky MaybeFromCallableTest.noErrorLoss

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
@@ -135,15 +135,13 @@ public class MaybeFromActionTest {
                 @Override
                 public void run() throws Exception {
                     cdl1.countDown();
-                    cdl2.await();
+                    cdl2.await(5, TimeUnit.SECONDS);
                 }
             }).subscribeOn(Schedulers.single()).test();
 
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
 
             to.cancel();
-
-            cdl2.countDown();
 
             int timeout = 10;
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
@@ -138,7 +138,7 @@ public class MaybeFromCallableTest {
                 @Override
                 public Integer call() throws Exception {
                     cdl1.countDown();
-                    cdl2.await();
+                    cdl2.await(5, TimeUnit.SECONDS);
                     return 1;
                 }
             }).subscribeOn(Schedulers.single()).test();
@@ -146,8 +146,6 @@ public class MaybeFromCallableTest {
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
 
             to.cancel();
-
-            cdl2.countDown();
 
             int timeout = 10;
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
@@ -134,7 +134,7 @@ public class MaybeFromRunnableTest {
                 public void run() {
                     cdl1.countDown();
                     try {
-                        cdl2.await();
+                        cdl2.await(5, TimeUnit.SECONDS);
                     } catch (InterruptedException ex) {
                         throw new RuntimeException(ex);
                     }
@@ -144,8 +144,6 @@ public class MaybeFromRunnableTest {
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
 
             to.cancel();
-
-            cdl2.countDown();
 
             int timeout = 10;
 


### PR DESCRIPTION
The `MaybeFromCallableTest.noErrorLoss` failed occasionally because the `await` didn't throw `InterruptedException` as expected. 

The reason for this is that if the main `to.cancel();` and the subsequent `cdl2.countDown();` happened just before `await()` was called, the `await` didn't even look at the thread's interrupt status but returned immediately as there was nothing to wait for.

The fix just removes that `cdl2.countDown` and adds a regular timeout to the inner `await`.

*(Detected while verifying RxJava 2 against JDK 9b181.)*