### PR TITLE
2.x: internal API to get distinct Workers from some Schedulers

### DIFF
--- a/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
@@ -15,19 +15,20 @@
  */
 package io.reactivex.internal.schedulers;
 
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
 import io.reactivex.Scheduler;
 import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.*;
-
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicReference;
+import io.reactivex.internal.functions.ObjectHelper;
 
 /**
  * Holds a fixed pool of worker threads and assigns them
  * to requested Scheduler.Workers in a round-robin fashion.
  */
-public final class ComputationScheduler extends Scheduler {
+public final class ComputationScheduler extends Scheduler implements SchedulerMultiWorkerSupport {
     /** This will indicate no pool is active. */
     static final FixedSchedulerPool NONE;
     /** Manages a fixed number of workers. */
@@ -67,7 +68,7 @@ public final class ComputationScheduler extends Scheduler {
         return paramThreads <= 0 || paramThreads > cpuCount ? cpuCount : paramThreads;
     }
 
-    static final class FixedSchedulerPool {
+    static final class FixedSchedulerPool implements SchedulerMultiWorkerSupport {
         final int cores;
 
         final PoolWorker[] eventLoops;
@@ -94,6 +95,25 @@ public final class ComputationScheduler extends Scheduler {
         public void shutdown() {
             for (PoolWorker w : eventLoops) {
                 w.dispose();
+            }
+        }
+
+        @Override
+        public void createWorkers(int number, WorkerCallback callback) {
+            int c = cores;
+            if (c == 0) {
+                for (int i = 0; i < number; i++) {
+                    callback.onWorker(i, SHUTDOWN_WORKER);
+                }
+            } else {
+                int index = (int)n % c;
+                for (int i = 0; i < number; i++) {
+                    callback.onWorker(i, new EventLoopWorker(eventLoops[index]));
+                    if (++index == c) {
+                        index = 0;
+                    }
+                }
+                n = index;
             }
         }
     }
@@ -123,6 +143,12 @@ public final class ComputationScheduler extends Scheduler {
     @Override
     public Worker createWorker() {
         return new EventLoopWorker(pool.get().getEventLoop());
+    }
+
+    @Override
+    public void createWorkers(int number, WorkerCallback callback) {
+        ObjectHelper.verifyPositive(number, "number > 0 required");
+        pool.get().createWorkers(number, callback);
     }
 
     @NonNull

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerMultiWorkerSupport.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerMultiWorkerSupport.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.schedulers;
+
+import io.reactivex.Scheduler;
+import io.reactivex.annotations.*;
+
+/**
+ * Allows retrieving multiple workers from the implementing
+ * {@link io.reactivex.Scheduler} in a way that when asking for
+ * at most the parallelism level of the Scheduler, those
+ * {@link io.reactivex.Scheduler.Worker} instances will be running
+ * with different backing threads.
+ *
+ * @since 2.1.7 - experimental
+ */
+@Experimental
+public interface SchedulerMultiWorkerSupport {
+
+    /**
+     * Creates the given number of {@link io.reactivex.Scheduler.Worker} instances
+     * that are possibly backed by distinct threads
+     * and calls the specified {@code Consumer} with them.
+     * @param number the number of workers to create, positive
+     * @param callback the callback to send worker instances to
+     */
+    void createWorkers(int number, @NonNull WorkerCallback callback);
+
+    /**
+     * The callback interface for the {@link SchedulerMultiWorkerSupport#createWorkers(int, WorkerCallback)}
+     * method.
+     */
+    interface WorkerCallback {
+        /**
+         * Called with the Worker index and instance.
+         * @param index the worker index, zero-based
+         * @param worker the worker instance
+         */
+        void onWorker(int index, @NonNull Scheduler.Worker worker);
+    }
+}

--- a/src/test/java/io/reactivex/internal/schedulers/SchedulerMultiWorkerSupportTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/SchedulerMultiWorkerSupportTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.schedulers;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import io.reactivex.Scheduler.Worker;
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.internal.schedulers.SchedulerMultiWorkerSupport.WorkerCallback;
+import io.reactivex.schedulers.Schedulers;
+
+public class SchedulerMultiWorkerSupportTest {
+
+    final int max = ComputationScheduler.MAX_THREADS;
+
+    @Test
+    public void moreThanMaxWorkers() {
+        final List<Worker> list = new ArrayList<Worker>();
+
+        SchedulerMultiWorkerSupport mws = (SchedulerMultiWorkerSupport)Schedulers.computation();
+
+        mws.createWorkers(max * 2, new WorkerCallback() {
+            @Override
+            public void onWorker(int i, Worker w) {
+                list.add(w);
+            }
+        });
+
+        assertEquals(max * 2, list.size());
+    }
+
+    @Test
+    public void getShutdownWorkers() {
+        final List<Worker> list = new ArrayList<Worker>();
+
+        ComputationScheduler.NONE.createWorkers(max * 2, new WorkerCallback() {
+            @Override
+            public void onWorker(int i, Worker w) {
+                list.add(w);
+            }
+        });
+
+        assertEquals(max * 2, list.size());
+
+        for (Worker w : list) {
+            assertEquals(ComputationScheduler.SHUTDOWN_WORKER, w);
+        }
+    }
+
+    @Test
+    public void distinctThreads() throws Exception {
+        for (int i = 0; i < 1000; i++) {
+
+            final CompositeDisposable composite = new CompositeDisposable();
+
+            try {
+                final CountDownLatch cdl = new CountDownLatch(max * 2);
+
+                final Set<String> threads1 = Collections.synchronizedSet(new HashSet<String>());
+
+                final Set<String> threads2 = Collections.synchronizedSet(new HashSet<String>());
+
+                Runnable parallel1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        final List<Worker> list1 = new ArrayList<Worker>();
+
+                        SchedulerMultiWorkerSupport mws = (SchedulerMultiWorkerSupport)Schedulers.computation();
+
+                        mws.createWorkers(max, new WorkerCallback() {
+                            @Override
+                            public void onWorker(int i, Worker w) {
+                                list1.add(w);
+                                composite.add(w);
+                            }
+                        });
+
+                        Runnable run = new Runnable() {
+                            @Override
+                            public void run() {
+                                threads1.add(Thread.currentThread().getName());
+                                cdl.countDown();
+                            }
+                        };
+
+                        for (Worker w : list1) {
+                            w.schedule(run);
+                        }
+                    }
+                };
+
+                Runnable parallel2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        final List<Worker> list2 = new ArrayList<Worker>();
+
+                        SchedulerMultiWorkerSupport mws = (SchedulerMultiWorkerSupport)Schedulers.computation();
+
+                        mws.createWorkers(max, new WorkerCallback() {
+                            @Override
+                            public void onWorker(int i, Worker w) {
+                                list2.add(w);
+                                composite.add(w);
+                            }
+                        });
+
+                        Runnable run = new Runnable() {
+                            @Override
+                            public void run() {
+                                threads2.add(Thread.currentThread().getName());
+                                cdl.countDown();
+                            }
+                        };
+
+                        for (Worker w : list2) {
+                            w.schedule(run);
+                        }
+                    }
+                };
+
+                TestHelper.race(parallel1, parallel2);
+
+                assertTrue(cdl.await(5, TimeUnit.SECONDS));
+
+                assertEquals(threads1.toString(), max, threads1.size());
+                assertEquals(threads2.toString(), max, threads2.size());
+            } finally {
+                composite.dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an internal interface `SchedulerMultiWorkerSupport` that allows retrieving multiple workers from a `Scheduler` that implements this interface.

The standard `Scheduler.getWorker()` can be invoked as many times as necessary, but specific implementations such as the `computation()` `Scheduler` and the [`ParallelScheduler`](https://github.com/akarnokd/RxJava2Extensions#parallelscheduler) is not guaranteed to return workers that are backed by distinct single-threaded thread pools. 

This does not effect other scheduler types because: 
- they are single threaded (`single()`) or don't use threads at all (`trampoline()`) and 
- already hand out distinct workers (`io()`, `newThread()`).

Such worker reuse can happen when in a highly concurrent application, typical tasks are mixed with parallel tasks and both pull out workers from these `Scheduler`s. If this is happens, it is possible there will be duplicate threads used by the parallel operations and thus not utilize the originally intended parallelism level.

By implementing this suggested interface, a batch-retrieval can be supported by the `Scheduler`s and they can make sure the caller gets as many distinct thread-pool as possible. If more workers are requested than the `Scheduler`'s parallelism, the workers are handed out in round-robin fashion similar to the standard `createWorker()`.

Why a callback instead of returning an array? 
- even if both require an allocation to set up, there is no need to have all workers visible at once,
- simply less memory usage, and
- avoids looping twice: once for filling in the array and once for using the elements of the array.

