### PR TITLE
2.x: Add missing {Maybe|Single}.mergeDelayError variants

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -787,9 +787,9 @@ public abstract class Single<T> implements SingleSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source2
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #mergeDelayError(SingleSource, SingleSource)
@@ -835,11 +835,11 @@ public abstract class Single<T> implements SingleSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source2
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source3
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #mergeDelayError(SingleSource, SingleSource, SingleSource)
@@ -887,13 +887,13 @@ public abstract class Single<T> implements SingleSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source2
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source3
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source4
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #mergeDelayError(SingleSource, SingleSource, SingleSource, SingleSource)
@@ -980,9 +980,9 @@ public abstract class Single<T> implements SingleSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source2
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #merge(SingleSource, SingleSource)
@@ -1018,11 +1018,11 @@ public abstract class Single<T> implements SingleSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source2
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source3
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #merge(SingleSource, SingleSource, SingleSource)
@@ -1060,13 +1060,13 @@ public abstract class Single<T> implements SingleSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source2
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source3
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @param source4
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #merge(SingleSource, SingleSource, SingleSource, SingleSource)
@@ -2592,7 +2592,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * </dl>
      *
      * @param other
-     *            a Single to be merged
+     *            a SingleSource to be merged
      * @return  that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -880,7 +880,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(SingleSource, SingleSource, SingleSource)} to merge sources and terminate only when all source {@code SingleSource}s
+     *  Use {@link #mergeDelayError(SingleSource, SingleSource, SingleSource, SingleSource)} to merge sources and terminate only when all source {@code SingleSource}s
      *  have completed or failed with an error.
      *  </dd>
      * </dl>
@@ -911,6 +911,181 @@ public abstract class Single<T> implements SingleSource<T> {
         ObjectHelper.requireNonNull(source3, "source3 is null");
         ObjectHelper.requireNonNull(source4, "source4 is null");
         return merge(Flowable.fromArray(source1, source2, source3, source4));
+    }
+
+
+    /**
+     * Merges an Iterable sequence of SingleSource instances into a single Flowable sequence,
+     * running all SingleSources at once and delaying any error(s) until all sources succeed or fail.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the common and resulting value type
+     * @param sources the Iterable sequence of SingleSource sources
+     * @return the new Flowable instance
+     * @since 2.1.9 - experimental
+     * @see #merge(Iterable)
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public static <T> Flowable<T> mergeDelayError(Iterable<? extends SingleSource<? extends T>> sources) {
+        return mergeDelayError(Flowable.fromIterable(sources));
+    }
+
+    /**
+     * Merges a Flowable sequence of SingleSource instances into a single Flowable sequence,
+     * running all SingleSources at once and delaying any error(s) until all sources succeed or fail.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the common and resulting value type
+     * @param sources the Flowable sequence of SingleSource sources
+     * @return the new Flowable instance
+     * @see #merge(Publisher)
+     * @since 2.1.9 - experimental
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Experimental
+    public static <T> Flowable<T> mergeDelayError(Publisher<? extends SingleSource<? extends T>> sources) {
+        ObjectHelper.requireNonNull(sources, "sources is null");
+        return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, SingleInternalHelper.toFlowable(), true, Integer.MAX_VALUE, Flowable.bufferSize()));
+    }
+
+
+    /**
+     * Flattens two Singles into a single Flowable, without any transformation, delaying
+     * any error(s) until all sources succeed or fail.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Flowable, by
+     * using the {@code mergeDelayError} method.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common value type
+     * @param source1
+     *            a Single to be merged
+     * @param source2
+     *            a Single to be merged
+     * @return a Flowable that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     * @see #merge(SingleSource, SingleSource)
+     * @since 2.1.9 - experimental
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @SuppressWarnings("unchecked")
+    @Experimental
+    public static <T> Flowable<T> mergeDelayError(
+            SingleSource<? extends T> source1, SingleSource<? extends T> source2
+     ) {
+        ObjectHelper.requireNonNull(source1, "source1 is null");
+        ObjectHelper.requireNonNull(source2, "source2 is null");
+        return mergeDelayError(Flowable.fromArray(source1, source2));
+    }
+
+    /**
+     * Flattens three Singles into a single Flowable, without any transformation, delaying
+     * any error(s) until all sources succeed or fail.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Flowable, by using
+     * the {@code mergeDelayError} method.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common value type
+     * @param source1
+     *            a Single to be merged
+     * @param source2
+     *            a Single to be merged
+     * @param source3
+     *            a Single to be merged
+     * @return a Flowable that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     * @see #merge(SingleSource, SingleSource, SingleSource)
+     * @since 2.1.9 - experimental
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @SuppressWarnings("unchecked")
+    @Experimental
+    public static <T> Flowable<T> mergeDelayError(
+            SingleSource<? extends T> source1, SingleSource<? extends T> source2,
+            SingleSource<? extends T> source3
+     ) {
+        ObjectHelper.requireNonNull(source1, "source1 is null");
+        ObjectHelper.requireNonNull(source2, "source2 is null");
+        ObjectHelper.requireNonNull(source3, "source3 is null");
+        return mergeDelayError(Flowable.fromArray(source1, source2, source3));
+    }
+
+    /**
+     * Flattens four Singles into a single Flowable, without any transformation, delaying
+     * any error(s) until all sources succeed or fail.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <p>
+     * You can combine items emitted by multiple Singles so that they appear as a single Flowable, by using
+     * the {@code mergeDelayError} method.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common value type
+     * @param source1
+     *            a Single to be merged
+     * @param source2
+     *            a Single to be merged
+     * @param source3
+     *            a Single to be merged
+     * @param source4
+     *            a Single to be merged
+     * @return a Flowable that emits all of the items emitted by the source Singles
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     * @see #merge(SingleSource, SingleSource, SingleSource, SingleSource)
+     * @since 2.1.9 - experimental
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @SuppressWarnings("unchecked")
+    @Experimental
+    public static <T> Flowable<T> mergeDelayError(
+            SingleSource<? extends T> source1, SingleSource<? extends T> source2,
+            SingleSource<? extends T> source3, SingleSource<? extends T> source4
+     ) {
+        ObjectHelper.requireNonNull(source1, "source1 is null");
+        ObjectHelper.requireNonNull(source2, "source2 is null");
+        ObjectHelper.requireNonNull(source3, "source3 is null");
+        ObjectHelper.requireNonNull(source4, "source4 is null");
+        return mergeDelayError(Flowable.fromArray(source1, source2, source3, source4));
     }
 
     /**

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.schedulers.Schedulers;
+
+public class MaybeMergeTest {
+
+    @Test
+    public void delayErrorWithMaxConcurrency() {
+        Maybe.mergeDelayError(
+                Flowable.just(Maybe.just(1), Maybe.just(2), Maybe.just(3)), 1)
+        .test()
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void delayErrorWithMaxConcurrencyError() {
+        Maybe.mergeDelayError(
+                Flowable.just(Maybe.just(1), Maybe.<Integer>error(new TestException()), Maybe.just(3)), 1)
+        .test()
+        .assertFailure(TestException.class, 1, 3);
+    }
+
+    @Test
+    public void delayErrorWithMaxConcurrencyAsync() {
+        final AtomicInteger count = new AtomicInteger();
+        @SuppressWarnings("unchecked")
+        Maybe<Integer>[] sources = new Maybe[3];
+        for (int i = 0; i < 3; i++) {
+            final int j = i + 1;
+            sources[i] = Maybe.fromCallable(new Callable<Integer>() {
+                @Override
+                public Integer call() throws Exception {
+                    return count.incrementAndGet() - j;
+                }
+            })
+            .subscribeOn(Schedulers.io());
+        }
+
+        for (int i = 0; i < 1000; i++) {
+            count.set(0);
+            Maybe.mergeDelayError(
+                    Flowable.fromArray(sources), 1)
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(0, 0, 0);
+        }
+    }
+
+    @Test
+    public void delayErrorWithMaxConcurrencyAsyncError() {
+        final AtomicInteger count = new AtomicInteger();
+        @SuppressWarnings("unchecked")
+        Maybe<Integer>[] sources = new Maybe[3];
+        for (int i = 0; i < 3; i++) {
+            final int j = i + 1;
+            sources[i] = Maybe.fromCallable(new Callable<Integer>() {
+                @Override
+                public Integer call() throws Exception {
+                    return count.incrementAndGet() - j;
+                }
+            })
+            .subscribeOn(Schedulers.io());
+        }
+        sources[1] = Maybe.fromCallable(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                throw new TestException("" + count.incrementAndGet());
+            }
+        })
+        .subscribeOn(Schedulers.io());
+
+        for (int i = 0; i < 1000; i++) {
+            count.set(0);
+            Maybe.mergeDelayError(
+                    Flowable.fromArray(sources), 1)
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailureAndMessage(TestException.class, "2", 0, 0);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMergeTest.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.single;
 
 import static org.junit.Assert.assertTrue;
 
-import java.util.List;
+import java.util.*;
 
 import org.junit.Test;
 
@@ -69,5 +69,72 @@ public class SingleMergeTest {
         } finally {
             RxJavaPlugins.reset();
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mergeDelayErrorIterable() {
+        Single.mergeDelayError(Arrays.asList(
+                Single.just(1),
+                Single.<Integer>error(new TestException()),
+                Single.just(2))
+        )
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @Test
+    public void mergeDelayErrorPublisher() {
+        Single.mergeDelayError(Flowable.just(
+                Single.just(1),
+                Single.<Integer>error(new TestException()),
+                Single.just(2))
+        )
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+    @Test
+    public void mergeDelayError2() {
+        Single.mergeDelayError(
+                Single.just(1),
+                Single.<Integer>error(new TestException())
+        )
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void mergeDelayError2ErrorFirst() {
+        Single.mergeDelayError(
+                Single.<Integer>error(new TestException()),
+                Single.just(1)
+        )
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void mergeDelayError3() {
+        Single.mergeDelayError(
+                Single.just(1),
+                Single.<Integer>error(new TestException()),
+                Single.just(2)
+        )
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
+
+
+    @Test
+    public void mergeDelayError4() {
+        Single.mergeDelayError(
+                Single.just(1),
+                Single.<Integer>error(new TestException()),
+                Single.just(2),
+                Single.just(3)
+        )
+        .test()
+        .assertFailure(TestException.class, 1, 2, 3);
     }
 }


### PR DESCRIPTION
This PR adds `mergeDelayError` overloads to `Maybe` and `Single`; the infrastructure was there from the beginning but the `delayErrors == true` settings were not exposed publicly.

- `Maybe.mergeDelayError(Publisher, int)`
- `Single.mergeDelayError(Iterable)`
- `Single.mergeDelayError(Publisher)`
- `Single.mergeDelayError(SingleSource, SingleSource)`
- `Single.mergeDelayError(SingleSource, SingleSource, SingleSource)`
- `Single.mergeDelayError(SingleSource, SingleSource, SingleSource, SingleSource)`