### PR TITLE
2.x: fix PublishProcessor cancel/emission overflow bug

### DIFF
--- a/src/main/java/io/reactivex/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/processors/PublishProcessor.java
@@ -313,9 +313,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
             }
             if (r != 0L) {
                 actual.onNext(t);
-                if (r != Long.MAX_VALUE) {
-                    decrementAndGet();
-                }
+                BackpressureHelper.producedCancel(this, 1);
             } else {
                 cancel();
                 actual.onError(new MissingBackpressureException("Could not emit value due to lack of requests"));


### PR DESCRIPTION
This PR should fix the bug that caused the test failure in #5545.

The bug manifested itself when a cancellation was happening the same time a request 1 was being fulfilled. Since the same request accounting was used for cancellation indicator, if the cancel happened between the `onNext()`'s `get()` check and `decrementAndGet`, this `decrementAndGet` decremented Long.MIN_VALUE unconditionally, which lead to a state that would appear the Subscriber still can receive events. A concurrent `offer`, which saves the current array of registered `Subscriber`s, then would emit an item and overflow the `Subscriber`.

The fix is to use the cancellation-aware `BackpressureHelper.producedCancel()` utility.

Unit test were added to verify the correct behavior on both `PublishProcessor` and `BehaviorProcessor` (the latter uses different cancellation mechanism via a dedicated field).