### PR TITLE
Update 'java' → 'java-library' Gradle plugin, update deps configurations.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ if (releaseTag != null && !releaseTag.isEmpty()) {
 
 description = "RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM."
 
-apply plugin: "java"
+apply plugin: "java-library"
 apply plugin: "checkstyle"
 apply plugin: "jacoco"
 apply plugin: "ru.vyarus.animalsniffer"
@@ -65,13 +65,14 @@ repositories {
 dependencies {
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 
-    compile "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
+    api "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
+    jmh "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
 
-    testCompile "junit:junit:$junitVersion"
-    testCompile "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 
-    testCompile "org.reactivestreams:reactive-streams-tck:$reactiveStreamsVersion"
-    testCompile "org.testng:testng:$testNgVersion"
+    testImplementation "org.reactivestreams:reactive-streams-tck:$reactiveStreamsVersion"
+    testImplementation "org.testng:testng:$testNgVersion"
 }
 
 javadoc {


### PR DESCRIPTION
Documentation: https://docs.gradle.org/4.2.1/userguide/java_library_plugin.html

Reasoning:

- `api` instead of `compile` shows intention better, ie RS should be available for RxJava users
- `testImplementation` instead of `testCompile` [should hide dependencies from RxJava pom.xml](https://search.maven.org/remotecontent?filepath=io/reactivex/rxjava2/rxjava/2.1.5/rxjava-2.1.5.pom)
- If [RxJava 3.x will actually be split into multiple modules](https://github.com/ReactiveX/RxJava/issues/5621), `api/implementation` configurations might be handy

Issues:

- JMH Gradle Plugin doesn't seem to properly support `api`, so I had to manually declare RS for `jmh` configuration

@akarnokd can you please check if Eclipse works ok with this?

If not, we probably need to add:

```groovy
plugins.withType(EclipsePlugin) {
    project.eclipse.classpath.plusConfigurations += [ configurations.api ]
}
```