### PR TITLE
2.x: Reactive-Streams 1.0.2-RCx - not for merge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 // ---------------------------------------
 
 def junitVersion = "4.12"
-def reactiveStreamsVersion = "1.0.1"
+def reactiveStreamsVersion = "1.0.2-RC1"
 def mockitoVersion = "2.1.0"
 def jmhLibVersion = "1.19"
 def testNgVersion = "6.11"
@@ -60,6 +60,7 @@ def testNgVersion = "6.11"
 
 repositories {
   mavenCentral()
+  maven { url "https://oss.sonatype.org/content/repositories/orgreactivestreams-1033" }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 // ---------------------------------------
 
 def junitVersion = "4.12"
-def reactiveStreamsVersion = "1.0.2-RC1"
+def reactiveStreamsVersion = "1.0.2-RC2"
 def mockitoVersion = "2.1.0"
 def jmhLibVersion = "1.19"
 def testNgVersion = "6.11"
@@ -60,7 +60,6 @@ def testNgVersion = "6.11"
 
 repositories {
   mavenCentral()
-  maven { url "https://oss.sonatype.org/content/repositories/orgreactivestreams-1033" }
 }
 
 dependencies {


### PR DESCRIPTION
This PR verifies the upcoming Reactive-Streams 1.0.2 with TCK changes are still okay with RxJava.