### PR TITLE
2.x: fix javadoc for ConnectableFlowable and others

### DIFF
--- a/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
+++ b/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
@@ -25,22 +25,22 @@ import io.reactivex.internal.util.ConnectConsumer;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
- * A {@code ConnectableObservable} resembles an ordinary {@link Flowable}, except that it does not begin
+ * A {@code ConnectableFlowable} resembles an ordinary {@link Flowable}, except that it does not begin
  * emitting items when it is subscribed to, but only when its {@link #connect} method is called. In this way you
- * can wait for all intended {@link Subscriber}s to {@link Flowable#subscribe} to the {@code Observable}
- * before the {@code Observable} begins emitting items.
+ * can wait for all intended {@link Subscriber}s to {@link Flowable#subscribe} to the {@code Flowable}
+ * before the {@code Flowable} begins emitting items.
  * <p>
  * <img width="640" height="510" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/publishConnect.png" alt="">
  *
  * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Connectable-Observable-Operators">RxJava Wiki:
  *      Connectable Observable Operators</a>
  * @param <T>
- *          the type of items emitted by the {@code ConnectableObservable}
+ *          the type of items emitted by the {@code ConnectableFlowable}
  */
 public abstract class ConnectableFlowable<T> extends Flowable<T> {
 
     /**
-     * Instructs the {@code ConnectableObservable} to begin emitting the items from its underlying
+     * Instructs the {@code ConnectableFlowable} to begin emitting the items from its underlying
      * {@link Flowable} to its {@link Subscriber}s.
      *
      * @param connection
@@ -51,7 +51,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     public abstract void connect(@NonNull Consumer<? super Disposable> connection);
 
     /**
-     * Instructs the {@code ConnectableObservable} to begin emitting the items from its underlying
+     * Instructs the {@code ConnectableFlowable} to begin emitting the items from its underlying
      * {@link Flowable} to its {@link Subscriber}s.
      * <p>
      * To disconnect from a synchronous source, use the {@link #connect(io.reactivex.functions.Consumer)} method.
@@ -66,8 +66,8 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     }
 
     /**
-     * Returns an {@code Observable} that stays connected to this {@code ConnectableObservable} as long as there
-     * is at least one subscription to this {@code ConnectableObservable}.
+     * Returns a {@code Flowable} that stays connected to this {@code ConnectableFlowable} as long as there
+     * is at least one subscription to this {@code ConnectableFlowable}.
      *
      * @return a {@link Flowable}
      * @see <a href="http://reactivex.io/documentation/operators/refcount.html">ReactiveX documentation: RefCount</a>
@@ -78,10 +78,10 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     }
 
     /**
-     * Returns an Observable that automatically connects to this ConnectableObservable
+     * Returns a Flowable that automatically connects to this ConnectableFlowable
      * when the first Subscriber subscribes.
      *
-     * @return an Observable that automatically connects to this ConnectableObservable
+     * @return a Flowable that automatically connects to this ConnectableFlowable
      *         when the first Subscriber subscribes
      */
     @NonNull
@@ -89,13 +89,13 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
         return autoConnect(1);
     }
     /**
-     * Returns an Observable that automatically connects to this ConnectableObservable
+     * Returns a Flowable that automatically connects to this ConnectableFlowable
      * when the specified number of Subscribers subscribe to it.
      *
      * @param numberOfSubscribers the number of subscribers to await before calling connect
-     *                            on the ConnectableObservable. A non-positive value indicates
+     *                            on the ConnectableFlowable. A non-positive value indicates
      *                            an immediate connection.
-     * @return an Observable that automatically connects to this ConnectableObservable
+     * @return a Flowable that automatically connects to this ConnectableFlowable
      *         when the specified number of Subscribers subscribe to it
      */
     @NonNull
@@ -104,16 +104,16 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     }
 
     /**
-     * Returns an Observable that automatically connects to this ConnectableObservable
+     * Returns a Flowable that automatically connects to this ConnectableFlowable
      * when the specified number of Subscribers subscribe to it and calls the
      * specified callback with the Subscription associated with the established connection.
      *
      * @param numberOfSubscribers the number of subscribers to await before calling connect
-     *                            on the ConnectableObservable. A non-positive value indicates
+     *                            on the ConnectableFlowable. A non-positive value indicates
      *                            an immediate connection.
      * @param connection the callback Consumer that will receive the Subscription representing the
      *                   established connection
-     * @return an Observable that automatically connects to this ConnectableObservable
+     * @return a Flowable that automatically connects to this ConnectableFlowable
      *         when the specified number of Subscribers subscribe to it and calls the
      *         specified callback with the Subscription associated with the established connection
      */

--- a/src/main/java/io/reactivex/flowables/GroupedFlowable.java
+++ b/src/main/java/io/reactivex/flowables/GroupedFlowable.java
@@ -20,7 +20,7 @@ import io.reactivex.annotations.Nullable;
  * <p>
  * <em>Note:</em> A {@link GroupedFlowable} will cache the items it is to emit until such time as it
  * is subscribed to. For this reason, in order to avoid memory leaks, you should not simply ignore those
- * {@code GroupedObservable}s that do not concern you. Instead, you can signal to them that they
+ * {@code GroupedFlowable}s that do not concern you. Instead, you can signal to them that they
  * may discard their buffers by applying an operator like {@link Flowable#take take}{@code (0)} to them.
  *
  * @param <K>
@@ -43,9 +43,9 @@ public abstract class GroupedFlowable<K, T> extends Flowable<T> {
     }
 
     /**
-     * Returns the key that identifies the group of items emitted by this {@code GroupedObservable}.
+     * Returns the key that identifies the group of items emitted by this {@code GroupedFlowable}.
      *
-     * @return the key that the items emitted by this {@code GroupedObservable} were grouped by
+     * @return the key that the items emitted by this {@code GroupedFlowable} were grouped by
      */
     @Nullable
     public K getKey() {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAutoConnect.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAutoConnect.java
@@ -23,8 +23,8 @@ import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.Consumer;
 
 /**
- * Wraps a ConnectableObservable and calls its connect() method once
- * the specified number of Subscribers have subscribed.
+ * Wraps a {@link ConnectableFlowable} and calls its {@code connect()} method once
+ * the specified number of {@link Subscriber}s have subscribed.
  *
  * @param <T> the value type of the chain
  */


### PR DESCRIPTION
Some javadoc fixes for ConnectableFlowable, GroupedFlowable and FlowableAutoConnect