### PR TITLE
2.x: add onTerminateDetach to Single and Completable

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -1381,6 +1381,24 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
+     * Nulls out references to the upstream producer and downstream CompletableObserver if
+     * the sequence is terminated or downstream calls dispose().
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return a Completable which nulls out references to the upstream producer and downstream CompletableObserver if
+     * the sequence is terminated or downstream calls dispose()
+     * @since 2.1.5 - experimental
+     */
+    @Experimental
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Completable onTerminateDetach() {
+        return RxJavaPlugins.onAssembly(new CompletableDetach(this));
+    }
+
+    /**
      * Returns a Completable that repeatedly subscribes to this Completable until cancelled.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3316,6 +3316,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         ObjectHelper.requireNonNull(next, "next is null");
         return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<T>(this, Functions.justFunction(next), false));
     }
+
     /**
      * Nulls out references to the upstream producer and downstream MaybeObserver if
      * the sequence is terminated or downstream calls dispose().
@@ -3323,7 +3324,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return a Maybe which out references to the upstream producer and downstream MaybeObserver if
+     * @return a Maybe which nulls out references to the upstream producer and downstream MaybeObserver if
      * the sequence is terminated or downstream calls dispose()
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2469,6 +2469,24 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
+     * Nulls out references to the upstream producer and downstream SingleObserver if
+     * the sequence is terminated or downstream calls dispose().
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return a Single which nulls out references to the upstream producer and downstream SingleObserver if
+     * the sequence is terminated or downstream calls dispose()
+     * @since 2.1.5 - experimental
+     */
+    @Experimental
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Single<T> onTerminateDetach() {
+        return RxJavaPlugins.onAssembly(new SingleDetach<T>(this));
+    }
+
+    /**
      * Repeatedly re-subscribes to the current Single and emits each success value.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDetach.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Breaks the references between the upstream and downstream when the Completable terminates.
+ * 
+ * @since 2.1.5 - experimental
+ */
+@Experimental
+public final class CompletableDetach extends Completable {
+
+    final CompletableSource source;
+
+    public CompletableDetach(CompletableSource source) {
+        this.source = source;
+    }
+
+    @Override
+    protected void subscribeActual(CompletableObserver observer) {
+        source.subscribe(new DetachCompletableObserver(observer));
+    }
+
+    static final class DetachCompletableObserver implements CompletableObserver, Disposable {
+
+        CompletableObserver actual;
+
+        Disposable d;
+
+        DetachCompletableObserver(CompletableObserver actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void dispose() {
+            actual = null;
+            d.dispose();
+            d = DisposableHelper.DISPOSED;
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            d = DisposableHelper.DISPOSED;
+            CompletableObserver a = actual;
+            if (a != null) {
+                a.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            d = DisposableHelper.DISPOSED;
+            CompletableObserver a = actual;
+            if (a != null) {
+                a.onComplete();
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDetach.java
@@ -73,6 +73,7 @@ public final class CompletableDetach extends Completable {
             d = DisposableHelper.DISPOSED;
             CompletableObserver a = actual;
             if (a != null) {
+                actual = null;
                 a.onError(e);
             }
         }
@@ -82,6 +83,7 @@ public final class CompletableDetach extends Completable {
             d = DisposableHelper.DISPOSED;
             CompletableObserver a = actual;
             if (a != null) {
+                actual = null;
                 a.onComplete();
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDetach.java
@@ -69,6 +69,7 @@ public final class MaybeDetach<T> extends AbstractMaybeWithUpstream<T, T> {
             d = DisposableHelper.DISPOSED;
             MaybeObserver<? super T> a = actual;
             if (a != null) {
+                actual = null;
                 a.onSuccess(value);
             }
         }
@@ -78,6 +79,7 @@ public final class MaybeDetach<T> extends AbstractMaybeWithUpstream<T, T> {
             d = DisposableHelper.DISPOSED;
             MaybeObserver<? super T> a = actual;
             if (a != null) {
+                actual = null;
                 a.onError(e);
             }
         }
@@ -87,6 +89,7 @@ public final class MaybeDetach<T> extends AbstractMaybeWithUpstream<T, T> {
             d = DisposableHelper.DISPOSED;
             MaybeObserver<? super T> a = actual;
             if (a != null) {
+                actual = null;
                 a.onComplete();
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDetach.java
@@ -74,6 +74,7 @@ public final class SingleDetach<T> extends Single<T> {
             d = DisposableHelper.DISPOSED;
             SingleObserver<? super T> a = actual;
             if (a != null) {
+                actual = null;
                 a.onSuccess(value);
             }
         }
@@ -83,6 +84,7 @@ public final class SingleDetach<T> extends Single<T> {
             d = DisposableHelper.DISPOSED;
             SingleObserver<? super T> a = actual;
             if (a != null) {
+                actual = null;
                 a.onError(e);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDetach.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.single;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Breaks the references between the upstream and downstream when the Maybe terminates.
+ *
+ * @param <T> the value type
+ * @since 2.1.5 - experimental
+ */
+@Experimental
+public final class SingleDetach<T> extends Single<T> {
+
+    final SingleSource<T> source;
+
+    public SingleDetach(SingleSource<T> source) {
+        this.source = source;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        source.subscribe(new DetachSingleObserver<T>(observer));
+    }
+
+    static final class DetachSingleObserver<T> implements SingleObserver<T>, Disposable {
+
+        SingleObserver<? super T> actual;
+
+        Disposable d;
+
+        DetachSingleObserver(SingleObserver<? super T> actual) {
+            this.actual = actual;
+        }
+
+        @Override
+        public void dispose() {
+            actual = null;
+            d.dispose();
+            d = DisposableHelper.DISPOSED;
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return d.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.d, d)) {
+                this.d = d;
+
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            d = DisposableHelper.DISPOSED;
+            SingleObserver<? super T> a = actual;
+            if (a != null) {
+                a.onSuccess(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            d = DisposableHelper.DISPOSED;
+            SingleObserver<? super T> a = actual;
+            if (a != null) {
+                a.onError(e);
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDetachTest.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.completable;
 
 import static org.junit.Assert.assertNull;
 
+import java.io.IOException;
 import java.lang.ref.WeakReference;
 
 import org.junit.Test;
@@ -96,6 +97,7 @@ public class CompletableDetachTest {
             protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(wr.get());
                 observer.onComplete();
+                observer.onComplete();
             };
         }
         .onTerminateDetach()
@@ -121,6 +123,7 @@ public class CompletableDetachTest {
             protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(wr.get());
                 observer.onError(new TestException());
+                observer.onError(new IOException());
             };
         }
         .onTerminateDetach()

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDetachTest.java
@@ -11,7 +11,7 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.operators.maybe;
+package io.reactivex.internal.operators.completable;
 
 import static org.junit.Assert.assertNull;
 
@@ -26,14 +26,14 @@ import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 
-public class MaybeDetachTest {
+public class CompletableDetachTest {
 
     @Test
     public void doubleSubscribe() {
 
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
+        TestHelper.checkDoubleOnSubscribeCompletable(new Function<Completable, CompletableSource>() {
             @Override
-            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
+            public CompletableSource apply(Completable m) throws Exception {
                 return m.onTerminateDetach();
             }
         });
@@ -41,12 +41,12 @@ public class MaybeDetachTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(PublishProcessor.create().singleElement().onTerminateDetach());
+        TestHelper.checkDisposed(PublishProcessor.create().ignoreElements().onTerminateDetach());
     }
 
     @Test
     public void onError() {
-        Maybe.error(new TestException())
+        Completable.error(new TestException())
         .onTerminateDetach()
         .test()
         .assertFailure(TestException.class);
@@ -54,7 +54,7 @@ public class MaybeDetachTest {
 
     @Test
     public void onComplete() {
-        Maybe.empty()
+        Completable.complete()
         .onTerminateDetach()
         .test()
         .assertResult();
@@ -65,9 +65,9 @@ public class MaybeDetachTest {
         Disposable d = Disposables.empty();
         final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
 
-        TestObserver<Object> to = new Maybe<Object>() {
+        TestObserver<Void> to = new Completable() {
             @Override
-            protected void subscribeActual(MaybeObserver<? super Object> observer) {
+            protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(wr.get());
             };
         }
@@ -91,9 +91,9 @@ public class MaybeDetachTest {
         Disposable d = Disposables.empty();
         final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
 
-        TestObserver<Integer> to = new Maybe<Integer>() {
+        TestObserver<Void> to = new Completable() {
             @Override
-            protected void subscribeActual(MaybeObserver<? super Integer> observer) {
+            protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(wr.get());
                 observer.onComplete();
             };
@@ -116,9 +116,9 @@ public class MaybeDetachTest {
         Disposable d = Disposables.empty();
         final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
 
-        TestObserver<Integer> to = new Maybe<Integer>() {
+        TestObserver<Void> to = new Completable() {
             @Override
-            protected void subscribeActual(MaybeObserver<? super Integer> observer) {
+            protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(wr.get());
                 observer.onError(new TestException());
             };
@@ -132,31 +132,6 @@ public class MaybeDetachTest {
         Thread.sleep(200);
 
         to.assertFailure(TestException.class);
-
-        assertNull(wr.get());
-    }
-
-    @Test
-    public void successDetaches() throws Exception {
-        Disposable d = Disposables.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
-
-        TestObserver<Integer> to = new Maybe<Integer>() {
-            @Override
-            protected void subscribeActual(MaybeObserver<? super Integer> observer) {
-                observer.onSubscribe(wr.get());
-                observer.onSuccess(1);
-            };
-        }
-        .onTerminateDetach()
-        .test();
-
-        d = null;
-
-        System.gc();
-        Thread.sleep(200);
-
-        to.assertResult(1);
 
         assertNull(wr.get());
     }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDetachTest.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.maybe;
 
 import static org.junit.Assert.assertNull;
 
+import java.io.IOException;
 import java.lang.ref.WeakReference;
 
 import org.junit.Test;
@@ -96,6 +97,7 @@ public class MaybeDetachTest {
             protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());
                 observer.onComplete();
+                observer.onComplete();
             };
         }
         .onTerminateDetach()
@@ -121,6 +123,7 @@ public class MaybeDetachTest {
             protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());
                 observer.onError(new TestException());
+                observer.onError(new IOException());
             };
         }
         .onTerminateDetach()
@@ -146,6 +149,7 @@ public class MaybeDetachTest {
             protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());
                 observer.onSuccess(1);
+                observer.onSuccess(2);
             };
         }
         .onTerminateDetach()

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDetachTest.java
@@ -11,9 +11,9 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.internal.operators.maybe;
+package io.reactivex.internal.operators.single;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 import java.lang.ref.WeakReference;
 
@@ -26,14 +26,14 @@ import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 
-public class MaybeDetachTest {
+public class SingleDetachTest {
 
     @Test
     public void doubleSubscribe() {
 
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
+        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
             @Override
-            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
+            public SingleSource<Object> apply(Single<Object> m) throws Exception {
                 return m.onTerminateDetach();
             }
         });
@@ -46,18 +46,18 @@ public class MaybeDetachTest {
 
     @Test
     public void onError() {
-        Maybe.error(new TestException())
+        Single.error(new TestException())
         .onTerminateDetach()
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
-    public void onComplete() {
-        Maybe.empty()
+    public void onSuccess() {
+        Single.just(1)
         .onTerminateDetach()
         .test()
-        .assertResult();
+        .assertResult(1);
     }
 
     @Test
@@ -65,9 +65,9 @@ public class MaybeDetachTest {
         Disposable d = Disposables.empty();
         final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
 
-        TestObserver<Object> to = new Maybe<Object>() {
+        TestObserver<Object> to = new Single<Object>() {
             @Override
-            protected void subscribeActual(MaybeObserver<? super Object> observer) {
+            protected void subscribeActual(SingleObserver<? super Object> observer) {
                 observer.onSubscribe(wr.get());
             };
         }
@@ -87,38 +87,13 @@ public class MaybeDetachTest {
     }
 
     @Test
-    public void completeDetaches() throws Exception {
-        Disposable d = Disposables.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
-
-        TestObserver<Integer> to = new Maybe<Integer>() {
-            @Override
-            protected void subscribeActual(MaybeObserver<? super Integer> observer) {
-                observer.onSubscribe(wr.get());
-                observer.onComplete();
-            };
-        }
-        .onTerminateDetach()
-        .test();
-
-        d = null;
-
-        System.gc();
-        Thread.sleep(200);
-
-        to.assertResult();
-
-        assertNull(wr.get());
-    }
-
-    @Test
     public void errorDetaches() throws Exception {
         Disposable d = Disposables.empty();
         final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
 
-        TestObserver<Integer> to = new Maybe<Integer>() {
+        TestObserver<Integer> to = new Single<Integer>() {
             @Override
-            protected void subscribeActual(MaybeObserver<? super Integer> observer) {
+            protected void subscribeActual(SingleObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());
                 observer.onError(new TestException());
             };
@@ -141,9 +116,9 @@ public class MaybeDetachTest {
         Disposable d = Disposables.empty();
         final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
 
-        TestObserver<Integer> to = new Maybe<Integer>() {
+        TestObserver<Integer> to = new Single<Integer>() {
             @Override
-            protected void subscribeActual(MaybeObserver<? super Integer> observer) {
+            protected void subscribeActual(SingleObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());
                 observer.onSuccess(1);
             };

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDetachTest.java
@@ -13,8 +13,9 @@
 
 package io.reactivex.internal.operators.single;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
 
+import java.io.IOException;
 import java.lang.ref.WeakReference;
 
 import org.junit.Test;
@@ -41,7 +42,7 @@ public class SingleDetachTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(PublishProcessor.create().singleElement().onTerminateDetach());
+        TestHelper.checkDisposed(PublishProcessor.create().singleOrError().onTerminateDetach());
     }
 
     @Test
@@ -96,6 +97,7 @@ public class SingleDetachTest {
             protected void subscribeActual(SingleObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());
                 observer.onError(new TestException());
+                observer.onError(new IOException());
             };
         }
         .onTerminateDetach()
@@ -121,6 +123,7 @@ public class SingleDetachTest {
             protected void subscribeActual(SingleObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());
                 observer.onSuccess(1);
+                observer.onSuccess(2);
             };
         }
         .onTerminateDetach()


### PR DESCRIPTION
This PR adds the `onTerminateDetach` operator to `Single` and `Completable`. It was available on `Flowable`, `Observable` and `Maybe` already.

Plus:

- Fixes the javadoc for `Maybe.onTerminateDetach`
- Adds unit tests for verifying terminal events do release references with `Maybe` as well.

Their non-existence came up on [StackOverflow](https://stackoverflow.com/questions/46397082/disposablecompletableobserver-leaking-activity-even-though-im-clearing-composit?noredirect=1#comment79870549_46397082).

**Update**

Turns out the downstream's `actual` references were not cleared in `Maybe` after all. Updated the PR to ensure that in all 3 of them and improved coverage.