### PR TITLE
2.x: Add assertValuesOnly to BaseTestConsumer.

### DIFF
--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -526,8 +526,10 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order without terminating.
      * @param values the values expected
      * @return this;
+     * @since 2.1.4
      */
     @SuppressWarnings("unchecked")
+    @Experimental
     public final U assertValuesOnly(T... values) {
         return assertSubscribed()
                 .assertValues(values)

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -523,6 +523,19 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     }
 
     /**
+     * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order without terminating.
+     * @param values the values expected
+     * @return this;
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertValuesOnly(T... values) {
+        return assertSubscribed()
+                .assertValues(values)
+                .assertNoErrors()
+                .assertNotComplete();
+    }
+
+    /**
      * Assert that the TestObserver/TestSubscriber received only the specified values in any order.
      * <p>This helps asserting when the order of the values is not guaranteed, i.e., when merging
      * asynchronous streams.

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -1439,4 +1439,47 @@ public class TestObserverTest {
             assertTrue(ex.toString(), ex.toString().contains("testing with item=2"));
         }
     }
+
+    @Test
+    public void assertValuesOnlyWantsOnlyValues() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+        to.assertValuesOnly();
+
+        to.onNext(5);
+        to.assertValuesOnly(5);
+
+        to.onNext(-1);
+        to.assertValuesOnly(5, -1);
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsWhenCompleted() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+
+        to.onComplete();
+
+        try {
+            to.assertValuesOnly();
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsWhenErrored() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+
+        to.onError(new TestException());
+
+        try {
+            to.assertValuesOnly();
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
 }

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -1441,7 +1441,7 @@ public class TestObserverTest {
     }
 
     @Test
-    public void assertValuesOnlyWantsOnlyValues() {
+    public void assertValuesOnly() {
         TestObserver<Integer> to = TestObserver.create();
         to.onSubscribe(Disposables.empty());
         to.assertValuesOnly();
@@ -1451,6 +1451,25 @@ public class TestObserverTest {
 
         to.onNext(-1);
         to.assertValuesOnly(5, -1);
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsOnUnexpectedValue() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+        to.assertValuesOnly();
+
+        to.onNext(5);
+        to.assertValuesOnly(5);
+
+        to.onNext(-1);
+
+        try {
+            to.assertValuesOnly(5);
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -1997,4 +1997,47 @@ public class TestSubscriberTest {
             ws.run();
         }
     }
+
+    @Test
+    public void assertValuesOnlyWantsOnlyValues() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+        ts.assertValuesOnly();
+
+        ts.onNext(5);
+        ts.assertValuesOnly(5);
+
+        ts.onNext(-1);
+        ts.assertValuesOnly(5, -1);
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsWhenCompleted() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+
+        ts.onComplete();
+
+        try {
+            ts.assertValuesOnly();
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsWhenErrored() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+
+        ts.onError(new TestException());
+
+        try {
+            ts.assertValuesOnly();
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
 }

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -1999,7 +1999,7 @@ public class TestSubscriberTest {
     }
 
     @Test
-    public void assertValuesOnlyWantsOnlyValues() {
+    public void assertValuesOnly() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.onSubscribe(new BooleanSubscription());
         ts.assertValuesOnly();
@@ -2009,6 +2009,25 @@ public class TestSubscriberTest {
 
         ts.onNext(-1);
         ts.assertValuesOnly(5, -1);
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsOnUnexpectedValue() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+        ts.assertValuesOnly();
+
+        ts.onNext(5);
+        ts.assertValuesOnly(5);
+
+        ts.onNext(-1);
+
+        try {
+            ts.assertValuesOnly(5);
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
     }
 
     @Test


### PR DESCRIPTION
Adds `assertValuesOnly` that asserts that the TestObserver/TestSubscriber received only the specified values in the specified order without terminating.

Fixes #5555 