### PR TITLE
2.x: add RxJavaPlugins.onCallbackCrash hook?

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
@@ -22,6 +22,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.subscribers.*;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableMap<T, U> extends AbstractFlowableWithUpstream<T, U> {
     final Function<? super T, ? extends U> mapper;
@@ -63,7 +64,7 @@ public final class FlowableMap<T, U> extends AbstractFlowableWithUpstream<T, U> 
             try {
                 v = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper function returned a null value.");
             } catch (Throwable ex) {
-                fail(ex);
+                fail(RxJavaPlugins.onCallbackCrash(ex, mapper));
                 return;
             }
             actual.onNext(v);
@@ -106,7 +107,7 @@ public final class FlowableMap<T, U> extends AbstractFlowableWithUpstream<T, U> 
             try {
                 v = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper function returned a null value.");
             } catch (Throwable ex) {
-                fail(ex);
+                fail(RxJavaPlugins.onCallbackCrash(ex, mapper));
                 return;
             }
             actual.onNext(v);
@@ -123,7 +124,7 @@ public final class FlowableMap<T, U> extends AbstractFlowableWithUpstream<T, U> 
             try {
                 v = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper function returned a null value.");
             } catch (Throwable ex) {
-                fail(ex);
+                fail(RxJavaPlugins.onCallbackCrash(ex, mapper));
                 return true;
             }
             return actual.tryOnNext(v);

--- a/src/test/java/io/reactivex/plugins/OnCallbackCrashTest.java
+++ b/src/test/java/io/reactivex/plugins/OnCallbackCrashTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.plugins;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.*;
+
+import org.junit.*;
+
+import io.reactivex.Flowable;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+
+/**
+ * Test operators that support reporting on callback crash.
+ * <p>Why a separate test file? We have to ensure the anonymous inner classes
+ * have predictable numbering.
+ * @since 2.1.5 - experimental
+ */
+@Experimental
+public class OnCallbackCrashTest {
+
+    List<String> error = Collections.synchronizedList(new ArrayList<String>());
+
+    final class CrashReport implements BiConsumer<Throwable, Object> {
+
+        @Override
+        public void accept(Throwable t1, Object t2) throws Exception {
+            StringBuilder sb = new StringBuilder(128);
+            sb
+            .append("Class: ").append(t2.getClass().getName())
+            .append(", Enclosing: ").append(t2.getClass().getEnclosingMethod());
+
+            error.add(sb.toString());
+        }
+    }
+
+    @Before
+    public void before() {
+        RxJavaPlugins.setOnCallbackCrash(new CrashReport());
+    }
+
+    @After
+    public void after() {
+        RxJavaPlugins.setOnCallbackCrash(null);
+    }
+
+    @Test
+    public void map() {
+        Flowable.just(1)
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception {
+                return null;
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertEquals(error.toString(), 1, error.size());
+        String s = error.get(0);
+        assertEquals("Class: io.reactivex.plugins.OnCallbackCrashTest$1, Enclosing: public void io.reactivex.plugins.OnCallbackCrashTest.map()", s);
+    }
+
+    @Test
+    public void mapConditional() {
+        Flowable.just(1)
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception {
+                return null;
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertEquals(error.toString(), 1, error.size());
+        String s = error.get(0);
+        assertEquals("Class: io.reactivex.plugins.OnCallbackCrashTest$2, Enclosing: public void io.reactivex.plugins.OnCallbackCrashTest.mapConditional()", s);
+    }
+
+    @Test
+    public void mapConditional2() {
+        Flowable.range(1, 2)
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception {
+                return null;
+            }
+        })
+        .filter(Functions.alwaysTrue())
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertEquals(error.toString(), 1, error.size());
+        String s = error.get(0);
+        assertEquals("Class: io.reactivex.plugins.OnCallbackCrashTest$3, Enclosing: public void io.reactivex.plugins.OnCallbackCrashTest.mapConditional2()", s);
+    }
+}

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -233,6 +233,12 @@ public class RxJavaPluginsTest {
                 }
             };
 
+            BiConsumer bc = new BiConsumer() {
+                @Override
+                public void accept(Object t1, Object t2) throws Exception {
+                }
+            };
+
             for (Method m : RxJavaPlugins.class.getMethods()) {
                 if (m.getName().startsWith("set")) {
 
@@ -263,6 +269,9 @@ public class RxJavaPluginsTest {
                         } else
                         if (paramType.isAssignableFrom(BooleanSupplier.class)) {
                             m.invoke(null, bs);
+                        } else
+                        if (paramType.isAssignableFrom(BiConsumer.class)) {
+                            m.invoke(null, bc);
                         } else {
                             m.invoke(null, f2);
                         }
@@ -2254,5 +2263,23 @@ public class RxJavaPluginsTest {
         assertTrue(RxJavaPlugins.isBug(new UndeliverableException(new TestException())));
         assertTrue(RxJavaPlugins.isBug(new CompositeException(new TestException())));
         assertTrue(RxJavaPlugins.isBug(new OnErrorNotImplementedException(new TestException())));
+    }
+
+    @Test
+    public void onCallbackCrashCrash() {
+        try {
+            RxJavaPlugins.setOnCallbackCrash(new BiConsumer<Throwable, Object>() {
+                @Override
+                public void accept(Throwable t, Object o) throws Exception {
+                    throw new TestException();
+                }
+            });
+            RxJavaPlugins.onCallbackCrash(new IOException(), new Object());
+            fail("Should have thrown");
+        } catch (TestException expected) {
+            // expected
+        } finally {
+            RxJavaPlugins.setOnCallbackCrash(null);
+        }
     }
 }


### PR DESCRIPTION
This PR suggests a new `RxJavaPlugins` hook: `onCallbackCrash` which should be called by operator implementations when the user-provided callback (`Function`, `Action`, `Consumer`, etc.) crashes for some reason but the exception itself may contain not enough information about what that callback was.

As the test demonstrates, one can call `getClass()` and `getClass().getEnclosingMethod()` to help narrow down the search for the callback's source; Java doesn't provide the source code location this way unfortunately. In addition `getEnclosingMethod()` may return null for Java 8 lambda callbacks and `getClass()` may return a cryptic and unhelpful synthetic method identifier.


Perhaps the only reasonable use case could be the help with finding `null`-returning `Function`s (and the other 0, 2..9 argument variants). This alternative could focus on `ObjectHelper` and replace `requireNonNull` with:

```java
public static <T, R> R nonNullInvoke(Function<T, R> f, T t, 
        String name, String returnDesc) throws Exception {
    R r = f.apply(t);
    if (r != null) {
       return r;
    }
    NullPointerException npe = new NullPointerException(
        "The " + name + " returned a null " + returnDesc);
    RxJavaPlugins.onCallbackCrash(npe, f);
    throw npe;
}
```

The drawback in this case is the heavily increased bytecode count involved which may lead to missed JIT optimizations due to JVM default limits.