### PR TITLE
2.x: improve package JavaDoc

### DIFF
--- a/src/main/java/io/reactivex/observers/package-info.java
+++ b/src/main/java/io/reactivex/observers/package-info.java
@@ -15,7 +15,10 @@
  */
 
 /**
- * Default wrappers and implementations for Observer-based consumer classes and interfaces;
- * utility classes for creating them from callbacks.
+ * Default wrappers and implementations for Observer-based consumer classes and interfaces,
+ * including disposable and resource-tracking variants and
+ * the {@link io.reactivex.subscribers.TestObserver} that allows unit testing
+ * {@link io.reactivex.Observable}-, {@link io.reactivex.Single}-, {@link io.reactivex.Maybe}-
+ * and {@link io.reactivex.Completable}-based flows.
  */
 package io.reactivex.observers;

--- a/src/main/java/io/reactivex/package-info.java
+++ b/src/main/java/io/reactivex/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * Base reactive classes: Flowable, Observable, Single and Completable; base reactive consumers;
+ * Base reactive classes: Flowable, Observable, Single, Maybe and Completable; base reactive consumers;
  * other common base interfaces.
  *
  * <p>A library that enables subscribing to and composing asynchronous events and
@@ -43,9 +43,9 @@
  *
  * <p>Services which intend on exposing data asynchronously and wish
  * to allow reactive processing and composition can implement the
- * {@link io.reactivex.Flowable}, {@link io.reactivex.Observable}, {@link io.reactivex.Single}
- * or {@link io.reactivex.Completable} class which then allow consumers to subscribe to them
- * and receive events.</p>
+ * {@link io.reactivex.Flowable}, {@link io.reactivex.Observable}, {@link io.reactivex.Single},
+ * {@link io.reactivex.Maybe} or {@link io.reactivex.Completable} class which then allow
+ * consumers to subscribe to them and receive events.</p>
  * <p>Usage examples can be found on the {@link io.reactivex.Flowable}/{@link io.reactivex.Observable} and {@link org.reactivestreams.Subscriber} classes.</p>
  */
 package io.reactivex;

--- a/src/main/java/io/reactivex/subscribers/package-info.java
+++ b/src/main/java/io/reactivex/subscribers/package-info.java
@@ -15,7 +15,9 @@
  */
 
 /**
- * Default wrappers and implementations for Subscriber-based consumer classes and interfaces;
- * utility classes for creating them from callbacks.
+ * Default wrappers and implementations for Subscriber-based consumer classes and interfaces,
+ * including disposable and resource-tracking variants and
+ * the {@link io.reactivex.subscribers.TestSubscriber} that allows unit testing
+ * {@link io.reactivex.Flowable}-based flows.
  */
 package io.reactivex.subscribers;


### PR DESCRIPTION
Add `Maybe` to the `io.reactivex` package Javadoc. Reword `io.reactivex.observers` and `io.reactivex.subscribers` as there are no utility classes in 2.x in them to create consumers from callbacks (those are internal and offered by the `subscribe()` overloads only).