### PR TITLE
2.x: Add efficient concatWith(Single|Maybe|Completable) overloads

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -7171,6 +7171,83 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
+     * Returns a {@code Flowable} that emits the items from this {@code Flowable} followed by the success item or error event
+     * of the other {@link SingleSource}.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concat.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator supports backpressure and makes sure the success item of the other {@code SingleSource}
+     *  is only emitted when there is a demand for it.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the SingleSource whose signal should be emitted after this {@code Flowable} completes normally.
+     * @return the new Flowable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Flowable<T> concatWith(@NonNull SingleSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new FlowableConcatWithSingle<T>(this, other));
+    }
+
+    /**
+     * Returns a {@code Flowable} that emits the items from this {@code Flowable} followed by the success item or terminal events
+     * of the other {@link MaybeSource}.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concat.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator supports backpressure and makes sure the success item of the other {@code MaybeSource}
+     *  is only emitted when there is a demand for it.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the MaybeSource whose signal should be emitted after this Flowable completes normally.
+     * @return the new Flowable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Flowable<T> concatWith(@NonNull MaybeSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new FlowableConcatWithMaybe<T>(this, other));
+    }
+
+    /**
+     * Returns a {@code Flowable} that emits items from this {@code Flowable} and when it completes normally, the
+     * other {@link CompletableSource} is subscribed to and the returned {@code Flowable} emits its terminal events.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concat.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator does not interfere with backpressure between the current Flowable and the
+     *  downstream consumer (i.e., acts as pass-through). When the operator switches to the
+     *  {@code Completable}, backpressure is no longer present because {@code Completable} doesn't
+     *  have items to apply backpressure to.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the {@code CompletableSource} to subscribe to once the current {@code Flowable} completes normally
+     * @return the new Flowable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Flowable<T> concatWith(@NonNull CompletableSource other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new FlowableConcatWithCompletable<T>(this, other));
+    }
+
+    /**
      * Returns a Single that emits a Boolean that indicates whether the source Publisher emitted a
      * specified item.
      * <p>

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -6574,6 +6574,69 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
+     * Returns an {@code Observable} that emits the items from this {@code Observable} followed by the success item or error event
+     * of the other {@link SingleSource}.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concat.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the SingleSource whose signal should be emitted after this {@code Observable} completes normally.
+     * @return the new Observable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Observable<T> concatWith(@NonNull SingleSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new ObservableConcatWithSingle<T>(this, other));
+    }
+
+    /**
+     * Returns an {@code Observable} that emits the items from this {@code Observable} followed by the success item or terminal events
+     * of the other {@link MaybeSource}.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concat.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the MaybeSource whose signal should be emitted after this Observable completes normally.
+     * @return the new Observable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Observable<T> concatWith(@NonNull MaybeSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new ObservableConcatWithMaybe<T>(this, other));
+    }
+
+    /**
+     * Returns an {@code Observable} that emits items from this {@code Observable} and when it completes normally, the
+     * other {@link CompletableSource} is subscribed to and the returned {@code Observable} emits its terminal events.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concat.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the {@code CompletableSource} to subscribe to once the current {@code Observable} completes normally
+     * @return the new Observable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Observable<T> concatWith(@NonNull CompletableSource other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new ObservableConcatWithCompletable<T>(this, other));
+    }
+
+    /**
      * Returns a Single that emits a Boolean that indicates whether the source ObservableSource emitted a
      * specified item.
      * <p>

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithCompletable.java
@@ -91,9 +91,9 @@ public final class FlowableConcatWithCompletable<T> extends AbstractFlowableWith
             } else {
                 inCompletable = true;
                 upstream = SubscriptionHelper.CANCELLED;
-                CompletableSource c = other;
+                CompletableSource cs = other;
                 other = null;
-                c.subscribe(this);
+                cs.subscribe(this);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithCompletable.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+/**
+ * Subscribe to a main Flowable first, then when it completes normally, subscribe to a Completable
+ * and terminate when it terminates.
+ * @param <T> the element type of the main source and output type
+ * @since 2.1.10 - experimental
+ */
+public final class FlowableConcatWithCompletable<T> extends AbstractFlowableWithUpstream<T, T> {
+
+    final CompletableSource other;
+
+    public FlowableConcatWithCompletable(Flowable<T> source, CompletableSource other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        source.subscribe(new ConcatWithSubscriber<T>(s, other));
+    }
+
+    static final class ConcatWithSubscriber<T>
+    extends AtomicReference<Disposable>
+    implements FlowableSubscriber<T>, CompletableObserver, Subscription {
+
+        private static final long serialVersionUID = -7346385463600070225L;
+
+        final Subscriber<? super T> actual;
+
+        Subscription upstream;
+
+        CompletableSource other;
+
+        boolean inCompletable;
+
+        ConcatWithSubscriber(Subscriber<? super T> actual, CompletableSource other) {
+            this.actual = actual;
+            this.other = other;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(upstream, s)) {
+                this.upstream = s;
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(this, d);
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (inCompletable) {
+                actual.onComplete();
+            } else {
+                inCompletable = true;
+                upstream = SubscriptionHelper.CANCELLED;
+                CompletableSource c = other;
+                other = null;
+                c.subscribe(this);
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            upstream.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            upstream.cancel();
+            DisposableHelper.dispose(this);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybe.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscribers.SinglePostCompleteSubscriber;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+/**
+ * Subscribe to a main Flowable first, then when it completes normally, subscribe to a Maybe,
+ * signal its success value followed by a completion or signal its error or completion signal as is.
+ * @param <T> the element type of the main source and output type
+ * @since 2.1.10 - experimental
+ */
+public final class FlowableConcatWithMaybe<T> extends AbstractFlowableWithUpstream<T, T> {
+
+    final MaybeSource<? extends T> other;
+
+    public FlowableConcatWithMaybe(Flowable<T> source, MaybeSource<? extends T> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        source.subscribe(new ConcatWithSubscriber<T>(s, other));
+    }
+
+    static final class ConcatWithSubscriber<T>
+    extends SinglePostCompleteSubscriber<T, T>
+    implements MaybeObserver<T> {
+
+        private static final long serialVersionUID = -7346385463600070225L;
+
+        final AtomicReference<Disposable> otherDisposable;
+
+        MaybeSource<? extends T> other;
+
+        boolean inMaybe;
+
+        ConcatWithSubscriber(Subscriber<? super T> actual, MaybeSource<? extends T> other) {
+            super(actual);
+            this.other = other;
+            this.otherDisposable = new AtomicReference<Disposable>();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(otherDisposable, d);
+        }
+
+        @Override
+        public void onNext(T t) {
+            produced++;
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            complete(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (inMaybe) {
+                actual.onComplete();
+            } else {
+                inMaybe = true;
+                s = SubscriptionHelper.CANCELLED;
+                MaybeSource<? extends T> c = other;
+                other = null;
+                c.subscribe(this);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            DisposableHelper.dispose(otherDisposable);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybe.java
@@ -89,9 +89,9 @@ public final class FlowableConcatWithMaybe<T> extends AbstractFlowableWithUpstre
             } else {
                 inMaybe = true;
                 s = SubscriptionHelper.CANCELLED;
-                MaybeSource<? extends T> c = other;
+                MaybeSource<? extends T> ms = other;
                 other = null;
-                c.subscribe(this);
+                ms.subscribe(this);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithSingle.java
@@ -83,9 +83,9 @@ public final class FlowableConcatWithSingle<T> extends AbstractFlowableWithUpstr
         @Override
         public void onComplete() {
             s = SubscriptionHelper.CANCELLED;
-            SingleSource<? extends T> c = other;
+            SingleSource<? extends T> ss = other;
             other = null;
-            c.subscribe(this);
+            ss.subscribe(this);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithSingle.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscribers.SinglePostCompleteSubscriber;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+/**
+ * Subscribe to a main Flowable first, then when it completes normally, subscribe to a Single,
+ * signal its success value followed by a completion or signal its error as is.
+ * @param <T> the element type of the main source and output type
+ * @since 2.1.10 - experimental
+ */
+public final class FlowableConcatWithSingle<T> extends AbstractFlowableWithUpstream<T, T> {
+
+    final SingleSource<? extends T> other;
+
+    public FlowableConcatWithSingle(Flowable<T> source, SingleSource<? extends T> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        source.subscribe(new ConcatWithSubscriber<T>(s, other));
+    }
+
+    static final class ConcatWithSubscriber<T>
+    extends SinglePostCompleteSubscriber<T, T>
+    implements SingleObserver<T> {
+
+        private static final long serialVersionUID = -7346385463600070225L;
+
+        final AtomicReference<Disposable> otherDisposable;
+
+        SingleSource<? extends T> other;
+
+        ConcatWithSubscriber(Subscriber<? super T> actual, SingleSource<? extends T> other) {
+            super(actual);
+            this.other = other;
+            this.otherDisposable = new AtomicReference<Disposable>();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(otherDisposable, d);
+        }
+
+        @Override
+        public void onNext(T t) {
+            produced++;
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            complete(t);
+        }
+
+        @Override
+        public void onComplete() {
+            s = SubscriptionHelper.CANCELLED;
+            SingleSource<? extends T> c = other;
+            other = null;
+            c.subscribe(this);
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            DisposableHelper.dispose(otherDisposable);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletable.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Subscribe to a main Observable first, then when it completes normally, subscribe to a Single,
+ * signal its success value followed by a completion or signal its error as is.
+ * @param <T> the element type of the main source and output type
+ * @since 2.1.10 - experimental
+ */
+public final class ObservableConcatWithCompletable<T> extends AbstractObservableWithUpstream<T, T> {
+
+    final CompletableSource other;
+
+    public ObservableConcatWithCompletable(Observable<T> source, CompletableSource other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new ConcatWithObserver<T>(observer, other));
+    }
+
+    static final class ConcatWithObserver<T>
+    extends AtomicReference<Disposable>
+    implements Observer<T>, CompletableObserver, Disposable {
+
+        private static final long serialVersionUID = -1953724749712440952L;
+
+        final Observer<? super T> actual;
+
+        CompletableSource other;
+
+        boolean inCompletable;
+
+        ConcatWithObserver(Observer<? super T> actual, CompletableSource other) {
+            this.actual = actual;
+            this.other = other;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.setOnce(this, d) && !inCompletable) {
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            if (inCompletable) {
+                actual.onComplete();
+            } else {
+                inCompletable = true;
+                DisposableHelper.replace(this, null);
+                CompletableSource c = other;
+                other = null;
+                c.subscribe(this);
+            }
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletable.java
@@ -80,9 +80,9 @@ public final class ObservableConcatWithCompletable<T> extends AbstractObservable
             } else {
                 inCompletable = true;
                 DisposableHelper.replace(this, null);
-                CompletableSource c = other;
+                CompletableSource cs = other;
                 other = null;
-                c.subscribe(this);
+                cs.subscribe(this);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybe.java
@@ -86,9 +86,9 @@ public final class ObservableConcatWithMaybe<T> extends AbstractObservableWithUp
             } else {
                 inMaybe = true;
                 DisposableHelper.replace(this, null);
-                MaybeSource<? extends T> c = other;
+                MaybeSource<? extends T> ms = other;
                 other = null;
-                c.subscribe(this);
+                ms.subscribe(this);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybe.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Subscribe to a main Observable first, then when it completes normally, subscribe to a Maybe,
+ * signal its success value followed by a completion or signal its error or completion signal as is.
+ * @param <T> the element type of the main source and output type
+ * @since 2.1.10 - experimental
+ */
+public final class ObservableConcatWithMaybe<T> extends AbstractObservableWithUpstream<T, T> {
+
+    final MaybeSource<? extends T> other;
+
+    public ObservableConcatWithMaybe(Observable<T> source, MaybeSource<? extends T> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new ConcatWithObserver<T>(observer, other));
+    }
+
+    static final class ConcatWithObserver<T>
+    extends AtomicReference<Disposable>
+    implements Observer<T>, MaybeObserver<T>, Disposable {
+
+        private static final long serialVersionUID = -1953724749712440952L;
+
+        final Observer<? super T> actual;
+
+        MaybeSource<? extends T> other;
+
+        boolean inMaybe;
+
+        ConcatWithObserver(Observer<? super T> actual, MaybeSource<? extends T> other) {
+            this.actual = actual;
+            this.other = other;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.setOnce(this, d) && !inMaybe) {
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            actual.onNext(t);
+            actual.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            if (inMaybe) {
+                actual.onComplete();
+            } else {
+                inMaybe = true;
+                DisposableHelper.replace(this, null);
+                MaybeSource<? extends T> c = other;
+                other = null;
+                c.subscribe(this);
+            }
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingle.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Subscribe to a main Observable first, then when it completes normally, subscribe to a Single,
+ * signal its success value followed by a completion or signal its error as is.
+ * @param <T> the element type of the main source and output type
+ * @since 2.1.10 - experimental
+ */
+public final class ObservableConcatWithSingle<T> extends AbstractObservableWithUpstream<T, T> {
+
+    final SingleSource<? extends T> other;
+
+    public ObservableConcatWithSingle(Observable<T> source, SingleSource<? extends T> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new ConcatWithObserver<T>(observer, other));
+    }
+
+    static final class ConcatWithObserver<T>
+    extends AtomicReference<Disposable>
+    implements Observer<T>, SingleObserver<T>, Disposable {
+
+        private static final long serialVersionUID = -1953724749712440952L;
+
+        final Observer<? super T> actual;
+
+        SingleSource<? extends T> other;
+
+        boolean inSingle;
+
+        ConcatWithObserver(Observer<? super T> actual, SingleSource<? extends T> other) {
+            this.actual = actual;
+            this.other = other;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.setOnce(this, d) && !inSingle) {
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            actual.onNext(t);
+            actual.onComplete();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            actual.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            inSingle = true;
+            DisposableHelper.replace(this, null);
+            SingleSource<? extends T> c = other;
+            other = null;
+            c.subscribe(this);
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingle.java
@@ -83,9 +83,9 @@ public final class ObservableConcatWithSingle<T> extends AbstractObservableWithU
         public void onComplete() {
             inSingle = true;
             DisposableHelper.replace(this, null);
-            SingleSource<? extends T> c = other;
+            SingleSource<? extends T> ss = other;
             other = null;
-            c.subscribe(this);
+            ss.subscribe(this);
         }
 
         @Override

--- a/src/test/java/io/reactivex/InternalWrongNaming.java
+++ b/src/test/java/io/reactivex/InternalWrongNaming.java
@@ -179,7 +179,10 @@ public class InternalWrongNaming {
                 "FlowableFlatMapCompletableCompletable",
                 "FlowableFlatMapSingle",
                 "FlowableFlatMapMaybe",
-                "FlowableSequenceEqualSingle"
+                "FlowableSequenceEqualSingle",
+                "FlowableConcatWithSingle",
+                "FlowableConcatWithMaybe",
+                "FlowableConcatWithCompletable"
         );
     }
 }

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -999,7 +999,7 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void concatWithNull() {
-        just1.concatWith(null);
+        just1.concatWith((Publisher<Integer>)null);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithCompletableTest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.subjects.CompletableSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableConcatWithCompletableTest {
+
+    @Test
+    public void normal() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .concatWith(Completable.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void mainError() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.<Integer>error(new TestException())
+        .concatWith(Completable.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .concatWith(Completable.error(new TestException()))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class, 1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void takeMain() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .concatWith(Completable.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancelOther() {
+        CompletableSubject other = CompletableSubject.create();
+
+        TestSubscriber<Object> ts = Flowable.empty()
+                .concatWith(other)
+                .test();
+
+        assertTrue(other.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(other.hasObservers());
+    }
+
+    @Test
+    public void badSource() {
+        new Flowable<Integer>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super Integer> s) {
+                BooleanSubscription bs1 = new BooleanSubscription();
+                s.onSubscribe(bs1);
+
+                BooleanSubscription bs2 = new BooleanSubscription();
+                s.onSubscribe(bs2);
+
+                assertFalse(bs1.isCancelled());
+                assertTrue(bs2.isCancelled());
+
+                s.onComplete();
+            }
+        }.concatWith(Completable.complete())
+        .test()
+        .assertResult();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybeTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
+import io.reactivex.subjects.MaybeSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableConcatWithMaybeTest {
+
+    @Test
+    public void normalEmpty() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .concatWith(Maybe.<Integer>fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+
+    @Test
+    public void normalNonEmpty() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .concatWith(Maybe.just(100))
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void backpressure() {
+        Flowable.range(1, 5)
+        .concatWith(Maybe.just(100))
+        .test(0)
+        .assertEmpty()
+        .requestMore(3)
+        .assertValues(1, 2, 3)
+        .requestMore(2)
+        .assertValues(1, 2, 3, 4, 5)
+        .requestMore(1)
+        .assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void mainError() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.<Integer>error(new TestException())
+        .concatWith(Maybe.<Integer>fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .concatWith(Maybe.<Integer>error(new TestException()))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class, 1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void takeMain() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .concatWith(Maybe.<Integer>fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancelOther() {
+        MaybeSubject<Object> other = MaybeSubject.create();
+
+        TestSubscriber<Object> ts = Flowable.empty()
+                .concatWith(other)
+                .test();
+
+        assertTrue(other.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(other.hasObservers());
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithSingleTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.subjects.SingleSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableConcatWithSingleTest {
+
+    @Test
+    public void normal() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .concatWith(Single.just(100))
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void backpressure() {
+        Flowable.range(1, 5)
+        .concatWith(Single.just(100))
+        .test(0)
+        .assertEmpty()
+        .requestMore(3)
+        .assertValues(1, 2, 3)
+        .requestMore(2)
+        .assertValues(1, 2, 3, 4, 5)
+        .requestMore(1)
+        .assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void mainError() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.<Integer>error(new TestException())
+        .concatWith(Single.just(100))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .concatWith(Single.<Integer>error(new TestException()))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class, 1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void takeMain() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5)
+        .concatWith(Single.just(100))
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancelOther() {
+        SingleSubject<Object> other = SingleSubject.create();
+
+        TestSubscriber<Object> ts = Flowable.empty()
+                .concatWith(other)
+                .test();
+
+        assertTrue(other.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(other.hasObservers());
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletableTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.subjects.CompletableSubject;
+
+public class ObservableConcatWithCompletableTest {
+
+    @Test
+    public void normal() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5)
+        .concatWith(Completable.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void mainError() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.<Integer>error(new TestException())
+        .concatWith(Completable.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5)
+        .concatWith(Completable.error(new TestException()))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class, 1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void takeMain() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5)
+        .concatWith(Completable.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancelOther() {
+        CompletableSubject other = CompletableSubject.create();
+
+        TestObserver<Object> ts = Observable.empty()
+                .concatWith(other)
+                .test();
+
+        assertTrue(other.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(other.hasObservers());
+    }
+
+    @Test
+    public void badSource() {
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> s) {
+                Disposable bs1 = Disposables.empty();
+                s.onSubscribe(bs1);
+
+                Disposable bs2 = Disposables.empty();
+                s.onSubscribe(bs2);
+
+                assertFalse(bs1.isDisposed());
+                assertTrue(bs2.isDisposed());
+
+                s.onComplete();
+            }
+        }.concatWith(Completable.complete())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void consumerDisposed() {
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> observer) {
+                Disposable bs1 = Disposables.empty();
+                observer.onSubscribe(bs1);
+
+                assertFalse(((Disposable)observer).isDisposed());
+
+                observer.onNext(1);
+
+                assertTrue(((Disposable)observer).isDisposed());
+                assertTrue(bs1.isDisposed());
+            }
+        }.concatWith(Completable.complete())
+        .take(1)
+        .test()
+        .assertResult(1);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybeTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.subjects.MaybeSubject;
+
+public class ObservableConcatWithMaybeTest {
+
+    @Test
+    public void normalEmpty() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5)
+        .concatWith(Maybe.<Integer>fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+
+    @Test
+    public void normalNonEmpty() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5)
+        .concatWith(Maybe.just(100))
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void mainError() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.<Integer>error(new TestException())
+        .concatWith(Maybe.<Integer>fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5)
+        .concatWith(Maybe.<Integer>error(new TestException()))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class, 1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void takeMain() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5)
+        .concatWith(Maybe.<Integer>fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                ts.onNext(100);
+            }
+        }))
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancelOther() {
+        MaybeSubject<Object> other = MaybeSubject.create();
+
+        TestObserver<Object> ts = Observable.empty()
+                .concatWith(other)
+                .test();
+
+        assertTrue(other.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(other.hasObservers());
+    }
+
+    @Test
+    public void consumerDisposed() {
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> observer) {
+                Disposable bs1 = Disposables.empty();
+                observer.onSubscribe(bs1);
+
+                assertFalse(((Disposable)observer).isDisposed());
+
+                observer.onNext(1);
+
+                assertTrue(((Disposable)observer).isDisposed());
+                assertTrue(bs1.isDisposed());
+            }
+        }.concatWith(Maybe.just(100))
+        .take(1)
+        .test()
+        .assertResult(1);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybeTest.java
@@ -134,4 +134,46 @@ public class ObservableConcatWithMaybeTest {
         .assertResult(1);
     }
 
+    @Test
+    public void badSource() {
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> s) {
+                Disposable bs1 = Disposables.empty();
+                s.onSubscribe(bs1);
+
+                Disposable bs2 = Disposables.empty();
+                s.onSubscribe(bs2);
+
+                assertFalse(bs1.isDisposed());
+                assertTrue(bs2.isDisposed());
+
+                s.onComplete();
+            }
+        }.concatWith(Maybe.<Integer>empty())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void badSource2() {
+        Flowable.empty().concatWith(new Maybe<Integer>() {
+            @Override
+            protected void subscribeActual(MaybeObserver<? super Integer> s) {
+                Disposable bs1 = Disposables.empty();
+                s.onSubscribe(bs1);
+
+                Disposable bs2 = Disposables.empty();
+                s.onSubscribe(bs2);
+
+                assertFalse(bs1.isDisposed());
+                assertTrue(bs2.isDisposed());
+
+                s.onComplete();
+            }
+        })
+        .test()
+        .assertResult();
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingleTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.subjects.SingleSubject;
+
+public class ObservableConcatWithSingleTest {
+
+    @Test
+    public void normal() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5)
+        .concatWith(Single.just(100))
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void mainError() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.<Integer>error(new TestException())
+        .concatWith(Single.just(100))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5)
+        .concatWith(Single.<Integer>error(new TestException()))
+        .subscribe(ts);
+
+        ts.assertFailure(TestException.class, 1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void takeMain() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5)
+        .concatWith(Single.just(100))
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancelOther() {
+        SingleSubject<Object> other = SingleSubject.create();
+
+        TestObserver<Object> ts = Observable.empty()
+                .concatWith(other)
+                .test();
+
+        assertTrue(other.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(other.hasObservers());
+    }
+
+    @Test
+    public void consumerDisposed() {
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> observer) {
+                Disposable bs1 = Disposables.empty();
+                observer.onSubscribe(bs1);
+
+                assertFalse(((Disposable)observer).isDisposed());
+
+                observer.onNext(1);
+
+                assertTrue(((Disposable)observer).isDisposed());
+                assertTrue(bs1.isDisposed());
+            }
+        }.concatWith(Single.just(100))
+        .take(1)
+        .test()
+        .assertResult(1);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingleTest.java
@@ -106,4 +106,46 @@ public class ObservableConcatWithSingleTest {
         .assertResult(1);
     }
 
+    @Test
+    public void badSource() {
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> s) {
+                Disposable bs1 = Disposables.empty();
+                s.onSubscribe(bs1);
+
+                Disposable bs2 = Disposables.empty();
+                s.onSubscribe(bs2);
+
+                assertFalse(bs1.isDisposed());
+                assertTrue(bs2.isDisposed());
+
+                s.onComplete();
+            }
+        }.concatWith(Single.<Integer>just(100))
+        .test()
+        .assertResult(100);
+    }
+
+    @Test
+    public void badSource2() {
+        Flowable.empty().concatWith(new Single<Integer>() {
+            @Override
+            protected void subscribeActual(SingleObserver<? super Integer> s) {
+                Disposable bs1 = Disposables.empty();
+                s.onSubscribe(bs1);
+
+                Disposable bs2 = Disposables.empty();
+                s.onSubscribe(bs2);
+
+                assertFalse(bs1.isDisposed());
+                assertTrue(bs2.isDisposed());
+
+                s.onSuccess(100);
+            }
+        })
+        .test()
+        .assertResult(100);
+    }
+
 }

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1088,7 +1088,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void concatWithNull() {
-        just1.concatWith(null);
+        just1.concatWith((ObservableSource<Integer>)null);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/tck/ConcatWithCompletableTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatWithCompletableTckTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 import io.reactivex.*;
 
 @Test
-public class ConcatWithMaybeCompletableTckTest extends BaseTck<Integer> {
+public class ConcatWithCompletableTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {

--- a/src/test/java/io/reactivex/tck/ConcatWithMaybeCompletableTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatWithMaybeCompletableTckTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.*;
+
+@Test
+public class ConcatWithMaybeCompletableTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(long elements) {
+        return
+                Flowable.range(1, (int)elements)
+                .concatWith(Completable.complete())
+            ;
+    }
+}

--- a/src/test/java/io/reactivex/tck/ConcatWithMaybeEmptyTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatWithMaybeEmptyTckTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.*;
+
+@Test
+public class ConcatWithMaybeEmptyTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(long elements) {
+        return
+                Flowable.range(1, (int)elements)
+                .concatWith(Maybe.<Integer>empty())
+            ;
+    }
+}

--- a/src/test/java/io/reactivex/tck/ConcatWithMaybeTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatWithMaybeTckTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.*;
+
+@Test
+public class ConcatWithMaybeTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(long elements) {
+        return
+                Flowable.range(1, Math.max(0, (int)elements - 1))
+                .concatWith(Maybe.just((int)elements))
+            ;
+    }
+}

--- a/src/test/java/io/reactivex/tck/ConcatWithSingleTckTest.java
+++ b/src/test/java/io/reactivex/tck/ConcatWithSingleTckTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.*;
+
+@Test
+public class ConcatWithSingleTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(long elements) {
+        return
+                Flowable.range(1, Math.max(0, (int)elements - 1))
+                .concatWith(Single.just((int)elements))
+            ;
+    }
+}


### PR DESCRIPTION
This PR adds specialized overloads to the `concatWith` operator in `Flowable` and `Observable`.

If accepted, the marbles will be updated in a separate PR.

Related: #5350.