### PR TITLE
2.x: make parallel() a fusion-async-boundary

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelFromPublisher.java
@@ -116,7 +116,7 @@ public final class ParallelFromPublisher<T> extends ParallelFlowable<T> {
                     @SuppressWarnings("unchecked")
                     QueueSubscription<T> qs = (QueueSubscription<T>) s;
 
-                    int m = qs.requestFusion(QueueSubscription.ANY);
+                    int m = qs.requestFusion(QueueSubscription.ANY | QueueSubscription.BOUNDARY);
 
                     if (m == QueueSubscription.SYNC) {
                         sourceMode = m;


### PR DESCRIPTION
The `parallel()` supports front-fusion but since the operator is almost always followed by the separate `runOn` operator, the parallel version of the `observeOn` operator, such front-fusion should be considered a `BOUNDARY`-type fusion just like with `observeOn`. 

A `requestFusion` with `BOUNDARY` tells the upstream operator(s) that when fused, their actions would be executed behind an async boundary and possibly on an unwanted thread. Operators, such as `map` and `doOnNext`, who are generally expected to be thread-confined, can then refuse to fuse, restoring the traditional queue hopping behavior (`source -> queue -> op -> queue -> op -> queue -> consumer`).

Reported in #5676.

/cc @smaldini & @simonbasle 