### PR TITLE
2.x: Implement as()

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -914,7 +914,7 @@ public abstract class Completable implements CompletableSource {
      * This allows fluent conversion to any other type.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the resulting object type
@@ -925,7 +925,7 @@ public abstract class Completable implements CompletableSource {
     @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R as(CompletableConverter<? extends R> converter) {
+    public final <R> R as(@NonNull CompletableConverter<? extends R> converter) {
         try {
             return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
         } catch (Throwable ex) {

--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -927,12 +927,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(@NonNull CompletableConverter<? extends R> converter) {
-        try {
-            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -921,6 +921,7 @@ public abstract class Completable implements CompletableSource {
      * @param converter the function that receives the current Completable instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
+     * @since 2.1.7 - experimental
      */
     @Experimental
     @CheckReturnValue

--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -922,6 +922,7 @@ public abstract class Completable implements CompletableSource {
      * @return the converted value
      * @throws NullPointerException if converter is null
      */
+    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(CompletableConverter<? extends R> converter) {

--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -909,6 +909,31 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
+     * Calls the specified converter function during assembly time and returns its resulting value.
+     * <p>
+     * This allows fluent conversion to any other type.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <R> the resulting object type
+     * @param converter the function that receives the current Completable instance and returns a value
+     * @return the converted value
+     * @throws NullPointerException if converter is null
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <R> R as(CompletableConverter<? extends R> converter) {
+        try {
+            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
+    }
+
+    /**
      * Subscribes to and awaits the termination of this Completable instance in a blocking manner and
      * rethrows any exception emitted.
      * <dl>

--- a/src/main/java/io/reactivex/CompletableConverter.java
+++ b/src/main/java/io/reactivex/CompletableConverter.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.*;
 
 /**
  * Convenience interface and callback used by the {@link Completable#as} operator to turn a Completable into another
@@ -21,6 +21,7 @@ import io.reactivex.annotations.NonNull;
  *
  * @param <R> the output type
  */
+@Experimental
 public interface CompletableConverter<R> {
     /**
      * Applies a function to the upstream Completable and returns a converted value of type <R>.

--- a/src/main/java/io/reactivex/CompletableConverter.java
+++ b/src/main/java/io/reactivex/CompletableConverter.java
@@ -24,7 +24,7 @@ import io.reactivex.annotations.*;
 @Experimental
 public interface CompletableConverter<R> {
     /**
-     * Applies a function to the upstream Completable and returns a converted value of type <R>.
+     * Applies a function to the upstream Completable and returns a converted value of type {@code R}.
      *
      * @param upstream the upstream Completable instance
      * @return the converted value

--- a/src/main/java/io/reactivex/CompletableConverter.java
+++ b/src/main/java/io/reactivex/CompletableConverter.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import io.reactivex.annotations.NonNull;
+
+/**
+ * Convenience interface and callback used by the {@link Completable#as} operator to turn a Completable into another
+ * value fluently.
+ *
+ * @param <R> the output type
+ */
+public interface CompletableConverter<R> {
+    /**
+     * Applies a function to the upstream Completable and returns a converted value of type <R>.
+     *
+     * @param upstream the upstream Completable instance
+     * @return the converted value
+     */
+    @NonNull
+    R apply(@NonNull Completable upstream) throws Exception;
+}

--- a/src/main/java/io/reactivex/CompletableConverter.java
+++ b/src/main/java/io/reactivex/CompletableConverter.java
@@ -20,6 +20,7 @@ import io.reactivex.annotations.*;
  * value fluently.
  *
  * @param <R> the output type
+ * @since 2.1.7 - experimental
  */
 @Experimental
 public interface CompletableConverter<R> {

--- a/src/main/java/io/reactivex/CompletableConverter.java
+++ b/src/main/java/io/reactivex/CompletableConverter.java
@@ -28,6 +28,7 @@ public interface CompletableConverter<R> {
      *
      * @param upstream the upstream Completable instance
      * @return the converted value
+     * @throws Exception on error
      */
     @NonNull
     R apply(@NonNull Completable upstream) throws Exception;

--- a/src/main/java/io/reactivex/CompletableConverter.java
+++ b/src/main/java/io/reactivex/CompletableConverter.java
@@ -29,8 +29,7 @@ public interface CompletableConverter<R> {
      *
      * @param upstream the upstream Completable instance
      * @return the converted value
-     * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull Completable upstream) throws Exception;
+    R apply(@NonNull Completable upstream);
 }

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -5259,12 +5259,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(@NonNull FlowableConverter<T, ? extends R> converter) {
-        try {
-            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -5253,6 +5253,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return the converted value
      * @throws NullPointerException if converter is null
      */
+    @Experimental
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -5252,6 +5252,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param converter the function that receives the current Flowable instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
+     * @since 2.1.7 - experimental
      */
     @Experimental
     @CheckReturnValue

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -5238,6 +5238,34 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
+     * Calls the specified converter function during assembly time and returns its resulting value.
+     * <p>
+     * This allows fluent conversion to any other type.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The backpressure behavior depends on what happens in the {@code converter} function.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <R> the resulting object type
+     * @param converter the function that receives the current Flowable instance and returns a value
+     * @return the converted value
+     * @throws NullPointerException if converter is null
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.SPECIAL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <R> R as(FlowableConverter<T, ? extends R> converter) {
+        try {
+            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
+    }
+
+    /**
      * Returns the first item emitted by this {@code Flowable}, or throws
      * {@code NoSuchElementException} if it emits no items.
      * <dl>

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -5245,7 +5245,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The backpressure behavior depends on what happens in the {@code converter} function.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the resulting object type
@@ -5257,7 +5257,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R as(FlowableConverter<T, ? extends R> converter) {
+    public final <R> R as(@NonNull FlowableConverter<T, ? extends R> converter) {
         try {
             return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
         } catch (Throwable ex) {

--- a/src/main/java/io/reactivex/FlowableConverter.java
+++ b/src/main/java/io/reactivex/FlowableConverter.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.*;
 
 /**
  * Convenience interface and callback used by the {@link Flowable#as} operator to turn a Flowable into another
@@ -22,6 +22,7 @@ import io.reactivex.annotations.NonNull;
  * @param <T> the upstream type
  * @param <R> the output type
  */
+@Experimental
 public interface FlowableConverter<T, R> {
     /**
      * Applies a function to the upstream Flowable and returns a converted value of type <R>.

--- a/src/main/java/io/reactivex/FlowableConverter.java
+++ b/src/main/java/io/reactivex/FlowableConverter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import io.reactivex.annotations.NonNull;
+
+/**
+ * Convenience interface and callback used by the {@link Flowable#as} operator to turn a Flowable into another
+ * value fluently.
+ *
+ * @param <T> the upstream type
+ * @param <R> the output type
+ */
+public interface FlowableConverter<T, R> {
+    /**
+     * Applies a function to the upstream Flowable and returns a converted value of type <R>.
+     *
+     * @param upstream the upstream Flowable instance
+     * @return the converted value
+     */
+    @NonNull
+    R apply(@NonNull Flowable<T> upstream) throws Exception;
+}

--- a/src/main/java/io/reactivex/FlowableConverter.java
+++ b/src/main/java/io/reactivex/FlowableConverter.java
@@ -30,8 +30,7 @@ public interface FlowableConverter<T, R> {
      *
      * @param upstream the upstream Flowable instance
      * @return the converted value
-     * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull Flowable<T> upstream) throws Exception;
+    R apply(@NonNull Flowable<T> upstream);
 }

--- a/src/main/java/io/reactivex/FlowableConverter.java
+++ b/src/main/java/io/reactivex/FlowableConverter.java
@@ -21,6 +21,7 @@ import io.reactivex.annotations.*;
  *
  * @param <T> the upstream type
  * @param <R> the output type
+ * @since 2.1.7 - experimental
  */
 @Experimental
 public interface FlowableConverter<T, R> {

--- a/src/main/java/io/reactivex/FlowableConverter.java
+++ b/src/main/java/io/reactivex/FlowableConverter.java
@@ -25,7 +25,7 @@ import io.reactivex.annotations.*;
 @Experimental
 public interface FlowableConverter<T, R> {
     /**
-     * Applies a function to the upstream Flowable and returns a converted value of type <R>.
+     * Applies a function to the upstream Flowable and returns a converted value of type {@code R}.
      *
      * @param upstream the upstream Flowable instance
      * @return the converted value

--- a/src/main/java/io/reactivex/FlowableConverter.java
+++ b/src/main/java/io/reactivex/FlowableConverter.java
@@ -29,6 +29,7 @@ public interface FlowableConverter<T, R> {
      *
      * @param upstream the upstream Flowable instance
      * @return the converted value
+     * @throws Exception on error
      */
     @NonNull
     R apply(@NonNull Flowable<T> upstream) throws Exception;

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2003,6 +2003,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return the converted value
      * @throws NullPointerException if converter is null
      */
+    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(MaybeConverter<T, ? extends R> converter) {

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -1990,6 +1990,31 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
+     * Calls the specified converter function during assembly time and returns its resulting value.
+     * <p>
+     * This allows fluent conversion to any other type.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <R> the resulting object type
+     * @param converter the function that receives the current Maybe instance and returns a value
+     * @return the converted value
+     * @throws NullPointerException if converter is null
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <R> R as(MaybeConverter<T, ? extends R> converter) {
+        try {
+            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
+    }
+
+    /**
      * Waits in a blocking fashion until the current Maybe signals a success value (which is returned),
      * null if completed or an exception (which is propagated).
      * <dl>

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2002,6 +2002,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param converter the function that receives the current Maybe instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
+     * @since 2.1.7 - experimental
      */
     @Experimental
     @CheckReturnValue

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -1995,7 +1995,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * This allows fluent conversion to any other type.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the resulting object type
@@ -2006,7 +2006,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R as(MaybeConverter<T, ? extends R> converter) {
+    public final <R> R as(@NonNull MaybeConverter<T, ? extends R> converter) {
         try {
             return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
         } catch (Throwable ex) {

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2008,12 +2008,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(@NonNull MaybeConverter<T, ? extends R> converter) {
-        try {
-            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/MaybeConverter.java
+++ b/src/main/java/io/reactivex/MaybeConverter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import io.reactivex.annotations.NonNull;
+
+/**
+ * Convenience interface and callback used by the {@link Maybe#as} operator to turn a Maybe into another
+ * value fluently.
+ *
+ * @param <T> the upstream type
+ * @param <R> the output type
+ */
+public interface MaybeConverter<T, R> {
+    /**
+     * Applies a function to the upstream Maybe and returns a converted value of type <R>.
+     *
+     * @param upstream the upstream Maybe instance
+     * @return the converted value
+     */
+    @NonNull
+    R apply(@NonNull Maybe<T> upstream) throws Exception;
+}

--- a/src/main/java/io/reactivex/MaybeConverter.java
+++ b/src/main/java/io/reactivex/MaybeConverter.java
@@ -29,6 +29,7 @@ public interface MaybeConverter<T, R> {
      *
      * @param upstream the upstream Maybe instance
      * @return the converted value
+     * @throws Exception on error
      */
     @NonNull
     R apply(@NonNull Maybe<T> upstream) throws Exception;

--- a/src/main/java/io/reactivex/MaybeConverter.java
+++ b/src/main/java/io/reactivex/MaybeConverter.java
@@ -30,8 +30,7 @@ public interface MaybeConverter<T, R> {
      *
      * @param upstream the upstream Maybe instance
      * @return the converted value
-     * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull Maybe<T> upstream) throws Exception;
+    R apply(@NonNull Maybe<T> upstream);
 }

--- a/src/main/java/io/reactivex/MaybeConverter.java
+++ b/src/main/java/io/reactivex/MaybeConverter.java
@@ -21,6 +21,7 @@ import io.reactivex.annotations.*;
  *
  * @param <T> the upstream type
  * @param <R> the output type
+ * @since 2.1.7 - experimental
  */
 @Experimental
 public interface MaybeConverter<T, R> {

--- a/src/main/java/io/reactivex/MaybeConverter.java
+++ b/src/main/java/io/reactivex/MaybeConverter.java
@@ -25,7 +25,7 @@ import io.reactivex.annotations.*;
 @Experimental
 public interface MaybeConverter<T, R> {
     /**
-     * Applies a function to the upstream Maybe and returns a converted value of type <R>.
+     * Applies a function to the upstream Maybe and returns a converted value of type {@code R}.
      *
      * @param upstream the upstream Maybe instance
      * @return the converted value

--- a/src/main/java/io/reactivex/MaybeConverter.java
+++ b/src/main/java/io/reactivex/MaybeConverter.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.*;
 
 /**
  * Convenience interface and callback used by the {@link Maybe#as} operator to turn a Maybe into another
@@ -22,6 +22,7 @@ import io.reactivex.annotations.NonNull;
  * @param <T> the upstream type
  * @param <R> the output type
  */
+@Experimental
 public interface MaybeConverter<T, R> {
     /**
      * Applies a function to the upstream Maybe and returns a converted value of type <R>.

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -4801,6 +4801,31 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
+     * Calls the specified converter function during assembly time and returns its resulting value.
+     * <p>
+     * This allows fluent conversion to any other type.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <R> the resulting object type
+     * @param converter the function that receives the current Observable instance and returns a value
+     * @return the converted value
+     * @throws NullPointerException if converter is null
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <R> R as(ObservableConverter<T, ? extends R> converter) {
+        try {
+            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
+    }
+
+    /**
      * Returns the first item emitted by this {@code Observable}, or throws
      * {@code NoSuchElementException} if it emits no items.
      * <dl>

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -4813,6 +4813,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param converter the function that receives the current Observable instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
+     * @since 2.1.7 - experimental
      */
     @Experimental
     @CheckReturnValue

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -4814,6 +4814,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the converted value
      * @throws NullPointerException if converter is null
      */
+    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(ObservableConverter<T, ? extends R> converter) {

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -4806,7 +4806,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * This allows fluent conversion to any other type.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the resulting object type
@@ -4817,7 +4817,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R as(ObservableConverter<T, ? extends R> converter) {
+    public final <R> R as(@NonNull ObservableConverter<T, ? extends R> converter) {
         try {
             return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
         } catch (Throwable ex) {

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -4819,12 +4819,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(@NonNull ObservableConverter<T, ? extends R> converter) {
-        try {
-            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/ObservableConverter.java
+++ b/src/main/java/io/reactivex/ObservableConverter.java
@@ -21,6 +21,7 @@ import io.reactivex.annotations.*;
  *
  * @param <T> the upstream type
  * @param <R> the output type
+ * @since 2.1.7 - experimental
  */
 @Experimental
 public interface ObservableConverter<T, R> {

--- a/src/main/java/io/reactivex/ObservableConverter.java
+++ b/src/main/java/io/reactivex/ObservableConverter.java
@@ -29,6 +29,7 @@ public interface ObservableConverter<T, R> {
      *
      * @param upstream the upstream Observable instance
      * @return the converted value
+     * @throws Exception on error
      */
     @NonNull
     R apply(@NonNull Observable<T> upstream) throws Exception;

--- a/src/main/java/io/reactivex/ObservableConverter.java
+++ b/src/main/java/io/reactivex/ObservableConverter.java
@@ -30,8 +30,7 @@ public interface ObservableConverter<T, R> {
      *
      * @param upstream the upstream Observable instance
      * @return the converted value
-     * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull Observable<T> upstream) throws Exception;
+    R apply(@NonNull Observable<T> upstream);
 }

--- a/src/main/java/io/reactivex/ObservableConverter.java
+++ b/src/main/java/io/reactivex/ObservableConverter.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.*;
 
 /**
  * Convenience interface and callback used by the {@link Observable#as} operator to turn an Observable into another
@@ -22,6 +22,7 @@ import io.reactivex.annotations.NonNull;
  * @param <T> the upstream type
  * @param <R> the output type
  */
+@Experimental
 public interface ObservableConverter<T, R> {
     /**
      * Applies a function to the upstream Observable and returns a converted value of type <R>.

--- a/src/main/java/io/reactivex/ObservableConverter.java
+++ b/src/main/java/io/reactivex/ObservableConverter.java
@@ -25,7 +25,7 @@ import io.reactivex.annotations.*;
 @Experimental
 public interface ObservableConverter<T, R> {
     /**
-     * Applies a function to the upstream Observable and returns a converted value of type <R>.
+     * Applies a function to the upstream Observable and returns a converted value of type {@code R}.
      *
      * @param upstream the upstream Observable instance
      * @return the converted value

--- a/src/main/java/io/reactivex/ObservableConverter.java
+++ b/src/main/java/io/reactivex/ObservableConverter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import io.reactivex.annotations.NonNull;
+
+/**
+ * Convenience interface and callback used by the {@link Observable#as} operator to turn an Observable into another
+ * value fluently.
+ *
+ * @param <T> the upstream type
+ * @param <R> the output type
+ */
+public interface ObservableConverter<T, R> {
+    /**
+     * Applies a function to the upstream Observable and returns a converted value of type <R>.
+     *
+     * @param upstream the upstream Observable instance
+     * @return the converted value
+     */
+    @NonNull
+    R apply(@NonNull Observable<T> upstream) throws Exception;
+}

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1528,7 +1528,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * This allows fluent conversion to any other type.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the resulting object type
@@ -1539,7 +1539,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R as(SingleConverter<T, ? extends R> converter) {
+    public final <R> R as(@NonNull SingleConverter<T, ? extends R> converter) {
         try {
             return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
         } catch (Throwable ex) {

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1541,12 +1541,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(@NonNull SingleConverter<T, ? extends R> converter) {
-        try {
-            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1535,6 +1535,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @param converter the function that receives the current Single instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
+     * @since 2.1.7 - experimental
      */
     @Experimental
     @CheckReturnValue

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1536,6 +1536,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return the converted value
      * @throws NullPointerException if converter is null
      */
+    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(SingleConverter<T, ? extends R> converter) {

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1523,6 +1523,31 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
+     * Calls the specified converter function during assembly time and returns its resulting value.
+     * <p>
+     * This allows fluent conversion to any other type.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <R> the resulting object type
+     * @param converter the function that receives the current Single instance and returns a value
+     * @return the converted value
+     * @throws NullPointerException if converter is null
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <R> R as(SingleConverter<T, ? extends R> converter) {
+        try {
+            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
+    }
+
+    /**
      * Hides the identity of the current Single, including the Disposable that is sent
      * to the downstream via {@code onSubscribe()}.
      * <dl>

--- a/src/main/java/io/reactivex/SingleConverter.java
+++ b/src/main/java/io/reactivex/SingleConverter.java
@@ -13,7 +13,7 @@
 
 package io.reactivex;
 
-import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.*;
 
 /**
  * Convenience interface and callback used by the {@link Single#as} operator to turn an Single into another
@@ -22,6 +22,7 @@ import io.reactivex.annotations.NonNull;
  * @param <T> the upstream type
  * @param <R> the output type
  */
+@Experimental
 public interface SingleConverter<T, R> {
     /**
      * Applies a function to the upstream Single and returns a converted value of type <R>.

--- a/src/main/java/io/reactivex/SingleConverter.java
+++ b/src/main/java/io/reactivex/SingleConverter.java
@@ -21,6 +21,7 @@ import io.reactivex.annotations.*;
  *
  * @param <T> the upstream type
  * @param <R> the output type
+ * @since 2.1.7 - experimental
  */
 @Experimental
 public interface SingleConverter<T, R> {

--- a/src/main/java/io/reactivex/SingleConverter.java
+++ b/src/main/java/io/reactivex/SingleConverter.java
@@ -30,8 +30,7 @@ public interface SingleConverter<T, R> {
      *
      * @param upstream the upstream Single instance
      * @return the converted value
-     * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull Single<T> upstream) throws Exception;
+    R apply(@NonNull Single<T> upstream);
 }

--- a/src/main/java/io/reactivex/SingleConverter.java
+++ b/src/main/java/io/reactivex/SingleConverter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import io.reactivex.annotations.NonNull;
+
+/**
+ * Convenience interface and callback used by the {@link Single#as} operator to turn an Single into another
+ * value fluently.
+ *
+ * @param <T> the upstream type
+ * @param <R> the output type
+ */
+public interface SingleConverter<T, R> {
+    /**
+     * Applies a function to the upstream Single and returns a converted value of type <R>.
+     *
+     * @param upstream the upstream Single instance
+     * @return the converted value
+     */
+    @NonNull
+    R apply(@NonNull Single<T> upstream) throws Exception;
+}

--- a/src/main/java/io/reactivex/SingleConverter.java
+++ b/src/main/java/io/reactivex/SingleConverter.java
@@ -16,7 +16,7 @@ package io.reactivex;
 import io.reactivex.annotations.*;
 
 /**
- * Convenience interface and callback used by the {@link Single#as} operator to turn an Single into another
+ * Convenience interface and callback used by the {@link Single#as} operator to turn a Single into another
  * value fluently.
  *
  * @param <T> the upstream type
@@ -25,7 +25,7 @@ import io.reactivex.annotations.*;
 @Experimental
 public interface SingleConverter<T, R> {
     /**
-     * Applies a function to the upstream Single and returns a converted value of type <R>.
+     * Applies a function to the upstream Single and returns a converted value of type {@code R}.
      *
      * @param upstream the upstream Single instance
      * @return the converted value

--- a/src/main/java/io/reactivex/SingleConverter.java
+++ b/src/main/java/io/reactivex/SingleConverter.java
@@ -29,6 +29,7 @@ public interface SingleConverter<T, R> {
      *
      * @param upstream the upstream Single instance
      * @return the converted value
+     * @throws Exception on error
      */
     @NonNull
     R apply(@NonNull Single<T> upstream) throws Exception;

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -123,6 +123,29 @@ public abstract class ParallelFlowable<T> {
     }
 
     /**
+     * Calls the specified converter function during assembly time and returns its resulting value.
+     * <p>
+     * This allows fluent conversion to any other type.
+     *
+     * @param <R> the resulting object type
+     * @param converter the function that receives the current ParallelFlowable instance and returns a value
+     * @return the converted value
+     * @throws NullPointerException if converter is null
+     * @since 2.1.7 - experimental
+     */
+    @Experimental
+    @CheckReturnValue
+    @NonNull
+    public final <R> R as(@NonNull ParallelFlowableConverter<T, R> converter) {
+        try {
+            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
+    }
+
+    /**
      * Maps the source values on each 'rail' to another value.
      * <p>
      * Note that the same mapper function may be called from multiple threads concurrently.

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -137,12 +137,7 @@ public abstract class ParallelFlowable<T> {
     @CheckReturnValue
     @NonNull
     public final <R> R as(@NonNull ParallelFlowableConverter<T, R> converter) {
-        try {
-            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/parallel/ParallelFlowableConverter.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowableConverter.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.parallel;
+
+import io.reactivex.annotations.*;
+
+/**
+ * Convenience interface and callback used by the {@link ParallelFlowable#as} operator to turn a ParallelFlowable into
+ * another value fluently.
+ *
+ * @param <T> the upstream type
+ * @param <R> the output type
+ * @since 2.1.7 - experimental
+ */
+@Experimental
+public interface ParallelFlowableConverter<T, R> {
+    /**
+     * Applies a function to the upstream ParallelFlowable and returns a converted value of type {@code R}.
+     *
+     * @param upstream the upstream ParallelFlowable instance
+     * @return the converted value
+     * @throws Exception on error
+     */
+    @NonNull
+    R apply(@NonNull ParallelFlowable<T> upstream) throws Exception;
+}

--- a/src/main/java/io/reactivex/parallel/ParallelFlowableConverter.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowableConverter.java
@@ -30,8 +30,7 @@ public interface ParallelFlowableConverter<T, R> {
      *
      * @param upstream the upstream ParallelFlowable instance
      * @return the converted value
-     * @throws Exception on error
      */
     @NonNull
-    R apply(@NonNull ParallelFlowable<T> upstream) throws Exception;
+    R apply(@NonNull ParallelFlowable<T> upstream);
 }

--- a/src/test/java/io/reactivex/ConverterTest.java
+++ b/src/test/java/io/reactivex/ConverterTest.java
@@ -1,0 +1,218 @@
+package io.reactivex;
+
+import io.reactivex.exceptions.TestException;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public final class ConverterTest {
+
+    @Test
+    public void flowableConverterThrows() {
+        try {
+            Flowable.just(1).as(new FlowableConverter<Integer, Integer>() {
+                @Override
+                public Integer apply(Flowable<Integer> v) {
+                    throw new TestException("Forced failure");
+                }
+            });
+            fail("Should have thrown!");
+        } catch (TestException ex) {
+            assertEquals("Forced failure", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void observableConverterThrows() {
+        try {
+            Observable.just(1).as(new ObservableConverter<Integer, Integer>() {
+                @Override
+                public Integer apply(Observable<Integer> v) {
+                    throw new TestException("Forced failure");
+                }
+            });
+            fail("Should have thrown!");
+        } catch (TestException ex) {
+            assertEquals("Forced failure", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void singleConverterThrows() {
+        try {
+            Single.just(1).as(new SingleConverter<Integer, Integer>() {
+                @Override
+                public Integer apply(Single<Integer> v) {
+                    throw new TestException("Forced failure");
+                }
+            });
+            fail("Should have thrown!");
+        } catch (TestException ex) {
+            assertEquals("Forced failure", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void maybeConverterThrows() {
+        try {
+            Maybe.just(1).as(new MaybeConverter<Integer, Integer>() {
+                @Override
+                public Integer apply(Maybe<Integer> v) {
+                    throw new TestException("Forced failure");
+                }
+            });
+            fail("Should have thrown!");
+        } catch (TestException ex) {
+            assertEquals("Forced failure", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void completableConverterThrows() {
+        try {
+            Completable.complete().as(new CompletableConverter() {
+                @Override
+                public Completable apply(Completable v) {
+                    throw new TestException("Forced failure");
+                }
+            });
+            fail("Should have thrown!");
+        } catch (TestException ex) {
+            assertEquals("Forced failure", ex.getMessage());
+        }
+    }
+
+    // Test demos for signature generics in compose() methods. Just needs to compile.
+
+    @Test
+    public void observableGenericsSignatureTest() {
+        A<String, Integer> a = new A<String, Integer>() { };
+
+        Observable.just(a).as(ConverterTest.<Integer>testObservableConverterCreator());
+    }
+
+    @Test
+    public void singleGenericsSignatureTest() {
+        A<String, Integer> a = new A<String, Integer>() { };
+
+        Single.just(a).as(ConverterTest.<Integer>testSingleConverterCreator());
+    }
+
+    @Test
+    public void maybeGenericsSignatureTest() {
+        A<String, Integer> a = new A<String, Integer>() { };
+
+        Maybe.just(a).as(ConverterTest.<Integer>testMaybeConverterCreator());
+    }
+
+    @Test
+    public void flowableGenericsSignatureTest() {
+        A<String, Integer> a = new A<String, Integer>() { };
+
+        Flowable.just(a).as(ConverterTest.<Integer>testFlowableConverterCreator());
+    }
+
+    @Test
+    public void compositeTest() {
+        CompositeConverter converter = new CompositeConverter();
+
+        Flowable.just(1)
+                .as(converter)
+                .test()
+                .assertValue(1);
+
+        Observable.just(1)
+                .as(converter)
+                .test()
+                .assertValue(1);
+
+        Maybe.just(1)
+                .as(converter)
+                .test()
+                .assertValue(1);
+
+        Single.just(1)
+                .as(converter)
+                .test()
+                .assertValue(1);
+
+        Completable.complete()
+                .as(converter)
+                .test()
+                .assertComplete();
+    }
+
+    interface A<T, R> { }
+    interface B<T> { }
+
+    private static <T> ObservableConverter<A<T, ?>, B<T>> testObservableConverterCreator() {
+        return new ObservableConverter<A<T, ?>, B<T>>() {
+            @Override
+            public B<T> apply(Observable<A<T, ?>> a) {
+                return new B<T>() {
+                };
+            }
+        };
+    }
+
+    private static <T> SingleConverter<A<T, ?>, B<T>> testSingleConverterCreator() {
+        return new SingleConverter<A<T, ?>, B<T>>() {
+            @Override
+            public B<T> apply(Single<A<T, ?>> a) {
+                return new B<T>() {
+                };
+            }
+        };
+    }
+
+    private static <T> MaybeConverter<A<T, ?>, B<T>> testMaybeConverterCreator() {
+        return new MaybeConverter<A<T, ?>, B<T>>() {
+            @Override
+            public B<T> apply(Maybe<A<T, ?>> a) {
+                return new B<T>() {
+                };
+            }
+        };
+    }
+
+    private static <T> FlowableConverter<A<T, ?>, B<T>> testFlowableConverterCreator() {
+        return new FlowableConverter<A<T, ?>, B<T>>() {
+            @Override
+            public B<T> apply(Flowable<A<T, ?>> a) {
+                return new B<T>() {
+                };
+            }
+        };
+    }
+
+    private static class CompositeConverter implements ObservableConverter<Integer, Flowable<Integer>>,
+            FlowableConverter<Integer, Observable<Integer>>,
+            MaybeConverter<Integer, Flowable<Integer>>,
+            SingleConverter<Integer, Flowable<Integer>>,
+            CompletableConverter<Flowable<Integer>> {
+        @Override
+        public Flowable<Integer> apply(Completable upstream) throws Exception {
+            return upstream.toFlowable();
+        }
+
+        @Override
+        public Observable<Integer> apply(Flowable<Integer> upstream) throws Exception {
+            return upstream.toObservable();
+        }
+
+        @Override
+        public Flowable<Integer> apply(Maybe<Integer> upstream) throws Exception {
+            return upstream.toFlowable();
+        }
+
+        @Override
+        public Flowable<Integer> apply(Observable<Integer> upstream) throws Exception {
+            return upstream.toFlowable(BackpressureStrategy.MISSING);
+        }
+
+        @Override
+        public Flowable<Integer> apply(Single<Integer> upstream) throws Exception {
+            return upstream.toFlowable();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/ConverterTest.java
+++ b/src/test/java/io/reactivex/ConverterTest.java
@@ -236,32 +236,32 @@ public final class ConverterTest {
             SingleConverter<Integer, Flowable<Integer>>,
             CompletableConverter<Flowable<Integer>> {
         @Override
-        public Flowable<Integer> apply(ParallelFlowable<Integer> upstream) throws Exception {
+        public Flowable<Integer> apply(ParallelFlowable<Integer> upstream) {
             return upstream.sequential();
         }
 
         @Override
-        public Flowable<Integer> apply(Completable upstream) throws Exception {
+        public Flowable<Integer> apply(Completable upstream) {
             return upstream.toFlowable();
         }
 
         @Override
-        public Observable<Integer> apply(Flowable<Integer> upstream) throws Exception {
+        public Observable<Integer> apply(Flowable<Integer> upstream) {
             return upstream.toObservable();
         }
 
         @Override
-        public Flowable<Integer> apply(Maybe<Integer> upstream) throws Exception {
+        public Flowable<Integer> apply(Maybe<Integer> upstream) {
             return upstream.toFlowable();
         }
 
         @Override
-        public Flowable<Integer> apply(Observable<Integer> upstream) throws Exception {
+        public Flowable<Integer> apply(Observable<Integer> upstream) {
             return upstream.toFlowable(BackpressureStrategy.MISSING);
         }
 
         @Override
-        public Flowable<Integer> apply(Single<Integer> upstream) throws Exception {
+        public Flowable<Integer> apply(Single<Integer> upstream) {
             return upstream.toFlowable();
         }
     }

--- a/src/test/java/io/reactivex/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/ParamValidationCheckerTest.java
@@ -565,32 +565,32 @@ public class ParamValidationCheckerTest {
         MaybeConverter, CompletableConverter, ParallelFlowableConverter {
 
             @Override
-            public Object apply(ParallelFlowable upstream) throws Exception {
+            public Object apply(ParallelFlowable upstream) {
                 return upstream;
             }
 
             @Override
-            public Object apply(Completable upstream) throws Exception {
+            public Object apply(Completable upstream) {
                 return upstream;
             }
 
             @Override
-            public Object apply(Maybe upstream) throws Exception {
+            public Object apply(Maybe upstream) {
                 return upstream;
             }
 
             @Override
-            public Object apply(Single upstream) throws Exception {
+            public Object apply(Single upstream) {
                 return upstream;
             }
 
             @Override
-            public Object apply(Observable upstream) throws Exception {
+            public Object apply(Observable upstream) {
                 return upstream;
             }
 
             @Override
-            public Object apply(Flowable upstream) throws Exception {
+            public Object apply(Flowable upstream) {
                 return upstream;
             }
         }

--- a/src/test/java/io/reactivex/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/ParamValidationCheckerTest.java
@@ -560,6 +560,46 @@ public class ParamValidationCheckerTest {
 
         defaultValues.put(ParallelFailureHandling.class, ParallelFailureHandling.ERROR);
 
+        @SuppressWarnings("rawtypes")
+        class MixedConverters implements FlowableConverter, ObservableConverter, SingleConverter,
+        MaybeConverter, CompletableConverter, ParallelFlowableConverter {
+
+            @Override
+            public Object apply(ParallelFlowable upstream) throws Exception {
+                return upstream;
+            }
+
+            @Override
+            public Object apply(Completable upstream) throws Exception {
+                return upstream;
+            }
+
+            @Override
+            public Object apply(Maybe upstream) throws Exception {
+                return upstream;
+            }
+
+            @Override
+            public Object apply(Single upstream) throws Exception {
+                return upstream;
+            }
+
+            @Override
+            public Object apply(Observable upstream) throws Exception {
+                return upstream;
+            }
+
+            @Override
+            public Object apply(Flowable upstream) throws Exception {
+                return upstream;
+            }
+        }
+
+        MixedConverters mc = new MixedConverters();
+        for (Class<?> c : MixedConverters.class.getInterfaces()) {
+            defaultValues.put(c, mc);
+        }
+
         // -----------------------------------------------------------------------------------
 
         defaultInstances = new HashMap<Class<?>, List<Object>>();

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -2815,7 +2815,7 @@ public class CompletableTest {
     public void as() {
         Completable.complete().as(new CompletableConverter<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Completable v) throws Exception {
+            public Flowable<Integer> apply(Completable v) {
                 return v.toFlowable();
             }
         })

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -2796,9 +2796,41 @@ public class CompletableTest {
         });
     }
 
+    @Test(timeout = 5000)
+    public void asNormal() {
+        Flowable<Object> flow = normal.completable.as(new CompletableConverter<Flowable<Object>>() {
+            @Override
+            public Flowable<Object> apply(Completable c) {
+                return c.toFlowable();
+            }
+        });
+
+        flow.blockingForEach(new Consumer<Object>() {
+            @Override
+            public void accept(Object e) { }
+        });
+    }
+
+    @Test
+    public void as() {
+        Completable.complete().as(new CompletableConverter<Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Completable v) throws Exception {
+                return v.toFlowable();
+            }
+        })
+        .test()
+        .assertComplete();
+    }
+
     @Test(expected = NullPointerException.class)
     public void toNull() {
         normal.completable.to(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void asNull() {
+        normal.completable.as(null);
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -2783,32 +2783,30 @@ public class CompletableTest {
 
     @Test(timeout = 5000)
     public void toNormal() {
-        Flowable<Object> flow = normal.completable.to(new Function<Completable, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Completable c) {
-                return c.toFlowable();
-            }
-        });
-
-        flow.blockingForEach(new Consumer<Object>() {
-            @Override
-            public void accept(Object e) { }
-        });
+        normal.completable
+                .to(new Function<Completable, Flowable<Object>>() {
+                    @Override
+                    public Flowable<Object> apply(Completable c) {
+                        return c.toFlowable();
+                    }
+                })
+                .test()
+                .assertComplete()
+                .assertNoValues();
     }
 
     @Test(timeout = 5000)
     public void asNormal() {
-        Flowable<Object> flow = normal.completable.as(new CompletableConverter<Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Completable c) {
-                return c.toFlowable();
-            }
-        });
-
-        flow.blockingForEach(new Consumer<Object>() {
-            @Override
-            public void accept(Object e) { }
-        });
+        normal.completable
+                .as(new CompletableConverter<Flowable<Object>>() {
+                    @Override
+                    public Flowable<Object> apply(Completable c) {
+                        return c.toFlowable();
+                    }
+                })
+                .test()
+                .assertComplete()
+                .assertNoValues();
     }
 
     @Test

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -2352,6 +2352,11 @@ public class FlowableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
+    public void asNull() {
+        just1.as(null);
+    }
+
+    @Test(expected = NullPointerException.class)
     public void toListNull() {
         just1.toList(null);
     }

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.Observable;
 import org.junit.*;
 import org.mockito.InOrder;
 import org.reactivestreams.*;
@@ -1123,6 +1124,34 @@ public class FlowableTests {
                     return subscriber.values().get(0);
                 }
         });
+    }
+
+    @Test
+    public void testAsExtend() {
+        final TestSubscriber<Object> subscriber = new TestSubscriber<Object>();
+        final Object value = new Object();
+        Flowable.just(value).as(new FlowableConverter<Object, Object>() {
+            @Override
+            public Object apply(Flowable<Object> onSubscribe) {
+                    onSubscribe.subscribe(subscriber);
+                    subscriber.assertNoErrors();
+                    subscriber.assertComplete();
+                    subscriber.assertValue(value);
+                    return subscriber.values().get(0);
+                }
+        });
+    }
+
+    @Test
+    public void as() {
+        Flowable.just(1).as(new FlowableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Flowable<Integer> v) throws Exception {
+                return v.toObservable();
+            }
+        })
+        .test()
+        .assertResult(1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -1114,7 +1114,7 @@ public class FlowableTests {
     public void testExtend() {
         final TestSubscriber<Object> subscriber = new TestSubscriber<Object>();
         final Object value = new Object();
-        Flowable.just(value).to(new Function<Flowable<Object>, Object>() {
+        Object returned = Flowable.just(value).to(new Function<Flowable<Object>, Object>() {
             @Override
             public Object apply(Flowable<Object> onSubscribe) {
                     onSubscribe.subscribe(subscriber);
@@ -1124,13 +1124,14 @@ public class FlowableTests {
                     return subscriber.values().get(0);
                 }
         });
+        assertSame(returned, value);
     }
 
     @Test
     public void testAsExtend() {
         final TestSubscriber<Object> subscriber = new TestSubscriber<Object>();
         final Object value = new Object();
-        Flowable.just(value).as(new FlowableConverter<Object, Object>() {
+        Object returned = Flowable.just(value).as(new FlowableConverter<Object, Object>() {
             @Override
             public Object apply(Flowable<Object> onSubscribe) {
                     onSubscribe.subscribe(subscriber);
@@ -1140,6 +1141,7 @@ public class FlowableTests {
                     return subscriber.values().get(0);
                 }
         });
+        assertSame(returned, value);
     }
 
     @Test

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -1146,7 +1146,7 @@ public class FlowableTests {
     public void as() {
         Flowable.just(1).as(new FlowableConverter<Integer, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Flowable<Integer> v) throws Exception {
+            public Observable<Integer> apply(Flowable<Integer> v) {
                 return v.toObservable();
             }
         })

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -381,9 +381,26 @@ public class MaybeTest {
         .assertResult(1);
     }
 
+    @Test
+    public void as() {
+        Maybe.just(1).as(new MaybeConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Maybe<Integer> v) throws Exception {
+                return v.toFlowable();
+            }
+        })
+        .test()
+        .assertResult(1);
+    }
+
     @Test(expected = NullPointerException.class)
     public void toNull() {
         Maybe.just(1).to(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void asNull() {
+        Maybe.just(1).as(null);
     }
 
     @Test

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -385,7 +385,7 @@ public class MaybeTest {
     public void as() {
         Maybe.just(1).as(new MaybeConverter<Integer, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Maybe<Integer> v) throws Exception {
+            public Flowable<Integer> apply(Maybe<Integer> v) {
                 return v.toFlowable();
             }
         })

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -2409,6 +2409,11 @@ public class ObservableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
+    public void asNull() {
+        just1.as(null);
+    }
+
+    @Test(expected = NullPointerException.class)
     public void toListNull() {
         just1.toList(null);
     }

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -1166,6 +1166,34 @@ public class ObservableTest {
     }
 
     @Test
+    public void testAsExtend() {
+        final TestObserver<Object> subscriber = new TestObserver<Object>();
+        final Object value = new Object();
+        Observable.just(value).as(new ObservableConverter<Object, Object>() {
+            @Override
+            public Object apply(Observable<Object> onSubscribe) {
+                onSubscribe.subscribe(subscriber);
+                subscriber.assertNoErrors();
+                subscriber.assertComplete();
+                subscriber.assertValue(value);
+                return subscriber.values().get(0);
+            }
+        });
+    }
+
+    @Test
+    public void as() {
+        Observable.just(1).as(new ObservableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Observable<Integer> v) throws Exception {
+                return v.toFlowable(BackpressureStrategy.MISSING);
+            }
+        })
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
     public void testFlatMap() {
         List<Integer> list = Observable.range(1, 5).flatMap(new Function<Integer, Observable<Integer>>() {
             @Override

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -1185,7 +1185,7 @@ public class ObservableTest {
     public void as() {
         Observable.just(1).as(new ObservableConverter<Integer, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Observable<Integer> v) throws Exception {
+            public Flowable<Integer> apply(Observable<Integer> v) {
                 return v.toFlowable(BackpressureStrategy.MISSING);
             }
         })

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -1153,7 +1153,7 @@ public class ObservableTest {
     public void testExtend() {
         final TestObserver<Object> subscriber = new TestObserver<Object>();
         final Object value = new Object();
-        Observable.just(value).to(new Function<Observable<Object>, Object>() {
+        Object returned = Observable.just(value).to(new Function<Observable<Object>, Object>() {
             @Override
             public Object apply(Observable<Object> onSubscribe) {
                     onSubscribe.subscribe(subscriber);
@@ -1163,13 +1163,14 @@ public class ObservableTest {
                     return subscriber.values().get(0);
                 }
         });
+        assertSame(returned, value);
     }
 
     @Test
     public void testAsExtend() {
         final TestObserver<Object> subscriber = new TestObserver<Object>();
         final Object value = new Object();
-        Observable.just(value).as(new ObservableConverter<Object, Object>() {
+        Object returned = Observable.just(value).as(new ObservableConverter<Object, Object>() {
             @Override
             public Object apply(Observable<Object> onSubscribe) {
                 onSubscribe.subscribe(subscriber);
@@ -1179,6 +1180,7 @@ public class ObservableTest {
                 return subscriber.values().get(0);
             }
         });
+        assertSame(returned, value);
     }
 
     @Test

--- a/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
@@ -1100,11 +1100,37 @@ public class ParallelFlowableTest {
         .assertResult(1, 2, 3, 4, 5);
     }
 
+    @Test
+    public void as() {
+        Flowable.range(1, 5)
+        .parallel()
+        .as(new ParallelFlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) throws Exception {
+                return pf.sequential();
+            }
+        })
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
     @Test(expected = TestException.class)
     public void toThrows() {
         Flowable.range(1, 5)
         .parallel()
         .to(new Function<ParallelFlowable<Integer>, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) throws Exception {
+                throw new TestException();
+            }
+        });
+    }
+
+    @Test(expected = TestException.class)
+    public void asThrows() {
+        Flowable.range(1, 5)
+        .parallel()
+        .as(new ParallelFlowableConverter<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(ParallelFlowable<Integer> pf) throws Exception {
                 throw new TestException();

--- a/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
@@ -1106,7 +1106,7 @@ public class ParallelFlowableTest {
         .parallel()
         .as(new ParallelFlowableConverter<Integer, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) throws Exception {
+            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) {
                 return pf.sequential();
             }
         })
@@ -1132,7 +1132,7 @@ public class ParallelFlowableTest {
         .parallel()
         .as(new ParallelFlowableConverter<Integer, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) throws Exception {
+            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) {
                 throw new TestException();
             }
         });

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -845,6 +845,11 @@ public class SingleNullTests {
     }
 
     @Test(expected = NullPointerException.class)
+    public void asNull() {
+        just1.as(null);
+    }
+
+    @Test(expected = NullPointerException.class)
     public void zipWithNull() {
         just1.zipWith(null, new BiFunction<Integer, Object, Object>() {
             @Override

--- a/src/test/java/io/reactivex/single/SingleTest.java
+++ b/src/test/java/io/reactivex/single/SingleTest.java
@@ -543,6 +543,18 @@ public class SingleTest {
         }).intValue());
     }
 
+    @Test
+    public void as() {
+        Single.just(1).as(new SingleConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Single<Integer> v) throws Exception {
+                return v.toFlowable();
+            }
+        })
+        .test()
+        .assertResult(1);
+    }
+
     @Test(expected = NullPointerException.class)
     public void fromObservableNull() {
         Single.fromObservable(null);

--- a/src/test/java/io/reactivex/single/SingleTest.java
+++ b/src/test/java/io/reactivex/single/SingleTest.java
@@ -547,7 +547,7 @@ public class SingleTest {
     public void as() {
         Single.just(1).as(new SingleConverter<Integer, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Single<Integer> v) throws Exception {
+            public Flowable<Integer> apply(Single<Integer> v) {
                 return v.toFlowable();
             }
         })


### PR DESCRIPTION
This implement `as()` support as discussed in #5654

I took the opportunity to try to standardize the docs and tests for it (which vary a little bit across implementations of `to()`)

Related: #5654