### PR TITLE
fix #5809 Prevent new windows to open once source has completed

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
@@ -67,6 +67,8 @@ extends AbstractFlowableWithUpstream<T, U> {
 
         final AtomicInteger windows = new AtomicInteger();
 
+        BufferOpenSubscriber bos;
+
         BufferBoundarySubscriber(Subscriber<? super U> actual,
                 Publisher<? extends Open> bufferOpen,
                 Function<? super Open, ? extends Publisher<? extends Close>> bufferClose,
@@ -85,6 +87,7 @@ extends AbstractFlowableWithUpstream<T, U> {
 
                 BufferOpenSubscriber<T, U, Open, Close> bos = new BufferOpenSubscriber<T, U, Open, Close>(this);
                 resources.add(bos);
+                this.bos = bos;
 
                 actual.onSubscribe(this);
 
@@ -116,6 +119,7 @@ extends AbstractFlowableWithUpstream<T, U> {
 
         @Override
         public void onComplete() {
+            resources.remove(bos);
             if (windows.decrementAndGet() == 0) {
                 complete();
             }


### PR DESCRIPTION
The idea of this PR is to keep a reference to the "open" `Publisher` and dispose it in main `onComplete`, so that it won't keep opening new windows once the source has completed.

It would open new windows due to an unbalanced opening/closing cycle when the open and close signal overlap (eg. interval-based signals where the close delay is shorter than the open delay). As a result, the `windows` counter would never reach `0` and actually complete the main sequence.