### PR TITLE
2.x: Added a .filter(value) operator shorthand

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -7317,7 +7317,29 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> filter(Predicate<? super T> predicate) {
         ObjectHelper.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new ObservableFilter<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new ObservablePredicateFilter<T>(this, predicate));
+    }
+
+    /**
+     * Filters items emitted by an ObservableSource by only emitting those that are equal to a specified matcher.
+     * <p>
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/filter.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code filter} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param matcher
+     *            an object that is compared with each item emitted by the source ObservableSource
+     * @return an Observable that emits only those items emitted by the source ObservableSource where (matcher.equals(item))
+     *         evaluates as {@code true}
+     * @see <a href="http://reactivex.io/documentation/operators/filter.html">ReactiveX operators documentation: Filter</a>
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Observable<T> filter(T matcher) {
+        ObjectHelper.requireNonNull(matcher, "matcher is null");
+        return RxJavaPlugins.onAssembly(new ObservableValueFilter<T>(this, matcher));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservablePredicateFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservablePredicateFilter.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Nullable;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.observers.BasicFuseableObserver;
+
+public final class ObservablePredicateFilter<T> extends AbstractObservableWithUpstream<T, T> {
+    final Predicate<? super T> predicate;
+    public ObservablePredicateFilter(ObservableSource<T> source, Predicate<? super T> predicate) {
+        super(source);
+        this.predicate = predicate;
+    }
+
+    @Override
+    public void subscribeActual(Observer<? super T> s) {
+        source.subscribe(new FilterObserver<T>(s, predicate));
+    }
+
+    static final class FilterObserver<T> extends BasicFuseableObserver<T, T> {
+        final Predicate<? super T> filter;
+
+        FilterObserver(Observer<? super T> actual, Predicate<? super T> filter) {
+            super(actual);
+            this.filter = filter;
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (sourceMode == NONE) {
+                boolean b;
+                try {
+                    b = filter.test(t);
+                } catch (Throwable e) {
+                    fail(e);
+                    return;
+                }
+                if (b) {
+                    actual.onNext(t);
+                }
+            } else {
+                actual.onNext(null);
+            }
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            return transitiveBoundaryFusion(mode);
+        }
+
+        @Nullable
+        @Override
+        public T poll() throws Exception {
+            for (;;) {
+                T v = qs.poll();
+                if (v == null || filter.test(v)) {
+                    return v;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableValueFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableValueFilter.java
@@ -13,29 +13,29 @@
 
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.*;
+import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
 import io.reactivex.annotations.Nullable;
-import io.reactivex.functions.Predicate;
 import io.reactivex.internal.observers.BasicFuseableObserver;
 
-public final class ObservableFilter<T> extends AbstractObservableWithUpstream<T, T> {
-    final Predicate<? super T> predicate;
-    public ObservableFilter(ObservableSource<T> source, Predicate<? super T> predicate) {
+public final class ObservableValueFilter<T> extends AbstractObservableWithUpstream<T, T> {
+    final T matcher;
+    public ObservableValueFilter(ObservableSource<T> source, T matcher) {
         super(source);
-        this.predicate = predicate;
+        this.matcher = matcher;
     }
 
     @Override
     public void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new FilterObserver<T>(s, predicate));
+        source.subscribe(new FilterObserver<T>(s, matcher));
     }
 
     static final class FilterObserver<T> extends BasicFuseableObserver<T, T> {
-        final Predicate<? super T> filter;
+        final T matcher;
 
-        FilterObserver(Observer<? super T> actual, Predicate<? super T> filter) {
+        FilterObserver(Observer<? super T> actual, T matcher) {
             super(actual);
-            this.filter = filter;
+            this.matcher = matcher;
         }
 
         @Override
@@ -43,7 +43,7 @@ public final class ObservableFilter<T> extends AbstractObservableWithUpstream<T,
             if (sourceMode == NONE) {
                 boolean b;
                 try {
-                    b = filter.test(t);
+                    b = matcher.equals(t);
                 } catch (Throwable e) {
                     fail(e);
                     return;
@@ -66,7 +66,7 @@ public final class ObservableFilter<T> extends AbstractObservableWithUpstream<T,
         public T poll() throws Exception {
             for (;;) {
                 T v = qs.poll();
-                if (v == null || filter.test(v)) {
+                if (v == null || matcher.equals(v)) {
                     return v;
                 }
             }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePredicateFilterTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePredicateFilterTest.java
@@ -13,21 +13,21 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import io.reactivex.*;
-import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
+import io.reactivex.observers.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.fuseable.QueueDisposable;
-import io.reactivex.observers.*;
 import io.reactivex.subjects.UnicastSubject;
 
-public class ObservableFilterTest {
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+
+public class ObservablePredicateFilterTest {
 
     @Test
     public void testFilter() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableValueFilterTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableValueFilterTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.reactivex.*;
+import io.reactivex.observers.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.subjects.UnicastSubject;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class ObservableValueFilterTest {
+
+    @Test
+    public void testFilter() {
+        Observable<String> w = Observable.just("one", "two", "three");
+        Observable<String> observable = w.filter("two");
+
+        Observer<String> observer = TestHelper.mockObserver();
+
+        observable.subscribe(observer);
+
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testPrimitiveFilter() {
+        Observable<Integer> w = Observable.just(1, 2, 3);
+        Observable<Integer> observable = w.filter(3);
+
+        Observer<Integer> observer = TestHelper.mockObserver();
+
+        observable.subscribe(observer);
+
+        verify(observer, Mockito.never()).onNext(1);
+        verify(observer, Mockito.never()).onNext(2);
+        verify(observer, times(1)).onNext(3);
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    @Test
+    public void testMultipleMatches() {
+        Observable<String> w = Observable.just("one", "two", "three", "two", "one");
+        Observable<String> observable = w.filter("two");
+
+        Observer<String> observer = TestHelper.mockObserver();
+
+        observable.subscribe(observer);
+
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, times(2)).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+    }
+
+    // FIXME subscribers are not allowed to throw
+//    @Test
+//    public void testFatalError() {
+//        try {
+//            Observable.just(1)
+//            .filter(new Predicate<Integer>() {
+//                @Override
+//                public boolean test(Integer t) {
+//                    return true;
+//                }
+//            })
+//            .first()
+//            .subscribe(new Consumer<Integer>() {
+//                @Override
+//                public void accept(Integer t) {
+//                    throw new TestException();
+//                }
+//            });
+//            Assert.fail("No exception was thrown");
+//        } catch (OnErrorNotImplementedException ex) {
+//            if (!(ex.getCause() instanceof TestException)) {
+//                Assert.fail("Failed to report the original exception, instead: " + ex.getCause());
+//            }
+//        }
+//    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.range(1, 5).filter(anyInt()));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
+                return o.filter(1);
+            }
+        });
+    }
+
+    @Test
+    public void fusedSync() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+
+        Observable.range(1, 5)
+                .filter(3)
+                .subscribe(to);
+
+        ObserverFusion.assertFusion(to, QueueDisposable.SYNC)
+                .assertResult(3);
+    }
+
+    @Test
+    public void fusedAsync() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+
+        UnicastSubject<Integer> us = UnicastSubject.create();
+
+        us
+                .filter(3)
+                .subscribe(to);
+
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        ObserverFusion.assertFusion(to, QueueDisposable.ASYNC)
+                .assertResult(3);
+    }
+
+    @Test
+    public void fusedReject() {
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY | QueueDisposable.BOUNDARY);
+
+        Observable.range(1, 5)
+                .filter(3)
+                .subscribe(to);
+
+        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+                .assertResult(3);
+    }
+
+}

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1326,8 +1326,13 @@ public class ObservableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void filterNull() {
-        just1.filter(null);
+    public void filterMatcherNull() {
+        just1.filter((Integer) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void filterPredicateNull() {
+        just1.filter((Predicate<? super Object>)null);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
NOTE: This is my first ever contribution to anything, so i'm sure there will be revising involved here.

There are times when you simply want to filter events by a single value, and implementing a predicate seems ugly.

I think you should be able to do thinks like ```.filter(false)``` or ```.filter(enum.SOME_EVENT)```.

Let me know what you all think!
