### PR TITLE
2.x: fix assertValueSequence reversed error message

### DIFF
--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -589,10 +589,10 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
         }
 
         if (actualNext) {
-            throw fail("More values received than expected (" + i + ")");
+            throw fail("Fewer values received than expected (" + i + ")");
         }
         if (expectedNext) {
-            throw fail("Fewer values received than expected (" + i + ")");
+            throw fail("More values received than expected (" + i + ")");
         }
         return (U)this;
     }

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -579,11 +579,11 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
                 break;
             }
 
-            T v = expectedIterator.next();
-            T u = actualIterator.next();
+            T u = expectedIterator.next();
+            T v = actualIterator.next();
 
             if (!ObjectHelper.equals(u, v)) {
-                throw fail("Values at position " + i + " differ; Expected: " + valueAndClass(v) + ", Actual: " + valueAndClass(u));
+                throw fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
             }
             i++;
         }

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -567,32 +567,32 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     @SuppressWarnings("unchecked")
     public final U assertValueSequence(Iterable<? extends T> sequence) {
         int i = 0;
-        Iterator<T> vit = values.iterator();
-        Iterator<? extends T> it = sequence.iterator();
+        Iterator<T> actualIterator = values.iterator();
+        Iterator<? extends T> expectedIterator = sequence.iterator();
         boolean actualNext;
         boolean expectedNext;
         for (;;) {
-            actualNext = it.hasNext();
-            expectedNext = vit.hasNext();
+            expectedNext = expectedIterator.hasNext();
+            actualNext = actualIterator.hasNext();
 
             if (!actualNext || !expectedNext) {
                 break;
             }
 
-            T v = it.next();
-            T u = vit.next();
+            T v = expectedIterator.next();
+            T u = actualIterator.next();
 
             if (!ObjectHelper.equals(u, v)) {
-                throw fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));
+                throw fail("Values at position " + i + " differ; Expected: " + valueAndClass(v) + ", Actual: " + valueAndClass(u));
             }
             i++;
         }
 
         if (actualNext) {
-            throw fail("Fewer values received than expected (" + i + ")");
+            throw fail("More values received than expected (" + i + ")");
         }
         if (expectedNext) {
-            throw fail("More values received than expected (" + i + ")");
+            throw fail("Fewer values received than expected (" + i + ")");
         }
         return (U)this;
     }

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -958,6 +958,7 @@ public class TestObserverTest {
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
+            assertTrue(ex.getMessage(), ex.getMessage().startsWith("More values received than expected (0)"));
         }
 
         try {
@@ -965,6 +966,7 @@ public class TestObserverTest {
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
+            assertTrue(ex.getMessage(), ex.getMessage().startsWith("More values received than expected (1)"));
         }
 
         ts.assertValueSequence(Arrays.asList(1, 2));
@@ -974,6 +976,7 @@ public class TestObserverTest {
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
+            assertTrue(ex.getMessage(), ex.getMessage().startsWith("Fewer values received than expected (2)"));
         }
     }
 

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -956,17 +956,15 @@ public class TestObserverTest {
         try {
             ts.assertValueSequence(Collections.<Integer>emptyList());
             throw new RuntimeException("Should have thrown");
-        } catch (AssertionError ex) {
-            // expected
-            assertTrue(ex.getMessage(), ex.getMessage().startsWith("More values received than expected (0)"));
+        } catch (AssertionError expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().startsWith("More values received than expected (0)"));
         }
 
         try {
             ts.assertValueSequence(Collections.singletonList(1));
             throw new RuntimeException("Should have thrown");
-        } catch (AssertionError ex) {
-            // expected
-            assertTrue(ex.getMessage(), ex.getMessage().startsWith("More values received than expected (1)"));
+        } catch (AssertionError expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().startsWith("More values received than expected (1)"));
         }
 
         ts.assertValueSequence(Arrays.asList(1, 2));
@@ -974,9 +972,8 @@ public class TestObserverTest {
         try {
             ts.assertValueSequence(Arrays.asList(1, 2, 3));
             throw new RuntimeException("Should have thrown");
-        } catch (AssertionError ex) {
-            // expected
-            assertTrue(ex.getMessage(), ex.getMessage().startsWith("Fewer values received than expected (2)"));
+        } catch (AssertionError expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().startsWith("Fewer values received than expected (2)"));
         }
     }
 


### PR DESCRIPTION
The error message/variable names in `TestBaseConsumer.assertValueSequence` was reversed: if more items were expected, it said "Fewer" and vice versa.