### PR TITLE
2.x: More Observable marbles, 01/10-a

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -9962,7 +9962,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Returns an Observable that mirrors the source ObservableSource, resubscribing to it if it calls {@code onError}
      * and the predicate returns true for that specific exception and retry count.
      * <p>
-     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
+     * <img width="640" height="235" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.o.ne.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -9987,7 +9987,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Returns an Observable that mirrors the source ObservableSource, resubscribing to it if it calls {@code onError}
      * up to a specified number of retries.
      * <p>
-     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
+     * <img width="640" height="325" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.o.n.png" alt="">
      * <p>
      * If the source ObservableSource calls {@link Observer#onError}, this method will resubscribe to the source
      * ObservableSource for a maximum of {@code count} resubscriptions rather than propagating the
@@ -10016,7 +10016,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Retries at most times or until the predicate returns false, whichever happens first.
      * <p>
-     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
+     * <img width="640" height="269" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.o.nfe.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -10039,7 +10039,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Retries the current Observable if the predicate returns true.
      * <p>
-     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
+     * <img width="640" height="248" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.o.e.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -10057,7 +10057,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Retries until the given stop function returns true.
      * <p>
-     * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">     * <dl>
+     * <img width="640" height="261" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retryUntil.o.png" alt="">
+     * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retryUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -10498,7 +10499,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * This is an alias for {@link #publish()}.{@link ConnectableObservable#refCount()}.
      * <p>
-     * <img width="640" height="510" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/publishRefCount.png" alt="">
+     * <img width="640" height="510" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/publishRefCount.o.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code share} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -11366,7 +11367,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * The resulting ObservableSource completes if both the upstream ObservableSource and the last inner SingleSource, if any, complete.
      * If the upstream ObservableSource signals an onError, the inner SingleSource is disposed and the error delivered in-sequence.
      * <p>
-     * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
+     * <img width="640" height="531" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMapSingle.o.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code switchMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -11397,7 +11398,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * If the upstream ObservableSource signals an onError, the termination of the last inner SingleSource will emit that error as is
      * or wrapped into a CompositeException along with the other possible errors the former inner SingleSources signalled.
      * <p>
-     * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
+     * <img width="640" height="467" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMapSingleDelayError.o.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code switchMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
More marbles for `Observable`:

- [retry(int)](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.o.n.png)
- [retry(BiFunction)](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.o.ne.png)
- [retry(Predicate)](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.o.e.png)
- [retry(int, Predicate)](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.o.nfe.png)
- [retryUntil(BooleanSupplier)](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retryUntil.o.png)
- [share](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/publishRefCount.o.png)
- [switchMapSingle](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMapSingle.o.png)
- [switchMapSingleDelayError](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMapSingleDelayError.o.png)

Images in https://github.com/ReactiveX/RxJava/issues/5319#issuecomment-356560596 .