### PR TITLE
2.x: Fix buffer(open, close) not disposing indicators properly

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
@@ -189,16 +189,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 SubscriptionHelper.cancel(upstream);
-                if (errors.addThrowable(ex)) {
-                    subscribers.dispose();
-                    synchronized (this) {
-                        buffers = null;
-                    }
-                    done = true;
-                    drain();
-                } else {
-                    RxJavaPlugins.onError(ex);
-                }
+                onError(ex);
                 return;
             }
 
@@ -249,16 +240,7 @@ extends AbstractFlowableWithUpstream<T, U> {
         void boundaryError(Disposable subscriber, Throwable ex) {
             SubscriptionHelper.cancel(upstream);
             subscribers.delete(subscriber);
-            if (errors.addThrowable(ex)) {
-                subscribers.dispose();
-                synchronized (this) {
-                    buffers = null;
-                }
-                done = true;
-                drain();
-            } else {
-                RxJavaPlugins.onError(ex);
-            }
+            onError(ex);
         }
 
         void drain() {
@@ -316,8 +298,7 @@ extends AbstractFlowableWithUpstream<T, U> {
                             Throwable ex = errors.terminate();
                             a.onError(ex);
                             return;
-                        } else
-                        if (q.isEmpty()) {
+                        } else if (q.isEmpty()) {
                             a.onComplete();
                             return;
                         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
@@ -15,22 +15,19 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.*;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.fuseable.SimplePlainQueue;
-import io.reactivex.internal.queue.MpscLinkedQueue;
-import io.reactivex.internal.subscribers.QueueDrainSubscriber;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.internal.util.QueueDrainHelper;
+import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.subscribers.*;
 
 public final class FlowableBufferBoundary<T, U extends Collection<? super T>, Open, Close>
 extends AbstractFlowableWithUpstream<T, U> {
@@ -48,48 +45,72 @@ extends AbstractFlowableWithUpstream<T, U> {
 
     @Override
     protected void subscribeActual(Subscriber<? super U> s) {
-        source.subscribe(new BufferBoundarySubscriber<T, U, Open, Close>(
-                new SerializedSubscriber<U>(s),
-                bufferOpen, bufferClose, bufferSupplier
-            ));
+        BufferBoundarySubscriber<T, U, Open, Close> parent =
+            new BufferBoundarySubscriber<T, U, Open, Close>(
+                s, bufferOpen, bufferClose, bufferSupplier
+            );
+        s.onSubscribe(parent);
+        source.subscribe(parent);
     }
 
-    static final class BufferBoundarySubscriber<T, U extends Collection<? super T>, Open, Close>
-    extends QueueDrainSubscriber<T, U, U> implements Subscription, Disposable {
+    static final class BufferBoundarySubscriber<T, C extends Collection<? super T>, Open, Close>
+    extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
+
+        private static final long serialVersionUID = -8466418554264089604L;
+
+        final Subscriber<? super C> actual;
+
+        final Callable<C> bufferSupplier;
+
         final Publisher<? extends Open> bufferOpen;
+
         final Function<? super Open, ? extends Publisher<? extends Close>> bufferClose;
-        final Callable<U> bufferSupplier;
-        final CompositeDisposable resources;
 
-        Subscription s;
+        final CompositeDisposable subscribers;
 
-        final List<U> buffers;
+        final AtomicLong requested;
 
-        final AtomicInteger windows = new AtomicInteger();
+        final AtomicReference<Subscription> upstream;
 
-        BufferBoundarySubscriber(Subscriber<? super U> actual,
+        final AtomicThrowable errors;
+
+        volatile boolean done;
+
+        final SpscLinkedArrayQueue<C> queue;
+
+        volatile boolean cancelled;
+
+        long index;
+
+        Map<Long, C> buffers;
+
+        long emitted;
+
+        BufferBoundarySubscriber(Subscriber<? super C> actual,
                 Publisher<? extends Open> bufferOpen,
                 Function<? super Open, ? extends Publisher<? extends Close>> bufferClose,
-                        Callable<U> bufferSupplier) {
-            super(actual, new MpscLinkedQueue<U>());
+                Callable<C> bufferSupplier
+        ) {
+            this.actual = actual;
+            this.bufferSupplier = bufferSupplier;
             this.bufferOpen = bufferOpen;
             this.bufferClose = bufferClose;
-            this.bufferSupplier = bufferSupplier;
-            this.buffers = new LinkedList<U>();
-            this.resources = new CompositeDisposable();
+            this.queue = new SpscLinkedArrayQueue<C>(bufferSize());
+            this.subscribers = new CompositeDisposable();
+            this.requested = new AtomicLong();
+            this.upstream = new AtomicReference<Subscription>();
+            this.buffers = new HashMap<Long, C>();
+            this.errors = new AtomicThrowable();
         }
+
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validate(this.s, s)) {
-                this.s = s;
+            if (SubscriptionHelper.setOnce(this.upstream, s)) {
 
-                BufferOpenSubscriber<T, U, Open, Close> bos = new BufferOpenSubscriber<T, U, Open, Close>(this);
-                resources.add(bos);
+                BufferOpenSubscriber<Open> open = new BufferOpenSubscriber<Open>(this);
+                subscribers.add(open);
 
-                actual.onSubscribe(this);
-
-                windows.lazySet(1);
-                bufferOpen.subscribe(bos);
+                bufferOpen.subscribe(open);
 
                 s.request(Long.MAX_VALUE);
             }
@@ -98,7 +119,11 @@ extends AbstractFlowableWithUpstream<T, U> {
         @Override
         public void onNext(T t) {
             synchronized (this) {
-                for (U b : buffers) {
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
+                    return;
+                }
+                for (C b : bufs.values()) {
                     b.add(t);
                 }
             }
@@ -106,206 +131,328 @@ extends AbstractFlowableWithUpstream<T, U> {
 
         @Override
         public void onError(Throwable t) {
-            cancel();
-            cancelled = true;
-            synchronized (this) {
-                buffers.clear();
+            if (errors.addThrowable(t)) {
+                subscribers.dispose();
+                synchronized (this) {
+                    buffers = null;
+                }
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(t);
             }
-            actual.onError(t);
         }
 
         @Override
         public void onComplete() {
-            if (windows.decrementAndGet() == 0) {
-                complete();
-            }
-        }
-
-        void complete() {
-            List<U> list;
+            subscribers.dispose();
             synchronized (this) {
-                list = new ArrayList<U>(buffers);
-                buffers.clear();
-            }
-
-            SimplePlainQueue<U> q = queue;
-            for (U u : list) {
-                q.offer(u);
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
+                    return;
+                }
+                for (C b : bufs.values()) {
+                    queue.offer(b);
+                }
+                bufs = null;
             }
             done = true;
-            if (enter()) {
-                QueueDrainHelper.drainMaxLoop(q, actual, false, this, this);
-            }
+            drain();
         }
 
         @Override
         public void request(long n) {
-            requested(n);
-        }
-
-        @Override
-        public void dispose() {
-            resources.dispose();
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return resources.isDisposed();
+            BackpressureHelper.add(requested, n);
+            drain();
         }
 
         @Override
         public void cancel() {
-            if (!cancelled) {
+            if (SubscriptionHelper.cancel(upstream)) {
                 cancelled = true;
-                dispose();
+                subscribers.dispose();
+                synchronized (this) {
+                    buffers = null;
+                }
+                if (getAndIncrement() != 0) {
+                    queue.clear();
+                }
             }
         }
 
-        @Override
-        public boolean accept(Subscriber<? super U> a, U v) {
-            a.onNext(v);
-            return true;
-        }
-
-        void open(Open window) {
-            if (cancelled) {
-                return;
-            }
-
-            U b;
-
-            try {
-                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                onError(e);
-                return;
-            }
-
+        void open(Open token) {
             Publisher<? extends Close> p;
-
+            C buf;
             try {
-                p = ObjectHelper.requireNonNull(bufferClose.apply(window), "The buffer closing publisher is null");
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                onError(e);
+                buf = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null Collection");
+                p = ObjectHelper.requireNonNull(bufferClose.apply(token), "The bufferClose returned a null Publisher");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                SubscriptionHelper.cancel(upstream);
+                if (errors.addThrowable(ex)) {
+                    subscribers.dispose();
+                    synchronized (this) {
+                        buffers = null;
+                    }
+                    done = true;
+                    drain();
+                } else {
+                    RxJavaPlugins.onError(ex);
+                }
                 return;
             }
 
-            if (cancelled) {
-                return;
-            }
-
+            long idx = index;
+            index = idx + 1;
             synchronized (this) {
-                if (cancelled) {
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
                     return;
                 }
-                buffers.add(b);
+                bufs.put(idx, buf);
             }
 
-            BufferCloseSubscriber<T, U, Open, Close> bcs = new BufferCloseSubscriber<T, U, Open, Close>(b, this);
-            resources.add(bcs);
-
-            windows.getAndIncrement();
-
-            p.subscribe(bcs);
+            BufferCloseSubscriber<T, C> bc = new BufferCloseSubscriber<T, C>(this, idx);
+            subscribers.add(bc);
+            p.subscribe(bc);
         }
 
-        void openFinished(Disposable d) {
-            if (resources.remove(d)) {
-                if (windows.decrementAndGet() == 0) {
-                    complete();
+        void openError(BufferOpenSubscriber<Open> os, Throwable ex) {
+            SubscriptionHelper.cancel(upstream);
+            subscribers.delete(os);
+            if (errors.addThrowable(ex)) {
+                subscribers.dispose();
+                synchronized (this) {
+                    buffers = null;
                 }
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
             }
         }
 
-        void close(U b, Disposable d) {
+        void openComplete(BufferOpenSubscriber<Open> os) {
+            subscribers.delete(os);
+            if (subscribers.size() == 0) {
+                SubscriptionHelper.cancel(upstream);
+                done = true;
+                drain();
+            }
+        }
 
-            boolean e;
+        void close(BufferCloseSubscriber<T, C> closer, long idx) {
+            subscribers.delete(closer);
+            boolean makeDone = false;
+            if (subscribers.size() == 0) {
+                makeDone = true;
+                SubscriptionHelper.cancel(upstream);
+            }
             synchronized (this) {
-                e = buffers.remove(b);
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
+                    return;
+                }
+                queue.offer(buffers.remove(idx));
+            }
+            if (makeDone) {
+                done = true;
+            }
+            drain();
+        }
+
+        void closeError(BufferCloseSubscriber<T, C> closer, Throwable ex) {
+            SubscriptionHelper.cancel(upstream);
+            subscribers.delete(closer);
+            if (errors.addThrowable(ex)) {
+                subscribers.dispose();
+                synchronized (this) {
+                    buffers = null;
+                }
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
             }
 
-            if (e) {
-                fastPathOrderedEmitMax(b, false, this);
-            }
+            int missed = 1;
+            long e = emitted;
+            Subscriber<? super C> a = actual;
+            SpscLinkedArrayQueue<C> q = queue;
 
-            if (resources.remove(d)) {
-                if (windows.decrementAndGet() == 0) {
-                    complete();
+            for (;;) {
+                long r = requested.get();
+
+                while (e != r) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+
+                    boolean d = done;
+                    if (d && errors.get() != null) {
+                        q.clear();
+                        Throwable ex = errors.terminate();
+                        a.onError(ex);
+                        return;
+                    }
+
+                    C v = q.poll();
+                    boolean empty = v == null;
+
+                    if (d && empty) {
+                        a.onComplete();
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    a.onNext(v);
+                    e++;
+                }
+
+                if (e == r) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+
+                    if (done) {
+                        if (errors.get() != null) {
+                            q.clear();
+                            Throwable ex = errors.terminate();
+                            a.onError(ex);
+                            return;
+                        } else
+                        if (q.isEmpty()) {
+                            a.onComplete();
+                            return;
+                        }
+                    }
+                }
+
+                emitted = e;
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
                 }
             }
         }
+
+        static final class BufferOpenSubscriber<Open>
+        extends AtomicReference<Subscription>
+        implements FlowableSubscriber<Open>, Disposable {
+
+            private static final long serialVersionUID = -8498650778633225126L;
+
+            final BufferBoundarySubscriber<?, ?, Open, ?> parent;
+
+            BufferOpenSubscriber(BufferBoundarySubscriber<?, ?, Open, ?> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                if (SubscriptionHelper.setOnce(this, s)) {
+                    s.request(Long.MAX_VALUE);
+                }
+            }
+
+            @Override
+            public void onNext(Open t) {
+                parent.open(t);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                lazySet(SubscriptionHelper.CANCELLED);
+                parent.openError(this, t);
+            }
+
+            @Override
+            public void onComplete() {
+                lazySet(SubscriptionHelper.CANCELLED);
+                parent.openComplete(this);
+            }
+
+            @Override
+            public void dispose() {
+                SubscriptionHelper.cancel(this);
+            }
+
+            @Override
+            public boolean isDisposed() {
+                return get() == SubscriptionHelper.CANCELLED;
+            }
+        }
     }
 
-    static final class BufferOpenSubscriber<T, U extends Collection<? super T>, Open, Close>
-    extends DisposableSubscriber<Open> {
-        final BufferBoundarySubscriber<T, U, Open, Close> parent;
+    static final class BufferCloseSubscriber<T, C extends Collection<? super T>>
+    extends AtomicReference<Subscription>
+    implements FlowableSubscriber<Object>, Disposable {
 
-        boolean done;
+        private static final long serialVersionUID = -8498650778633225126L;
 
-        BufferOpenSubscriber(BufferBoundarySubscriber<T, U, Open, Close> parent) {
+        final BufferBoundarySubscriber<T, C, ?, ?> parent;
+
+        final long index;
+
+        BufferCloseSubscriber(BufferBoundarySubscriber<T, C, ?, ?> parent, long index) {
             this.parent = parent;
+            this.index = index;
         }
+
         @Override
-        public void onNext(Open t) {
-            if (done) {
-                return;
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(Long.MAX_VALUE);
             }
-            parent.open(t);
+        }
+
+        @Override
+        public void onNext(Object t) {
+            Subscription s = get();
+            if (s != SubscriptionHelper.CANCELLED) {
+                lazySet(SubscriptionHelper.CANCELLED);
+                s.cancel();
+                parent.close(this, index);
+            }
         }
 
         @Override
         public void onError(Throwable t) {
-            if (done) {
+            if (get() != SubscriptionHelper.CANCELLED) {
+                lazySet(SubscriptionHelper.CANCELLED);
+                parent.closeError(this, t);
+            } else {
                 RxJavaPlugins.onError(t);
-                return;
             }
-            done = true;
-            parent.onError(t);
         }
 
         @Override
         public void onComplete() {
-            if (done) {
-                return;
+            if (get() != SubscriptionHelper.CANCELLED) {
+                lazySet(SubscriptionHelper.CANCELLED);
+                parent.close(this, index);
             }
-            done = true;
-            parent.openFinished(this);
-        }
-    }
-
-    static final class BufferCloseSubscriber<T, U extends Collection<? super T>, Open, Close>
-    extends DisposableSubscriber<Close> {
-        final BufferBoundarySubscriber<T, U, Open, Close> parent;
-        final U value;
-        boolean done;
-        BufferCloseSubscriber(U value, BufferBoundarySubscriber<T, U, Open, Close> parent) {
-            this.parent = parent;
-            this.value = value;
         }
 
         @Override
-        public void onNext(Close t) {
-            onComplete();
+        public void dispose() {
+            SubscriptionHelper.cancel(this);
         }
 
         @Override
-        public void onError(Throwable t) {
-            if (done) {
-                RxJavaPlugins.onError(t);
-                return;
-            }
-            parent.onError(t);
-        }
-
-        @Override
-        public void onComplete() {
-            if (done) {
-                return;
-            }
-            done = true;
-            parent.close(value, this);
+        public boolean isDisposed() {
+            return get() == SubscriptionHelper.CANCELLED;
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
@@ -180,16 +180,7 @@ extends AbstractObservableWithUpstream<T, U> {
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 DisposableHelper.dispose(upstream);
-                if (errors.addThrowable(ex)) {
-                    observers.dispose();
-                    synchronized (this) {
-                        buffers = null;
-                    }
-                    done = true;
-                    drain();
-                } else {
-                    RxJavaPlugins.onError(ex);
-                }
+                onError(ex);
                 return;
             }
 
@@ -240,16 +231,7 @@ extends AbstractObservableWithUpstream<T, U> {
         void boundaryError(Disposable observer, Throwable ex) {
             DisposableHelper.dispose(upstream);
             observers.delete(observer);
-            if (errors.addThrowable(ex)) {
-                observers.dispose();
-                synchronized (this) {
-                    buffers = null;
-                }
-                done = true;
-                drain();
-            } else {
-                RxJavaPlugins.onError(ex);
-            }
+            onError(ex);
         }
 
         void drain() {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.observable;
 
 import java.util.*;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.*;
 
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
@@ -24,11 +24,8 @@ import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.fuseable.SimplePlainQueue;
-import io.reactivex.internal.observers.QueueDrainObserver;
-import io.reactivex.internal.queue.MpscLinkedQueue;
-import io.reactivex.internal.util.QueueDrainHelper;
-import io.reactivex.observers.*;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.util.AtomicThrowable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableBufferBoundary<T, U extends Collection<? super T>, Open, Close>
@@ -47,55 +44,78 @@ extends AbstractObservableWithUpstream<T, U> {
 
     @Override
     protected void subscribeActual(Observer<? super U> t) {
-        source.subscribe(new BufferBoundaryObserver<T, U, Open, Close>(
-                new SerializedObserver<U>(t),
-                bufferOpen, bufferClose, bufferSupplier
-                ));
+        BufferBoundaryObserver<T, U, Open, Close> parent =
+            new BufferBoundaryObserver<T, U, Open, Close>(
+                t, bufferOpen, bufferClose, bufferSupplier
+            );
+        t.onSubscribe(parent);
+        source.subscribe(parent);
     }
 
-    static final class BufferBoundaryObserver<T, U extends Collection<? super T>, Open, Close>
-    extends QueueDrainObserver<T, U, U> implements Disposable {
+    static final class BufferBoundaryObserver<T, C extends Collection<? super T>, Open, Close>
+    extends AtomicInteger implements Observer<T>, Disposable {
+
+        private static final long serialVersionUID = -8466418554264089604L;
+
+        final Observer<? super C> actual;
+
+        final Callable<C> bufferSupplier;
+
         final ObservableSource<? extends Open> bufferOpen;
+
         final Function<? super Open, ? extends ObservableSource<? extends Close>> bufferClose;
-        final Callable<U> bufferSupplier;
-        final CompositeDisposable resources;
 
-        Disposable s;
+        final CompositeDisposable observers;
 
-        final List<U> buffers;
+        final AtomicReference<Disposable> upstream;
 
-        final AtomicInteger windows = new AtomicInteger();
+        final AtomicThrowable errors;
 
-        BufferBoundaryObserver(Observer<? super U> actual,
+        volatile boolean done;
+
+        final SpscLinkedArrayQueue<C> queue;
+
+        volatile boolean cancelled;
+
+        long index;
+
+        Map<Long, C> buffers;
+
+        BufferBoundaryObserver(Observer<? super C> actual,
                 ObservableSource<? extends Open> bufferOpen,
                 Function<? super Open, ? extends ObservableSource<? extends Close>> bufferClose,
-                        Callable<U> bufferSupplier) {
-            super(actual, new MpscLinkedQueue<U>());
+                Callable<C> bufferSupplier
+        ) {
+            this.actual = actual;
+            this.bufferSupplier = bufferSupplier;
             this.bufferOpen = bufferOpen;
             this.bufferClose = bufferClose;
-            this.bufferSupplier = bufferSupplier;
-            this.buffers = new LinkedList<U>();
-            this.resources = new CompositeDisposable();
+            this.queue = new SpscLinkedArrayQueue<C>(bufferSize());
+            this.observers = new CompositeDisposable();
+            this.upstream = new AtomicReference<Disposable>();
+            this.buffers = new HashMap<Long, C>();
+            this.errors = new AtomicThrowable();
         }
+
         @Override
         public void onSubscribe(Disposable s) {
-            if (DisposableHelper.validate(this.s, s)) {
-                this.s = s;
+            if (DisposableHelper.setOnce(this.upstream, s)) {
 
-                BufferOpenObserver<T, U, Open, Close> bos = new BufferOpenObserver<T, U, Open, Close>(this);
-                resources.add(bos);
+                BufferOpenObserver<Open> open = new BufferOpenObserver<Open>(this);
+                observers.add(open);
 
-                actual.onSubscribe(this);
-
-                windows.lazySet(1);
-                bufferOpen.subscribe(bos);
+                bufferOpen.subscribe(open);
             }
         }
 
         @Override
         public void onNext(T t) {
             synchronized (this) {
-                for (U b : buffers) {
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
+                    return;
+                }
+                for (C b : bufs.values()) {
                     b.add(t);
                 }
             }
@@ -103,194 +123,298 @@ extends AbstractObservableWithUpstream<T, U> {
 
         @Override
         public void onError(Throwable t) {
-            dispose();
-            cancelled = true;
-            synchronized (this) {
-                buffers.clear();
+            if (errors.addThrowable(t)) {
+                observers.dispose();
+                synchronized (this) {
+                    buffers = null;
+                }
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(t);
             }
-            actual.onError(t);
         }
 
         @Override
         public void onComplete() {
-            if (windows.decrementAndGet() == 0) {
-                complete();
+            observers.dispose();
+            synchronized (this) {
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
+                    return;
+                }
+                for (C b : bufs.values()) {
+                    queue.offer(b);
+                }
+                bufs = null;
+            }
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void dispose() {
+            if (DisposableHelper.dispose(upstream)) {
+                cancelled = true;
+                observers.dispose();
+                synchronized (this) {
+                    buffers = null;
+                }
+                if (getAndIncrement() != 0) {
+                    queue.clear();
+                }
             }
         }
 
-        void complete() {
-            List<U> list;
-            synchronized (this) {
-                list = new ArrayList<U>(buffers);
-                buffers.clear();
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(upstream.get());
+        }
+
+        void open(Open token) {
+            ObservableSource<? extends Close> p;
+            C buf;
+            try {
+                buf = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null Collection");
+                p = ObjectHelper.requireNonNull(bufferClose.apply(token), "The bufferClose returned a null ObservableSource");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                DisposableHelper.dispose(upstream);
+                if (errors.addThrowable(ex)) {
+                    observers.dispose();
+                    synchronized (this) {
+                        buffers = null;
+                    }
+                    done = true;
+                    drain();
+                } else {
+                    RxJavaPlugins.onError(ex);
+                }
+                return;
             }
 
-            SimplePlainQueue<U> q = queue;
-            for (U u : list) {
-                q.offer(u);
+            long idx = index;
+            index = idx + 1;
+            synchronized (this) {
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
+                    return;
+                }
+                bufs.put(idx, buf);
             }
-            done = true;
-            if (enter()) {
-                QueueDrainHelper.drainLoop(q, actual, false, this, this);
+
+            BufferCloseObserver<T, C> bc = new BufferCloseObserver<T, C>(this, idx);
+            observers.add(bc);
+            p.subscribe(bc);
+        }
+
+        void openError(BufferOpenObserver<Open> os, Throwable ex) {
+            DisposableHelper.dispose(upstream);
+            observers.delete(os);
+            if (errors.addThrowable(ex)) {
+                observers.dispose();
+                synchronized (this) {
+                    buffers = null;
+                }
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        void openComplete(BufferOpenObserver<Open> os) {
+            observers.delete(os);
+            if (observers.size() == 0) {
+                DisposableHelper.dispose(upstream);
+                done = true;
+                drain();
+            }
+        }
+
+        void close(BufferCloseObserver<T, C> closer, long idx) {
+            observers.delete(closer);
+            boolean makeDone = false;
+            if (observers.size() == 0) {
+                makeDone = true;
+                DisposableHelper.dispose(upstream);
+            }
+            synchronized (this) {
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
+                    return;
+                }
+                queue.offer(buffers.remove(idx));
+            }
+            if (makeDone) {
+                done = true;
+            }
+            drain();
+        }
+
+        void closeError(BufferCloseObserver<T, C> closer, Throwable ex) {
+            DisposableHelper.dispose(upstream);
+            observers.delete(closer);
+            if (errors.addThrowable(ex)) {
+                observers.dispose();
+                synchronized (this) {
+                    buffers = null;
+                }
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            Observer<? super C> a = actual;
+            SpscLinkedArrayQueue<C> q = queue;
+
+            for (;;) {
+                for (;;) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+
+                    boolean d = done;
+                    if (d && errors.get() != null) {
+                        q.clear();
+                        Throwable ex = errors.terminate();
+                        a.onError(ex);
+                        return;
+                    }
+
+                    C v = q.poll();
+                    boolean empty = v == null;
+
+                    if (d && empty) {
+                        a.onComplete();
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    a.onNext(v);
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class BufferOpenObserver<Open>
+        extends AtomicReference<Disposable>
+        implements Observer<Open>, Disposable {
+
+            private static final long serialVersionUID = -8498650778633225126L;
+
+            final BufferBoundaryObserver<?, ?, Open, ?> parent;
+
+            BufferOpenObserver(BufferBoundaryObserver<?, ?, Open, ?> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable s) {
+                DisposableHelper.setOnce(this, s);
+            }
+
+            @Override
+            public void onNext(Open t) {
+                parent.open(t);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                lazySet(DisposableHelper.DISPOSED);
+                parent.openError(this, t);
+            }
+
+            @Override
+            public void onComplete() {
+                lazySet(DisposableHelper.DISPOSED);
+                parent.openComplete(this);
+            }
+
+            @Override
+            public void dispose() {
+                DisposableHelper.dispose(this);
+            }
+
+            @Override
+            public boolean isDisposed() {
+                return get() == DisposableHelper.DISPOSED;
+            }
+        }
+    }
+
+    static final class BufferCloseObserver<T, C extends Collection<? super T>>
+    extends AtomicReference<Disposable>
+    implements Observer<Object>, Disposable {
+
+        private static final long serialVersionUID = -8498650778633225126L;
+
+        final BufferBoundaryObserver<T, C, ?, ?> parent;
+
+        final long index;
+
+        BufferCloseObserver(BufferBoundaryObserver<T, C, ?, ?> parent, long index) {
+            this.parent = parent;
+            this.index = index;
+        }
+
+        @Override
+        public void onSubscribe(Disposable s) {
+            DisposableHelper.setOnce(this, s);
+        }
+
+        @Override
+        public void onNext(Object t) {
+            Disposable s = get();
+            if (s != DisposableHelper.DISPOSED) {
+                lazySet(DisposableHelper.DISPOSED);
+                s.dispose();
+                parent.close(this, index);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (get() != DisposableHelper.DISPOSED) {
+                lazySet(DisposableHelper.DISPOSED);
+                parent.closeError(this, t);
+            } else {
+                RxJavaPlugins.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (get() != DisposableHelper.DISPOSED) {
+                lazySet(DisposableHelper.DISPOSED);
+                parent.close(this, index);
             }
         }
 
         @Override
         public void dispose() {
-            if (!cancelled) {
-                cancelled = true;
-                resources.dispose();
-            }
-        }
-
-        @Override public boolean isDisposed() {
-            return cancelled;
+            DisposableHelper.dispose(this);
         }
 
         @Override
-        public void accept(Observer<? super U> a, U v) {
-            a.onNext(v);
-        }
-
-        void open(Open window) {
-            if (cancelled) {
-                return;
-            }
-
-            U b;
-
-            try {
-                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                onError(e);
-                return;
-            }
-
-            ObservableSource<? extends Close> p;
-
-            try {
-                p = ObjectHelper.requireNonNull(bufferClose.apply(window), "The buffer closing Observable is null");
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                onError(e);
-                return;
-            }
-
-            if (cancelled) {
-                return;
-            }
-
-            synchronized (this) {
-                if (cancelled) {
-                    return;
-                }
-                buffers.add(b);
-            }
-
-            BufferCloseObserver<T, U, Open, Close> bcs = new BufferCloseObserver<T, U, Open, Close>(b, this);
-            resources.add(bcs);
-
-            windows.getAndIncrement();
-
-            p.subscribe(bcs);
-        }
-
-        void openFinished(Disposable d) {
-            if (resources.remove(d)) {
-                if (windows.decrementAndGet() == 0) {
-                    complete();
-                }
-            }
-        }
-
-        void close(U b, Disposable d) {
-
-            boolean e;
-            synchronized (this) {
-                e = buffers.remove(b);
-            }
-
-            if (e) {
-                fastPathOrderedEmit(b, false, this);
-            }
-
-            if (resources.remove(d)) {
-                if (windows.decrementAndGet() == 0) {
-                    complete();
-                }
-            }
-        }
-    }
-
-    static final class BufferOpenObserver<T, U extends Collection<? super T>, Open, Close>
-    extends DisposableObserver<Open> {
-        final BufferBoundaryObserver<T, U, Open, Close> parent;
-
-        boolean done;
-
-        BufferOpenObserver(BufferBoundaryObserver<T, U, Open, Close> parent) {
-            this.parent = parent;
-        }
-        @Override
-        public void onNext(Open t) {
-            if (done) {
-                return;
-            }
-            parent.open(t);
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            if (done) {
-                RxJavaPlugins.onError(t);
-                return;
-            }
-            done = true;
-            parent.onError(t);
-        }
-
-        @Override
-        public void onComplete() {
-            if (done) {
-                return;
-            }
-            done = true;
-            parent.openFinished(this);
-        }
-    }
-
-    static final class BufferCloseObserver<T, U extends Collection<? super T>, Open, Close>
-    extends DisposableObserver<Close> {
-        final BufferBoundaryObserver<T, U, Open, Close> parent;
-        final U value;
-        boolean done;
-        BufferCloseObserver(U value, BufferBoundaryObserver<T, U, Open, Close> parent) {
-            this.parent = parent;
-            this.value = value;
-        }
-
-        @Override
-        public void onNext(Close t) {
-            onComplete();
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            if (done) {
-                RxJavaPlugins.onError(t);
-                return;
-            }
-            parent.onError(t);
-        }
-
-        @Override
-        public void onComplete() {
-            if (done) {
-                return;
-            }
-            done = true;
-            parent.close(value, this);
+        public boolean isDisposed() {
+            return get() == DisposableHelper.DISPOSED;
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -26,7 +27,8 @@ import org.mockito.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.exceptions.TestException;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
@@ -2073,5 +2075,365 @@ public class FlowableBufferTest {
         .assertResult(Collections.<Integer>emptyList());
 
         assertEquals(0, counter.get());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void boundaryOpenCloseDisposedOnComplete() {
+        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestSubscriber<List<Integer>> ts = pp0
+        .buffer(pp1, Functions.justFunction(pp2))
+        .test();
+
+        assertTrue(pp0.hasSubscribers());
+        assertTrue(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+
+        pp1.onNext(1);
+
+        assertTrue(pp1.hasSubscribers());
+        assertTrue(pp2.hasSubscribers());
+
+        pp0.onComplete();
+
+        ts.assertResult(Collections.<Integer>emptyList());
+
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+    }
+
+    @Test
+    public void bufferedCanCompleteIfOpenNeverCompletesDropping() {
+        Flowable.range(1, 50)
+                .zipWith(Flowable.interval(5, TimeUnit.MILLISECONDS),
+                        new BiFunction<Integer, Long, Integer>() {
+                            @Override
+                            public Integer apply(Integer integer, Long aLong) {
+                                return integer;
+                            }
+                        })
+                .buffer(Flowable.interval(0,200, TimeUnit.MILLISECONDS),
+                        new Function<Long, Publisher<?>>() {
+                            @Override
+                            public Publisher<?> apply(Long a) {
+                                return Flowable.just(a).delay(100, TimeUnit.MILLISECONDS);
+                            }
+                        })
+                .test()
+                .assertSubscribed()
+                .awaitDone(3, TimeUnit.SECONDS)
+                .assertComplete();
+    }
+
+    @Test
+    public void bufferedCanCompleteIfOpenNeverCompletesOverlapping() {
+        Flowable.range(1, 50)
+                .zipWith(Flowable.interval(5, TimeUnit.MILLISECONDS),
+                        new BiFunction<Integer, Long, Integer>() {
+                            @Override
+                            public Integer apply(Integer integer, Long aLong) {
+                                return integer;
+                            }
+                        })
+                .buffer(Flowable.interval(0,100, TimeUnit.MILLISECONDS),
+                        new Function<Long, Publisher<?>>() {
+                            @Override
+                            public Publisher<?> apply(Long a) {
+                                return Flowable.just(a).delay(200, TimeUnit.MILLISECONDS);
+                            }
+                        })
+                .test()
+                .assertSubscribed()
+                .awaitDone(3, TimeUnit.SECONDS)
+                .assertComplete();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openClosemainError() {
+        Flowable.error(new TestException())
+        .buffer(Flowable.never(), Functions.justFunction(Flowable.never()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openClosebadSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new Flowable<Object>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Object> s) {
+                    BooleanSubscription bs1 = new BooleanSubscription();
+                    BooleanSubscription bs2 = new BooleanSubscription();
+
+                    s.onSubscribe(bs1);
+
+                    assertFalse(bs1.isCancelled());
+                    assertFalse(bs2.isCancelled());
+
+                    s.onSubscribe(bs2);
+
+                    assertFalse(bs1.isCancelled());
+                    assertTrue(bs2.isCancelled());
+
+                    s.onError(new IOException());
+                    s.onComplete();
+                    s.onNext(1);
+                    s.onError(new TestException());
+                }
+            }
+            .buffer(Flowable.never(), Functions.justFunction(Flowable.never()))
+            .test()
+            .assertFailure(IOException.class);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseOpenCompletes() {
+        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestSubscriber<List<Integer>> ts = pp0
+        .buffer(pp1, Functions.justFunction(pp2))
+        .test();
+
+        pp1.onNext(1);
+
+        assertTrue(pp2.hasSubscribers());
+
+        pp1.onComplete();
+
+        assertTrue(pp0.hasSubscribers());
+        assertTrue(pp2.hasSubscribers());
+
+        pp2.onComplete();
+
+        assertFalse(pp0.hasSubscribers());
+
+        ts.assertResult(Collections.<Integer>emptyList());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseOpenCompletesNoBuffers() {
+        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestSubscriber<List<Integer>> ts = pp0
+        .buffer(pp1, Functions.justFunction(pp2))
+        .test();
+
+        pp1.onNext(1);
+
+        assertTrue(pp2.hasSubscribers());
+
+        pp2.onComplete();
+
+        assertTrue(pp0.hasSubscribers());
+        assertTrue(pp1.hasSubscribers());
+
+        pp1.onComplete();
+
+        assertFalse(pp0.hasSubscribers());
+
+        ts.assertResult(Collections.<Integer>emptyList());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseTake() {
+        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestSubscriber<List<Integer>> ts = pp0
+        .buffer(pp1, Functions.justFunction(pp2))
+        .take(1)
+        .test(2);
+
+        pp1.onNext(1);
+        pp2.onComplete();
+
+        assertFalse(pp0.hasSubscribers());
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+
+        ts.assertResult(Collections.<Integer>emptyList());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseLimit() {
+        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestSubscriber<List<Integer>> ts = pp0
+        .buffer(pp1, Functions.justFunction(pp2))
+        .limit(1)
+        .test(2);
+
+        pp1.onNext(1);
+        pp2.onComplete();
+
+        assertFalse(pp0.hasSubscribers());
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+
+        ts.assertResult(Collections.<Integer>emptyList());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseEmptyBackpressure() {
+        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestSubscriber<List<Integer>> ts = pp0
+        .buffer(pp1, Functions.justFunction(pp2))
+        .test(0);
+
+        pp0.onComplete();
+
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+
+        ts.assertResult();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseErrorBackpressure() {
+        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+
+        TestSubscriber<List<Integer>> ts = pp0
+        .buffer(pp1, Functions.justFunction(pp2))
+        .test(0);
+
+        pp0.onError(new TestException());
+
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
+
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseBadOpen() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.never()
+            .buffer(new Flowable<Object>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Object> s) {
+
+                    assertFalse(((Disposable)s).isDisposed());
+
+                    BooleanSubscription bs1 = new BooleanSubscription();
+                    BooleanSubscription bs2 = new BooleanSubscription();
+
+                    s.onSubscribe(bs1);
+
+                    assertFalse(bs1.isCancelled());
+                    assertFalse(bs2.isCancelled());
+
+                    s.onSubscribe(bs2);
+
+                    assertFalse(bs1.isCancelled());
+                    assertTrue(bs2.isCancelled());
+
+                    s.onError(new IOException());
+
+                    assertTrue(((Disposable)s).isDisposed());
+
+                    s.onComplete();
+                    s.onNext(1);
+                    s.onError(new TestException());
+                }
+            }, Functions.justFunction(Flowable.never()))
+            .test()
+            .assertFailure(IOException.class);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseBadClose() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.never()
+            .buffer(Flowable.just(1).concatWith(Flowable.<Integer>never()),
+                    Functions.justFunction(new Flowable<Object>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Object> s) {
+
+                    assertFalse(((Disposable)s).isDisposed());
+
+                    BooleanSubscription bs1 = new BooleanSubscription();
+                    BooleanSubscription bs2 = new BooleanSubscription();
+
+                    s.onSubscribe(bs1);
+
+                    assertFalse(bs1.isCancelled());
+                    assertFalse(bs2.isCancelled());
+
+                    s.onSubscribe(bs2);
+
+                    assertFalse(bs1.isCancelled());
+                    assertTrue(bs2.isCancelled());
+
+                    s.onError(new IOException());
+
+                    assertTrue(((Disposable)s).isDisposed());
+
+                    s.onComplete();
+                    s.onNext(1);
+                    s.onError(new TestException());
+                }
+            }))
+            .test()
+            .assertFailure(IOException.class);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -2080,31 +2080,31 @@ public class FlowableBufferTest {
     @Test
     @SuppressWarnings("unchecked")
     public void boundaryOpenCloseDisposedOnComplete() {
-        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+        PublishProcessor<Integer> source = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> openIndicator = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+        PublishProcessor<Integer> closeIndicator = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> ts = pp0
-        .buffer(pp1, Functions.justFunction(pp2))
+        TestSubscriber<List<Integer>> ts = source
+        .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .test();
 
-        assertTrue(pp0.hasSubscribers());
-        assertTrue(pp1.hasSubscribers());
-        assertFalse(pp2.hasSubscribers());
+        assertTrue(source.hasSubscribers());
+        assertTrue(openIndicator.hasSubscribers());
+        assertFalse(closeIndicator.hasSubscribers());
 
-        pp1.onNext(1);
+        openIndicator.onNext(1);
 
-        assertTrue(pp1.hasSubscribers());
-        assertTrue(pp2.hasSubscribers());
+        assertTrue(openIndicator.hasSubscribers());
+        assertTrue(closeIndicator.hasSubscribers());
 
-        pp0.onComplete();
+        source.onComplete();
 
         ts.assertResult(Collections.<Integer>emptyList());
 
-        assertFalse(pp1.hasSubscribers());
-        assertFalse(pp2.hasSubscribers());
+        assertFalse(openIndicator.hasSubscribers());
+        assertFalse(closeIndicator.hasSubscribers());
     }
 
     @Test
@@ -2203,28 +2203,28 @@ public class FlowableBufferTest {
     @Test
     @SuppressWarnings("unchecked")
     public void openCloseOpenCompletes() {
-        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+        PublishProcessor<Integer> source = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> openIndicator = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+        PublishProcessor<Integer> closeIndicator = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> ts = pp0
-        .buffer(pp1, Functions.justFunction(pp2))
+        TestSubscriber<List<Integer>> ts = source
+        .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .test();
 
-        pp1.onNext(1);
+        openIndicator.onNext(1);
 
-        assertTrue(pp2.hasSubscribers());
+        assertTrue(closeIndicator.hasSubscribers());
 
-        pp1.onComplete();
+        openIndicator.onComplete();
 
-        assertTrue(pp0.hasSubscribers());
-        assertTrue(pp2.hasSubscribers());
+        assertTrue(source.hasSubscribers());
+        assertTrue(closeIndicator.hasSubscribers());
 
-        pp2.onComplete();
+        closeIndicator.onComplete();
 
-        assertFalse(pp0.hasSubscribers());
+        assertFalse(source.hasSubscribers());
 
         ts.assertResult(Collections.<Integer>emptyList());
     }
@@ -2232,28 +2232,28 @@ public class FlowableBufferTest {
     @Test
     @SuppressWarnings("unchecked")
     public void openCloseOpenCompletesNoBuffers() {
-        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+        PublishProcessor<Integer> source = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> openIndicator = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+        PublishProcessor<Integer> closeIndicator = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> ts = pp0
-        .buffer(pp1, Functions.justFunction(pp2))
+        TestSubscriber<List<Integer>> ts = source
+        .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .test();
 
-        pp1.onNext(1);
+        openIndicator.onNext(1);
 
-        assertTrue(pp2.hasSubscribers());
+        assertTrue(closeIndicator.hasSubscribers());
 
-        pp2.onComplete();
+        closeIndicator.onComplete();
 
-        assertTrue(pp0.hasSubscribers());
-        assertTrue(pp1.hasSubscribers());
+        assertTrue(source.hasSubscribers());
+        assertTrue(openIndicator.hasSubscribers());
 
-        pp1.onComplete();
+        openIndicator.onComplete();
 
-        assertFalse(pp0.hasSubscribers());
+        assertFalse(source.hasSubscribers());
 
         ts.assertResult(Collections.<Integer>emptyList());
     }
@@ -2261,23 +2261,23 @@ public class FlowableBufferTest {
     @Test
     @SuppressWarnings("unchecked")
     public void openCloseTake() {
-        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+        PublishProcessor<Integer> source = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> openIndicator = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+        PublishProcessor<Integer> closeIndicator = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> ts = pp0
-        .buffer(pp1, Functions.justFunction(pp2))
+        TestSubscriber<List<Integer>> ts = source
+        .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .take(1)
         .test(2);
 
-        pp1.onNext(1);
-        pp2.onComplete();
+        openIndicator.onNext(1);
+        closeIndicator.onComplete();
 
-        assertFalse(pp0.hasSubscribers());
-        assertFalse(pp1.hasSubscribers());
-        assertFalse(pp2.hasSubscribers());
+        assertFalse(source.hasSubscribers());
+        assertFalse(openIndicator.hasSubscribers());
+        assertFalse(closeIndicator.hasSubscribers());
 
         ts.assertResult(Collections.<Integer>emptyList());
     }
@@ -2285,23 +2285,23 @@ public class FlowableBufferTest {
     @Test
     @SuppressWarnings("unchecked")
     public void openCloseLimit() {
-        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+        PublishProcessor<Integer> source = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> openIndicator = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+        PublishProcessor<Integer> closeIndicator = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> ts = pp0
-        .buffer(pp1, Functions.justFunction(pp2))
+        TestSubscriber<List<Integer>> ts = source
+        .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .limit(1)
         .test(2);
 
-        pp1.onNext(1);
-        pp2.onComplete();
+        openIndicator.onNext(1);
+        closeIndicator.onComplete();
 
-        assertFalse(pp0.hasSubscribers());
-        assertFalse(pp1.hasSubscribers());
-        assertFalse(pp2.hasSubscribers());
+        assertFalse(source.hasSubscribers());
+        assertFalse(openIndicator.hasSubscribers());
+        assertFalse(closeIndicator.hasSubscribers());
 
         ts.assertResult(Collections.<Integer>emptyList());
     }
@@ -2309,20 +2309,20 @@ public class FlowableBufferTest {
     @Test
     @SuppressWarnings("unchecked")
     public void openCloseEmptyBackpressure() {
-        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+        PublishProcessor<Integer> source = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> openIndicator = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+        PublishProcessor<Integer> closeIndicator = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> ts = pp0
-        .buffer(pp1, Functions.justFunction(pp2))
+        TestSubscriber<List<Integer>> ts = source
+        .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .test(0);
 
-        pp0.onComplete();
+        source.onComplete();
 
-        assertFalse(pp1.hasSubscribers());
-        assertFalse(pp2.hasSubscribers());
+        assertFalse(openIndicator.hasSubscribers());
+        assertFalse(closeIndicator.hasSubscribers());
 
         ts.assertResult();
     }
@@ -2330,20 +2330,20 @@ public class FlowableBufferTest {
     @Test
     @SuppressWarnings("unchecked")
     public void openCloseErrorBackpressure() {
-        PublishProcessor<Integer> pp0 = PublishProcessor.create();
+        PublishProcessor<Integer> source = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> openIndicator = PublishProcessor.create();
 
-        PublishProcessor<Integer> pp2 = PublishProcessor.create();
+        PublishProcessor<Integer> closeIndicator = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> ts = pp0
-        .buffer(pp1, Functions.justFunction(pp2))
+        TestSubscriber<List<Integer>> ts = source
+        .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .test(0);
 
-        pp0.onError(new TestException());
+        source.onError(new TestException());
 
-        assertFalse(pp1.hasSubscribers());
-        assertFalse(pp2.hasSubscribers());
+        assertFalse(openIndicator.hasSubscribers());
+        assertFalse(closeIndicator.hasSubscribers());
 
         ts.assertFailure(TestException.class);
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -1506,31 +1506,31 @@ public class ObservableBufferTest {
     @Test
     @SuppressWarnings("unchecked")
     public void boundaryOpenCloseDisposedOnComplete() {
-        PublishSubject<Integer> pp0 = PublishSubject.create();
+        PublishSubject<Integer> source = PublishSubject.create();
 
-        PublishSubject<Integer> pp1 = PublishSubject.create();
+        PublishSubject<Integer> openIndicator = PublishSubject.create();
 
-        PublishSubject<Integer> pp2 = PublishSubject.create();
+        PublishSubject<Integer> closeIndicator = PublishSubject.create();
 
-        TestObserver<List<Integer>> ts = pp0
-        .buffer(pp1, Functions.justFunction(pp2))
+        TestObserver<List<Integer>> ts = source
+        .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .test();
 
-        assertTrue(pp0.hasObservers());
-        assertTrue(pp1.hasObservers());
-        assertFalse(pp2.hasObservers());
+        assertTrue(source.hasObservers());
+        assertTrue(openIndicator.hasObservers());
+        assertFalse(closeIndicator.hasObservers());
 
-        pp1.onNext(1);
+        openIndicator.onNext(1);
 
-        assertTrue(pp1.hasObservers());
-        assertTrue(pp2.hasObservers());
+        assertTrue(openIndicator.hasObservers());
+        assertTrue(closeIndicator.hasObservers());
 
-        pp0.onComplete();
+        source.onComplete();
 
         ts.assertResult(Collections.<Integer>emptyList());
 
-        assertFalse(pp1.hasObservers());
-        assertFalse(pp2.hasObservers());
+        assertFalse(openIndicator.hasObservers());
+        assertFalse(closeIndicator.hasObservers());
     }
 
     @Test
@@ -1629,28 +1629,28 @@ public class ObservableBufferTest {
     @Test
     @SuppressWarnings("unchecked")
     public void openCloseOpenCompletes() {
-        PublishSubject<Integer> pp0 = PublishSubject.create();
+        PublishSubject<Integer> source = PublishSubject.create();
 
-        PublishSubject<Integer> pp1 = PublishSubject.create();
+        PublishSubject<Integer> openIndicator = PublishSubject.create();
 
-        PublishSubject<Integer> pp2 = PublishSubject.create();
+        PublishSubject<Integer> closeIndicator = PublishSubject.create();
 
-        TestObserver<List<Integer>> ts = pp0
-        .buffer(pp1, Functions.justFunction(pp2))
+        TestObserver<List<Integer>> ts = source
+        .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .test();
 
-        pp1.onNext(1);
+        openIndicator.onNext(1);
 
-        assertTrue(pp2.hasObservers());
+        assertTrue(closeIndicator.hasObservers());
 
-        pp1.onComplete();
+        openIndicator.onComplete();
 
-        assertTrue(pp0.hasObservers());
-        assertTrue(pp2.hasObservers());
+        assertTrue(source.hasObservers());
+        assertTrue(closeIndicator.hasObservers());
 
-        pp2.onComplete();
+        closeIndicator.onComplete();
 
-        assertFalse(pp0.hasObservers());
+        assertFalse(source.hasObservers());
 
         ts.assertResult(Collections.<Integer>emptyList());
     }
@@ -1658,28 +1658,28 @@ public class ObservableBufferTest {
     @Test
     @SuppressWarnings("unchecked")
     public void openCloseOpenCompletesNoBuffers() {
-        PublishSubject<Integer> pp0 = PublishSubject.create();
+        PublishSubject<Integer> source = PublishSubject.create();
 
-        PublishSubject<Integer> pp1 = PublishSubject.create();
+        PublishSubject<Integer> openIndicator = PublishSubject.create();
 
-        PublishSubject<Integer> pp2 = PublishSubject.create();
+        PublishSubject<Integer> closeIndicator = PublishSubject.create();
 
-        TestObserver<List<Integer>> ts = pp0
-        .buffer(pp1, Functions.justFunction(pp2))
+        TestObserver<List<Integer>> ts = source
+        .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .test();
 
-        pp1.onNext(1);
+        openIndicator.onNext(1);
 
-        assertTrue(pp2.hasObservers());
+        assertTrue(closeIndicator.hasObservers());
 
-        pp2.onComplete();
+        closeIndicator.onComplete();
 
-        assertTrue(pp0.hasObservers());
-        assertTrue(pp1.hasObservers());
+        assertTrue(source.hasObservers());
+        assertTrue(openIndicator.hasObservers());
 
-        pp1.onComplete();
+        openIndicator.onComplete();
 
-        assertFalse(pp0.hasObservers());
+        assertFalse(source.hasObservers());
 
         ts.assertResult(Collections.<Integer>emptyList());
     }
@@ -1687,23 +1687,23 @@ public class ObservableBufferTest {
     @Test
     @SuppressWarnings("unchecked")
     public void openCloseTake() {
-        PublishSubject<Integer> pp0 = PublishSubject.create();
+        PublishSubject<Integer> source = PublishSubject.create();
 
-        PublishSubject<Integer> pp1 = PublishSubject.create();
+        PublishSubject<Integer> openIndicator = PublishSubject.create();
 
-        PublishSubject<Integer> pp2 = PublishSubject.create();
+        PublishSubject<Integer> closeIndicator = PublishSubject.create();
 
-        TestObserver<List<Integer>> ts = pp0
-        .buffer(pp1, Functions.justFunction(pp2))
+        TestObserver<List<Integer>> ts = source
+        .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .take(1)
         .test();
 
-        pp1.onNext(1);
-        pp2.onComplete();
+        openIndicator.onNext(1);
+        closeIndicator.onComplete();
 
-        assertFalse(pp0.hasObservers());
-        assertFalse(pp1.hasObservers());
-        assertFalse(pp2.hasObservers());
+        assertFalse(source.hasObservers());
+        assertFalse(openIndicator.hasObservers());
+        assertFalse(closeIndicator.hasObservers());
 
         ts.assertResult(Collections.<Integer>emptyList());
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -27,11 +28,12 @@ import org.mockito.*;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.disposables.Disposables;
-import io.reactivex.exceptions.TestException;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.*;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
 
@@ -1499,5 +1501,299 @@ public class ObservableBufferTest {
         .assertResult(Collections.<Integer>emptyList());
 
         assertEquals(0, counter.get());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void boundaryOpenCloseDisposedOnComplete() {
+        PublishSubject<Integer> pp0 = PublishSubject.create();
+
+        PublishSubject<Integer> pp1 = PublishSubject.create();
+
+        PublishSubject<Integer> pp2 = PublishSubject.create();
+
+        TestObserver<List<Integer>> ts = pp0
+        .buffer(pp1, Functions.justFunction(pp2))
+        .test();
+
+        assertTrue(pp0.hasObservers());
+        assertTrue(pp1.hasObservers());
+        assertFalse(pp2.hasObservers());
+
+        pp1.onNext(1);
+
+        assertTrue(pp1.hasObservers());
+        assertTrue(pp2.hasObservers());
+
+        pp0.onComplete();
+
+        ts.assertResult(Collections.<Integer>emptyList());
+
+        assertFalse(pp1.hasObservers());
+        assertFalse(pp2.hasObservers());
+    }
+
+    @Test
+    public void bufferedCanCompleteIfOpenNeverCompletesDropping() {
+        Observable.range(1, 50)
+                .zipWith(Observable.interval(5, TimeUnit.MILLISECONDS),
+                        new BiFunction<Integer, Long, Integer>() {
+                            @Override
+                            public Integer apply(Integer integer, Long aLong) {
+                                return integer;
+                            }
+                        })
+                .buffer(Observable.interval(0,200, TimeUnit.MILLISECONDS),
+                        new Function<Long, Observable<?>>() {
+                            @Override
+                            public Observable<?> apply(Long a) {
+                                return Observable.just(a).delay(100, TimeUnit.MILLISECONDS);
+                            }
+                        })
+                .test()
+                .assertSubscribed()
+                .awaitDone(3, TimeUnit.SECONDS)
+                .assertComplete();
+    }
+
+    @Test
+    public void bufferedCanCompleteIfOpenNeverCompletesOverlapping() {
+        Observable.range(1, 50)
+                .zipWith(Observable.interval(5, TimeUnit.MILLISECONDS),
+                        new BiFunction<Integer, Long, Integer>() {
+                            @Override
+                            public Integer apply(Integer integer, Long aLong) {
+                                return integer;
+                            }
+                        })
+                .buffer(Observable.interval(0,100, TimeUnit.MILLISECONDS),
+                        new Function<Long, Observable<?>>() {
+                            @Override
+                            public Observable<?> apply(Long a) {
+                                return Observable.just(a).delay(200, TimeUnit.MILLISECONDS);
+                            }
+                        })
+                .test()
+                .assertSubscribed()
+                .awaitDone(3, TimeUnit.SECONDS)
+                .assertComplete();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openClosemainError() {
+        Observable.error(new TestException())
+        .buffer(Observable.never(), Functions.justFunction(Observable.never()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openClosebadSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new Observable<Object>() {
+                @Override
+                protected void subscribeActual(Observer<? super Object> s) {
+                    Disposable bs1 = Disposables.empty();
+                    Disposable bs2 = Disposables.empty();
+
+                    s.onSubscribe(bs1);
+
+                    assertFalse(bs1.isDisposed());
+                    assertFalse(bs2.isDisposed());
+
+                    s.onSubscribe(bs2);
+
+                    assertFalse(bs1.isDisposed());
+                    assertTrue(bs2.isDisposed());
+
+                    s.onError(new IOException());
+                    s.onComplete();
+                    s.onNext(1);
+                    s.onError(new TestException());
+                }
+            }
+            .buffer(Observable.never(), Functions.justFunction(Observable.never()))
+            .test()
+            .assertFailure(IOException.class);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseOpenCompletes() {
+        PublishSubject<Integer> pp0 = PublishSubject.create();
+
+        PublishSubject<Integer> pp1 = PublishSubject.create();
+
+        PublishSubject<Integer> pp2 = PublishSubject.create();
+
+        TestObserver<List<Integer>> ts = pp0
+        .buffer(pp1, Functions.justFunction(pp2))
+        .test();
+
+        pp1.onNext(1);
+
+        assertTrue(pp2.hasObservers());
+
+        pp1.onComplete();
+
+        assertTrue(pp0.hasObservers());
+        assertTrue(pp2.hasObservers());
+
+        pp2.onComplete();
+
+        assertFalse(pp0.hasObservers());
+
+        ts.assertResult(Collections.<Integer>emptyList());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseOpenCompletesNoBuffers() {
+        PublishSubject<Integer> pp0 = PublishSubject.create();
+
+        PublishSubject<Integer> pp1 = PublishSubject.create();
+
+        PublishSubject<Integer> pp2 = PublishSubject.create();
+
+        TestObserver<List<Integer>> ts = pp0
+        .buffer(pp1, Functions.justFunction(pp2))
+        .test();
+
+        pp1.onNext(1);
+
+        assertTrue(pp2.hasObservers());
+
+        pp2.onComplete();
+
+        assertTrue(pp0.hasObservers());
+        assertTrue(pp1.hasObservers());
+
+        pp1.onComplete();
+
+        assertFalse(pp0.hasObservers());
+
+        ts.assertResult(Collections.<Integer>emptyList());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseTake() {
+        PublishSubject<Integer> pp0 = PublishSubject.create();
+
+        PublishSubject<Integer> pp1 = PublishSubject.create();
+
+        PublishSubject<Integer> pp2 = PublishSubject.create();
+
+        TestObserver<List<Integer>> ts = pp0
+        .buffer(pp1, Functions.justFunction(pp2))
+        .take(1)
+        .test();
+
+        pp1.onNext(1);
+        pp2.onComplete();
+
+        assertFalse(pp0.hasObservers());
+        assertFalse(pp1.hasObservers());
+        assertFalse(pp2.hasObservers());
+
+        ts.assertResult(Collections.<Integer>emptyList());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseBadOpen() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable.never()
+            .buffer(new Observable<Object>() {
+                @Override
+                protected void subscribeActual(Observer<? super Object> s) {
+
+                    assertFalse(((Disposable)s).isDisposed());
+
+                    Disposable bs1 = Disposables.empty();
+                    Disposable bs2 = Disposables.empty();
+
+                    s.onSubscribe(bs1);
+
+                    assertFalse(bs1.isDisposed());
+                    assertFalse(bs2.isDisposed());
+
+                    s.onSubscribe(bs2);
+
+                    assertFalse(bs1.isDisposed());
+                    assertTrue(bs2.isDisposed());
+
+                    s.onError(new IOException());
+
+                    assertTrue(((Disposable)s).isDisposed());
+
+                    s.onComplete();
+                    s.onNext(1);
+                    s.onError(new TestException());
+                }
+            }, Functions.justFunction(Observable.never()))
+            .test()
+            .assertFailure(IOException.class);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void openCloseBadClose() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable.never()
+            .buffer(Observable.just(1).concatWith(Observable.<Integer>never()),
+                    Functions.justFunction(new Observable<Object>() {
+                @Override
+                protected void subscribeActual(Observer<? super Object> s) {
+
+                    assertFalse(((Disposable)s).isDisposed());
+
+                    Disposable bs1 = Disposables.empty();
+                    Disposable bs2 = Disposables.empty();
+
+                    s.onSubscribe(bs1);
+
+                    assertFalse(bs1.isDisposed());
+                    assertFalse(bs2.isDisposed());
+
+                    s.onSubscribe(bs2);
+
+                    assertFalse(bs1.isDisposed());
+                    assertTrue(bs2.isDisposed());
+
+                    s.onError(new IOException());
+
+                    assertTrue(((Disposable)s).isDisposed());
+
+                    s.onComplete();
+                    s.onNext(1);
+                    s.onError(new TestException());
+                }
+            }))
+            .test()
+            .assertFailure(IOException.class);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }


### PR DESCRIPTION
The PR fixes the resource management in the `buffer` operator that uses other reactive sources to indicate when a buffer starts and ends. Both `Flowable` and `Observable` implementations had to be fixed.

Fixes: #5809