### PR TITLE
2.x: fix Single.timeout unnecessary dispose calls

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/single/SingleTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTimeout.java
@@ -14,10 +14,11 @@
 package io.reactivex.internal.operators.single;
 
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
-import io.reactivex.disposables.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
 
 public final class SingleTimeout<T> extends Single<T> {
 
@@ -43,97 +44,116 @@ public final class SingleTimeout<T> extends Single<T> {
     @Override
     protected void subscribeActual(final SingleObserver<? super T> s) {
 
-        final CompositeDisposable set = new CompositeDisposable();
-        s.onSubscribe(set);
+        TimeoutMainObserver<T> parent = new TimeoutMainObserver<T>(s, other);
+        s.onSubscribe(parent);
 
-        final AtomicBoolean once = new AtomicBoolean();
+        DisposableHelper.replace(parent.task, scheduler.scheduleDirect(parent, timeout, unit));
 
-        Disposable timer = scheduler.scheduleDirect(new TimeoutDispose(once, set, s), timeout, unit);
-
-        set.add(timer);
-
-        source.subscribe(new TimeoutObserver(once, set, s));
-
+        source.subscribe(parent);
     }
 
-    final class TimeoutDispose implements Runnable {
-        private final AtomicBoolean once;
-        final CompositeDisposable set;
-        final SingleObserver<? super T> s;
+    static final class TimeoutMainObserver<T> extends AtomicReference<Disposable>
+    implements SingleObserver<T>, Runnable, Disposable {
 
-        TimeoutDispose(AtomicBoolean once, CompositeDisposable set, SingleObserver<? super T> s) {
-            this.once = once;
-            this.set = set;
-            this.s = s;
-        }
+        private static final long serialVersionUID = 37497744973048446L;
 
-        @Override
-        public void run() {
-            if (once.compareAndSet(false, true)) {
-                if (other != null) {
-                    set.clear();
-                    other.subscribe(new TimeoutObserver());
-                } else {
-                    set.dispose();
-                    s.onError(new TimeoutException());
-                }
-            }
-        }
+        final SingleObserver<? super T> actual;
 
-        final class TimeoutObserver implements SingleObserver<T> {
+        final AtomicReference<Disposable> task;
 
-            @Override
-            public void onError(Throwable e) {
-                set.dispose();
-                s.onError(e);
+        final TimeoutFallbackObserver<T> fallback;
+
+        SingleSource<? extends T> other;
+
+        static final class TimeoutFallbackObserver<T> extends AtomicReference<Disposable>
+        implements SingleObserver<T> {
+
+            private static final long serialVersionUID = 2071387740092105509L;
+            final SingleObserver<? super T> actual;
+
+            TimeoutFallbackObserver(SingleObserver<? super T> actual) {
+                this.actual = actual;
             }
 
             @Override
             public void onSubscribe(Disposable d) {
-                set.add(d);
+                DisposableHelper.setOnce(this, d);
             }
 
             @Override
-            public void onSuccess(T value) {
-                set.dispose();
-                s.onSuccess(value);
+            public void onSuccess(T t) {
+                actual.onSuccess(t);
             }
 
+            @Override
+            public void onError(Throwable e) {
+                actual.onError(e);
+            }
         }
-    }
 
-    final class TimeoutObserver implements SingleObserver<T> {
-
-        private final AtomicBoolean once;
-        private final CompositeDisposable set;
-        private final SingleObserver<? super T> s;
-
-        TimeoutObserver(AtomicBoolean once, CompositeDisposable set, SingleObserver<? super T> s) {
-            this.once = once;
-            this.set = set;
-            this.s = s;
+        TimeoutMainObserver(SingleObserver<? super T> actual, SingleSource<? extends T> other) {
+            this.actual = actual;
+            this.other = other;
+            this.task = new AtomicReference<Disposable>();
+            if (other != null) {
+                this.fallback = new TimeoutFallbackObserver<T>(actual);
+            } else {
+                this.fallback = null;
+            }
         }
 
         @Override
-        public void onError(Throwable e) {
-            if (once.compareAndSet(false, true)) {
-                set.dispose();
-                s.onError(e);
+        public void run() {
+            Disposable d = get();
+            if (d != DisposableHelper.DISPOSED && compareAndSet(d, DisposableHelper.DISPOSED)) {
+                if (d != null) {
+                    d.dispose();
+                }
+                SingleSource<? extends T> other = this.other;
+                if (other == null) {
+                    actual.onError(new TimeoutException());
+                } else {
+                    this.other = null;
+                    other.subscribe(fallback);
+                }
             }
         }
 
         @Override
         public void onSubscribe(Disposable d) {
-            set.add(d);
+            DisposableHelper.setOnce(this, d);
         }
 
         @Override
-        public void onSuccess(T value) {
-            if (once.compareAndSet(false, true)) {
-                set.dispose();
-                s.onSuccess(value);
+        public void onSuccess(T t) {
+            Disposable d = get();
+            if (d != DisposableHelper.DISPOSED && compareAndSet(d, DisposableHelper.DISPOSED)) {
+                DisposableHelper.dispose(task);
+                actual.onSuccess(t);
             }
         }
 
+        @Override
+        public void onError(Throwable e) {
+            Disposable d = get();
+            if (d != DisposableHelper.DISPOSED && compareAndSet(d, DisposableHelper.DISPOSED)) {
+                DisposableHelper.dispose(task);
+                actual.onError(e);
+            }
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+            DisposableHelper.dispose(task);
+            if (fallback != null) {
+                DisposableHelper.dispose(fallback);
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTimeout.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class SingleTimeout<T> extends Single<T> {
 
@@ -139,6 +140,8 @@ public final class SingleTimeout<T> extends Single<T> {
             if (d != DisposableHelper.DISPOSED && compareAndSet(d, DisposableHelper.DISPOSED)) {
                 DisposableHelper.dispose(task);
                 actual.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTest.java
@@ -19,11 +19,12 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import io.reactivex.Single;
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subjects.*;
 
 public class SingleTimeoutTest {
 
@@ -68,5 +69,134 @@ public class SingleTimeoutTest {
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void disposeWhenFallback() {
+        TestScheduler sch = new TestScheduler();
+
+        SingleSubject<Integer> subj = SingleSubject.create();
+
+        subj.timeout(1, TimeUnit.SECONDS, sch, Single.just(1))
+        .test(true)
+        .assertEmpty();
+
+        assertFalse(subj.hasObservers());
+    }
+
+    @Test
+    public void isDisposed() {
+        TestHelper.checkDisposed(SingleSubject.create().timeout(1, TimeUnit.DAYS));
+    }
+
+    @Test
+    public void fallbackDispose() {
+        TestScheduler sch = new TestScheduler();
+
+        SingleSubject<Integer> subj = SingleSubject.create();
+
+        SingleSubject<Integer> fallback = SingleSubject.create();
+
+        TestObserver<Integer> to = subj.timeout(1, TimeUnit.SECONDS, sch, fallback)
+        .test();
+
+        assertFalse(fallback.hasObservers());
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        assertFalse(subj.hasObservers());
+        assertTrue(fallback.hasObservers());
+
+        to.cancel();
+
+        assertFalse(fallback.hasObservers());
+    }
+
+    @Test
+    public void normalSuccessDoesntDisposeMain() {
+        final int[] calls = { 0 };
+
+        Single.just(1)
+        .doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                calls[0]++;
+            }
+        })
+        .timeout(1, TimeUnit.DAYS)
+        .test()
+        .assertResult(1);
+
+        assertEquals(0, calls[0]);
+    }
+
+    @Test
+    public void successTimeoutRace() {
+        for (int i = 0; i < 1000; i++) {
+            final SingleSubject<Integer> subj = SingleSubject.create();
+            SingleSubject<Integer> fallback = SingleSubject.create();
+
+            final TestScheduler sch = new TestScheduler();
+
+            TestObserver<Integer> to = subj.timeout(1, TimeUnit.MILLISECONDS, sch, fallback).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    subj.onSuccess(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    sch.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            if (!fallback.hasObservers()) {
+                to.assertResult(1);
+            } else {
+                to.assertEmpty();
+            }
+        }
+    }
+
+    @Test
+    public void errorTimeoutRace() {
+        final TestException ex = new TestException();
+
+        for (int i = 0; i < 1000; i++) {
+            final SingleSubject<Integer> subj = SingleSubject.create();
+            SingleSubject<Integer> fallback = SingleSubject.create();
+
+            final TestScheduler sch = new TestScheduler();
+
+            TestObserver<Integer> to = subj.timeout(1, TimeUnit.MILLISECONDS, sch, fallback).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    subj.onError(ex);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    sch.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            if (!fallback.hasObservers()) {
+                to.assertFailure(TestException.class);
+            } else {
+                to.assertEmpty();
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the unnecessary `dispose` call towards the main source when the source terminates and reworks the internals to use less allocation and indirection.