### PR TITLE
2.x Add concatMapCompletable() to Observable

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -6092,7 +6092,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param mapper
@@ -6113,7 +6113,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param mapper
@@ -6128,6 +6128,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<T>(this, mapper, prefetch));
     }
 

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -6262,7 +6262,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param mapper
      *            a function that, when applied to an item emitted by the source ObservableSource, returns a CompletableSource
      * @return a Completable that signals {@code onComplete} when the upstream and all CompletableSources complete
+     * @since 2.1.6 - experimental
      */
+    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper) {
@@ -6279,16 +6281,20 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param mapper
      *            a function that, when applied to an item emitted by the source ObservableSource, returns a CompletableSource
-     * @param prefetch
-     *            the number of elements to prefetch from the current Observable
+     *
+     * @param capacityHint
+     *            the number of upstream items expected to be buffered until the current CompletableSource,  mapped from
+     *            the current item, completes.
      * @return a Completable that signals {@code onComplete} when the upstream and all CompletableSources complete
+     * @since 2.1.6 - experimental
      */
+    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, int prefetch) {
+    public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, int capacityHint) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<T>(this, mapper, prefetch));
+        ObjectHelper.verifyPositive(capacityHint, "capacityHint");
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<T>(this, mapper, capacityHint));
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -6260,9 +6260,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @param mapper
-     *            a function that, when applied to an item emitted by the source ObservableSource, returns an
-     *            CompletableSource
-     * @return a Completable that emits onComplete when the upstream and all CompletableSources complete
+     *            a function that, when applied to an item emitted by the source ObservableSource, returns a CompletableSource
+     * @return a Completable that signals {@code onComplete} when the upstream and all CompletableSources complete
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -6279,11 +6278,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @param mapper
-     *            a function that, when applied to an item emitted by the source ObservableSource, returns an
-     *            CompletableSource
+     *            a function that, when applied to an item emitted by the source ObservableSource, returns a CompletableSource
      * @param prefetch
      *            the number of elements to prefetch from the current Observable
-     * @return a Completable that emits onComplete when the upstream and all CompletableSources complete
+     * @return a Completable that signals {@code onComplete} when the upstream and all CompletableSources complete
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2016-present, RxJava Contributors.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  * compliance with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is
  * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
  * the License for the specific language governing permissions and limitations under the License.
@@ -13,34 +13,25 @@
 
 package io.reactivex;
 
+import java.util.*;
+import java.util.concurrent.*;
+
+import org.reactivestreams.Publisher;
+
 import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
-import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.functions.*;
 import io.reactivex.internal.fuseable.ScalarCallable;
 import io.reactivex.internal.observers.*;
-import io.reactivex.internal.operators.flowable.FlowableFromObservable;
-import io.reactivex.internal.operators.flowable.FlowableOnBackpressureError;
+import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.operators.observable.*;
-import io.reactivex.internal.util.ArrayListSupplier;
-import io.reactivex.internal.util.ErrorMode;
-import io.reactivex.internal.util.ExceptionHelper;
-import io.reactivex.internal.util.HashMapSupplier;
-import io.reactivex.observables.ConnectableObservable;
-import io.reactivex.observables.GroupedObservable;
-import io.reactivex.observers.SafeObserver;
-import io.reactivex.observers.TestObserver;
+import io.reactivex.internal.util.*;
+import io.reactivex.observables.*;
+import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
-import io.reactivex.schedulers.Timed;
-import org.reactivestreams.Publisher;
-
-import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import io.reactivex.schedulers.*;
 
 /**
  * The Observable class is the non-backpressured, optionally multi-valued base reactive class that
@@ -158,7 +149,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             return empty();
         }
         if (len == 1) {
-            return (Observable<T>) wrap(sources[0]);
+            return (Observable<T>)wrap(sources[0]);
         }
         return RxJavaPlugins.onAssembly(new ObservableAmb<T>(sources, null));
     }
@@ -255,7 +246,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableSource<? extends T>> sources,
-                                                     Function<? super Object[], ? extends R> combiner) {
+            Function<? super Object[], ? extends R> combiner) {
         return combineLatest(sources, combiner, bufferSize());
     }
 
@@ -299,7 +290,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableSource<? extends T>> sources,
-                                                     Function<? super Object[], ? extends R> combiner, int bufferSize) {
+            Function<? super Object[], ? extends R> combiner, int bufferSize) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -347,7 +338,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatest(ObservableSource<? extends T>[] sources,
-                                                     Function<? super Object[], ? extends R> combiner) {
+            Function<? super Object[], ? extends R> combiner) {
         return combineLatest(sources, combiner, bufferSize());
     }
 
@@ -391,7 +382,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatest(ObservableSource<? extends T>[] sources,
-                                                     Function<? super Object[], ? extends R> combiner, int bufferSize) {
+            Function<? super Object[], ? extends R> combiner, int bufferSize) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return empty();
@@ -882,7 +873,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatestDelayError(ObservableSource<? extends T>[] sources,
-                                                               Function<? super Object[], ? extends R> combiner) {
+            Function<? super Object[], ? extends R> combiner) {
         return combineLatestDelayError(sources, combiner, bufferSize());
     }
 
@@ -927,7 +918,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatestDelayError(Function<? super Object[], ? extends R> combiner,
-                                                               int bufferSize, ObservableSource<? extends T>... sources) {
+            int bufferSize, ObservableSource<? extends T>... sources) {
         return combineLatestDelayError(sources, combiner, bufferSize);
     }
 
@@ -972,7 +963,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatestDelayError(ObservableSource<? extends T>[] sources,
-                                                               Function<? super Object[], ? extends R> combiner, int bufferSize) {
+            Function<? super Object[], ? extends R> combiner, int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
         if (sources.length == 0) {
@@ -1022,7 +1013,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatestDelayError(Iterable<? extends ObservableSource<? extends T>> sources,
-                                                               Function<? super Object[], ? extends R> combiner) {
+            Function<? super Object[], ? extends R> combiner) {
         return combineLatestDelayError(sources, combiner, bufferSize());
     }
 
@@ -1067,7 +1058,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> combineLatestDelayError(Iterable<? extends ObservableSource<? extends T>> sources,
-                                                               Function<? super Object[], ? extends R> combiner, int bufferSize) {
+            Function<? super Object[], ? extends R> combiner, int bufferSize) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -1090,12 +1081,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param sources the Iterable sequence of ObservableSources
      * @return the new Observable instance
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concat(Iterable<? extends ObservableSource<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return fromIterable(sources).concatMapDelayError((Function) Functions.identity(), bufferSize(), false);
+        return fromIterable(sources).concatMapDelayError((Function)Functions.identity(), bufferSize(), false);
     }
 
     /**
@@ -1140,7 +1131,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         {@code ObservableSources}, one after the other, without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concat(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch) {
@@ -1261,14 +1252,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new Observable instance
      * @throws NullPointerException if sources is null
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatArray(ObservableSource<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
-        } else if (sources.length == 1) {
-            return wrap((ObservableSource<T>) sources[0]);
+        } else
+        if (sources.length == 1) {
+            return wrap((ObservableSource<T>)sources[0]);
         }
         return RxJavaPlugins.onAssembly(new ObservableConcatMap(fromArray(sources), Functions.identity(), bufferSize(), ErrorMode.BOUNDARY));
     }
@@ -1287,14 +1279,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new Observable instance
      * @throws NullPointerException if sources is null
      */
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({ "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatArrayDelayError(ObservableSource<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
-        } else if (sources.length == 1) {
-            return (Observable<T>) wrap(sources[0]);
+        } else
+        if (sources.length == 1) {
+            return (Observable<T>)wrap(sources[0]);
         }
         return concatDelayError(fromArray(sources));
     }
@@ -1340,11 +1333,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new ObservableSource instance with the specified concatenation behavior
      * @since 2.0
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatArrayEager(int maxConcurrency, int prefetch, ObservableSource<? extends T>... sources) {
-        return fromArray(sources).concatMapEagerDelayError((Function) Functions.identity(), maxConcurrency, prefetch, false);
+        return fromArray(sources).concatMapEagerDelayError((Function)Functions.identity(), maxConcurrency, prefetch, false);
     }
 
     /**
@@ -1405,7 +1398,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                   if false, exception from the outer ObservableSource is delayed till the current ObservableSource terminates
      * @return the new ObservableSource with the concatenating behavior
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch, boolean tillTheEnd) {
@@ -1457,13 +1450,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new ObservableSource instance with the specified concatenation behavior
      * @since 2.0
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatEager(ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
         ObjectHelper.requireNonNull(maxConcurrency, "maxConcurrency is null");
         ObjectHelper.requireNonNull(prefetch, "prefetch is null");
-        return wrap(sources).concatMapEager((Function) Functions.identity(), maxConcurrency, prefetch);
+        return wrap(sources).concatMapEager((Function)Functions.identity(), maxConcurrency, prefetch);
     }
 
     /**
@@ -1509,13 +1502,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new ObservableSource instance with the specified concatenation behavior
      * @since 2.0
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatEager(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
         ObjectHelper.requireNonNull(maxConcurrency, "maxConcurrency is null");
         ObjectHelper.requireNonNull(prefetch, "prefetch is null");
-        return fromIterable(sources).concatMapEagerDelayError((Function) Functions.identity(), maxConcurrency, prefetch, false);
+        return fromIterable(sources).concatMapEagerDelayError((Function)Functions.identity(), maxConcurrency, prefetch, false);
     }
 
     /**
@@ -1695,7 +1688,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(items, "items is null");
         if (items.length == 0) {
             return empty();
-        } else if (items.length == 1) {
+        } else
+        if (items.length == 1) {
             return just(items[0]);
         }
         return RxJavaPlugins.onAssembly(new ObservableFromArray<T>(items));
@@ -1956,7 +1950,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T> Observable<T> generate(final Consumer<Emitter<T>> generator) {
         ObjectHelper.requireNonNull(generator, "generator  is null");
         return generate(Functions.<Object>nullSupplier(),
-                ObservableInternalHelper.simpleGenerator(generator), Functions.<Object>emptyConsumer());
+        ObservableInternalHelper.simpleGenerator(generator), Functions.<Object>emptyConsumer());
     }
 
     /**
@@ -2063,7 +2057,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, S> Observable<T> generate(Callable<S> initialState, BiFunction<S, Emitter<T>, S> generator,
-                                                Consumer<? super S> disposeState) {
+            Consumer<? super S> disposeState) {
         ObjectHelper.requireNonNull(initialState, "initialState is null");
         ObjectHelper.requireNonNull(generator, "generator  is null");
         ObjectHelper.requireNonNull(disposeState, "disposeState is null");
@@ -2654,11 +2648,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *             if {@code maxConcurrent} is less than or equal to 0
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> merge(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
-        return fromIterable(sources).flatMap((Function) Functions.identity(), false, maxConcurrency, bufferSize);
+        return fromIterable(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
     }
 
     /**
@@ -2687,11 +2681,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *             if {@code maxConcurrent} is less than or equal to 0
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeArray(int maxConcurrency, int bufferSize, ObservableSource<? extends T>... sources) {
-        return fromArray(sources).flatMap((Function) Functions.identity(), false, maxConcurrency, bufferSize);
+        return fromArray(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
     }
 
     /**
@@ -2713,11 +2707,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         ObservableSources in the Iterable
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> merge(Iterable<? extends ObservableSource<? extends T>> sources) {
-        return fromIterable(sources).flatMap((Function) Functions.identity());
+        return fromIterable(sources).flatMap((Function)Functions.identity());
     }
 
     /**
@@ -2744,11 +2738,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *             if {@code maxConcurrent} is less than or equal to 0
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> merge(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
-        return fromIterable(sources).flatMap((Function) Functions.identity(), maxConcurrency);
+        return fromIterable(sources).flatMap((Function)Functions.identity(), maxConcurrency);
     }
 
     /**
@@ -2773,7 +2767,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Observable<T> merge(ObservableSource<? extends ObservableSource<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), false, Integer.MAX_VALUE, bufferSize()));
@@ -2805,7 +2799,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @since 1.1.0
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> merge(ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
@@ -2834,13 +2828,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits all of the items emitted by the source ObservableSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> merge(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2) {
         ObjectHelper.requireNonNull(source1, "source1 is null");
         ObjectHelper.requireNonNull(source2, "source2 is null");
-        return fromArray(source1, source2).flatMap((Function) Functions.identity(), false, 2);
+        return fromArray(source1, source2).flatMap((Function)Functions.identity(), false, 2);
     }
 
     /**
@@ -2865,14 +2859,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits all of the items emitted by the source ObservableSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> merge(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2, ObservableSource<? extends T> source3) {
         ObjectHelper.requireNonNull(source1, "source1 is null");
         ObjectHelper.requireNonNull(source2, "source2 is null");
         ObjectHelper.requireNonNull(source3, "source3 is null");
-        return fromArray(source1, source2, source3).flatMap((Function) Functions.identity(), false, 3);
+        return fromArray(source1, source2, source3).flatMap((Function)Functions.identity(), false, 3);
     }
 
     /**
@@ -2899,7 +2893,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits all of the items emitted by the source ObservableSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> merge(
@@ -2909,7 +2903,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(source2, "source2 is null");
         ObjectHelper.requireNonNull(source3, "source3 is null");
         ObjectHelper.requireNonNull(source4, "source4 is null");
-        return fromArray(source1, source2, source3, source4).flatMap((Function) Functions.identity(), false, 4);
+        return fromArray(source1, source2, source3, source4).flatMap((Function)Functions.identity(), false, 4);
     }
 
     /**
@@ -2930,11 +2924,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits all of the items emitted by the ObservableSources in the Array
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeArray(ObservableSource<? extends T>... sources) {
-        return fromArray(sources).flatMap((Function) Functions.identity(), sources.length);
+        return fromArray(sources).flatMap((Function)Functions.identity(), sources.length);
     }
 
     /**
@@ -2962,11 +2956,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         ObservableSources in the Iterable
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeDelayError(Iterable<? extends ObservableSource<? extends T>> sources) {
-        return fromIterable(sources).flatMap((Function) Functions.identity(), true);
+        return fromIterable(sources).flatMap((Function)Functions.identity(), true);
     }
 
     /**
@@ -2998,11 +2992,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         ObservableSources in the Iterable
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeDelayError(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
-        return fromIterable(sources).flatMap((Function) Functions.identity(), true, maxConcurrency, bufferSize);
+        return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
     /**
@@ -3034,11 +3028,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         ObservableSources in the Iterable
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeArrayDelayError(int maxConcurrency, int bufferSize, ObservableSource<? extends T>... sources) {
-        return fromArray(sources).flatMap((Function) Functions.identity(), true, maxConcurrency, bufferSize);
+        return fromArray(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
     /**
@@ -3068,11 +3062,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         ObservableSources in the Iterable
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeDelayError(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
-        return fromIterable(sources).flatMap((Function) Functions.identity(), true, maxConcurrency);
+        return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency);
     }
 
     /**
@@ -3102,7 +3096,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Observable<T> mergeDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), true, Integer.MAX_VALUE, bufferSize()));
@@ -3137,7 +3131,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @since 2.0
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
@@ -3172,13 +3166,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits all of the items that are emitted by the two source ObservableSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeDelayError(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2) {
         ObjectHelper.requireNonNull(source1, "source1 is null");
         ObjectHelper.requireNonNull(source2, "source2 is null");
-        return fromArray(source1, source2).flatMap((Function) Functions.identity(), true, 2);
+        return fromArray(source1, source2).flatMap((Function)Functions.identity(), true, 2);
     }
 
     /**
@@ -3210,14 +3204,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits all of the items that are emitted by the source ObservableSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeDelayError(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2, ObservableSource<? extends T> source3) {
         ObjectHelper.requireNonNull(source1, "source1 is null");
         ObjectHelper.requireNonNull(source2, "source2 is null");
         ObjectHelper.requireNonNull(source3, "source3 is null");
-        return fromArray(source1, source2, source3).flatMap((Function) Functions.identity(), true, 3);
+        return fromArray(source1, source2, source3).flatMap((Function)Functions.identity(), true, 3);
     }
 
     /**
@@ -3251,7 +3245,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits all of the items that are emitted by the source ObservableSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeDelayError(
@@ -3261,7 +3255,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(source2, "source2 is null");
         ObjectHelper.requireNonNull(source3, "source3 is null");
         ObjectHelper.requireNonNull(source4, "source4 is null");
-        return fromArray(source1, source2, source3, source4).flatMap((Function) Functions.identity(), true, 4);
+        return fromArray(source1, source2, source3, source4).flatMap((Function)Functions.identity(), true, 4);
     }
 
     /**
@@ -3289,11 +3283,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         ObservableSources in the Iterable
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> mergeArrayDelayError(ObservableSource<? extends T>... sources) {
-        return fromArray(sources).flatMap((Function) Functions.identity(), true, sources.length);
+        return fromArray(sources).flatMap((Function)Functions.identity(), true, sources.length);
     }
 
     /**
@@ -3350,7 +3344,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (count == 1) {
             return just(start);
         }
-        if ((long) start + (count - 1) > Integer.MAX_VALUE) {
+        if ((long)start + (count - 1) > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("Integer overflow");
         }
         return RxJavaPlugins.onAssembly(new ObservableRange(start, count));
@@ -3449,7 +3443,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
-                                                    BiPredicate<? super T, ? super T> isEqual) {
+            BiPredicate<? super T, ? super T> isEqual) {
         return sequenceEqual(source1, source2, isEqual, bufferSize());
     }
 
@@ -3481,7 +3475,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
-                                                    BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
+            BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
         ObjectHelper.requireNonNull(source1, "source1 is null");
         ObjectHelper.requireNonNull(source2, "source2 is null");
         ObjectHelper.requireNonNull(isEqual, "isEqual is null");
@@ -3513,7 +3507,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
-                                                    int bufferSize) {
+            int bufferSize) {
         return sequenceEqual(source1, source2, ObjectHelper.equalsPredicate(), bufferSize);
     }
 
@@ -3544,7 +3538,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> switchOnNext(ObservableSource<? extends ObservableSource<? extends T>> sources, int bufferSize) {
@@ -3646,7 +3640,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
      * @since 2.0
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> switchOnNextDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch) {
@@ -3814,7 +3808,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T> Observable<T> wrap(ObservableSource<T> source) {
         ObjectHelper.requireNonNull(source, "source is null");
         if (source instanceof Observable) {
-            return RxJavaPlugins.onAssembly((Observable<T>) source);
+            return RxJavaPlugins.onAssembly((Observable<T>)source);
         }
         return RxJavaPlugins.onAssembly(new ObservableFromUnsafeSource<T>(source));
     }
@@ -3917,7 +3911,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> zip(ObservableSource<? extends ObservableSource<? extends T>> sources, final Function<? super Object[], ? extends R> zipper) {
@@ -4657,7 +4651,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> zipArray(Function<? super Object[], ? extends R> zipper,
-                                                boolean delayError, int bufferSize, ObservableSource<? extends T>... sources) {
+            boolean delayError, int bufferSize, ObservableSource<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         }
@@ -4719,8 +4713,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, R> Observable<R> zipIterable(Iterable<? extends ObservableSource<? extends T>> sources,
-                                                   Function<? super Object[], ? extends R> zipper, boolean delayError,
-                                                   int bufferSize) {
+            Function<? super Object[], ? extends R> zipper, boolean delayError,
+            int bufferSize) {
         ObjectHelper.requireNonNull(zipper, "zipper is null");
         ObjectHelper.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -4889,7 +4883,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
                 onNext.accept(it.next());
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                ((Disposable) it).dispose();
+                ((Disposable)it).dispose();
                 throw ExceptionHelper.wrapOrThrow(e);
             }
         }
@@ -6077,59 +6071,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>) this).call();
+            T v = ((ScalarCallable<T>)this).call();
             if (v == null) {
                 return empty();
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
         return RxJavaPlugins.onAssembly(new ObservableConcatMap<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE));
-    }
-
-    /**
-     * Maps each element of the upstream Observable into CompletableSources, subscribes to them one at a time in
-     * order and waits until the upstream and all CompletableSources complete.
-     * <p>
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param mapper
-     *            a function that, when applied to an item emitted by the source ObservableSource, returns an
-     *            CompletableSource
-     * @return a Completable that emits onComplete when the upstream and all CompletableSources complete
-     * @see <a href="http://reactivex.io/documentation/operators/concatmap.html">ReactiveX operators documentation: FlatMap</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper) {
-        return concatMapCompletable(mapper, 2);
-    }
-
-    /**
-     * Maps each element of the upstream Observable into CompletableSources, subscribes to them one at a time in
-     * order and waits until the upstream and all CompletableSources complete.
-     * <p>
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param mapper
-     *            a function that, when applied to an item emitted by the source ObservableSource, returns an
-     *            CompletableSource
-     * @param prefetch
-     *            the number of elements to prefetch from the current Observable
-     * @return a Completable that emits onComplete when the upstream and all CompletableSources complete
-     * @see <a href="http://reactivex.io/documentation/operators/concatmap.html">ReactiveX operators documentation: FlatMap</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, int prefetch) {
-        ObjectHelper.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<T>(this, mapper, prefetch));
     }
 
     /**
@@ -6176,12 +6124,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-                                                       int prefetch, boolean tillTheEnd) {
+            int prefetch, boolean tillTheEnd) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>) this).call();
+            T v = ((ScalarCallable<T>)this).call();
             if (v == null) {
                 return empty();
             }
@@ -6235,7 +6183,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapEager(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-                                                  int maxConcurrency, int prefetch) {
+            int maxConcurrency, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -6265,7 +6213,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapEagerDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-                                                            boolean tillTheEnd) {
+            boolean tillTheEnd) {
         return concatMapEagerDelayError(mapper, Integer.MAX_VALUE, bufferSize(), tillTheEnd);
     }
 
@@ -6296,11 +6244,53 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapEagerDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-                                                            int maxConcurrency, int prefetch, boolean tillTheEnd) {
+            int maxConcurrency, int prefetch, boolean tillTheEnd) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new ObservableConcatMapEager<T, R>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, maxConcurrency, prefetch));
+    }
+
+    /**
+     * Maps each element of the upstream Observable into CompletableSources, subscribes to them one at a time in
+     * order and waits until the upstream and all CompletableSources complete.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param mapper
+     *            a function that, when applied to an item emitted by the source ObservableSource, returns an
+     *            CompletableSource
+     * @return a Completable that emits onComplete when the upstream and all CompletableSources complete
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper) {
+        return concatMapCompletable(mapper, 2);
+    }
+
+    /**
+     * Maps each element of the upstream Observable into CompletableSources, subscribes to them one at a time in
+     * order and waits until the upstream and all CompletableSources complete.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param mapper
+     *            a function that, when applied to an item emitted by the source ObservableSource, returns an
+     *            CompletableSource
+     * @param prefetch
+     *            the number of elements to prefetch from the current Observable
+     * @return a Completable that emits onComplete when the upstream and all CompletableSources complete
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, int prefetch) {
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<T>(this, mapper, prefetch));
     }
 
     /**
@@ -6716,7 +6706,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, V> Observable<T> delay(ObservableSource<U> subscriptionDelay,
-                                            Function<? super T, ? extends ObservableSource<V>> itemDelay) {
+            Function<? super T, ? extends ObservableSource<V>> itemDelay) {
         return delaySubscription(subscriptionDelay).delay(itemDelay);
     }
 
@@ -6812,7 +6802,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T2> Observable<T2> dematerialize() {
         @SuppressWarnings("unchecked")
-        Observable<Notification<T2>> m = (Observable<Notification<T2>>) this;
+        Observable<Notification<T2>> m = (Observable<Notification<T2>>)this;
         return RxJavaPlugins.onAssembly(new ObservableDematerialize<T2>(m));
     }
 
@@ -7119,7 +7109,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
                 Functions.notificationOnError(onNotification),
                 Functions.notificationOnComplete(onNotification),
                 Functions.EMPTY_ACTION
-        );
+            );
     }
 
     /**
@@ -7558,13 +7548,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-                                           boolean delayErrors, int maxConcurrency, int bufferSize) {
+            boolean delayErrors, int maxConcurrency, int bufferSize) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>) this).call();
+            T v = ((ScalarCallable<T>)this).call();
             if (v == null) {
                 return empty();
             }
@@ -7706,7 +7696,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-                                              BiFunction<? super T, ? super U, ? extends R> resultSelector) {
+            BiFunction<? super T, ? super U, ? extends R> resultSelector) {
         return flatMap(mapper, resultSelector, false, bufferSize(), bufferSize());
     }
 
@@ -7739,7 +7729,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-                                              BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors) {
+            BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors) {
         return flatMap(mapper, combiner, delayErrors, bufferSize(), bufferSize());
     }
 
@@ -7776,7 +7766,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-                                              BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency) {
+            BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency) {
         return flatMap(mapper, combiner, delayErrors, maxConcurrency, bufferSize());
     }
 
@@ -7815,7 +7805,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> flatMap(final Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-                                              final BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency, int bufferSize) {
+            final BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency, int bufferSize) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
         return flatMap(ObservableInternalHelper.flatMapWithCombiner(mapper, combiner), delayErrors, maxConcurrency, bufferSize);
@@ -7851,7 +7841,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-                                              BiFunction<? super T, ? super U, ? extends R> combiner, int maxConcurrency) {
+            BiFunction<? super T, ? super U, ? extends R> combiner, int maxConcurrency) {
         return flatMap(mapper, combiner, false, maxConcurrency, bufferSize());
     }
 
@@ -7943,7 +7933,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, V> Observable<V> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper,
-                                                      BiFunction<? super T, ? super U, ? extends V> resultSelector) {
+            BiFunction<? super T, ? super U, ? extends V> resultSelector) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.requireNonNull(resultSelector, "resultSelector is null");
         return flatMap(ObservableInternalHelper.flatMapIntoIterable(mapper), resultSelector, false, bufferSize(), bufferSize());
@@ -8130,7 +8120,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable forEachWhile(final Predicate<? super T> onNext, Consumer<? super Throwable> onError,
-                                         final Action onComplete) {
+            final Action onComplete) {
         ObjectHelper.requireNonNull(onNext, "onNext is null");
         ObjectHelper.requireNonNull(onError, "onError is null");
         ObjectHelper.requireNonNull(onComplete, "onComplete is null");
@@ -8167,11 +8157,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Observable<GroupedObservable<K, T>> groupBy(Function<? super T, ? extends K> keySelector) {
-        return groupBy(keySelector, (Function) Functions.identity(), false, bufferSize());
+        return groupBy(keySelector, (Function)Functions.identity(), false, bufferSize());
     }
 
     /**
@@ -8204,11 +8194,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Observable<GroupedObservable<K, T>> groupBy(Function<? super T, ? extends K> keySelector, boolean delayError) {
-        return groupBy(keySelector, (Function) Functions.identity(), delayError, bufferSize());
+        return groupBy(keySelector, (Function)Functions.identity(), delayError, bufferSize());
     }
 
     /**
@@ -8245,7 +8235,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Observable<GroupedObservable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
-                                                                    Function<? super T, ? extends V> valueSelector) {
+            Function<? super T, ? extends V> valueSelector) {
         return groupBy(keySelector, valueSelector, false, bufferSize());
     }
 
@@ -8286,7 +8276,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Observable<GroupedObservable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
-                                                                    Function<? super T, ? extends V> valueSelector, boolean delayError) {
+            Function<? super T, ? extends V> valueSelector, boolean delayError) {
         return groupBy(keySelector, valueSelector, delayError, bufferSize());
     }
 
@@ -8329,8 +8319,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Observable<GroupedObservable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
-                                                                    Function<? super T, ? extends V> valueSelector,
-                                                                    boolean delayError, int bufferSize) {
+            Function<? super T, ? extends V> valueSelector,
+            boolean delayError, int bufferSize) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -8376,7 +8366,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Function<? super T, ? extends ObservableSource<TLeftEnd>> leftEnd,
             Function<? super TRight, ? extends ObservableSource<TRightEnd>> rightEnd,
             BiFunction<? super T, ? super Observable<TRight>, ? extends R> resultSelector
-    ) {
+                    ) {
         ObjectHelper.requireNonNull(other, "other is null");
         ObjectHelper.requireNonNull(leftEnd, "leftEnd is null");
         ObjectHelper.requireNonNull(rightEnd, "rightEnd is null");
@@ -8481,7 +8471,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Function<? super T, ? extends ObservableSource<TLeftEnd>> leftEnd,
             Function<? super TRight, ? extends ObservableSource<TRightEnd>> rightEnd,
             BiFunction<? super T, ? super TRight, ? extends R> resultSelector
-    ) {
+                    ) {
         ObjectHelper.requireNonNull(other, "other is null");
         ObjectHelper.requireNonNull(leftEnd, "leftEnd is null");
         ObjectHelper.requireNonNull(rightEnd, "rightEnd is null");
@@ -10904,7 +10894,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
-                                      Action onComplete) {
+            Action onComplete) {
         return subscribe(onNext, onError, onComplete, Functions.emptyConsumer());
     }
 
@@ -10937,7 +10927,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
-                                      Action onComplete, Consumer<? super Disposable> onSubscribe) {
+            Action onComplete, Consumer<? super Disposable> onSubscribe) {
         ObjectHelper.requireNonNull(onNext, "onNext is null");
         ObjectHelper.requireNonNull(onError, "onError is null");
         ObjectHelper.requireNonNull(onComplete, "onComplete is null");
@@ -11050,7 +11040,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param other
      *              the alternate ObservableSource to subscribe to if the source does not emit any items
-     * @return an ObservableSource that emits the items emitted by the source ObservableSource or the items of an
+     * @return  an ObservableSource that emits the items emitted by the source ObservableSource or the items of an
      *          alternate ObservableSource if the source ObservableSource is empty.
      * @since 1.1.0
      */
@@ -11118,7 +11108,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>) this).call();
+            T v = ((ScalarCallable<T>)this).call();
             if (v == null) {
                 return empty();
             }
@@ -11249,7 +11239,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         if (this instanceof ScalarCallable) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>) this).call();
+            T v = ((ScalarCallable<T>)this).call();
             if (v == null) {
                 return empty();
             }
@@ -11359,9 +11349,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> takeLast(int count) {
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
-        } else if (count == 0) {
+        } else
+        if (count == 0) {
             return RxJavaPlugins.onAssembly(new ObservableIgnoreElements<T>(this));
-        } else if (count == 1) {
+        } else
+        if (count == 1) {
             return RxJavaPlugins.onAssembly(new ObservableTakeLastOne<T>(this));
         }
         return RxJavaPlugins.onAssembly(new ObservableTakeLast<T>(this, count));
@@ -12029,7 +12021,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <V> Observable<T> timeout(Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
-                                           ObservableSource<? extends T> other) {
+            ObservableSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(null, itemTimeoutIndicator, other);
     }
@@ -12174,7 +12166,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, V> Observable<T> timeout(ObservableSource<U> firstTimeoutIndicator,
-                                              Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator) {
+            Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator) {
         ObjectHelper.requireNonNull(firstTimeoutIndicator, "firstTimeoutIndicator is null");
         return timeout0(firstTimeoutIndicator, itemTimeoutIndicator, null);
     }
@@ -12216,14 +12208,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <U, V> Observable<T> timeout(
             ObservableSource<U> firstTimeoutIndicator,
             Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
-            ObservableSource<? extends T> other) {
+                    ObservableSource<? extends T> other) {
         ObjectHelper.requireNonNull(firstTimeoutIndicator, "firstTimeoutIndicator is null");
         ObjectHelper.requireNonNull(other, "other is null");
         return timeout0(firstTimeoutIndicator, itemTimeoutIndicator, other);
     }
 
     private Observable<T> timeout0(long timeout, TimeUnit timeUnit, ObservableSource<? extends T> other,
-                                   Scheduler scheduler) {
+            Scheduler scheduler) {
         ObjectHelper.requireNonNull(timeUnit, "timeUnit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new ObservableTimeoutTimed<T>(this, timeout, timeUnit, scheduler, other));
@@ -12232,7 +12224,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     private <U, V> Observable<T> timeout0(
             ObservableSource<U> firstTimeoutIndicator,
             Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
-            ObservableSource<? extends T> other) {
+                    ObservableSource<? extends T> other) {
         ObjectHelper.requireNonNull(itemTimeoutIndicator, "itemTimeoutIndicator is null");
         return RxJavaPlugins.onAssembly(new ObservableTimeout<T, U, V>(this, firstTimeoutIndicator, itemTimeoutIndicator, other));
     }
@@ -12561,8 +12553,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Single<Map<K, Collection<T>>> toMultimap(Function<? super T, ? extends K> keySelector) {
-        @SuppressWarnings({"rawtypes", "unchecked"})
-        Function<? super T, ? extends T> valueSelector = (Function) Functions.identity();
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        Function<? super T, ? extends T> valueSelector = (Function)Functions.identity();
         Callable<Map<K, Collection<T>>> mapSupplier = HashMapSupplier.asCallable();
         Function<K, List<T>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
@@ -12665,7 +12657,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Function<? super T, ? extends K> keySelector,
             Function<? super T, ? extends V> valueSelector,
             Callable<Map<K, Collection<V>>> mapSupplier
-    ) {
+            ) {
         return toMultimap(keySelector, valueSelector, mapSupplier, ArrayListSupplier.<V, K>asFunction());
     }
 
@@ -13061,7 +13053,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Observable<Observable<T>> window(long timespan, TimeUnit unit,
-                                                  long count) {
+            long count) {
         return window(timespan, unit, Schedulers.computation(), count, false);
     }
 
@@ -13095,7 +13087,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Observable<Observable<T>> window(long timespan, TimeUnit unit,
-                                                  long count, boolean restart) {
+            long count, boolean restart) {
         return window(timespan, unit, Schedulers.computation(), count, restart);
     }
 
@@ -13125,7 +13117,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<Observable<T>> window(long timespan, TimeUnit unit,
-                                                  Scheduler scheduler) {
+            Scheduler scheduler) {
         return window(timespan, unit, scheduler, Long.MAX_VALUE, false);
     }
 
@@ -13159,7 +13151,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<Observable<T>> window(long timespan, TimeUnit unit,
-                                                  Scheduler scheduler, long count) {
+            Scheduler scheduler, long count) {
         return window(timespan, unit, scheduler, count, false);
     }
 
@@ -13195,7 +13187,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<Observable<T>> window(long timespan, TimeUnit unit,
-                                                  Scheduler scheduler, long count, boolean restart) {
+            Scheduler scheduler, long count, boolean restart) {
         return window(timespan, unit, scheduler, count, restart, bufferSize());
     }
 
@@ -13487,7 +13479,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(o2, "o2 is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
-        return withLatestFrom(new ObservableSource[]{o1, o2}, f);
+        return withLatestFrom(new ObservableSource[] { o1, o2 }, f);
     }
 
     /**
@@ -13527,7 +13519,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(o3, "o3 is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
-        return withLatestFrom(new ObservableSource[]{o1, o2, o3}, f);
+        return withLatestFrom(new ObservableSource[] { o1, o2, o3 }, f);
     }
 
     /**
@@ -13570,7 +13562,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(o4, "o4 is null");
         ObjectHelper.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
-        return withLatestFrom(new ObservableSource[]{o1, o2, o3, o4}, f);
+        return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4 }, f);
     }
 
     /**
@@ -13659,7 +13651,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Observable<R> zipWith(Iterable<U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
+    public final <U, R> Observable<R> zipWith(Iterable<U> other,  BiFunction<? super T, ? super U, ? extends R> zipper) {
         ObjectHelper.requireNonNull(other, "other is null");
         ObjectHelper.requireNonNull(zipper, "zipper is null");
         return RxJavaPlugins.onAssembly(new ObservableZipIterable<T, U, R>(this, other, zipper));
@@ -13703,7 +13695,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> zipWith(ObservableSource<? extends U> other,
-                                              BiFunction<? super T, ? super U, ? extends R> zipper) {
+            BiFunction<? super T, ? super U, ? extends R> zipper) {
         ObjectHelper.requireNonNull(other, "other is null");
         return zip(this, other, zipper);
     }
@@ -13749,7 +13741,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> zipWith(ObservableSource<? extends U> other,
-                                              BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError) {
+            BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError) {
         return zip(this, other, zipper, delayError);
     }
 
@@ -13796,14 +13788,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Observable<R> zipWith(ObservableSource<? extends U> other,
-                                              BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
+            BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
         return zip(this, other, zipper, delayError, bufferSize);
     }
 
     // -------------------------------------------------------------------------
     // Fluent test support, super handy and reduces test preparation boilerplate
     // -------------------------------------------------------------------------
-
     /**
      * Creates a TestObserver and subscribes
      * it to this Observable.

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -83,12 +83,12 @@ import io.reactivex.schedulers.*;
  *             System.out.println("Done!");
  *         }
  *     });
- *
+ * 
  * Thread.sleep(500);
  * // the sequence now can be cancelled via dispose()
  * d.dispose();
  * </code></pre>
- *
+ * 
  * @param <T>
  *            the type of the items emitted by the Observable
  * @see Flowable

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletable.java
@@ -45,7 +45,7 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
 
     static final class SourceObserver<T> extends AtomicInteger implements Observer<T>, Disposable {
 
-        private static final long serialVersionUID = -7332607315705607415L;
+        private static final long serialVersionUID = 6893587405571511048L;
         final CompletableObserver actual;
         final SequentialDisposable sa;
         final Function<? super T, ? extends CompletableSource> mapper;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletable.java
@@ -1,0 +1,247 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.SequentialDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.SimpleQueue;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.plugins.RxJavaPlugins;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class ObservableConcatMapCompletable<T> extends Completable {
+
+    final ObservableSource<T> source;
+    final Function<? super T, ? extends CompletableSource> mapper;
+    final int bufferSize;
+
+    public ObservableConcatMapCompletable(ObservableSource<T> source,
+            Function<? super T, ? extends CompletableSource> mapper, int bufferSize) {
+        this.source = source;
+        this.mapper = mapper;
+        this.bufferSize = Math.max(8, bufferSize);
+    }
+    @Override
+    public void subscribeActual(CompletableObserver observer) {
+        source.subscribe(new SourceObserver<T>(observer, mapper, bufferSize));
+    }
+
+    static final class SourceObserver<T> extends AtomicInteger implements Observer<T>, Disposable {
+
+        private static final long serialVersionUID = -7332607315705607415L;
+        final CompletableObserver actual;
+        final SequentialDisposable sa;
+        final Function<? super T, ? extends CompletableSource> mapper;
+        final CompletableObserver inner;
+        final int bufferSize;
+
+        SimpleQueue<T> queue;
+
+        Disposable s;
+
+        volatile boolean active;
+
+        volatile boolean disposed;
+
+        volatile boolean done;
+
+        int sourceMode;
+
+        SourceObserver(CompletableObserver actual,
+                                Function<? super T, ? extends CompletableSource> mapper, int bufferSize) {
+            this.actual = actual;
+            this.mapper = mapper;
+            this.bufferSize = bufferSize;
+            this.inner = new InnerObserver(actual, this);
+            this.sa = new SequentialDisposable();
+        }
+        @Override
+        public void onSubscribe(Disposable s) {
+            if (DisposableHelper.validate(this.s, s)) {
+                this.s = s;
+                if (s instanceof QueueDisposable) {
+                    @SuppressWarnings("unchecked")
+                    QueueDisposable<T> qd = (QueueDisposable<T>) s;
+
+                    int m = qd.requestFusion(QueueDisposable.ANY);
+                    if (m == QueueDisposable.SYNC) {
+                        sourceMode = m;
+                        queue = qd;
+                        done = true;
+
+                        actual.onSubscribe(this);
+
+                        drain();
+                        return;
+                    }
+
+                    if (m == QueueDisposable.ASYNC) {
+                        sourceMode = m;
+                        queue = qd;
+
+                        actual.onSubscribe(this);
+
+                        return;
+                    }
+                }
+
+                queue = new SpscLinkedArrayQueue<T>(bufferSize);
+
+                actual.onSubscribe(this);
+            }
+        }
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            if (sourceMode == QueueDisposable.NONE) {
+                queue.offer(t);
+            }
+            drain();
+        }
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            dispose();
+            actual.onError(t);
+        }
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            drain();
+        }
+
+        void innerComplete() {
+            active = false;
+            drain();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return disposed;
+        }
+
+        @Override
+        public void dispose() {
+            disposed = true;
+            sa.dispose();
+            s.dispose();
+
+            if (getAndIncrement() == 0) {
+                queue.clear();
+            }
+        }
+
+        void innerSubscribe(Disposable s) {
+            sa.update(s);
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            for (;;) {
+                if (disposed) {
+                    queue.clear();
+                    return;
+                }
+                if (!active) {
+
+                    boolean d = done;
+
+                    T t;
+
+                    try {
+                        t = queue.poll();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        dispose();
+                        queue.clear();
+                        actual.onError(ex);
+                        return;
+                    }
+
+                    boolean empty = t == null;
+
+                    if (d && empty) {
+                        disposed = true;
+                        actual.onComplete();
+                        return;
+                    }
+
+                    if (!empty) {
+                        CompletableSource c;
+
+                        try {
+                            c = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null CompletableSource");
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            dispose();
+                            queue.clear();
+                            actual.onError(ex);
+                            return;
+                        }
+
+                        active = true;
+                        c.subscribe(inner);
+                    }
+                }
+
+                if (decrementAndGet() == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class InnerObserver implements CompletableObserver {
+            final CompletableObserver actual;
+            final SourceObserver<?> parent;
+
+            InnerObserver(CompletableObserver actual, SourceObserver<?> parent) {
+                this.actual = actual;
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable s) {
+                parent.innerSubscribe(s);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                parent.dispose();
+                actual.onError(t);
+            }
+            @Override
+            public void onComplete() {
+                parent.innerComplete();
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletableTest.java
@@ -22,7 +22,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subjects.UnicastSubject;
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 import java.util.List;
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletableTest.java
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.Disposables;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subjects.UnicastSubject;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+public class ObservableConcatMapCompletableTest {
+
+    @Test
+    public void asyncFused() throws Exception {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+
+        TestObserver to = us.concatMapCompletable(completableComplete(), 2).test();
+
+        us.onNext(1);
+        us.onComplete();
+
+        to.assertComplete();
+        to.assertValueCount(0);
+    }
+
+    @Test
+    public void notFused() throws Exception {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestObserver to = us.hide().concatMapCompletable(completableComplete(), 2).test();
+
+        us.onNext(1);
+        us.onNext(2);
+        us.onComplete();
+
+        to.assertComplete();
+        to.assertValueCount(0);
+        to.assertNoErrors();
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.<Integer>just(1).hide()
+        .concatMapCompletable(completableError()));
+    }
+
+    @Test
+    public void mainError() {
+        Observable.<Integer>error(new TestException())
+        .concatMapCompletable(completableComplete())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerError() {
+        Observable.<Integer>just(1).hide()
+        .concatMapCompletable(completableError())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void badSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+
+                    observer.onNext(1);
+                    observer.onComplete();
+                    observer.onNext(2);
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .concatMapCompletable(completableComplete())
+            .test()
+            .assertComplete();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorRace() {
+        for (int i = 0; i < 500; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final PublishSubject<Integer> ps1 = PublishSubject.create();
+                final PublishSubject<Integer> ps2 = PublishSubject.create();
+
+                TestObserver to = ps1.concatMapCompletable(new Function<Integer, CompletableSource>() {
+                    @Override
+                    public CompletableSource apply(Integer v) throws Exception {
+                        return Completable.fromObservable(ps2);
+                    }
+                }).test();
+
+                final TestException ex1 = new TestException();
+                final TestException ex2 = new TestException();
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps1.onError(ex1);
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps2.onError(ex2);
+                    }
+                };
+
+                TestHelper.race(r1, r2, Schedulers.single());
+
+                to.assertFailure(TestException.class);
+
+                if (!errors.isEmpty()) {
+                    TestHelper.assertError(errors, 0, TestException.class);
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void mapperThrows() {
+        Observable.just(1).hide()
+        .concatMapCompletable(completableThrows())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+
+    @Test
+    public void fusedPollThrows() {
+        Observable.just(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .concatMapCompletable(completableComplete())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatReportsDisposedOnComplete() {
+        final Disposable[] disposable = { null };
+
+        Observable.just(1)
+        .hide()
+        .concatMapCompletable(completableComplete())
+        .subscribe(new CompletableObserver() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                disposable[0] = d;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+
+        assertTrue(disposable[0].isDisposed());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concatReportsDisposedOnError() {
+        final Disposable[] disposable = { null };
+
+        Observable.just(1)
+        .hide()
+        .concatMapCompletable(completableError())
+        .subscribe(new CompletableObserver() {
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                disposable[0] = d;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+
+        assertTrue(disposable[0].isDisposed());
+    }
+
+    private Function<Integer, CompletableSource> completableComplete() {
+        return new Function<Integer, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Integer v) throws Exception {
+                return Completable.complete();
+            }
+        };
+    }
+
+    private Function<Integer, CompletableSource> completableError() {
+        return new Function<Integer, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Integer v) throws Exception {
+                return Completable.error(new TestException());
+            }
+        };
+    }
+
+    private Function<Integer, CompletableSource> completableThrows() {
+        return new Function<Integer, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Add `concatMapCompletable()` to `Observable` as discussed in #4853
I didn't think it made sense in other reactive types.

Code is mostly a copy of `ObservableConcatMap`.  Let me know if there is a better style of code to base this off instead.  It also does not have the option to delay errors as concatMap() does, not sure if that is needed.