### PR TITLE
2.x: Add PublishProcessor JMH perf comparison

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 def junitVersion = "4.12"
 def reactiveStreamsVersion = "1.0.1"
 def mockitoVersion = "2.1.0"
-def jmhVersion = "1.16"
+def jmhLibVersion = "1.19"
 def testNgVersion = "6.11"
 
 // --------------------------------------
@@ -192,8 +192,9 @@ publishing.publications.all {
 }
 
 jmh {
-    jmhVersion = "1.19"
+    jmhVersion = jmhLibVersion
     humanOutputFile = null
+    includeTests = false
 
     if (project.hasProperty("jmh")) {
         include = ".*" + project.jmh + ".*"

--- a/src/jmh/java/io/reactivex/PerfBoundedSubscriber.java
+++ b/src/jmh/java/io/reactivex/PerfBoundedSubscriber.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Subscription;
+
+/**
+ * Performance subscriber with a one-time request from the upstream.
+ */
+public class PerfBoundedSubscriber extends CountDownLatch implements FlowableSubscriber<Object> {
+
+    final Blackhole bh;
+
+    final long request;
+
+    public PerfBoundedSubscriber(Blackhole bh, long request) {
+        super(1);
+        this.bh = bh;
+        this.request = request;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        s.request(request);
+    }
+
+    @Override
+    public void onComplete() {
+        countDown();
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        countDown();
+    }
+
+    @Override
+    public void onNext(Object t) {
+        bh.consume(t);
+    }
+
+}

--- a/src/jmh/java/io/reactivex/PublishProcessorPerf.java
+++ b/src/jmh/java/io/reactivex/PublishProcessorPerf.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subjects.PublishSubject;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class PublishProcessorPerf {
+
+    PublishProcessor<Integer> unbounded;
+
+    PublishProcessor<Integer> bounded;
+
+    PublishSubject<Integer> subject;
+
+    @Setup
+    public void setup(Blackhole bh) {
+        unbounded = PublishProcessor.create();
+        unbounded.subscribe(new PerfConsumer(bh));
+
+        bounded = PublishProcessor.create();
+        bounded.subscribe(new PerfBoundedSubscriber(bh, 1000 * 1000));
+
+        subject = PublishSubject.create();
+        subject.subscribe(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public void unbounded1() {
+        unbounded.onNext(1);
+    }
+
+    @Benchmark
+    public void unbounded1k() {
+        for (int i = 0; i < 1000; i++) {
+            unbounded.onNext(1);
+        }
+    }
+
+    @Benchmark
+    public void unbounded1m() {
+        for (int i = 0; i < 1000000; i++) {
+            unbounded.onNext(1);
+        }
+    }
+
+    @Benchmark
+    public void bounded1() {
+        bounded.onNext(1);
+    }
+
+
+    @Benchmark
+    public void bounded1k() {
+        for (int i = 0; i < 1000; i++) {
+            bounded.onNext(1);
+        }
+    }
+
+    @Benchmark
+    public void bounded1m() {
+        for (int i = 0; i < 1000000; i++) {
+            bounded.onNext(1);
+        }
+    }
+
+
+    @Benchmark
+    public void subject1() {
+        subject.onNext(1);
+    }
+
+
+    @Benchmark
+    public void subject1k() {
+        for (int i = 0; i < 1000; i++) {
+            subject.onNext(1);
+        }
+    }
+
+    @Benchmark
+    public void subject1m() {
+        for (int i = 0; i < 1000000; i++) {
+            subject.onNext(1);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a Perf class to measure the overhead of request management inside `PublishProcessor` and a comparison with `PublishSubject`.

Note that running JMH with RxJava under Windows is currently not possible because Gradle adds so many of its own jar dependencies that the resulting command line classpath exceeds the 32k limit.

Results with 2.1.5 release (separate gradle project, Windows 7, i7 4790, Java 8u144)

![image](https://user-images.githubusercontent.com/1269832/31654835-74257c76-b327-11e7-801f-49c46e0321b2.png)

The bounded benchmark indicates a 4x the throughput for some reason I don't understand yet.