### PR TITLE
1.x: fix Completable.concat to use replace (don't dispose old)

### DIFF
--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatArray.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatArray.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import rx.*;
 import rx.Completable.OnSubscribe;
-import rx.subscriptions.SerialSubscription;
+import rx.internal.subscriptions.SequentialSubscription;
 
 public final class CompletableOnSubscribeConcatArray implements OnSubscribe {
     final Completable[] sources;
@@ -45,17 +45,17 @@ public final class CompletableOnSubscribeConcatArray implements OnSubscribe {
 
         int index;
 
-        final SerialSubscription sd;
+        final SequentialSubscription sd;
 
         public ConcatInnerSubscriber(CompletableSubscriber actual, Completable[] sources) {
             this.actual = actual;
             this.sources = sources;
-            this.sd = new SerialSubscription();
+            this.sd = new SequentialSubscription();
         }
 
         @Override
         public void onSubscribe(Subscription d) {
-            sd.set(d);
+            sd.replace(d);
         }
 
         @Override

--- a/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatIterable.java
+++ b/src/main/java/rx/internal/operators/CompletableOnSubscribeConcatIterable.java
@@ -21,7 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import rx.*;
 import rx.Completable.OnSubscribe;
-import rx.subscriptions.*;
+import rx.internal.subscriptions.SequentialSubscription;
+import rx.subscriptions.Subscriptions;
 
 public final class CompletableOnSubscribeConcatIterable implements OnSubscribe {
     final Iterable<? extends Completable> sources;
@@ -61,17 +62,17 @@ public final class CompletableOnSubscribeConcatIterable implements OnSubscribe {
         final CompletableSubscriber actual;
         final Iterator<? extends Completable> sources;
 
-        final SerialSubscription sd;
+        final SequentialSubscription sd;
 
         public ConcatInnerSubscriber(CompletableSubscriber actual, Iterator<? extends Completable> sources) {
             this.actual = actual;
             this.sources = sources;
-            this.sd = new SerialSubscription();
+            this.sd = new SequentialSubscription();
         }
 
         @Override
         public void onSubscribe(Subscription d) {
-            sd.set(d);
+            sd.replace(d);
         }
 
         @Override


### PR DESCRIPTION
Fixes the same bug as with the 2.x `Completable.andThen` and `Completable.concat`.

See #5694 & #5695.