### PR TITLE
2.x: improve wording and links in package-infos + remove unused imports

### DIFF
--- a/src/main/java/io/reactivex/flowables/package-info.java
+++ b/src/main/java/io/reactivex/flowables/package-info.java
@@ -15,7 +15,8 @@
  */
 
 /**
- * Classes supporting the Flowable base reactive class: connectable and grouped
- * flowables.
+ * Classes supporting the Flowable base reactive class:
+ * {@link io.reactivex.flowables.ConnectableFlowable} and
+ * {@link io.reactivex.flowables.GroupedFlowable}.
  */
 package io.reactivex.flowables;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFromCallable.java
@@ -19,7 +19,6 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 

--- a/src/main/java/io/reactivex/observables/package-info.java
+++ b/src/main/java/io/reactivex/observables/package-info.java
@@ -15,7 +15,8 @@
  */
 
 /**
- * Classes supporting the Observable base reactive class: connectable and grouped
- * observables.
+ * Classes supporting the Observable base reactive class:
+ * {@link io.reactivex.observable.ConnectableObservable} and
+ * {@link io.reactivex.observable.GroupedObservable}.
  */
 package io.reactivex.observables;

--- a/src/main/java/io/reactivex/package-info.java
+++ b/src/main/java/io/reactivex/package-info.java
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 /**
- * Base reactive classes: Flowable, Observable, Single, Maybe and Completable; base reactive consumers;
+ * Base reactive classes: {@link io.reactivex.Flowable},  {@link io.reactivex.Observable},
+ * {@link io.reactivex.Single},  {@link io.reactivex.Maybe} and
+ *  {@link io.reactivex.Completable}; base reactive consumers;
  * other common base interfaces.
  *
  * <p>A library that enables subscribing to and composing asynchronous events and

--- a/src/main/java/io/reactivex/parallel/package-info.java
+++ b/src/main/java/io/reactivex/parallel/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * Base type for the parallel type offering a sub-DSL for working with Flowable items
- * in parallel.
+ * Contains the base type {@link io.reactivex.parallel.ParallelFlowable},
+ * a sub-DSL for working with {@link io.reactivex.Flowable} sequences in parallel.
  */
 package io.reactivex.parallel;

--- a/src/main/java/io/reactivex/plugins/package-info.java
+++ b/src/main/java/io/reactivex/plugins/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * Callback types and a central plugin handler class to hook into the lifecycle
- * of the base reactive types and schedulers.
+ * Contains the central plugin handler {@link io.reactivex.plugins.RxJavaPlugins}
+ * class to hook into the lifecycle of the base reactive types and schedulers.
  */
 package io.reactivex.plugins;

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableFromCallableTest.java
@@ -18,7 +18,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.TestHelper;
 import io.reactivex.disposables.Disposable;


### PR DESCRIPTION
This PR is to improve the wording of a few `package-info.java` JavaDocs and removes two unused imports.