### PR TITLE
1.x: Single.subscribe should not crash onSuccess into onError

### DIFF
--- a/src/main/java/rx/Single.java
+++ b/src/main/java/rx/Single.java
@@ -1792,6 +1792,9 @@ public class Single<T> {
             public final void onError(Throwable e) {
                 try {
                     onError.call(e);
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    RxJavaHooks.onError(new CompositeException(e, ex));
                 } finally {
                     unsubscribe();
                 }
@@ -1801,6 +1804,9 @@ public class Single<T> {
             public final void onSuccess(T args) {
                 try {
                     onSuccess.call(args);
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    RxJavaHooks.onError(ex);
                 } finally {
                     unsubscribe();
                 }


### PR DESCRIPTION
Fix `Single.subscribe(Action1, Action1)` to not call `onError` if the `onSuccess` action crashes, ensuring that the `Single` protocol `onSuccess|onError` is maintained. Crashes will go into the `RxJavaHooks.onError` handler.

Fixes: #5237.