### PR TITLE
2.x: fix incorrect error message at SubscriptionHelper.setOnce

### DIFF
--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
@@ -137,7 +137,7 @@ public enum SubscriptionHelper implements Subscription {
      * @return true if the operation succeeded, false if the target field was not null.
      */
     public static boolean setOnce(AtomicReference<Subscription> field, Subscription s) {
-        ObjectHelper.requireNonNull(s, "d is null");
+        ObjectHelper.requireNonNull(s, "s is null");
         if (!field.compareAndSet(null, s)) {
             s.cancel();
             if (field.get() != CANCELLED) {


### PR DESCRIPTION
I found an incorrect error message at `SubscriptionHelper.setOnce`.
The error message should mention that the second argument `Subscription s` is null, but the error message says `"d is null"`.