### PR TITLE
2.x: Add toMap overload with a merge function for updating existing mappings

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -12545,6 +12545,85 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
+     * Returns a Single that emits a single HashMap containing values corresponding to items emitted by the
+     * source ObservableSource, mapped by the keys returned by a specified {@code keySelector} function, where
+     * values are merged for duplicate keys by a specified {@code mergeFunction} function.
+     * <p>
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toMap.2.png" alt="">
+     * <p>
+     * If more than one source item maps to the same key, the HashMap will contain a single entry that
+     * corresponds to the merged result of those items.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code toMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <K> the key type of the Map
+     * @param <V> the value type of the Map
+     * @param keySelector
+     *            the function that extracts the key from a source item to be used in the HashMap
+     * @param valueSelector
+     *            the function that extracts the value from a source item to be used in the HashMap
+     * @param mergeFunction
+     *            the binary operator that merges items that map to the same key
+     * @return a Single that emits a single item: a HashMap containing the mapped items from the source
+     *         ObservableSource
+     * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <K, V> Single<Map<K, V>> toMap(
+            final Function<? super T, ? extends K> keySelector,
+            final Function<? super T, ? extends V> valueSelector,
+            final BiFunction<V, V, V> mergeFunction) {
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
+        ObjectHelper.requireNonNull(mergeFunction, "mergeFunction is null");
+        return collect(HashMapSupplier.<K, V>asCallable(), Functions.toMapKeyValueMergeSelector(keySelector, valueSelector, mergeFunction));
+    }
+
+    /**
+     * Returns a Single that emits a single HashMap containing values corresponding to items emitted by the
+     * source ObservableSource, mapped by the keys returned by a specified {@code keySelector} function, where
+     * values are merged for duplicate keys by a specified {@code mergeFunction} function.
+     * <p>
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toMap.2.png" alt="">
+     * <p>
+     * If more than one source item maps to the same key, the HashMap will contain a single entry that
+     * corresponds to the merged result of those items.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code toMap} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <K> the key type of the Map
+     * @param <V> the value type of the Map
+     * @param keySelector
+     *            the function that extracts the key from a source item to be used in the HashMap
+     * @param valueSelector
+     *            the function that extracts the value from a source item to be used in the HashMap
+     * @param mergeFunction
+     *            the binary operator that merges items that map to the same key
+     * @param mapSupplier
+     *            the function that returns a Map instance to be used
+     * @return a Single that emits a single item: a HashMap containing the mapped items from the source
+     *         ObservableSource
+     * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <K, V> Single<Map<K, V>> toMap(
+            final Function<? super T, ? extends K> keySelector,
+            final Function<? super T, ? extends V> valueSelector,
+            final BiFunction<V, V, V> mergeFunction,
+            final Callable<? extends Map<K, V>> mapSupplier) {
+        ObjectHelper.requireNonNull(keySelector, "keySelector is null");
+        ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
+        ObjectHelper.requireNonNull(mergeFunction, "mergeFunction is null");
+        return collect(mapSupplier, Functions.toMapKeyValueMergeSelector(keySelector, valueSelector, mergeFunction));
+    }
+
+    /**
      * Returns a Single that emits a single HashMap that contains an ArrayList of items emitted by the
      * source ObservableSource keyed by a specified {@code keySelector} function.
      * <p>

--- a/src/main/java/io/reactivex/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/internal/functions/Functions.java
@@ -472,6 +472,40 @@ public final class Functions {
         }
     }
 
+    public static <T, K, V> BiConsumer<Map<K, V>, T> toMapKeyValueMergeSelector(final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector, final BiFunction<V, V, V> mergeFunction) {
+        return new ToMapKeyValueMergeSelector<K, V, T>(valueSelector, keySelector, mergeFunction);
+    }
+
+    private static final class ToMapKeyValueMergeSelector<K, V, T>
+            implements BiConsumer<Map<K, V>, T> {
+        private final Function<? super T, ? extends K> keySelector;
+        private final Function<? super T, ? extends V> valueSelector;
+        private final BiFunction<V, V, V> mergeFunction;
+
+        ToMapKeyValueMergeSelector(
+                Function<? super T, ? extends V> valueSelector,
+                Function<? super T, ? extends K> keySelector,
+                BiFunction<V, V, V> mergeFunction) {
+            this.valueSelector = valueSelector;
+            this.keySelector = keySelector;
+            this.mergeFunction = mergeFunction;
+        }
+
+        @Override
+        public void accept(Map<K, V> m, T t) throws Exception {
+            K key = keySelector.apply(t);
+            V value = valueSelector.apply(t);
+            V oldValue = m.get(key);
+            V newValue = (oldValue == null) ? value :
+                    mergeFunction.apply(oldValue, value);
+            if(newValue == null) {
+                m.remove(key);
+            } else {
+                m.put(key, newValue);
+            }
+        }
+    }
+
     public static <T, K, V> BiConsumer<Map<K, Collection<V>>, T> toMultimapKeyValueSelector(
             final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector,
             final Function<? super K, ? extends Collection<? super V>> collectionFactory) {

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -2470,7 +2470,42 @@ public class ObservableNullTests {
             public Object apply(Integer v) {
                 return v;
             }
-        }, null);
+        }, (Callable<? extends Map<Object,Object>>) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toMapMergeFunctionNull() {
+        just1.toMap(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) {
+                return v;
+            }
+        }, new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) {
+                return v;
+            }
+        }, (BiFunction<Object, Object, Object>) null);
+    }
+
+    @Test
+    public void toMapMergeFunctionReturnsNullAllowed() {
+        just1.toMap(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) {
+                return v;
+            }
+        }, new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) {
+                return v;
+            }
+        }, new BiFunction<Object, Object, Object>() {
+            @Override
+            public Object apply(Object o, Object o2) throws Exception {
+                return null;
+            }
+        } );
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
Equivalent to the `java.util.stream.Collectors#toMap` merge map functionality. Could compliment the other map collectors nicely. There is an argument that this isn't suitable because we can't delegate to `Map#merge` with a language level lower than 8, but wanted to get your thoughts. Thanks!