### PR TITLE
2.x: Fix flatMap inner fused poll crash not cancelling the upstream

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -1033,4 +1033,47 @@ public class FlowableFlatMapTest {
         .test()
         .assertFailureAndMessage(NullPointerException.class, "The mapper returned a null Publisher");
     }
+
+    @Test
+    public void failingFusedInnerCancelsSource() {
+        final AtomicInteger counter = new AtomicInteger();
+        Flowable.range(1, 5)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                counter.getAndIncrement();
+            }
+        })
+        .flatMap(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.<Integer>fromIterable(new Iterable<Integer>() {
+                    @Override
+                    public Iterator<Integer> iterator() {
+                        return new Iterator<Integer>() {
+                            @Override
+                            public boolean hasNext() {
+                                return true;
+                            }
+
+                            @Override
+                            public Integer next() {
+                                throw new TestException();
+                            }
+
+                            @Override
+                            public void remove() {
+                                throw new UnsupportedOperationException();
+                            }
+                        };
+                    }
+                });
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, counter.get());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
@@ -894,4 +894,48 @@ public class ObservableFlatMapTest {
         .test()
         .assertFailureAndMessage(NullPointerException.class, "The mapper returned a null ObservableSource");
     }
+
+
+    @Test
+    public void failingFusedInnerCancelsSource() {
+        final AtomicInteger counter = new AtomicInteger();
+        Observable.range(1, 5)
+        .doOnNext(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                counter.getAndIncrement();
+            }
+        })
+        .flatMap(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.<Integer>fromIterable(new Iterable<Integer>() {
+                    @Override
+                    public Iterator<Integer> iterator() {
+                        return new Iterator<Integer>() {
+                            @Override
+                            public boolean hasNext() {
+                                return true;
+                            }
+
+                            @Override
+                            public Integer next() {
+                                throw new TestException();
+                            }
+
+                            @Override
+                            public void remove() {
+                                throw new UnsupportedOperationException();
+                            }
+                        };
+                    }
+                });
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, counter.get());
+    }
 }


### PR DESCRIPTION
This PR fixes the lack of upstream `cancel()` call when an inner, fused source's `queue.poll()` crashes in a non-delayed error mode.

Unit tests were added to verify `Observable.flatMap`, `Flowable.flatMapIterable` and `Observable.flatMapIterable` as well.
  
Fixes #5791