### PR TITLE
2.x: Strawman proposal for uncaught exception configuration

### DIFF
--- a/src/main/java/io/reactivex/plugins/UncaughtRxJavaException.java
+++ b/src/main/java/io/reactivex/plugins/UncaughtRxJavaException.java
@@ -1,0 +1,16 @@
+package io.reactivex.plugins;
+
+import io.reactivex.annotations.Experimental;
+
+/**
+ * An exception thrown when an uncaught throwable was received and the {@link RxJavaPlugins#UNCAUGHT_THROW} property was
+ * set. This guarantees the existence of an underlying cause retrievable via {@link #getCause()}.
+ */
+@Experimental
+public final class UncaughtRxJavaException extends RuntimeException {
+
+    public UncaughtRxJavaException(Throwable cause) {
+        super(cause);
+    }
+
+}


### PR DESCRIPTION
This is a strawman example/proposal for configurable uncaught exception handling in RxJavaPlugins. This is in ref to #5234.

The two options are to defer to current thread's handler (the current implementation and remains the default) and an optional `throw` option that wraps the throwable into an `UncaughtRxJavaException` for developers to watch for separately (and rethrowing, which requires some sort of `RuntimeException` wrapping).

If the proposal is agreeable/after API design is in place, I can add tests.