### PR TITLE
Remove unnecessary git command from build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,6 @@ To build:
 ```
 $ git clone git@github.com:ReactiveX/RxJava.git
 $ cd RxJava/
-$ git checkout -b 2.x
 $ ./gradlew build
 ```
 


### PR DESCRIPTION
Removing line to match wiki instructions and since 2.x is the default branch
