### PR TITLE
2.x: Added Automatic-Module-Name instruction in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ jar {
         instruction "Bundle-DocURL", "https://github.com/ReactiveX/RxJava"
         instruction "Import-Package", "!org.junit,!junit.framework,!org.mockito.*,!org.testng.*,*"
         instruction "Eclipse-ExtensibleAPI", "true"
+        instruction "Automatic-Module-Name", "io.reactivex.rxjava2"
     }
 }
 


### PR DESCRIPTION
Credits to @zyxist for pointing this out in the issue #5618 

This will assign a module name to RxJava 2 according to the the recommended module naming conventions in the generated manifest.