### PR TITLE
Fix a misleading documentation of Observable.singleElement()

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -10277,8 +10277,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the single item emitted by this Observable or completes if this Observable is empty.
-     * If this Observable emits more than one item, an {@code IllegalArgumentException} is signalled instead.
+     * Returns a Maybe that completes if this Observable is empty or emits the single item emitted by this Observable,
+     * or signals an {@code IllegalArgumentException} if this Observable emits more than one item.
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleElement.png" alt="">
      * <dl>

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -10277,9 +10277,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the single item emitted by this Observable if this Observable
-     * emits only a single item, otherwise if this Observable emits more than one item or no items, an
-     * {@code IllegalArgumentException} or {@code NoSuchElementException} is signalled respectively.
+     * Returns a Maybe that emits the single item emitted by this Observable or completes if this Observable is empty.
+     * If this Observable emits more than one item, an {@code IllegalArgumentException} is signalled instead.
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleElement.png" alt="">
      * <dl>

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -10280,7 +10280,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Returns a Maybe that completes if this Observable is empty or emits the single item emitted by this Observable,
      * or signals an {@code IllegalArgumentException} if this Observable emits more than one item.
      * <p>
-     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleElement.png" alt="">
+     * <img width="640" height="217" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/singleElement.o.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code singleElement} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
@@ -282,6 +282,7 @@ public class ObservableSingleTest {
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer).onComplete();
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verifyNoMoreInteractions();
     }
 


### PR DESCRIPTION
This PR improves the documentation of `Observable.singleElement()`, as mentioned in  https://github.com/ReactiveX/RxJava/issues/5317.

An appropriate unit test to verify the `empty` behaviour already exist (`ObservableSingleTest. testSingleWithEmpty()`), I just added one more check there to make it very explicit that an error is not thrown.

As a side note, I'm attaching an updated Marble diagram for the method that includes all 3 states of the resulting Maybe (empty, success, error). I believe this is listed in https://github.com/ReactiveX/RxJava/issues/5319.


![singleelement](https://user-images.githubusercontent.com/4089934/31583261-a6da996a-b18f-11e7-8682-dffa647c7e4a.png)
