### PR TITLE
2.x: Fix JavaDoc wording of onTerminateDetach

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -10524,7 +10524,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return a Flowable which out references to the upstream producer and downstream Subscriber if
+     * @return a Flowable which nulls out references to the upstream producer and downstream Subscriber if
      * the sequence is terminated or downstream cancels
      * @since 2.0
      */

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -9012,7 +9012,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return an Observable which out references to the upstream producer and downstream Observer if
+     * @return an Observable which nulls out references to the upstream producer and downstream Observer if
      * the sequence is terminated or downstream calls dispose()
      * @since 2.0
      */


### PR DESCRIPTION
A missing `nulls` word from `Flowable.onTerminateDetach` and `Observable.onTerminateDetach` JavaDoc. The other types have this word already.

Related: #5782.