### PR TITLE
2.x: Add missing license headers

### DIFF
--- a/src/main/java/io/reactivex/observers/LambdaConsumerIntrospection.java
+++ b/src/main/java/io/reactivex/observers/LambdaConsumerIntrospection.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.observers;
 
 import io.reactivex.annotations.Experimental;

--- a/src/test/java/io/reactivex/internal/observers/CallbackCompletableObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/CallbackCompletableObserverTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.observers;
 
 import io.reactivex.internal.functions.Functions;

--- a/src/test/java/io/reactivex/internal/observers/ConsumerSingleObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/ConsumerSingleObserverTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.observers;
 
 import io.reactivex.internal.functions.Functions;

--- a/src/test/java/io/reactivex/internal/observers/EmptyCompletableObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/EmptyCompletableObserverTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
 package io.reactivex.internal.observers;
 
 import org.junit.Test;


### PR DESCRIPTION
`FixLicenseHeaders` is currently failing when run locally (it's skipped on CI).