### PR TITLE
Added formatting to license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ For bugs, questions and discussions please use the [Github Issues](https://githu
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-    <http://www.apache.org/licenses/LICENSE-2.0>
+    http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -263,19 +263,19 @@ For bugs, questions and discussions please use the [Github Issues](https://githu
  
 ## LICENSE
 
-Copyright (c) 2016-present, RxJava Contributors.
+    Copyright (c) 2016-present, RxJava Contributors.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
-<http://www.apache.org/licenses/LICENSE-2.0>
+    <http://www.apache.org/licenses/LICENSE-2.0>
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 
 [beta source link]: https://github.com/ReactiveX/RxJava/blob/2.x/src/main/java/io/reactivex/annotations/Beta.java
 [experimental source link]: https://github.com/ReactiveX/RxJava/blob/2.x/src/main/java/io/reactivex/annotations/Experimental.java


### PR DESCRIPTION
The license section did not previously contain markdown syntax formatting. Added 4 spaces to add it.
