### PR TITLE
2.x: fix Completable.concat to use replace (don't dispose old)

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatArray.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatArray.java
@@ -52,7 +52,7 @@ public final class CompletableConcatArray extends Completable {
 
         @Override
         public void onSubscribe(Disposable d) {
-            sd.update(d);
+            sd.replace(d);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatIterable.java
@@ -64,7 +64,7 @@ public final class CompletableConcatIterable extends Completable {
 
         @Override
         public void onSubscribe(Disposable d) {
-            sd.update(d);
+            sd.replace(d);
         }
 
         @Override

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableAndThenTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableAndThenTest.java
@@ -15,7 +15,13 @@ package io.reactivex.internal.operators.completable;
 
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
+import io.reactivex.functions.Action;
+import io.reactivex.schedulers.Schedulers;
+
+import java.util.concurrent.CountDownLatch;
+
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class CompletableAndThenTest {
     @Test(expected = NullPointerException.class)
@@ -62,5 +68,40 @@ public class CompletableAndThenTest {
             .assertNoValues()
             .assertError(RuntimeException.class)
             .assertErrorMessage("bla");
+    }
+
+    @Test
+    public void andThenNoInterrupt() throws InterruptedException {
+        for (int k = 0; k < 100; k++) {
+            final int count = 10;
+            final CountDownLatch latch = new CountDownLatch(count);
+            final boolean[] interrupted = { false };
+
+            for (int i = 0; i < count; i++) {
+                Completable.complete()
+                .subscribeOn(Schedulers.io())
+                .observeOn(Schedulers.io()) // The problem does not occur if you comment out this line
+                .andThen(Completable.fromAction(new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        try {
+                            Thread.sleep(30);
+                        } catch (InterruptedException e) {
+                            System.out.println("Interrupted! " + Thread.currentThread()); // This is output periodically
+                            interrupted[0] = true;
+                        }
+                    }
+                }))
+                .subscribe(new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            latch.await();
+            assertFalse("The second Completable was interrupted!", interrupted[0]);
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableAndThenTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableAndThenTest.java
@@ -80,14 +80,14 @@ public class CompletableAndThenTest {
             for (int i = 0; i < count; i++) {
                 Completable.complete()
                 .subscribeOn(Schedulers.io())
-                .observeOn(Schedulers.io()) // The problem does not occur if you comment out this line
+                .observeOn(Schedulers.io())
                 .andThen(Completable.fromAction(new Action() {
                     @Override
                     public void run() throws Exception {
                         try {
                             Thread.sleep(30);
                         } catch (InterruptedException e) {
-                            System.out.println("Interrupted! " + Thread.currentThread()); // This is output periodically
+                            System.out.println("Interrupted! " + Thread.currentThread());
                             interrupted[0] = true;
                         }
                     }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.completable;
 import static org.junit.Assert.*;
 
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
 
 import org.junit.Test;
 import org.reactivestreams.*;
@@ -23,7 +24,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -252,6 +253,43 @@ public class CompletableConcatTest {
             };
 
             TestHelper.race(r1, r2, Schedulers.single());
+        }
+    }
+
+    @Test
+    public void noInterrupt() throws InterruptedException {
+        for (int k = 0; k < 100; k++) {
+            final int count = 10;
+            final CountDownLatch latch = new CountDownLatch(count);
+            final boolean[] interrupted = { false };
+
+            for (int i = 0; i < count; i++) {
+                Completable c0 = Completable.fromAction(new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        try {
+                            Thread.sleep(30);
+                        } catch (InterruptedException e) {
+                            System.out.println("Interrupted! " + Thread.currentThread()); // This is output periodically
+                            interrupted[0] = true;
+                        }
+                    }
+                });
+                Completable.concat(Arrays.asList(Completable.complete()
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(Schedulers.io()),
+                    c0)
+                )
+                .subscribe(new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            latch.await();
+            assertFalse("The second Completable was interrupted!", interrupted[0]);
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
@@ -270,7 +270,7 @@ public class CompletableConcatTest {
                         try {
                             Thread.sleep(30);
                         } catch (InterruptedException e) {
-                            System.out.println("Interrupted! " + Thread.currentThread()); // This is output periodically
+                            System.out.println("Interrupted! " + Thread.currentThread());
                             interrupted[0] = true;
                         }
                     }


### PR DESCRIPTION
`Completable.andThen`, `concat(Iterable)` and `concatArray()` disposed the previous `Disposable` when receiving the new `Disposable` from the next source which could lead to interruption. `concat(Publisher)` already uses `replace` instead of `update`.

There is a peculiar interplay between `subscribeOn`, `observeOn` and the trampoline in `concat` which can trigger such an interruption: the task of the `observeOn` is cancelled with `mayInterruptIfRunning == true` because the `dispose` call chain shuts down the worker of the `observeOn` from the `subscribeOn`'s thread.

Reported in #5694