### PR TITLE
2.x: Fix race conditions in observeOn operators.

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableObserveOn.java
@@ -82,6 +82,10 @@ public final class CompletableObserveOn extends Completable {
 
         @Override
         public void run() {
+            if (isDisposed()) {
+                return;
+            }
+
             Throwable ex = error;
             if (ex != null) {
                 error = null;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeObserveOn.java
@@ -93,6 +93,10 @@ public final class MaybeObserveOn<T> extends AbstractMaybeWithUpstream<T, T> {
 
         @Override
         public void run() {
+            if (isDisposed()) {
+                return;
+            }
+
             Throwable ex = error;
             if (ex != null) {
                 error = null;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleObserveOn.java
@@ -74,6 +74,10 @@ public final class SingleObserveOn<T> extends Single<T> {
 
         @Override
         public void run() {
+            if (isDisposed()) {
+                return;
+            }
+
             Throwable ex = error;
             if (ex != null) {
                 actual.onError(ex);


### PR DESCRIPTION
We should check isDisposed() just before emitting results.

This PR fixes https://github.com/ReactiveX/RxJava/issues/5776