### PR TITLE
2.x: improve request accounting overhead in retry/repeat

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
@@ -260,6 +260,19 @@ public class FlowableRepeatTest {
     }
 
     @Test
+    public void repeatUntilCancel() {
+        Flowable.just(1)
+        .repeatUntil(new BooleanSupplier() {
+            @Override
+            public boolean getAsBoolean() throws Exception {
+                return true;
+            }
+        })
+        .test(2L, true)
+        .assertEmpty();
+    }
+
+    @Test
     public void repeatLongPredicateInvalid() {
         try {
             Flowable.just(1).repeat(-99);


### PR DESCRIPTION
This PR improves the request accounting overhead in the `retry` and `repeat` operators.

Previously, every individual `onNext` invocation signaled a an item production, which had a lot of overhead since the `SubscriptionArbiter` has to serialize invocations of `setSubscription`, `request` and `produced`. The improved algorithm counts the `onNext` calls in a field and calls `produced` once with the total count before subscribing to the upstream again.

Other small changes:
- rename inner class to `RetrySubscriber` (sloppy copy-paste),
- add `isCancelled()` check to `repeatUntil` subscription loop, which was somehow missing.