### PR TITLE
2.x: Check runnable == null in *Scheduler.schedule*().

### DIFF
--- a/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/TrampolineScheduler.java
@@ -49,6 +49,8 @@ public final class TrampolineScheduler extends Scheduler {
     @NonNull
     @Override
     public Disposable scheduleDirect(@NonNull Runnable run) {
+        // TODO remove if https://github.com/ReactiveX/RxJava/pull/5747 gets merged.
+        ObjectHelper.requireNonNull(run, "runnable is null");
         run.run();
         return EmptyDisposable.INSTANCE;
     }
@@ -56,6 +58,8 @@ public final class TrampolineScheduler extends Scheduler {
     @NonNull
     @Override
     public Disposable scheduleDirect(@NonNull Runnable run, long delay, TimeUnit unit) {
+        // TODO remove if https://github.com/ReactiveX/RxJava/pull/5747 gets merged.
+        ObjectHelper.requireNonNull(run, "runnable is null");
         try {
             unit.sleep(delay);
             run.run();

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -446,6 +446,8 @@ public final class RxJavaPlugins {
      */
     @NonNull
     public static Runnable onSchedule(@NonNull Runnable run) {
+        ObjectHelper.requireNonNull(run, "runnable is null");
+
         Function<? super Runnable, ? extends Runnable> f = onScheduleHandler;
         if (f == null) {
             return run;

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -446,7 +446,7 @@ public final class RxJavaPlugins {
      */
     @NonNull
     public static Runnable onSchedule(@NonNull Runnable run) {
-        ObjectHelper.requireNonNull(run, "runnable is null");
+        ObjectHelper.requireNonNull(run, "run is null");
 
         Function<? super Runnable, ? extends Runnable> f = onScheduleHandler;
         if (f == null) {

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -1369,8 +1369,6 @@ public class RxJavaPluginsTest {
 
             assertNull(RxJavaPlugins.onAssembly((Maybe)null));
 
-            assertNull(RxJavaPlugins.onSchedule(null));
-
             Maybe myb = new Maybe() {
                 @Override
                 public void subscribeActual(MaybeObserver t) {
@@ -1381,10 +1379,7 @@ public class RxJavaPluginsTest {
             assertSame(myb, RxJavaPlugins.onAssembly(myb));
 
 
-            assertNull(RxJavaPlugins.onSchedule(null));
-
             Runnable action = Functions.EMPTY_RUNNABLE;
-
             assertSame(action, RxJavaPlugins.onSchedule(action));
 
             class AllSubscriber implements Subscriber, Observer, SingleObserver, CompletableObserver, MaybeObserver {

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
@@ -749,7 +749,7 @@ public abstract class AbstractSchedulerTests {
             getScheduler().scheduleDirect(null);
             fail();
         } catch (NullPointerException npe) {
-            assertEquals("runnable is null", npe.getMessage());
+            assertEquals("run is null", npe.getMessage());
         }
     }
 
@@ -759,7 +759,7 @@ public abstract class AbstractSchedulerTests {
             getScheduler().scheduleDirect(null, 10, TimeUnit.MILLISECONDS);
             fail();
         } catch (NullPointerException npe) {
-            assertEquals("runnable is null", npe.getMessage());
+            assertEquals("run is null", npe.getMessage());
         }
     }
 
@@ -769,7 +769,7 @@ public abstract class AbstractSchedulerTests {
             getScheduler().schedulePeriodicallyDirect(null, 5, 10, TimeUnit.MILLISECONDS);
             fail();
         } catch (NullPointerException npe) {
-            assertEquals("runnable is null", npe.getMessage());
+            assertEquals("run is null", npe.getMessage());
         }
     }
 }

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerTests.java
@@ -626,4 +626,34 @@ public abstract class AbstractSchedulerTests {
             }
         }
     }
+
+    @Test
+    public void scheduleDirectNullRunnable() {
+        try {
+            getScheduler().scheduleDirect(null);
+            fail();
+        } catch (NullPointerException npe) {
+            assertEquals("runnable is null", npe.getMessage());
+        }
+    }
+
+    @Test
+    public void scheduleDirectWithDelayNullRunnable() {
+        try {
+            getScheduler().scheduleDirect(null, 10, TimeUnit.MILLISECONDS);
+            fail();
+        } catch (NullPointerException npe) {
+            assertEquals("runnable is null", npe.getMessage());
+        }
+    }
+
+    @Test
+    public void schedulePeriodicallyDirectNullRunnable() {
+        try {
+            getScheduler().schedulePeriodicallyDirect(null, 5, 10, TimeUnit.MILLISECONDS);
+            fail();
+        } catch (NullPointerException npe) {
+            assertEquals("runnable is null", npe.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
To enforce `@NotNull` guarantee for the PR #5734, see  https://github.com/ReactiveX/RxJava/pull/5734/files#r153951238