### PR TITLE
2.x: Add TCK test for limit()

### DIFF
--- a/src/test/java/io/reactivex/tck/LimitTckTest.java
+++ b/src/test/java/io/reactivex/tck/LimitTckTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.Flowable;
+
+@Test
+public class LimitTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(long elements) {
+        return
+                Flowable.range(0, (int)elements * 2).limit(elements)
+        ;
+    }
+}


### PR DESCRIPTION
This PR adds a Reactive-Streams TCK test for `limit()` .