### PR TITLE
1.x: fix broken backpressure through unsubscribeOn()

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorUnsubscribeOn.java
+++ b/src/main/java/rx/internal/operators/OperatorUnsubscribeOn.java
@@ -52,6 +52,10 @@ public class OperatorUnsubscribeOn<T> implements Operator<T, T> {
                 subscriber.onNext(t);
             }
 
+            @Override
+            public void setProducer(Producer p) {
+                subscriber.setProducer(p);
+            }
         };
 
         subscriber.add(Subscriptions.create(new Action0() {

--- a/src/test/java/rx/internal/operators/OperatorUnsubscribeOnTest.java
+++ b/src/test/java/rx/internal/operators/OperatorUnsubscribeOnTest.java
@@ -204,4 +204,31 @@ public class OperatorUnsubscribeOnTest {
         }
 
     }
+
+    @Test
+    public void backpressure() {
+        AssertableSubscriber<Integer> as = Observable.range(1, 10)
+        .unsubscribeOn(Schedulers.trampoline())
+        .test(0);
+
+        as.assertNoValues()
+        .assertNoErrors()
+        .assertNotCompleted();
+
+        as.requestMore(1);
+
+        as.assertValue(1)
+        .assertNoErrors()
+        .assertNotCompleted();
+
+        as.requestMore(3);
+
+        as.assertValues(1, 2, 3, 4)
+        .assertNoErrors()
+        .assertNotCompleted();
+
+        as.requestMore(10);
+
+        as.assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
 }


### PR DESCRIPTION
The `unsubscribeOn` did not properly forward the upstream's `Producer` to the downstream, thus the default `Subscriber` request behavior of `Long.MAX_VALUE` was incorrectly in effect.

Fixes: #5725