### PR TITLE
2.x: Improved XSubject JavaDocs

### DIFF
--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -86,7 +86,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * given {@code Subscription} being cancelled immediately.
  * <p>
  * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
- * is still required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * is required to be serialized (called from the same thread or called non-overlappingly from different threads
  * through external means of serialization). The {@link #toSerialized()} method available to all {@code FlowableProcessor}s
  * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Subscriber}
  * consuming this processor also wants to call {@link #onNext(Object)} on this processor recursively).

--- a/src/main/java/io/reactivex/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/subjects/AsyncSubject.java
@@ -50,7 +50,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * given {@code Disposable} being disposed immediately.
  * <p>
  * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
- * is still required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * is required to be serialized (called from the same thread or called non-overlappingly from different threads
  * through external means of serialization). The {@link #toSerialized()} method available to all {@code Subject}s
  * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Observer}
  * consuming this subject also wants to call {@link #onNext(Object)} on this subject recursively).

--- a/src/main/java/io/reactivex/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/subjects/AsyncSubject.java
@@ -24,14 +24,86 @@ import io.reactivex.internal.observers.DeferredScalarDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
- * An Subject that emits the very last value followed by a completion event or the received error to Observers.
- *
- * <p>The implementation of onXXX methods are technically thread-safe but non-serialized calls
+ * A Subject that emits the very last value followed by a completion event or the received error to Observers.
+ * <p>
+ * This subject does not have a public constructor by design; a new empty instance of this
+ * {@code AsyncSubject} can be created via the {@link #create()} method.
+ * <p>
+ * Since a {@code Subject} is conceptionally derived from the {@code Processor} type in the Reactive Streams specification,
+ * {@code null}s are not allowed (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">Rule 2.13</a>)
+ * as parameters to {@link #onNext(Object)} and {@link #onError(Throwable)}. Such calls will result in a
+ * {@link NullPointerException} being thrown and the subject's state is not changed.
+ * <p>
+ * Since an {@code AsyncSubject} is an {@link io.reactivex.Observable}, it does not support backpressure.
+ * <p>
+ * When this {@code AsyncSubject} is terminated via {@link #onError(Throwable)}, the
+ * last observed item (if any) is cleared and late {@link io.reactivex.Observer}s only receive
+ * the {@code onError} event.
+ * <p>
+ * The {@code AsyncSubject} caches the latest item internally and it emits this item only when {@code onComplete} is called.
+ * Therefore, it is not recommended to use this {@code Subject} with infinite or never-completing sources.
+ * <p>
+ * Even though {@code AsyncSubject} implements the {@code Observer} interface, calling
+ * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
+ * if the subject is used as a standalone source. However, calling {@code onSubscribe}
+ * after the {@code AsyncSubject} reached its terminal state will result in the
+ * given {@code Disposable} being disposed immediately.
+ * <p>
+ * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
+ * is still required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * through external means of serialization). The {@link #toSerialized()} method available to all {@code Subject}s
+ * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Observer}
+ * consuming this subject also wants to call {@link #onNext(Object)} on this subject recursively).
+ * The implementation of onXXX methods are technically thread-safe but non-serialized calls
  * to them may lead to undefined state in the currently subscribed Observers.
+ * <p>
+ * This {@code AsyncSubject} supports the standard state-peeking methods {@link #hasComplete()}, {@link #hasThrowable()},
+ * {@link #getThrowable()} and {@link #hasObservers()} as well as means to read the very last observed value -
+ * after this {@code AsyncSubject} has been completed - in a non-blocking and thread-safe
+ * manner via {@link #hasValue()}, {@link #getValue()}, {@link #getValues()} or {@link #getValues(Object[])}.
+ * <dl>
+ *  <dt><b>Scheduler:</b></dt>
+ *  <dd>{@code AsyncSubject} does not operate by default on a particular {@link io.reactivex.Scheduler} and
+ *  the {@code Observer}s get notified on the thread where the terminating {@code onError} or {@code onComplete}
+ *  methods were invoked.</dd>
+ *  <dt><b>Error handling:</b></dt>
+ *  <dd>When the {@link #onError(Throwable)} is called, the {@code AsyncSubject} enters into a terminal state
+ *  and emits the same {@code Throwable} instance to the last set of {@code Observer}s. During this emission,
+ *  if one or more {@code Observer}s dispose their respective {@code Disposable}s, the
+ *  {@code Throwable} is delivered to the global error handler via
+ *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} (multiple times if multiple {@code Observer}s
+ *  cancel at once).
+ *  If there were no {@code Observer}s subscribed to this {@code AsyncSubject} when the {@code onError()}
+ *  was called, the global error handler is not invoked.
+ *  </dd>
+ * </dl>
+ * <p>
+ * Example usage:
+ * <pre><code>
+ * AsyncSubject&lt;Object&gt; subject = AsyncSubject.create();
+ * 
+ * TestObserver&lt;Object&gt; to1 = subject.test();
+ * 
+ * to1.assertEmpty();
+ * 
+ * subject.onNext(1);
+ * 
+ * // AsyncSubject only emits when onComplete was called.
+ * to1.assertEmpty();
  *
+ * subject.onNext(2);
+ * subject.onComplete();
+ * 
+ * // onComplete triggers the emission of the last cached item and the onComplete event.
+ * to1.assertResult(2);
+ * 
+ * TestObserver&lt;Object&gt; to2 = subject.test();
+ * 
+ * // late Observers receive the last cached item too
+ * to2.assertResult(2);
+ * </code></pre>
  * @param <T> the value type
  */
-
 public final class AsyncSubject<T> extends Subject<T> {
 
     @SuppressWarnings("rawtypes")

--- a/src/main/java/io/reactivex/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/subjects/BehaviorSubject.java
@@ -88,7 +88,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * given {@code Disposable} being disposed immediately.
  * <p>
  * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
- * is still required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * is required to be serialized (called from the same thread or called non-overlappingly from different threads
  * through external means of serialization). The {@link #toSerialized()} method available to all {@code Subject}s
  * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Observer}
  * consuming this subject also wants to call {@link #onNext(Object)} on this subject recursively).

--- a/src/main/java/io/reactivex/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/subjects/BehaviorSubject.java
@@ -36,10 +36,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * a new non-empty instance can be created via {@link #createDefault(Object)} (named as such to avoid
  * overload resolution conflict with {@code Observable.create} that creates an Observable, not a {@code BehaviorSubject}).
  * <p>
- * Since the {@code Subject} is conceptionally derived from the {@code Processor} type in the Reactive Streams specification,
+ * Since a {@code Subject} is conceptionally derived from the {@code Processor} type in the Reactive Streams specification,
  * {@code null}s are not allowed (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">Rule 2.13</a>) as
  * default initial values in {@link #createDefault(Object)} or as parameters to {@link #onNext(Object)} and
- * {@link #onError(Throwable)}.
+ * {@link #onError(Throwable)}. Such calls will result in a
+ * {@link NullPointerException} being thrown and the subject's state is not changed.
  * <p>
  * Since a {@code BehaviorSubject} is an {@link io.reactivex.Observable}, it does not support backpressure.
  * <p>
@@ -83,7 +84,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Even though {@code BehaviorSubject} implements the {@code Observer} interface, calling
  * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
  * if the subject is used as a standalone source. However, calling {@code onSubscribe}
- * after the {@code BehaviorSubjecct} reached its terminal state will result in the
+ * after the {@code BehaviorSubject} reached its terminal state will result in the
  * given {@code Disposable} being disposed immediately.
  * <p>
  * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}

--- a/src/main/java/io/reactivex/subjects/CompletableSubject.java
+++ b/src/main/java/io/reactivex/subjects/CompletableSubject.java
@@ -24,12 +24,61 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Represents a hot Completable-like source and consumer of events similar to Subjects.
  * <p>
- * All methods are thread safe. Calling onComplete multiple
- * times has no effect. Calling onError multiple times relays the Throwable to
- * the RxJavaPlugins' error handler.
+ * This subject does not have a public constructor by design; a new non-terminated instance of this
+ * {@code CompletableSubject} can be created via the {@link #create()} method.
  * <p>
- * The CompletableSubject doesn't store the Disposables coming through onSubscribe but
- * disposes them once the other onXXX methods were called (terminal state reached).
+ * Since the {@code CompletableSubject} is conceptionally derived from the {@code Processor} type in the Reactive Streams specification,
+ * {@code null}s are not allowed (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">Rule 2.13</a>)
+ * as parameters to {@link #onError(Throwable)}.
+ * <p>
+ * Even though {@code CompletableSubject} implements the {@code CompletableObserver} interface, calling
+ * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
+ * if the subject is used as a standalone source. However, calling {@code onSubscribe}
+ * after the {@code CompletableSubject} reached its terminal state will result in the
+ * given {@code Disposable} being disposed immediately.
+ * <p>
+ * All methods are thread safe. Calling {@link #onComplete()} multiple
+ * times has no effect. Calling {@link #onError(Throwable)} multiple times relays the {@code Throwable} to
+ * the {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} global error handler.
+ * <p>
+ * This {@code CompletableSubject} supports the standard state-peeking methods {@link #hasComplete()},
+ * {@link #hasThrowable()}, {@link #getThrowable()} and {@link #hasObservers()}.
+ * <dl>
+ *  <dt><b>Scheduler:</b></dt>
+ *  <dd>{@code CompletableSubject} does not operate by default on a particular {@link io.reactivex.Scheduler} and
+ *  the {@code CompletableObserver}s get notified on the thread where the terminating {@code onError} or {@code onComplete}
+ *  methods were invoked.</dd>
+ *  <dt><b>Error handling:</b></dt>
+ *  <dd>When the {@link #onError(Throwable)} is called, the {@code CompletableSubject} enters into a terminal state
+ *  and emits the same {@code Throwable} instance to the last set of {@code CompletableObserver}s. During this emission,
+ *  if one or more {@code CompletableObserver}s dispose their respective {@code Disposable}s, the
+ *  {@code Throwable} is delivered to the global error handler via
+ *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} (multiple times if multiple {@code CompletableObserver}s
+ *  cancel at once).
+ *  If there were no {@code CompletableObserver}s subscribed to this {@code CompletableSubject} when the {@code onError()}
+ *  was called, the global error handler is not invoked.
+ *  </dd>
+ * </dl>
+ * <p>
+ * Example usage:
+ * <pre><code>
+ * CompletableSubject subject = CompletableSubject.create();
+ * 
+ * TestObserver&lt;Void&gt; to1 = subject.test();
+ *
+ * // a fresh CompletableSubject is empty
+ * to1.assertEmpty();
+ * 
+ * subject.onComplete();
+ *
+ * // a CompletableSubject is always void of items
+ * to1.assertResult();
+ *
+ * TestObserver&lt;Void&gt; to2 = subject.test()
+ *
+ * // late CompletableObservers receive the terminal event
+ * to2.assertResult();
+ * </code></pre>
  * <p>History: 2.0.5 - experimental
  * @since 2.1
  */

--- a/src/main/java/io/reactivex/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/subjects/PublishSubject.java
@@ -22,10 +22,56 @@ import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
- * Subject that, once an {@link Observer} has subscribed, emits all subsequently observed items to the
- * subscriber.
+ * A Subject that emits (multicasts) items to currently subscribed {@link Observer}s and terminal events to current
+ * or late {@code Observer}s.
  * <p>
  * <img width="640" height="405" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/S.PublishSubject.png" alt="">
+ * <p>
+ * This subject does not have a public constructor by design; a new empty instance of this
+ * {@code PublishSubject} can be created via the {@link #create()} method.
+ * <p>
+ * Since a {@code Subject} is conceptionally derived from the {@code Processor} type in the Reactive Streams specification,
+ * {@code null}s are not allowed (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">Rule 2.13</a>) as
+ * parameters to {@link #onNext(Object)} and {@link #onError(Throwable)}. Such calls will result in a
+ * {@link NullPointerException} being thrown and the subject's state is not changed.
+ * <p>
+ * Since a {@code PublishSubject} is an {@link io.reactivex.Observable}, it does not support backpressure.
+ * <p>
+ * When this {@code PublishSubject} is terminated via {@link #onError(Throwable)} or {@link #onComplete()},
+ * late {@link io.reactivex.Observer}s only receive the respective terminal event.
+ * <p>
+ * Unlike a {@link BehaviorSubject}, a {@code PublishSubject} doesn't retain/cache items, therefore, a new
+ * {@code Observer} won't receive any past items.
+ * <p>
+ * Even though {@code PublishSubject} implements the {@code Observer} interface, calling
+ * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
+ * if the subject is used as a standalone source. However, calling {@code onSubscribe}
+ * after the {@code PublishSubject} reached its terminal state will result in the
+ * given {@code Disposable} being disposed immediately.
+ * <p>
+ * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
+ * is still required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * through external means of serialization). The {@link #toSerialized()} method available to all {@code Subject}s
+ * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Observer}
+ * consuming this subject also wants to call {@link #onNext(Object)} on this subject recursively).
+ * <p>
+ * This {@code PublishSubject} supports the standard state-peeking methods {@link #hasComplete()}, {@link #hasThrowable()},
+ * {@link #getThrowable()} and {@link #hasObservers()}.
+ * <dl>
+ *  <dt><b>Scheduler:</b></dt>
+ *  <dd>{@code PublishSubject} does not operate by default on a particular {@link io.reactivex.Scheduler} and
+ *  the {@code Observer}s get notified on the thread the respective {@code onXXX} methods were invoked.</dd>
+ *  <dt><b>Error handling:</b></dt>
+ *  <dd>When the {@link #onError(Throwable)} is called, the {@code PublishSubject} enters into a terminal state
+ *  and emits the same {@code Throwable} instance to the last set of {@code Observer}s. During this emission,
+ *  if one or more {@code Observer}s dispose their respective {@code Disposable}s, the
+ *  {@code Throwable} is delivered to the global error handler via
+ *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} (multiple times if multiple {@code Observer}s
+ *  cancel at once).
+ *  If there were no {@code Observer}s subscribed to this {@code PublishSubject} when the {@code onError()}
+ *  was called, the global error handler is not invoked.
+ *  </dd>
+ * </dl>
  * <p>
  * Example usage:
  * <pre> {@code
@@ -40,6 +86,8 @@ import io.reactivex.plugins.RxJavaPlugins;
   subject.onNext("three");
   subject.onComplete();
 
+  // late Observers only receive the terminal event
+  subject.test().assertEmpty();
   } </pre>
  *
  * @param <T>

--- a/src/main/java/io/reactivex/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/subjects/PublishSubject.java
@@ -50,7 +50,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * given {@code Disposable} being disposed immediately.
  * <p>
  * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
- * is still required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * is required to be serialized (called from the same thread or called non-overlappingly from different threads
  * through external means of serialization). The {@link #toSerialized()} method available to all {@code Subject}s
  * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Observer}
  * consuming this subject also wants to call {@link #onNext(Object)} on this subject recursively).

--- a/src/main/java/io/reactivex/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/subjects/ReplaySubject.java
@@ -27,14 +27,80 @@ import io.reactivex.internal.util.NotificationLite;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
- * Replays events to Observers.
+ * Replays events (in a configurable bounded or unbounded manner) to current and late {@link Observer}s.
  * <p>
  * <img width="640" height="405" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/S.ReplaySubject.png" alt="">
+ * <p>
+ * This subject does not have a public constructor by design; a new empty instance of this
+ * {@code ReplaySubject} can be created via the following {@code create} methods that
+ * allow specifying the retention policy for items:
+ * <ul>
+ * <li>{@link #create()} - creates an empty, unbounded {@code ReplaySubject} that
+ *     caches all items and the terminal event it receives.</li>
+ * <li>{@link #create(int)} - creates an empty, unbounded {@code ReplaySubject}
+ *     with a hint about how many <b>total</b> items one expects to retain.</li>
+ * <li>{@link #createWithSize(int)} - creates an empty, size-bound {@code ReplaySubject}
+ *     that retains at most the given number of the latest item it receives.</li>
+ * <li>{@link #createWithTime(long, TimeUnit, Scheduler)} - creates an empty, time-bound
+ *     {@code ReplaySubject} that retains items no older than the specified time amount.</li>
+ * <li>{@link #createWithTimeAndSize(long, TimeUnit, Scheduler, int)} - creates an empty,
+ *     time- and size-bound {@code ReplaySubject} that retains at most the given number
+ *     items that are also not older than the specified time amount.</li>
+ * </ul>
+ * <p>
+ * Since a {@code Subject} is conceptionally derived from the {@code Processor} type in the Reactive Streams specification,
+ * {@code null}s are not allowed (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">Rule 2.13</a>) as
+ * parameters to {@link #onNext(Object)} and {@link #onError(Throwable)}. Such calls will result in a
+ * {@link NullPointerException} being thrown and the subject's state is not changed.
+ * <p>
+ * Since a {@code ReplaySubject} is an {@link io.reactivex.Observable}, it does not support backpressure.
+ * <p>
+ * When this {@code ReplaySubject} is terminated via {@link #onError(Throwable)} or {@link #onComplete()},
+ * late {@link io.reactivex.Observer}s will receive the retained/cached items first (if any) followed by the respective
+ * terminal event. If the {@code ReplaySubject} has a time-bound, the age of the retained/cached items are still considered
+ * when replaying and thus it may result in no items being emitted before the terminal event.
+ * <p>
+ * Once an {@code Observer} has subscribed, it will receive items continuously from that point on. Bounds only affect how
+ * many past items a new {@code Observer} will receive before it catches up with the live event feed.
+ * <p>
+ * Even though {@code ReplaySubject} implements the {@code Observer} interface, calling
+ * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
+ * if the subject is used as a standalone source. However, calling {@code onSubscribe}
+ * after the {@code ReplaySubject} reached its terminal state will result in the
+ * given {@code Disposable} being disposed immediately.
+ * <p>
+ * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
+ * is still required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * through external means of serialization). The {@link #toSerialized()} method available to all {@code Subject}s
+ * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Observer}
+ * consuming this subject also wants to call {@link #onNext(Object)} on this subject recursively).
+ * <p>
+ * This {@code ReplaySubject} supports the standard state-peeking methods {@link #hasComplete()}, {@link #hasThrowable()},
+ * {@link #getThrowable()} and {@link #hasObservers()} as well as means to read the retained/cached items
+ * in a non-blocking and thread-safe manner via {@link #hasValue()}, {@link #getValue()},
+ * {@link #getValues()} or {@link #getValues(Object[])}.
+ * <dl>
+ *  <dt><b>Scheduler:</b></dt>
+ *  <dd>{@code ReplaySubject} does not operate by default on a particular {@link io.reactivex.Scheduler} and
+ *  the {@code Observer}s get notified on the thread the respective {@code onXXX} methods were invoked.
+ *  Time-bound {@code ReplaySubject}s use the given {@code Scheduler} in their {@code create} methods
+ *  as time source to timestamp of items received for the age checks.</dd>
+ *  <dt><b>Error handling:</b></dt>
+ *  <dd>When the {@link #onError(Throwable)} is called, the {@code ReplaySubject} enters into a terminal state
+ *  and emits the same {@code Throwable} instance to the last set of {@code Observer}s. During this emission,
+ *  if one or more {@code Observer}s dispose their respective {@code Disposable}s, the
+ *  {@code Throwable} is delivered to the global error handler via
+ *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} (multiple times if multiple {@code Observer}s
+ *  cancel at once).
+ *  If there were no {@code Observer}s subscribed to this {@code ReplaySubject} when the {@code onError()}
+ *  was called, the global error handler is not invoked.
+ *  </dd>
+ * </dl>
  * <p>
  * Example usage:
  * <pre> {@code
 
-  ReplaySubject<Object> subject = new ReplaySubject<>();
+  ReplaySubject<Object> subject = ReplaySubject.create();
   subject.onNext("one");
   subject.onNext("two");
   subject.onNext("three");

--- a/src/main/java/io/reactivex/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/subjects/ReplaySubject.java
@@ -70,7 +70,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * given {@code Disposable} being disposed immediately.
  * <p>
  * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
- * is still required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * is required to be serialized (called from the same thread or called non-overlappingly from different threads
  * through external means of serialization). The {@link #toSerialized()} method available to all {@code Subject}s
  * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Observer}
  * consuming this subject also wants to call {@link #onNext(Object)} on this subject recursively).

--- a/src/main/java/io/reactivex/subjects/Subject.java
+++ b/src/main/java/io/reactivex/subjects/Subject.java
@@ -17,9 +17,11 @@ import io.reactivex.*;
 import io.reactivex.annotations.*;
 
 /**
- * Represents an Observer and an Observable at the same time, allowing
- * multicasting events from a single source to multiple child Subscribers.
- * <p>All methods except the onSubscribe, onNext, onError and onComplete are thread-safe.
+ * Represents an {@link Observer} and an {@link Observable} at the same time, allowing
+ * multicasting events from a single source to multiple child {@code Observer}s.
+ * <p>
+ * All methods except the {@link #onSubscribe(io.reactivex.disposables.Disposable)}, {@link #onNext(Object)},
+ * {@link #onError(Throwable)} and {@link #onComplete()} are thread-safe.
  * Use {@link #toSerialized()} to make these methods thread-safe as well.
  *
  * @param <T> the item value type

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -79,7 +79,7 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
  * given {@code Disposable} being disposed immediately.
  * <p>
  * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
- * is still required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * is required to be serialized (called from the same thread or called non-overlappingly from different threads
  * through external means of serialization). The {@link #toSerialized()} method available to all {@code Subject}s
  * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Observer}
  * consuming this subject also wants to call {@link #onNext(Object)} on this subject recursively).

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -16,9 +16,10 @@ package io.reactivex.subjects;
 import io.reactivex.annotations.Experimental;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.plugins.RxJavaPlugins;
+
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.Observer;
+import io.reactivex.*;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.EmptyDisposable;
@@ -28,19 +29,116 @@ import io.reactivex.internal.observers.BasicIntQueueDisposable;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 
 /**
- * Subject that allows only a single Subscriber to subscribe to it during its lifetime.
- *
- * <p>This subject buffers notifications and replays them to the Subscriber as requested.
- *
- * <p>This subject holds an unbounded internal buffer.
- *
- * <p>If more than one Subscriber attempts to subscribe to this Subject, they
- * will receive an IllegalStateException if this Subject hasn't terminated yet,
- * or the Subscribers receive the terminal event (error or completion) if this
- * Subject has terminated.
+ * A Subject that queues up events until a single {@link Observer} subscribes to it, replays
+ * those events to it until the {@code Observer} catches up and then switches to relaying events live to
+ * this single {@code Observer} until this {@code UnicastSubject} terminates or the {@code Observer} unsubscribes.
  * <p>
  * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/UnicastSubject.png" alt="">
- *
+ * <p>
+ * Note that {@code UnicastSubject} holds an unbounded internal buffer.
+ * <p>
+ * This subject does not have a public constructor by design; a new empty instance of this
+ * {@code UnicastSubject} can be created via the following {@code create} methods that
+ * allow specifying the retention policy for items:
+ * <ul>
+ * <li>{@link #create()} - creates an empty, unbounded {@code UnicastSubject} that
+ *     caches all items and the terminal event it receives.</li>
+ * <li>{@link #create(int)} - creates an empty, unbounded {@code UnicastSubject}
+ *     with a hint about how many <b>total</b> items one expects to retain.</li>
+ * <li>{@link #create(boolean)} - creates an empty, unbounded {@code UnicastSubject} that
+ *     optionally delays an error it receives and replays it after the regular items have been emitted.</li>
+ * <li>{@link #create(int, Runnable)} - creates an empty, unbounded {@code UnicastSubject}
+ *     with a hint about how many <b>total</b> items one expects to retain and a callback that will be
+ *     called exactly once when the {@code UnicastSubject} gets terminated or the single {@code Observer} unsubscribes.</li>
+ * <li>{@link #create(int, Runnable, boolean)} - creates an empty, unbounded {@code UnicastSubject}
+ *     with a hint about how many <b>total</b> items one expects to retain and a callback that will be
+ *     called exactly once when the {@code UnicastSubject} gets terminated or the single {@code Observer} unsubscribes
+ *     and optionally delays an error it receives and replays it after the regular items have been emitted.</li>
+ * </ul>
+ * <p>
+ * If more than one {@code Observer} attempts to subscribe to this {@code UnicastSubject}, they
+ * will receive an {@code IllegalStateException} indicating the single-use-only nature of this {@code UnicastSubject},
+ * even if the {@code UnicastSubject} already terminated with an error.
+ * <p>
+ * Since a {@code Subject} is conceptionally derived from the {@code Processor} type in the Reactive Streams specification,
+ * {@code null}s are not allowed (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">Rule 2.13</a>) as
+ * parameters to {@link #onNext(Object)} and {@link #onError(Throwable)}. Such calls will result in a
+ * {@link NullPointerException} being thrown and the subject's state is not changed.
+ * <p>
+ * Since a {@code UnicastSubject} is an {@link io.reactivex.Observable}, it does not support backpressure.
+ * <p>
+ * When this {@code UnicastSubject} is terminated via {@link #onError(Throwable)} the current or late single {@code Observer}
+ * may receive the {@code Throwable} before any available items could be emitted. To make sure an onError event is delivered
+ * to the {@code Observer} after the normal items, create a {@code UnicastSubject} with the {@link #create(boolean)} or
+ * {@link #create(int, Runnable, boolean)} factory methods.
+ * <p>
+ * Even though {@code UnicastSubject} implements the {@code Observer} interface, calling
+ * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
+ * if the subject is used as a standalone source. However, calling {@code onSubscribe}
+ * after the {@code UnicastSubject} reached its terminal state will result in the
+ * given {@code Disposable} being disposed immediately.
+ * <p>
+ * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
+ * is still required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * through external means of serialization). The {@link #toSerialized()} method available to all {@code Subject}s
+ * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Observer}
+ * consuming this subject also wants to call {@link #onNext(Object)} on this subject recursively).
+ * <p>
+ * This {@code UnicastSubject} supports the standard state-peeking methods {@link #hasComplete()}, {@link #hasThrowable()},
+ * {@link #getThrowable()} and {@link #hasObservers()}.
+ * <dl>
+ *  <dt><b>Scheduler:</b></dt>
+ *  <dd>{@code UnicastSubject} does not operate by default on a particular {@link io.reactivex.Scheduler} and
+ *  the {@code Observer}s get notified on the thread the respective {@code onXXX} methods were invoked.</dd>
+ *  <dt><b>Error handling:</b></dt>
+ *  <dd>When the {@link #onError(Throwable)} is called, the {@code UnicastSubject} enters into a terminal state
+ *  and emits the same {@code Throwable} instance to the last set of {@code Observer}s. During this emission,
+ *  if one or more {@code Observer}s dispose their respective {@code Disposable}s, the
+ *  {@code Throwable} is delivered to the global error handler via
+ *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} (multiple times if multiple {@code Observer}s
+ *  cancel at once).
+ *  If there were no {@code Observer}s subscribed to this {@code UnicastSubject} when the {@code onError()}
+ *  was called, the global error handler is not invoked.
+ *  </dd>
+ * </dl>
+ * <p>
+ * Example usage:
+ * <pre><code>
+ * UnicastSubject&lt;Integer&gt; subject = UnicastSubject.create();
+ * 
+ * TestObserver&lt;Integer&gt; to1 = subject.test();
+ * 
+ * // fresh UnicastSubjects are empty
+ * to1.assertEmpty();
+ * 
+ * TestObserver&lt;Integer&gt; to2 = subject.test();
+ * 
+ * // A UnicastSubject only allows one Observer during its lifetime
+ * to2.assertFailure(IllegalStateException.class);
+ * 
+ * subject.onNext(1);
+ * to1.assertValue(1);
+ * 
+ * subject.onNext(2);
+ * to1.assertValues(1, 2);
+ * 
+ * subject.onComplete();
+ * to1.assertResult(1, 2);
+ * 
+ * // ----------------------------------------------------
+ * 
+ * UnicastSubject&lt;Integer&gt; subject2 = UnicastSubject.create();
+ * 
+ * // a UnicastSubject caches events util its single Observer subscribes
+ * subject.onNext(1);
+ * subject.onNext(2);
+ * subject.onComplete();
+ * 
+ * TestObserver&lt;Integer&gt; to3 = subject2.test();
+ * 
+ * // the cached events are emitted in order
+ * to3.assertResult(1, 2);
+ * </code></pre>
  * @param <T> the value type received and emitted by this Subject subclass
  * @since 2.0
  */

--- a/src/main/java/io/reactivex/subjects/package-info.java
+++ b/src/main/java/io/reactivex/subjects/package-info.java
@@ -15,7 +15,44 @@
  */
 
 /**
- * Classes extending the Observable base reactive class and implementing
- * the Observer interface at the same time (aka hot Observables).
+ * Classes representing so-called hot sources, aka subjects, that implement a base reactive class and
+ * the respective consumer type at once to allow forms of multicasting events to multiple
+ * consumers as well as consuming another base reactive type of their kind.
+ * <p>
+ * Available subject classes with their respective base classes and consumer interfaces:
+ * <br>
+ * <table border="1" style="border-collapse: collapse;" summary="The available subject classes with their respective base classes and consumer interfaces.">
+ * <tr><td><b>Subject type</b></td><td><b>Base class</b></td><td><b>Consumer interface</b></td></tr>
+ * <tr>
+ *     <td>{@link io.reactivex.subjects.Subject Subject}
+ *     <br>&nbsp;&nbsp;&nbsp;{@link io.reactivex.subjects.AsyncSubject AsyncSubject}
+ *     <br>&nbsp;&nbsp;&nbsp;{@link io.reactivex.subjects.BehaviorSubject BehaviorSubject}
+ *     <br>&nbsp;&nbsp;&nbsp;{@link io.reactivex.subjects.PublishSubject PublishSubject}
+ *     <br>&nbsp;&nbsp;&nbsp;{@link io.reactivex.subjects.ReplaySubject ReplaySubject}
+ *     <br>&nbsp;&nbsp;&nbsp;{@link io.reactivex.subjects.UnicastSubject UnicastSubjectSubject}
+ *     </td>
+ *     <td>{@link io.reactivex.Observable Observable}</td>
+ *     <td>{@link io.reactivex.Observer Observer}</td>
+ * </tr>
+ * <tr>
+ *     <td>{@link io.reactivex.subjects.SingleSubject SingleSubject}</td>
+ *     <td>{@link io.reactivex.Single Single}</td>
+ *     <td>{@link io.reactivex.SingleObserver SingleObserver}</td>
+ * </tr>
+ * <tr>
+ *     <td>{@link io.reactivex.subjects.MaybeSubject MaybeSubject}</td>
+ *     <td>{@link io.reactivex.Maybe Maybe}</td>
+ *     <td>{@link io.reactivex.MaybeObserver MaybeObserver}</td>
+ * </tr>
+ * <tr>
+ *     <td>{@link io.reactivex.subjects.CompletableSubject CompletableSubject}</td>
+ *     <td>{@link io.reactivex.Completable Completable}</td>
+ *     <td>{@link io.reactivex.CompletableObserver CompletableObserver}</td>
+ * </tr>
+ * </table>
+ * <p>
+ * The backpressure-aware variants of the {@code Subject} class are called
+ * {@link org.reactivestreams.Processor}s and reside in the {@code io.reactivex.processors} package.
+ * @see io.reactivex.processors
  */
 package io.reactivex.subjects;


### PR DESCRIPTION
This PR adds more detailed JavaDoc descriptions to the various `XSubject` types.

Some of them are missing a marble diagram which will be created (or found) in a separate PR after this PR.

The `package-info.java` has been extended as well.