### PR TITLE
2.x: Add efficient mergeWith(Single|Maybe|Completable) overloads.

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -5771,7 +5771,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Runs the source observable to a terminal event, ignoring any values and rethrowing any exception.
+     * Runs the source Flowable to a terminal event, ignoring any values and rethrowing any exception.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes the source {@code Flowable} in an unbounded manner
@@ -10033,6 +10033,89 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Flowable<T> mergeWith(Publisher<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return merge(this, other);
+    }
+
+    /**
+     * Merges the sequence of items of this Flowable with the success value of the other SingleSource.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.png" alt="">
+     * <p>
+     * The success value of the other {@code SingleSource} can get interleaved at any point of this
+     * {@code Flowable} sequence.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream and ensures the success item from the
+     *  {@code SingleSource} is emitted only when there is a downstream demand.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other the {@code SingleSource} whose success value to merge with
+     * @return the new Flowable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Flowable<T> mergeWith(@NonNull SingleSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new FlowableMergeWithSingle<T>(this, other));
+    }
+
+    /**
+     * Merges the sequence of items of this Flowable with the success value of the other MaybeSource
+     * or waits both to complete normally if the MaybeSource is empty.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.png" alt="">
+     * <p>
+     * The success value of the other {@code MaybeSource} can get interleaved at any point of this
+     * {@code Flowable} sequence.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream and ensures the success item from the
+     *  {@code MaybeSource} is emitted only when there is a downstream demand.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other the {@code MaybeSource} which provides a success value to merge with or completes
+     * @return the new Flowable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Flowable<T> mergeWith(@NonNull MaybeSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new FlowableMergeWithMaybe<T>(this, other));
+    }
+
+    /**
+     * Relays the items of this Flowable and completes only when the other CompletableSource completes
+     * as well.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s backpressure
+     *  behavior.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other the {@code CompletableSource} to await for completion
+     * @return the new Flowable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Flowable<T> mergeWith(@NonNull CompletableSource other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new FlowableMergeWithCompletable<T>(this, other));
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -8929,6 +8929,77 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
+     * Merges the sequence of items of this Observable with the success value of the other SingleSource.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.png" alt="">
+     * <p>
+     * The success value of the other {@code SingleSource} can get interleaved at any point of this
+     * {@code Observable} sequence.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other the {@code SingleSource} whose success value to merge with
+     * @return the new Observable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Observable<T> mergeWith(@NonNull SingleSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new ObservableMergeWithSingle<T>(this, other));
+    }
+
+    /**
+     * Merges the sequence of items of this Observable with the success value of the other MaybeSource
+     * or waits both to complete normally if the MaybeSource is empty.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.png" alt="">
+     * <p>
+     * The success value of the other {@code MaybeSource} can get interleaved at any point of this
+     * {@code Observable} sequence.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other the {@code MaybeSource} which provides a success value to merge with or completes
+     * @return the new Observable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Observable<T> mergeWith(@NonNull MaybeSource<? extends T> other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new ObservableMergeWithMaybe<T>(this, other));
+    }
+
+    /**
+     * Relays the items of this Observable and completes only when the other CompletableSource completes
+     * as well.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param other the {@code CompletableSource} to await for completion
+     * @return the new Observable instance
+     * @since 2.1.10 - experimental
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Observable<T> mergeWith(@NonNull CompletableSource other) {
+        ObjectHelper.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new ObservableMergeWithCompletable<T>(this, other));
+    }
+
+    /**
      * Modifies an ObservableSource to perform its emissions and notifications on a specified {@link Scheduler},
      * asynchronously with an unbounded buffer with {@link Flowable#bufferSize()} "island size".
      *

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletable.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+
+/**
+ * Merges a Flowable and a Completable by emitting the items of the Flowable and waiting until
+ * both the Flowable and Completable complete normally.
+ *
+ * @param <T> the element type of the Flowable
+ * @since 2.1.10 - experimental
+ */
+public final class FlowableMergeWithCompletable<T> extends AbstractFlowableWithUpstream<T, T> {
+
+    final CompletableSource other;
+
+    public FlowableMergeWithCompletable(Flowable<T> source, CompletableSource other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> observer) {
+        MergeWithSubscriber<T> parent = new MergeWithSubscriber<T>(observer);
+        observer.onSubscribe(parent);
+        source.subscribe(parent);
+        other.subscribe(parent.otherObserver);
+    }
+
+    static final class MergeWithSubscriber<T> extends AtomicInteger
+    implements FlowableSubscriber<T>, Subscription {
+
+        private static final long serialVersionUID = -4592979584110982903L;
+
+        final Subscriber<? super T> actual;
+
+        final AtomicReference<Subscription> mainSubscription;
+
+        final OtherObserver otherObserver;
+
+        final AtomicThrowable error;
+
+        final AtomicLong requested;
+
+        volatile boolean mainDone;
+
+        volatile boolean otherDone;
+
+        MergeWithSubscriber(Subscriber<? super T> actual) {
+            this.actual = actual;
+            this.mainSubscription = new AtomicReference<Subscription>();
+            this.otherObserver = new OtherObserver(this);
+            this.error = new AtomicThrowable();
+            this.requested = new AtomicLong();
+        }
+
+        @Override
+        public void onSubscribe(Subscription d) {
+            SubscriptionHelper.deferredSetOnce(mainSubscription, requested, d);
+        }
+
+        @Override
+        public void onNext(T t) {
+            HalfSerializer.onNext(actual, t, this, error);
+        }
+
+        @Override
+        public void onError(Throwable ex) {
+            SubscriptionHelper.cancel(mainSubscription);
+            HalfSerializer.onError(actual, ex, this, error);
+        }
+
+        @Override
+        public void onComplete() {
+            mainDone = true;
+            if (otherDone) {
+                HalfSerializer.onComplete(actual, this, error);
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            SubscriptionHelper.deferredRequest(mainSubscription, requested, n);
+        }
+
+        @Override
+        public void cancel() {
+            SubscriptionHelper.cancel(mainSubscription);
+            DisposableHelper.dispose(otherObserver);
+        }
+
+        void otherError(Throwable ex) {
+            SubscriptionHelper.cancel(mainSubscription);
+            HalfSerializer.onError(actual, ex, this, error);
+        }
+
+        void otherComplete() {
+            otherDone = true;
+            if (mainDone) {
+                HalfSerializer.onComplete(actual, this, error);
+            }
+        }
+
+        static final class OtherObserver extends AtomicReference<Disposable>
+        implements CompletableObserver {
+
+            private static final long serialVersionUID = -2935427570954647017L;
+
+            final MergeWithSubscriber<?> parent;
+
+            OtherObserver(MergeWithSubscriber<?> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(this, d);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                parent.otherError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                parent.otherComplete();
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
@@ -1,0 +1,355 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Merges an Observable and a Maybe by emitting the items of the Observable and the success
+ * value of the Maybe and waiting until both the Observable and Maybe terminate normally.
+ *
+ * @param <T> the element type of the Observable
+ * @since 2.1.10 - experimental
+ */
+public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstream<T, T> {
+
+    final MaybeSource<? extends T> other;
+
+    public FlowableMergeWithMaybe(Flowable<T> source, MaybeSource<? extends T> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> observer) {
+        MergeWithObserver<T> parent = new MergeWithObserver<T>(observer);
+        observer.onSubscribe(parent);
+        source.subscribe(parent);
+        other.subscribe(parent.otherObserver);
+    }
+
+    static final class MergeWithObserver<T> extends AtomicInteger
+    implements FlowableSubscriber<T>, Subscription {
+
+        private static final long serialVersionUID = -4592979584110982903L;
+
+        final Subscriber<? super T> actual;
+
+        final AtomicReference<Subscription> mainSubscription;
+
+        final OtherObserver<T> otherObserver;
+
+        final AtomicThrowable error;
+
+        final AtomicLong requested;
+
+        final int prefetch;
+
+        final int limit;
+
+        volatile SimplePlainQueue<T> queue;
+
+        T singleItem;
+
+        volatile boolean cancelled;
+
+        volatile boolean mainDone;
+
+        volatile int otherState;
+
+        long emitted;
+
+        int consumed;
+
+        MergeWithObserver(Subscriber<? super T> actual) {
+            this.actual = actual;
+            this.mainSubscription = new AtomicReference<Subscription>();
+            this.otherObserver = new OtherObserver<T>(this);
+            this.error = new AtomicThrowable();
+            this.requested = new AtomicLong();
+            this.prefetch = bufferSize();
+            this.limit = prefetch - (prefetch >> 2);
+        }
+
+        @Override
+        public void onSubscribe(Subscription d) {
+            if (SubscriptionHelper.setOnce(mainSubscription, d)) {
+                d.request(prefetch);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (compareAndSet(0, 1)) {
+                long e = emitted;
+                if (requested.get() != e) {
+                    SimplePlainQueue<T> q = queue;
+                    if (q == null || q.isEmpty()) {
+
+                        emitted = e + 1;
+                        actual.onNext(t);
+
+                        int c = consumed + 1;
+                        if (c == limit) {
+                            consumed = 0;
+                            mainSubscription.get().request(c);
+                        } else {
+                            consumed = c;
+                        }
+                    } else {
+                        q.offer(t);
+                    }
+                } else {
+                    SimplePlainQueue<T> q = getOrCreateQueue();
+                    q.offer(t);
+                }
+                if (decrementAndGet() == 0) {
+                    return;
+                }
+            } else {
+                SimplePlainQueue<T> q = getOrCreateQueue();
+                q.offer(t);
+                if (getAndIncrement() != 0) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+
+        @Override
+        public void onError(Throwable ex) {
+            if (error.addThrowable(ex)) {
+                SubscriptionHelper.cancel(mainSubscription);
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            mainDone = true;
+            drain();
+        }
+
+        @Override
+        public void request(long n) {
+            BackpressureHelper.add(requested, n);
+            drain();
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+            SubscriptionHelper.cancel(mainSubscription);
+            DisposableHelper.dispose(otherObserver);
+            if (getAndIncrement() == 0) {
+                queue = null;
+                singleItem = null;
+            }
+        }
+
+        void otherSuccess(T value) {
+            if (compareAndSet(0, 1)) {
+                long e = emitted;
+                if (requested.get() != e) {
+
+                    emitted = e + 1;
+                    actual.onNext(value);
+                    otherState = 2;
+                } else {
+                    singleItem = value;
+                    otherState = 1;
+                    if (decrementAndGet() == 0) {
+                        return;
+                    }
+                }
+            } else {
+                singleItem = value;
+                otherState = 1;
+                if (getAndIncrement() != 0) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+
+        void otherError(Throwable ex) {
+            if (error.addThrowable(ex)) {
+                SubscriptionHelper.cancel(mainSubscription);
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        void otherComplete() {
+            otherState = 2;
+            drain();
+        }
+
+        SimplePlainQueue<T> getOrCreateQueue() {
+            SimplePlainQueue<T> q = queue;
+            if (q == null) {
+                q = new SpscArrayQueue<T>(bufferSize());
+                queue = q;
+            }
+            return q;
+        }
+
+        void drain() {
+            if (getAndIncrement() == 0) {
+                drainLoop();
+            }
+        }
+
+        void drainLoop() {
+            Subscriber<? super T> actual = this.actual;
+            int missed = 1;
+            long e = emitted;
+            int c = consumed;
+            int lim = limit;
+            for (;;) {
+
+                long r = requested.get();
+
+                while (e != r) {
+                    if (cancelled) {
+                        singleItem = null;
+                        queue = null;
+                        return;
+                    }
+
+                    if (error.get() != null) {
+                        singleItem = null;
+                        queue = null;
+                        actual.onError(error.terminate());
+                        return;
+                    }
+
+                    int os = otherState;
+                    if (os == 1) {
+                        T v = singleItem;
+                        singleItem = null;
+                        otherState = 2;
+                        os = 2;
+                        actual.onNext(v);
+
+                        e++;
+                        continue;
+                    }
+
+                    boolean d = mainDone;
+                    SimplePlainQueue<T> q = queue;
+                    T v = q != null ? q.poll() : null;
+                    boolean empty = v == null;
+
+                    if (d && empty && os == 2) {
+                        queue = null;
+                        actual.onComplete();
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    actual.onNext(v);
+
+                    e++;
+
+                    if (++c == lim) {
+                        c = 0;
+                        mainSubscription.get().request(lim);
+                    }
+                }
+
+                if (e == r) {
+                    if (cancelled) {
+                        singleItem = null;
+                        queue = null;
+                        return;
+                    }
+
+                    if (error.get() != null) {
+                        singleItem = null;
+                        queue = null;
+                        actual.onError(error.terminate());
+                        return;
+                    }
+
+                    boolean d = mainDone;
+                    SimplePlainQueue<T> q = queue;
+                    boolean empty = q == null || q.isEmpty();
+
+                    if (d && empty && otherState == 2) {
+                        queue = null;
+                        actual.onComplete();
+                        return;
+                    }
+                }
+
+                emitted = e;
+                consumed = c;
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class OtherObserver<T> extends AtomicReference<Disposable>
+        implements MaybeObserver<T> {
+
+            private static final long serialVersionUID = -2935427570954647017L;
+
+            final MergeWithObserver<T> parent;
+
+            OtherObserver(MergeWithObserver<T> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(this, d);
+            }
+
+            @Override
+            public void onSuccess(T t) {
+                parent.otherSuccess(t);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                parent.otherError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                parent.otherComplete();
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
@@ -83,6 +83,10 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
 
         int consumed;
 
+        static final int OTHER_STATE_HAS_VALUE = 1;
+
+        static final int OTHER_STATE_CONSUMED_OR_EMPTY = 2;
+
         MergeWithObserver(Subscriber<? super T> actual) {
             this.actual = actual;
             this.mainSubscription = new AtomicReference<Subscription>();
@@ -178,17 +182,17 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
 
                     emitted = e + 1;
                     actual.onNext(value);
-                    otherState = 2;
+                    otherState = OTHER_STATE_CONSUMED_OR_EMPTY;
                 } else {
                     singleItem = value;
-                    otherState = 1;
+                    otherState = OTHER_STATE_HAS_VALUE;
                     if (decrementAndGet() == 0) {
                         return;
                     }
                 }
             } else {
                 singleItem = value;
-                otherState = 1;
+                otherState = OTHER_STATE_HAS_VALUE;
                 if (getAndIncrement() != 0) {
                     return;
                 }
@@ -206,7 +210,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
         }
 
         void otherComplete() {
-            otherState = 2;
+            otherState = OTHER_STATE_CONSUMED_OR_EMPTY;
             drain();
         }
 
@@ -250,11 +254,11 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
                     }
 
                     int os = otherState;
-                    if (os == 1) {
+                    if (os == OTHER_STATE_HAS_VALUE) {
                         T v = singleItem;
                         singleItem = null;
-                        otherState = 2;
-                        os = 2;
+                        otherState = OTHER_STATE_CONSUMED_OR_EMPTY;
+                        os = OTHER_STATE_CONSUMED_OR_EMPTY;
                         actual.onNext(v);
 
                         e++;
@@ -266,7 +270,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
                     T v = q != null ? q.poll() : null;
                     boolean empty = v == null;
 
-                    if (d && empty && os == 2) {
+                    if (d && empty && os == OTHER_STATE_CONSUMED_OR_EMPTY) {
                         queue = null;
                         actual.onComplete();
                         return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingle.java
@@ -1,0 +1,345 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Merges an Observable and a Maybe by emitting the items of the Observable and the success
+ * value of the Maybe and waiting until both the Observable and Maybe terminate normally.
+ *
+ * @param <T> the element type of the Observable
+ * @since 2.1.10 - experimental
+ */
+public final class FlowableMergeWithSingle<T> extends AbstractFlowableWithUpstream<T, T> {
+
+    final SingleSource<? extends T> other;
+
+    public FlowableMergeWithSingle(Flowable<T> source, SingleSource<? extends T> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> observer) {
+        MergeWithObserver<T> parent = new MergeWithObserver<T>(observer);
+        observer.onSubscribe(parent);
+        source.subscribe(parent);
+        other.subscribe(parent.otherObserver);
+    }
+
+    static final class MergeWithObserver<T> extends AtomicInteger
+    implements FlowableSubscriber<T>, Subscription {
+
+        private static final long serialVersionUID = -4592979584110982903L;
+
+        final Subscriber<? super T> actual;
+
+        final AtomicReference<Subscription> mainSubscription;
+
+        final OtherObserver<T> otherObserver;
+
+        final AtomicThrowable error;
+
+        final AtomicLong requested;
+
+        final int prefetch;
+
+        final int limit;
+
+        volatile SimplePlainQueue<T> queue;
+
+        T singleItem;
+
+        volatile boolean cancelled;
+
+        volatile boolean mainDone;
+
+        volatile int otherState;
+
+        long emitted;
+
+        int consumed;
+
+        MergeWithObserver(Subscriber<? super T> actual) {
+            this.actual = actual;
+            this.mainSubscription = new AtomicReference<Subscription>();
+            this.otherObserver = new OtherObserver<T>(this);
+            this.error = new AtomicThrowable();
+            this.requested = new AtomicLong();
+            this.prefetch = bufferSize();
+            this.limit = prefetch - (prefetch >> 2);
+        }
+
+        @Override
+        public void onSubscribe(Subscription d) {
+            if (SubscriptionHelper.setOnce(mainSubscription, d)) {
+                d.request(prefetch);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (compareAndSet(0, 1)) {
+                long e = emitted;
+                if (requested.get() != e) {
+                    SimplePlainQueue<T> q = queue;
+                    if (q == null || q.isEmpty()) {
+
+                        emitted = e + 1;
+                        actual.onNext(t);
+
+                        int c = consumed + 1;
+                        if (c == limit) {
+                            consumed = 0;
+                            mainSubscription.get().request(c);
+                        } else {
+                            consumed = c;
+                        }
+                    } else {
+                        q.offer(t);
+                    }
+                } else {
+                    SimplePlainQueue<T> q = getOrCreateQueue();
+                    q.offer(t);
+                }
+                if (decrementAndGet() == 0) {
+                    return;
+                }
+            } else {
+                SimplePlainQueue<T> q = getOrCreateQueue();
+                q.offer(t);
+                if (getAndIncrement() != 0) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+
+        @Override
+        public void onError(Throwable ex) {
+            if (error.addThrowable(ex)) {
+                SubscriptionHelper.cancel(mainSubscription);
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            mainDone = true;
+            drain();
+        }
+
+        @Override
+        public void request(long n) {
+            BackpressureHelper.add(requested, n);
+            drain();
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+            SubscriptionHelper.cancel(mainSubscription);
+            DisposableHelper.dispose(otherObserver);
+            if (getAndIncrement() == 0) {
+                queue = null;
+                singleItem = null;
+            }
+        }
+
+        void otherSuccess(T value) {
+            if (compareAndSet(0, 1)) {
+                long e = emitted;
+                if (requested.get() != e) {
+
+                    emitted = e + 1;
+                    actual.onNext(value);
+                    otherState = 2;
+                } else {
+                    singleItem = value;
+                    otherState = 1;
+                    if (decrementAndGet() == 0) {
+                        return;
+                    }
+                }
+            } else {
+                singleItem = value;
+                otherState = 1;
+                if (getAndIncrement() != 0) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+
+        void otherError(Throwable ex) {
+            if (error.addThrowable(ex)) {
+                SubscriptionHelper.cancel(mainSubscription);
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        SimplePlainQueue<T> getOrCreateQueue() {
+            SimplePlainQueue<T> q = queue;
+            if (q == null) {
+                q = new SpscArrayQueue<T>(bufferSize());
+                queue = q;
+            }
+            return q;
+        }
+
+        void drain() {
+            if (getAndIncrement() == 0) {
+                drainLoop();
+            }
+        }
+
+        void drainLoop() {
+            Subscriber<? super T> actual = this.actual;
+            int missed = 1;
+            long e = emitted;
+            int c = consumed;
+            int lim = limit;
+            for (;;) {
+
+                long r = requested.get();
+
+                while (e != r) {
+                    if (cancelled) {
+                        singleItem = null;
+                        queue = null;
+                        return;
+                    }
+
+                    if (error.get() != null) {
+                        singleItem = null;
+                        queue = null;
+                        actual.onError(error.terminate());
+                        return;
+                    }
+
+                    int os = otherState;
+                    if (os == 1) {
+                        T v = singleItem;
+                        singleItem = null;
+                        otherState = 2;
+                        os = 2;
+                        actual.onNext(v);
+
+                        e++;
+                        continue;
+                    }
+
+                    boolean d = mainDone;
+                    SimplePlainQueue<T> q = queue;
+                    T v = q != null ? q.poll() : null;
+                    boolean empty = v == null;
+
+                    if (d && empty && os == 2) {
+                        queue = null;
+                        actual.onComplete();
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    actual.onNext(v);
+
+                    e++;
+
+                    if (++c == lim) {
+                        c = 0;
+                        mainSubscription.get().request(lim);
+                    }
+                }
+
+                if (e == r) {
+                    if (cancelled) {
+                        singleItem = null;
+                        queue = null;
+                        return;
+                    }
+
+                    if (error.get() != null) {
+                        singleItem = null;
+                        queue = null;
+                        actual.onError(error.terminate());
+                        return;
+                    }
+
+                    boolean d = mainDone;
+                    SimplePlainQueue<T> q = queue;
+                    boolean empty = q == null || q.isEmpty();
+
+                    if (d && empty && otherState == 2) {
+                        queue = null;
+                        actual.onComplete();
+                        return;
+                    }
+                }
+
+                emitted = e;
+                consumed = c;
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class OtherObserver<T> extends AtomicReference<Disposable>
+        implements SingleObserver<T> {
+
+            private static final long serialVersionUID = -2935427570954647017L;
+
+            final MergeWithObserver<T> parent;
+
+            OtherObserver(MergeWithObserver<T> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(this, d);
+            }
+
+            @Override
+            public void onSuccess(T t) {
+                parent.otherSuccess(t);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                parent.otherError(e);
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletable.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.atomic.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.util.*;
+
+/**
+ * Merges an Observable and a Completable by emitting the items of the Observable and waiting until
+ * both the Observable and Completable complete normally.
+ *
+ * @param <T> the element type of the Observable
+ * @since 2.1.10 - experimental
+ */
+public final class ObservableMergeWithCompletable<T> extends AbstractObservableWithUpstream<T, T> {
+
+    final CompletableSource other;
+
+    public ObservableMergeWithCompletable(Observable<T> source, CompletableSource other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        MergeWithObserver<T> parent = new MergeWithObserver<T>(observer);
+        observer.onSubscribe(parent);
+        source.subscribe(parent);
+        other.subscribe(parent.otherObserver);
+    }
+
+    static final class MergeWithObserver<T> extends AtomicInteger
+    implements Observer<T>, Disposable {
+
+        private static final long serialVersionUID = -4592979584110982903L;
+
+        final Observer<? super T> actual;
+
+        final AtomicReference<Disposable> mainDisposable;
+
+        final OtherObserver otherObserver;
+
+        final AtomicThrowable error;
+
+        volatile boolean mainDone;
+
+        volatile boolean otherDone;
+
+        MergeWithObserver(Observer<? super T> actual) {
+            this.actual = actual;
+            this.mainDisposable = new AtomicReference<Disposable>();
+            this.otherObserver = new OtherObserver(this);
+            this.error = new AtomicThrowable();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(mainDisposable, d);
+        }
+
+        @Override
+        public void onNext(T t) {
+            HalfSerializer.onNext(actual, t, this, error);
+        }
+
+        @Override
+        public void onError(Throwable ex) {
+            DisposableHelper.dispose(mainDisposable);
+            HalfSerializer.onError(actual, ex, this, error);
+        }
+
+        @Override
+        public void onComplete() {
+            mainDone = true;
+            if (otherDone) {
+                HalfSerializer.onComplete(actual, this, error);
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(mainDisposable.get());
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(mainDisposable);
+            DisposableHelper.dispose(otherObserver);
+        }
+
+        void otherError(Throwable ex) {
+            DisposableHelper.dispose(mainDisposable);
+            HalfSerializer.onError(actual, ex, this, error);
+        }
+
+        void otherComplete() {
+            otherDone = true;
+            if (mainDone) {
+                HalfSerializer.onComplete(actual, this, error);
+            }
+        }
+
+        static final class OtherObserver extends AtomicReference<Disposable>
+        implements CompletableObserver {
+
+            private static final long serialVersionUID = -2935427570954647017L;
+
+            final MergeWithObserver<?> parent;
+
+            OtherObserver(MergeWithObserver<?> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(this, d);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                parent.otherError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                parent.otherComplete();
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybe.java
@@ -1,0 +1,262 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.atomic.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.util.AtomicThrowable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Merges an Observable and a Maybe by emitting the items of the Observable and the success
+ * value of the Maybe and waiting until both the Observable and Maybe terminate normally.
+ *
+ * @param <T> the element type of the Observable
+ * @since 2.1.10 - experimental
+ */
+public final class ObservableMergeWithMaybe<T> extends AbstractObservableWithUpstream<T, T> {
+
+    final MaybeSource<? extends T> other;
+
+    public ObservableMergeWithMaybe(Observable<T> source, MaybeSource<? extends T> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        MergeWithObserver<T> parent = new MergeWithObserver<T>(observer);
+        observer.onSubscribe(parent);
+        source.subscribe(parent);
+        other.subscribe(parent.otherObserver);
+    }
+
+    static final class MergeWithObserver<T> extends AtomicInteger
+    implements Observer<T>, Disposable {
+
+        private static final long serialVersionUID = -4592979584110982903L;
+
+        final Observer<? super T> actual;
+
+        final AtomicReference<Disposable> mainDisposable;
+
+        final OtherObserver<T> otherObserver;
+
+        final AtomicThrowable error;
+
+        volatile SimplePlainQueue<T> queue;
+
+        T singleItem;
+
+        volatile boolean disposed;
+
+        volatile boolean mainDone;
+
+        volatile int otherState;
+
+        MergeWithObserver(Observer<? super T> actual) {
+            this.actual = actual;
+            this.mainDisposable = new AtomicReference<Disposable>();
+            this.otherObserver = new OtherObserver<T>(this);
+            this.error = new AtomicThrowable();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(mainDisposable, d);
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (compareAndSet(0, 1)) {
+                actual.onNext(t);
+                if (decrementAndGet() == 0) {
+                    return;
+                }
+            } else {
+                SimplePlainQueue<T> q = getOrCreateQueue();
+                q.offer(t);
+                if (getAndIncrement() != 0) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+
+        @Override
+        public void onError(Throwable ex) {
+            if (error.addThrowable(ex)) {
+                DisposableHelper.dispose(mainDisposable);
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            mainDone = true;
+            drain();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(mainDisposable.get());
+        }
+
+        @Override
+        public void dispose() {
+            disposed = true;
+            DisposableHelper.dispose(mainDisposable);
+            DisposableHelper.dispose(otherObserver);
+            if (getAndIncrement() == 0) {
+                queue = null;
+                singleItem = null;
+            }
+        }
+
+        void otherSuccess(T value) {
+            if (compareAndSet(0, 1)) {
+                actual.onNext(value);
+                otherState = 2;
+            } else {
+                singleItem = value;
+                otherState = 1;
+                if (getAndIncrement() != 0) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+
+        void otherError(Throwable ex) {
+            if (error.addThrowable(ex)) {
+                DisposableHelper.dispose(mainDisposable);
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        void otherComplete() {
+            otherState = 2;
+            drain();
+        }
+
+        SimplePlainQueue<T> getOrCreateQueue() {
+            SimplePlainQueue<T> q = queue;
+            if (q == null) {
+                q = new SpscLinkedArrayQueue<T>(bufferSize());
+                queue = q;
+            }
+            return q;
+        }
+
+        void drain() {
+            if (getAndIncrement() == 0) {
+                drainLoop();
+            }
+        }
+
+        void drainLoop() {
+            Observer<? super T> actual = this.actual;
+            int missed = 1;
+            for (;;) {
+
+                for (;;) {
+                    if (disposed) {
+                        singleItem = null;
+                        queue = null;
+                        return;
+                    }
+
+                    if (error.get() != null) {
+                        singleItem = null;
+                        queue = null;
+                        actual.onError(error.terminate());
+                        return;
+                    }
+
+                    int os = otherState;
+                    if (os == 1) {
+                        T v = singleItem;
+                        singleItem = null;
+                        otherState = 2;
+                        os = 2;
+                        actual.onNext(v);
+                    }
+
+                    boolean d = mainDone;
+                    SimplePlainQueue<T> q = queue;
+                    T v = q != null ? q.poll() : null;
+                    boolean empty = v == null;
+
+                    if (d && empty && os == 2) {
+                        queue = null;
+                        actual.onComplete();
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    actual.onNext(v);
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class OtherObserver<T> extends AtomicReference<Disposable>
+        implements MaybeObserver<T> {
+
+            private static final long serialVersionUID = -2935427570954647017L;
+
+            final MergeWithObserver<T> parent;
+
+            OtherObserver(MergeWithObserver<T> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(this, d);
+            }
+
+            @Override
+            public void onSuccess(T t) {
+                parent.otherSuccess(t);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                parent.otherError(e);
+            }
+
+            @Override
+            public void onComplete() {
+                parent.otherComplete();
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingle.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.atomic.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.util.AtomicThrowable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Merges an Observable and a Single by emitting the items of the Observable and the success
+ * value of the Single and waiting until both the Observable and Single terminate normally.
+ *
+ * @param <T> the element type of the Observable
+ * @since 2.1.10 - experimental
+ */
+public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUpstream<T, T> {
+
+    final SingleSource<? extends T> other;
+
+    public ObservableMergeWithSingle(Observable<T> source, SingleSource<? extends T> other) {
+        super(source);
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        MergeWithObserver<T> parent = new MergeWithObserver<T>(observer);
+        observer.onSubscribe(parent);
+        source.subscribe(parent);
+        other.subscribe(parent.otherObserver);
+    }
+
+    static final class MergeWithObserver<T> extends AtomicInteger
+    implements Observer<T>, Disposable {
+
+        private static final long serialVersionUID = -4592979584110982903L;
+
+        final Observer<? super T> actual;
+
+        final AtomicReference<Disposable> mainDisposable;
+
+        final OtherObserver<T> otherObserver;
+
+        final AtomicThrowable error;
+
+        volatile SimplePlainQueue<T> queue;
+
+        T singleItem;
+
+        volatile boolean disposed;
+
+        volatile boolean mainDone;
+
+        volatile int otherState;
+
+        MergeWithObserver(Observer<? super T> actual) {
+            this.actual = actual;
+            this.mainDisposable = new AtomicReference<Disposable>();
+            this.otherObserver = new OtherObserver<T>(this);
+            this.error = new AtomicThrowable();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(mainDisposable, d);
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (compareAndSet(0, 1)) {
+                actual.onNext(t);
+                if (decrementAndGet() == 0) {
+                    return;
+                }
+            } else {
+                SimplePlainQueue<T> q = getOrCreateQueue();
+                q.offer(t);
+                if (getAndIncrement() != 0) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+
+        @Override
+        public void onError(Throwable ex) {
+            if (error.addThrowable(ex)) {
+                DisposableHelper.dispose(mainDisposable);
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            mainDone = true;
+            drain();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(mainDisposable.get());
+        }
+
+        @Override
+        public void dispose() {
+            disposed = true;
+            DisposableHelper.dispose(mainDisposable);
+            DisposableHelper.dispose(otherObserver);
+            if (getAndIncrement() == 0) {
+                queue = null;
+                singleItem = null;
+            }
+        }
+
+        void otherSuccess(T value) {
+            if (compareAndSet(0, 1)) {
+                actual.onNext(value);
+                otherState = 2;
+            } else {
+                singleItem = value;
+                otherState = 1;
+                if (getAndIncrement() != 0) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+
+        void otherError(Throwable ex) {
+            if (error.addThrowable(ex)) {
+                DisposableHelper.dispose(mainDisposable);
+                drain();
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        SimplePlainQueue<T> getOrCreateQueue() {
+            SimplePlainQueue<T> q = queue;
+            if (q == null) {
+                q = new SpscLinkedArrayQueue<T>(bufferSize());
+                queue = q;
+            }
+            return q;
+        }
+
+        void drain() {
+            if (getAndIncrement() == 0) {
+                drainLoop();
+            }
+        }
+
+        void drainLoop() {
+            Observer<? super T> actual = this.actual;
+            int missed = 1;
+            for (;;) {
+
+                for (;;) {
+                    if (disposed) {
+                        singleItem = null;
+                        queue = null;
+                        return;
+                    }
+
+                    if (error.get() != null) {
+                        singleItem = null;
+                        queue = null;
+                        actual.onError(error.terminate());
+                        return;
+                    }
+
+                    int os = otherState;
+                    if (os == 1) {
+                        T v = singleItem;
+                        singleItem = null;
+                        otherState = 2;
+                        os = 2;
+                        actual.onNext(v);
+                    }
+
+                    boolean d = mainDone;
+                    SimplePlainQueue<T> q = queue;
+                    T v = q != null ? q.poll() : null;
+                    boolean empty = v == null;
+
+                    if (d && empty && os == 2) {
+                        queue = null;
+                        actual.onComplete();
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    actual.onNext(v);
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class OtherObserver<T> extends AtomicReference<Disposable>
+        implements SingleObserver<T> {
+
+            private static final long serialVersionUID = -2935427570954647017L;
+
+            final MergeWithObserver<T> parent;
+
+            OtherObserver(MergeWithObserver<T> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(this, d);
+            }
+
+            @Override
+            public void onSuccess(T t) {
+                parent.otherSuccess(t);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                parent.otherError(e);
+            }
+
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingle.java
@@ -70,6 +70,10 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
 
         volatile int otherState;
 
+        static final int OTHER_STATE_HAS_VALUE = 1;
+
+        static final int OTHER_STATE_CONSUMED_OR_EMPTY = 2;
+
         MergeWithObserver(Observer<? super T> actual) {
             this.actual = actual;
             this.mainDisposable = new AtomicReference<Disposable>();
@@ -134,10 +138,10 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
         void otherSuccess(T value) {
             if (compareAndSet(0, 1)) {
                 actual.onNext(value);
-                otherState = 2;
+                otherState = OTHER_STATE_CONSUMED_OR_EMPTY;
             } else {
                 singleItem = value;
-                otherState = 1;
+                otherState = OTHER_STATE_HAS_VALUE;
                 if (getAndIncrement() != 0) {
                     return;
                 }
@@ -189,11 +193,11 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
                     }
 
                     int os = otherState;
-                    if (os == 1) {
+                    if (os == OTHER_STATE_HAS_VALUE) {
                         T v = singleItem;
                         singleItem = null;
-                        otherState = 2;
-                        os = 2;
+                        otherState = OTHER_STATE_CONSUMED_OR_EMPTY;
+                        os = OTHER_STATE_CONSUMED_OR_EMPTY;
                         actual.onNext(v);
                     }
 
@@ -202,7 +206,7 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
                     T v = q != null ? q.poll() : null;
                     boolean empty = v == null;
 
-                    if (d && empty && os == 2) {
+                    if (d && empty && os == OTHER_STATE_CONSUMED_OR_EMPTY) {
                         queue = null;
                         actual.onComplete();
                         return;

--- a/src/test/java/io/reactivex/InternalWrongNaming.java
+++ b/src/test/java/io/reactivex/InternalWrongNaming.java
@@ -179,7 +179,13 @@ public class InternalWrongNaming {
                 "FlowableFlatMapCompletableCompletable",
                 "FlowableFlatMapSingle",
                 "FlowableFlatMapMaybe",
-                "FlowableSequenceEqualSingle"
+                "FlowableSequenceEqualSingle",
+                "FlowableConcatWithSingle",
+                "FlowableConcatWithMaybe",
+                "FlowableConcatWithCompletable",
+                "FlowableMergeWithSingle",
+                "FlowableMergeWithMaybe",
+                "FlowableMergeWithCompletable"
         );
     }
 }

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -1620,7 +1620,7 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void mergeWithNull() {
-        just1.mergeWith(null);
+        just1.mergeWith((Publisher<Integer>)null);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subjects.CompletableSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableMergeWithCompletableTest {
+
+    @Test
+    public void normal() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5).mergeWith(
+                Completable.fromAction(new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        ts.onNext(100);
+                    }
+                })
+        )
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void take() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5).mergeWith(
+                Completable.complete()
+        )
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancel() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final CompletableSubject cs = CompletableSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
+
+        assertTrue(pp.hasSubscribers());
+        assertTrue(cs.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+        assertFalse(cs.hasObservers());
+    }
+
+    @Test
+    public void normalBackpressured() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+
+        Flowable.range(1, 5).mergeWith(
+                Completable.fromAction(new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        ts.onNext(100);
+                    }
+                })
+        )
+        .subscribe(ts);
+
+        ts
+        .assertValue(100)
+        .requestMore(2)
+        .assertValues(100, 1, 2)
+        .requestMore(2)
+        .assertValues(100, 1, 2, 3, 4)
+        .requestMore(1)
+        .assertResult(100, 1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void mainError() {
+        Flowable.error(new TestException())
+        .mergeWith(Completable.complete())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        Flowable.never()
+        .mergeWith(Completable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 1000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final CompletableSubject cs = CompletableSubject.create();
+
+            TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                    pp.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    cs.onComplete();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
@@ -45,15 +45,11 @@ public class FlowableMergeWithCompletableTest {
 
     @Test
     public void take() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-
-        Flowable.range(1, 5).mergeWith(
-                Completable.complete()
-        )
+        Flowable.range(1, 5)
+        .mergeWith(Completable.complete())
         .take(3)
-        .subscribe(ts);
-
-        ts.assertResult(1, 2, 3);
+        .test()
+        .assertResult(1, 2, 3);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybeTest.java
@@ -1,0 +1,428 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subjects.MaybeSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableMergeWithMaybeTest {
+
+    @Test
+    public void normal() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5).mergeWith(
+                Maybe.just(100)
+        )
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void emptyOther() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5).mergeWith(
+                Maybe.<Integer>empty()
+        )
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void normalLong() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 512).mergeWith(
+                Maybe.just(100)
+        )
+        .subscribe(ts);
+
+        ts.assertValueCount(513)
+        .assertComplete();
+    }
+
+    @Test
+    public void normalLongRequestExact() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(513);
+
+        Flowable.range(1, 512).mergeWith(
+                Maybe.just(100)
+        )
+        .subscribe(ts);
+
+        ts.assertValueCount(513)
+        .assertComplete();
+    }
+
+    @Test
+    public void take() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5).mergeWith(
+                Maybe.just(100)
+        )
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancel() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
+
+        assertTrue(pp.hasSubscribers());
+        assertTrue(cs.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+        assertFalse(cs.hasObservers());
+    }
+
+    @Test
+    public void normalBackpressured() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+
+        Flowable.range(1, 5).mergeWith(
+                Maybe.just(100)
+        )
+        .subscribe(ts);
+
+        ts
+        .assertEmpty()
+        .requestMore(2)
+        .assertValues(100, 1)
+        .requestMore(2)
+        .assertValues(100, 1, 2, 3)
+        .requestMore(2)
+        .assertResult(100, 1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void mainError() {
+        Flowable.error(new TestException())
+        .mergeWith(Maybe.just(100))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        Flowable.never()
+        .mergeWith(Maybe.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+            TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                    pp.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    cs.onSuccess(1);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1, 1);
+        }
+    }
+
+    @Test
+    public void onNextSlowPath() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    pp.onNext(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+        cs.onSuccess(3);
+
+        pp.onNext(4);
+        pp.onComplete();
+
+        ts.assertResult(1, 2, 3, 4);
+    }
+
+    @Test
+    public void onSuccessSlowPath() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    cs.onSuccess(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+
+        pp.onNext(3);
+        pp.onComplete();
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void onSuccessSlowPathBackpressured() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<Integer>(1) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    cs.onSuccess(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+
+        pp.onNext(3);
+        pp.onComplete();
+
+        ts.request(2);
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void onSuccessFastPathBackpressuredRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+            final TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<Integer>(0));
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    cs.onSuccess(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.request(2);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            pp.onNext(2);
+            pp.onComplete();
+
+            ts.assertResult(1, 2);
+        }
+    }
+
+    @Test
+    public void onErrorMainOverflow() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final AtomicReference<Subscriber<?>> subscriber = new AtomicReference<Subscriber<?>>();
+            TestSubscriber<Integer> ts = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    subscriber.set(s);
+                }
+            }
+            .mergeWith(Maybe.<Integer>error(new IOException()))
+            .test();
+
+            subscriber.get().onError(new TestException());
+
+            ts.assertFailure(IOException.class)
+            ;
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorOtherOverflow() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.error(new IOException())
+            .mergeWith(Maybe.error(new TestException()))
+            .test()
+            .assertFailure(IOException.class)
+            ;
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onNextRequestRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+            final TestSubscriber<Integer> ts = pp.mergeWith(cs).test(0);
+
+            pp.onNext(0);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.request(3);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            cs.onSuccess(1);
+            pp.onComplete();
+
+            ts.assertResult(0, 1, 1);
+        }
+    }
+
+    @Test
+    public void doubleOnSubscribeMain() {
+        TestHelper.checkDoubleOnSubscribeFlowable(
+                new Function<Flowable<Object>, Publisher<Object>>() {
+                    @Override
+                    public Publisher<Object> apply(Flowable<Object> f)
+                            throws Exception {
+                        return f.mergeWith(Maybe.just(1));
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void noRequestOnError() {
+        Flowable.empty()
+        .mergeWith(Maybe.error(new TestException()))
+        .test(0)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void drainExactRequestCancel() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs)
+                .limit(2)
+                .subscribeWith(new TestSubscriber<Integer>(2) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    cs.onSuccess(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+
+        pp.onComplete();
+
+        ts.request(2);
+        ts.assertResult(1, 2);
+    }
+
+    @Test
+    public void drainRequestWhenLimitReached() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs)
+                .subscribeWith(new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    for (int i = 0; i < Flowable.bufferSize() - 1; i++) {
+                        pp.onNext(i + 2);
+                    }
+                }
+            }
+        });
+
+        cs.onSuccess(1);
+
+        pp.onComplete();
+
+        ts.request(2);
+        ts.assertValueCount(Flowable.bufferSize());
+        ts.assertComplete();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybeTest.java
@@ -35,65 +35,45 @@ public class FlowableMergeWithMaybeTest {
 
     @Test
     public void normal() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-
-        Flowable.range(1, 5).mergeWith(
-                Maybe.just(100)
-        )
-        .subscribe(ts);
-
-        ts.assertResult(1, 2, 3, 4, 5, 100);
+        Flowable.range(1, 5)
+        .mergeWith(Maybe.just(100))
+        .test()
+        .assertResult(1, 2, 3, 4, 5, 100);
     }
 
     @Test
     public void emptyOther() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-
-        Flowable.range(1, 5).mergeWith(
-                Maybe.<Integer>empty()
-        )
-        .subscribe(ts);
-
-        ts.assertResult(1, 2, 3, 4, 5);
+        Flowable.range(1, 5)
+        .mergeWith(Maybe.<Integer>empty())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void normalLong() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-
-        Flowable.range(1, 512).mergeWith(
-                Maybe.just(100)
-        )
-        .subscribe(ts);
-
-        ts.assertValueCount(513)
+        Flowable.range(1, 512)
+        .mergeWith(Maybe.just(100))
+        .test()
+        .assertValueCount(513)
         .assertComplete();
     }
 
     @Test
     public void normalLongRequestExact() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(513);
-
-        Flowable.range(1, 512).mergeWith(
-                Maybe.just(100)
-        )
-        .subscribe(ts);
-
-        ts.assertValueCount(513)
+        Flowable.range(1, 512)
+        .mergeWith(Maybe.just(100))
+        .test(513)
+        .assertValueCount(513)
         .assertComplete();
     }
 
     @Test
     public void take() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-
-        Flowable.range(1, 5).mergeWith(
-                Maybe.just(100)
-        )
+        Flowable.range(1, 5)
+        .mergeWith(Maybe.just(100))
         .take(3)
-        .subscribe(ts);
-
-        ts.assertResult(1, 2, 3);
+        .test()
+        .assertResult(1, 2, 3);
     }
 
     @Test
@@ -114,14 +94,10 @@ public class FlowableMergeWithMaybeTest {
 
     @Test
     public void normalBackpressured() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
-
         Flowable.range(1, 5).mergeWith(
                 Maybe.just(100)
         )
-        .subscribe(ts);
-
-        ts
+        .test(0L)
         .assertEmpty()
         .requestMore(2)
         .assertValues(100, 1)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
@@ -1,0 +1,416 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subjects.SingleSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableMergeWithSingleTest {
+
+    @Test
+    public void normal() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5).mergeWith(
+                Single.just(100)
+        )
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void normalLong() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 512).mergeWith(
+                Single.just(100)
+        )
+        .subscribe(ts);
+
+        ts.assertValueCount(513)
+        .assertComplete();
+    }
+
+    @Test
+    public void normalLongRequestExact() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(513);
+
+        Flowable.range(1, 512).mergeWith(
+                Single.just(100)
+        )
+        .subscribe(ts);
+
+        ts.assertValueCount(513)
+        .assertComplete();
+    }
+
+    @Test
+    public void take() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.range(1, 5).mergeWith(
+                Single.just(100)
+        )
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancel() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final SingleSubject<Integer> cs = SingleSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
+
+        assertTrue(pp.hasSubscribers());
+        assertTrue(cs.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+        assertFalse(cs.hasObservers());
+    }
+
+    @Test
+    public void normalBackpressured() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+
+        Flowable.range(1, 5).mergeWith(
+                Single.just(100)
+        )
+        .subscribe(ts);
+
+        ts
+        .assertEmpty()
+        .requestMore(2)
+        .assertValues(100, 1)
+        .requestMore(2)
+        .assertValues(100, 1, 2, 3)
+        .requestMore(2)
+        .assertResult(100, 1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void mainError() {
+        Flowable.error(new TestException())
+        .mergeWith(Single.just(100))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        Flowable.never()
+        .mergeWith(Single.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final SingleSubject<Integer> cs = SingleSubject.create();
+
+            TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                    pp.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    cs.onSuccess(1);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1, 1);
+        }
+    }
+
+    @Test
+    public void onNextSlowPath() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final SingleSubject<Integer> cs = SingleSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    pp.onNext(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+        cs.onSuccess(3);
+
+        pp.onNext(4);
+        pp.onComplete();
+
+        ts.assertResult(1, 2, 3, 4);
+    }
+
+    @Test
+    public void onSuccessSlowPath() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final SingleSubject<Integer> cs = SingleSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    cs.onSuccess(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+
+        pp.onNext(3);
+        pp.onComplete();
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void onSuccessSlowPathBackpressured() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final SingleSubject<Integer> cs = SingleSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<Integer>(1) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    cs.onSuccess(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+
+        pp.onNext(3);
+        pp.onComplete();
+
+        ts.request(2);
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void onSuccessFastPathBackpressuredRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final SingleSubject<Integer> cs = SingleSubject.create();
+
+            final TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<Integer>(0));
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    cs.onSuccess(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.request(2);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            pp.onNext(2);
+            pp.onComplete();
+
+            ts.assertResult(1, 2);
+        }
+    }
+
+    @Test
+    public void onErrorMainOverflow() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final AtomicReference<Subscriber<?>> subscriber = new AtomicReference<Subscriber<?>>();
+            TestSubscriber<Integer> ts = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    subscriber.set(s);
+                }
+            }
+            .mergeWith(Single.<Integer>error(new IOException()))
+            .test();
+
+            subscriber.get().onError(new TestException());
+
+            ts.assertFailure(IOException.class)
+            ;
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorOtherOverflow() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.error(new IOException())
+            .mergeWith(Single.error(new TestException()))
+            .test()
+            .assertFailure(IOException.class)
+            ;
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onNextRequestRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final SingleSubject<Integer> cs = SingleSubject.create();
+
+            final TestSubscriber<Integer> ts = pp.mergeWith(cs).test(0);
+
+            pp.onNext(0);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.request(3);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            cs.onSuccess(1);
+            pp.onComplete();
+
+            ts.assertResult(0, 1, 1);
+        }
+    }
+
+    @Test
+    public void doubleOnSubscribeMain() {
+        TestHelper.checkDoubleOnSubscribeFlowable(
+                new Function<Flowable<Object>, Publisher<Object>>() {
+                    @Override
+                    public Publisher<Object> apply(Flowable<Object> f)
+                            throws Exception {
+                        return f.mergeWith(Single.just(1));
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void noRequestOnError() {
+        Flowable.empty()
+        .mergeWith(Single.error(new TestException()))
+        .test(0)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void drainExactRequestCancel() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final SingleSubject<Integer> cs = SingleSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs)
+                .limit(2)
+                .subscribeWith(new TestSubscriber<Integer>(2) {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    cs.onSuccess(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+
+        pp.onComplete();
+
+        ts.request(2);
+        ts.assertResult(1, 2);
+    }
+
+    @Test
+    public void drainRequestWhenLimitReached() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final SingleSubject<Integer> cs = SingleSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs)
+                .subscribeWith(new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    for (int i = 0; i < Flowable.bufferSize() - 1; i++) {
+                        pp.onNext(i + 2);
+                    }
+                }
+            }
+        });
+
+        cs.onSuccess(1);
+
+        pp.onComplete();
+
+        ts.request(2);
+        ts.assertValueCount(Flowable.bufferSize());
+        ts.assertComplete();
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
@@ -35,53 +35,37 @@ public class FlowableMergeWithSingleTest {
 
     @Test
     public void normal() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-
-        Flowable.range(1, 5).mergeWith(
-                Single.just(100)
-        )
-        .subscribe(ts);
-
-        ts.assertResult(1, 2, 3, 4, 5, 100);
+        Flowable.range(1, 5)
+        .mergeWith(Single.just(100))
+        .test()
+        .assertResult(1, 2, 3, 4, 5, 100);
     }
 
     @Test
     public void normalLong() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-
-        Flowable.range(1, 512).mergeWith(
-                Single.just(100)
-        )
-        .subscribe(ts);
-
-        ts.assertValueCount(513)
+        Flowable.range(1, 512)
+        .mergeWith(Single.just(100))
+        .test()
+        .assertValueCount(513)
         .assertComplete();
     }
 
     @Test
     public void normalLongRequestExact() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(513);
-
-        Flowable.range(1, 512).mergeWith(
-                Single.just(100)
-        )
-        .subscribe(ts);
-
-        ts.assertValueCount(513)
+        Flowable.range(1, 512)
+        .mergeWith(Single.just(100))
+        .test(513)
+        .assertValueCount(513)
         .assertComplete();
     }
 
     @Test
     public void take() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-
-        Flowable.range(1, 5).mergeWith(
-                Single.just(100)
-        )
+        Flowable.range(1, 5)
+        .mergeWith(Single.just(100))
         .take(3)
-        .subscribe(ts);
-
-        ts.assertResult(1, 2, 3);
+        .test()
+        .assertResult(1, 2, 3);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletableTest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.subjects.*;
+
+public class ObservableMergeWithCompletableTest {
+
+    @Test
+    public void normal() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5).mergeWith(
+                Completable.fromAction(new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        ts.onNext(100);
+                    }
+                })
+        )
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void take() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5).mergeWith(
+                Completable.complete()
+        )
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancel() {
+        final PublishSubject<Integer> pp = PublishSubject.create();
+        final CompletableSubject cs = CompletableSubject.create();
+
+        TestObserver<Integer> ts = pp.mergeWith(cs).test();
+
+        assertTrue(pp.hasObservers());
+        assertTrue(cs.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasObservers());
+        assertFalse(cs.hasObservers());
+    }
+
+    @Test
+    public void mainError() {
+        Observable.error(new TestException())
+        .mergeWith(Completable.complete())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        Observable.never()
+        .mergeWith(Completable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 1000; i++) {
+            final PublishSubject<Integer> pp = PublishSubject.create();
+            final CompletableSubject cs = CompletableSubject.create();
+
+            TestObserver<Integer> ts = pp.mergeWith(cs).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                    pp.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    cs.onComplete();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1);
+        }
+    }
+
+    @Test
+    public void isDisposed() {
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposables.empty());
+
+                assertFalse(((Disposable)observer).isDisposed());
+
+                observer.onNext(1);
+
+                assertTrue(((Disposable)observer).isDisposed());
+            }
+        }.mergeWith(Completable.complete())
+        .take(1)
+        .test()
+        .assertResult(1);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletableTest.java
@@ -28,47 +28,47 @@ public class ObservableMergeWithCompletableTest {
 
     @Test
     public void normal() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5).mergeWith(
                 Completable.fromAction(new Action() {
                     @Override
                     public void run() throws Exception {
-                        ts.onNext(100);
+                        to.onNext(100);
                     }
                 })
         )
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertResult(1, 2, 3, 4, 5, 100);
+        to.assertResult(1, 2, 3, 4, 5, 100);
     }
 
     @Test
     public void take() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5).mergeWith(
                 Completable.complete()
         )
         .take(3)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertResult(1, 2, 3);
+        to.assertResult(1, 2, 3);
     }
 
     @Test
     public void cancel() {
-        final PublishSubject<Integer> pp = PublishSubject.create();
+        final PublishSubject<Integer> ps = PublishSubject.create();
         final CompletableSubject cs = CompletableSubject.create();
 
-        TestObserver<Integer> ts = pp.mergeWith(cs).test();
+        TestObserver<Integer> to = ps.mergeWith(cs).test();
 
-        assertTrue(pp.hasObservers());
+        assertTrue(ps.hasObservers());
         assertTrue(cs.hasObservers());
 
-        ts.cancel();
+        to.cancel();
 
-        assertFalse(pp.hasObservers());
+        assertFalse(ps.hasObservers());
         assertFalse(cs.hasObservers());
     }
 
@@ -91,16 +91,16 @@ public class ObservableMergeWithCompletableTest {
     @Test
     public void completeRace() {
         for (int i = 0; i < 1000; i++) {
-            final PublishSubject<Integer> pp = PublishSubject.create();
+            final PublishSubject<Integer> ps = PublishSubject.create();
             final CompletableSubject cs = CompletableSubject.create();
 
-            TestObserver<Integer> ts = pp.mergeWith(cs).test();
+            TestObserver<Integer> to = ps.mergeWith(cs).test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.onNext(1);
-                    pp.onComplete();
+                    ps.onNext(1);
+                    ps.onComplete();
                 }
             };
 
@@ -113,7 +113,7 @@ public class ObservableMergeWithCompletableTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertResult(1);
+            to.assertResult(1);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybeTest.java
@@ -1,0 +1,291 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.*;
+
+public class ObservableMergeWithMaybeTest {
+
+    @Test
+    public void normal() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5).mergeWith(
+                Maybe.just(100)
+        )
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void emptyOther() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5).mergeWith(
+                Maybe.<Integer>empty()
+        )
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void normalLong() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 512).mergeWith(
+                Maybe.just(100)
+        )
+        .subscribe(ts);
+
+        ts.assertValueCount(513)
+        .assertComplete();
+    }
+
+    @Test
+    public void take() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5).mergeWith(
+                Maybe.just(100)
+        )
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancel() {
+        final PublishSubject<Integer> pp = PublishSubject.create();
+        final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+        TestObserver<Integer> ts = pp.mergeWith(cs).test();
+
+        assertTrue(pp.hasObservers());
+        assertTrue(cs.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasObservers());
+        assertFalse(cs.hasObservers());
+    }
+
+    @Test
+    public void mainError() {
+        Observable.error(new TestException())
+        .mergeWith(Maybe.just(100))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        Observable.never()
+        .mergeWith(Maybe.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishSubject<Integer> pp = PublishSubject.create();
+            final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+            TestObserver<Integer> ts = pp.mergeWith(cs).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                    pp.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    cs.onSuccess(1);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1, 1);
+        }
+    }
+
+    @Test
+    public void onNextSlowPath() {
+        final PublishSubject<Integer> pp = PublishSubject.create();
+        final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+        TestObserver<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    pp.onNext(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+        cs.onSuccess(3);
+
+        pp.onNext(4);
+        pp.onComplete();
+
+        ts.assertResult(1, 2, 3, 4);
+    }
+
+    @Test
+    public void onSuccessSlowPath() {
+        final PublishSubject<Integer> pp = PublishSubject.create();
+        final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+        TestObserver<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    cs.onSuccess(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+
+        pp.onNext(3);
+        pp.onComplete();
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void onErrorMainOverflow() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final AtomicReference<Observer<?>> subscriber = new AtomicReference<Observer<?>>();
+            TestObserver<Integer> ts = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> s) {
+                    s.onSubscribe(Disposables.empty());
+                    subscriber.set(s);
+                }
+            }
+            .mergeWith(Maybe.<Integer>error(new IOException()))
+            .test();
+
+            subscriber.get().onError(new TestException());
+
+            ts.assertFailure(IOException.class)
+            ;
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorOtherOverflow() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable.error(new IOException())
+            .mergeWith(Maybe.error(new TestException()))
+            .test()
+            .assertFailure(IOException.class)
+            ;
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void doubleOnSubscribeMain() {
+        TestHelper.checkDoubleOnSubscribeObservable(
+                new Function<Observable<Object>, Observable<Object>>() {
+                    @Override
+                    public Observable<Object> apply(Observable<Object> f)
+                            throws Exception {
+                        return f.mergeWith(Maybe.just(1));
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void isDisposed() {
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposables.empty());
+
+                assertFalse(((Disposable)observer).isDisposed());
+
+                observer.onNext(1);
+
+                assertTrue(((Disposable)observer).isDisposed());
+            }
+        }.mergeWith(Maybe.<Integer>empty())
+        .take(1)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void onNextSlowPathCreateQueue() {
+        final PublishSubject<Integer> pp = PublishSubject.create();
+        final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+        TestObserver<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    pp.onNext(2);
+                    pp.onNext(3);
+                }
+            }
+        });
+
+        cs.onSuccess(0);
+        pp.onNext(1);
+
+        pp.onNext(4);
+        pp.onComplete();
+
+        ts.assertResult(0, 1, 2, 3, 4);
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
@@ -33,55 +33,43 @@ public class ObservableMergeWithSingleTest {
 
     @Test
     public void normal() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
-
-        Observable.range(1, 5).mergeWith(
-                Single.just(100)
-        )
-        .subscribe(ts);
-
-        ts.assertResult(1, 2, 3, 4, 5, 100);
+        Observable.range(1, 5)
+        .mergeWith(Single.just(100))
+        .test()
+        .assertResult(1, 2, 3, 4, 5, 100);
     }
 
     @Test
     public void normalLong() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
-
-        Observable.range(1, 512).mergeWith(
-                Single.just(100)
-        )
-        .subscribe(ts);
-
-        ts.assertValueCount(513)
+        Observable.range(1, 512)
+        .mergeWith(Single.just(100))
+        .test()
+        .assertValueCount(513)
         .assertComplete();
     }
 
     @Test
     public void take() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
-
-        Observable.range(1, 5).mergeWith(
-                Single.just(100)
-        )
+        Observable.range(1, 5)
+        .mergeWith(Single.just(100))
         .take(3)
-        .subscribe(ts);
-
-        ts.assertResult(1, 2, 3);
+        .test()
+        .assertResult(1, 2, 3);
     }
 
     @Test
     public void cancel() {
-        final PublishSubject<Integer> pp = PublishSubject.create();
+        final PublishSubject<Integer> ps = PublishSubject.create();
         final SingleSubject<Integer> cs = SingleSubject.create();
 
-        TestObserver<Integer> ts = pp.mergeWith(cs).test();
+        TestObserver<Integer> to = ps.mergeWith(cs).test();
 
-        assertTrue(pp.hasObservers());
+        assertTrue(ps.hasObservers());
         assertTrue(cs.hasObservers());
 
-        ts.cancel();
+        to.cancel();
 
-        assertFalse(pp.hasObservers());
+        assertFalse(ps.hasObservers());
         assertFalse(cs.hasObservers());
     }
 
@@ -104,16 +92,16 @@ public class ObservableMergeWithSingleTest {
     @Test
     public void completeRace() {
         for (int i = 0; i < 10000; i++) {
-            final PublishSubject<Integer> pp = PublishSubject.create();
+            final PublishSubject<Integer> ps = PublishSubject.create();
             final SingleSubject<Integer> cs = SingleSubject.create();
 
-            TestObserver<Integer> ts = pp.mergeWith(cs).test();
+            TestObserver<Integer> to = ps.mergeWith(cs).test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.onNext(1);
-                    pp.onComplete();
+                    ps.onNext(1);
+                    ps.onComplete();
                 }
             };
 
@@ -126,40 +114,40 @@ public class ObservableMergeWithSingleTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertResult(1, 1);
+            to.assertResult(1, 1);
         }
     }
 
     @Test
     public void onNextSlowPath() {
-        final PublishSubject<Integer> pp = PublishSubject.create();
+        final PublishSubject<Integer> ps = PublishSubject.create();
         final SingleSubject<Integer> cs = SingleSubject.create();
 
-        TestObserver<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+        TestObserver<Integer> to = ps.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
                 if (t == 1) {
-                    pp.onNext(2);
+                    ps.onNext(2);
                 }
             }
         });
 
-        pp.onNext(1);
+        ps.onNext(1);
         cs.onSuccess(3);
 
-        pp.onNext(4);
-        pp.onComplete();
+        ps.onNext(4);
+        ps.onComplete();
 
-        ts.assertResult(1, 2, 3, 4);
+        to.assertResult(1, 2, 3, 4);
     }
 
     @Test
     public void onSuccessSlowPath() {
-        final PublishSubject<Integer> pp = PublishSubject.create();
+        final PublishSubject<Integer> ps = PublishSubject.create();
         final SingleSubject<Integer> cs = SingleSubject.create();
 
-        TestObserver<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+        TestObserver<Integer> to = ps.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -169,12 +157,12 @@ public class ObservableMergeWithSingleTest {
             }
         });
 
-        pp.onNext(1);
+        ps.onNext(1);
 
-        pp.onNext(3);
-        pp.onComplete();
+        ps.onNext(3);
+        ps.onComplete();
 
-        ts.assertResult(1, 2, 3);
+        to.assertResult(1, 2, 3);
     }
 
     @Test
@@ -182,7 +170,7 @@ public class ObservableMergeWithSingleTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final AtomicReference<Observer<?>> subscriber = new AtomicReference<Observer<?>>();
-            TestObserver<Integer> ts = new Observable<Integer>() {
+            TestObserver<Integer> to = new Observable<Integer>() {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> s) {
                     s.onSubscribe(Disposables.empty());
@@ -194,7 +182,7 @@ public class ObservableMergeWithSingleTest {
 
             subscriber.get().onError(new TestException());
 
-            ts.assertFailure(IOException.class)
+            to.assertFailure(IOException.class)
             ;
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
@@ -253,26 +241,26 @@ public class ObservableMergeWithSingleTest {
 
     @Test
     public void onNextSlowPathCreateQueue() {
-        final PublishSubject<Integer> pp = PublishSubject.create();
+        final PublishSubject<Integer> ps = PublishSubject.create();
         final SingleSubject<Integer> cs = SingleSubject.create();
 
-        TestObserver<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+        TestObserver<Integer> to = ps.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
                 if (t == 1) {
-                    pp.onNext(2);
-                    pp.onNext(3);
+                    ps.onNext(2);
+                    ps.onNext(3);
                 }
             }
         });
 
         cs.onSuccess(0);
-        pp.onNext(1);
+        ps.onNext(1);
 
-        pp.onNext(4);
-        pp.onComplete();
+        ps.onNext(4);
+        ps.onComplete();
 
-        ts.assertResult(0, 1, 2, 3, 4);
+        to.assertResult(0, 1, 2, 3, 4);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
@@ -1,0 +1,278 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subjects.*;
+
+public class ObservableMergeWithSingleTest {
+
+    @Test
+    public void normal() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5).mergeWith(
+                Single.just(100)
+        )
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5, 100);
+    }
+
+    @Test
+    public void normalLong() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 512).mergeWith(
+                Single.just(100)
+        )
+        .subscribe(ts);
+
+        ts.assertValueCount(513)
+        .assertComplete();
+    }
+
+    @Test
+    public void take() {
+        final TestObserver<Integer> ts = new TestObserver<Integer>();
+
+        Observable.range(1, 5).mergeWith(
+                Single.just(100)
+        )
+        .take(3)
+        .subscribe(ts);
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void cancel() {
+        final PublishSubject<Integer> pp = PublishSubject.create();
+        final SingleSubject<Integer> cs = SingleSubject.create();
+
+        TestObserver<Integer> ts = pp.mergeWith(cs).test();
+
+        assertTrue(pp.hasObservers());
+        assertTrue(cs.hasObservers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasObservers());
+        assertFalse(cs.hasObservers());
+    }
+
+    @Test
+    public void mainError() {
+        Observable.error(new TestException())
+        .mergeWith(Single.just(100))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void otherError() {
+        Observable.never()
+        .mergeWith(Single.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishSubject<Integer> pp = PublishSubject.create();
+            final SingleSubject<Integer> cs = SingleSubject.create();
+
+            TestObserver<Integer> ts = pp.mergeWith(cs).test();
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(1);
+                    pp.onComplete();
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    cs.onSuccess(1);
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1, 1);
+        }
+    }
+
+    @Test
+    public void onNextSlowPath() {
+        final PublishSubject<Integer> pp = PublishSubject.create();
+        final SingleSubject<Integer> cs = SingleSubject.create();
+
+        TestObserver<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    pp.onNext(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+        cs.onSuccess(3);
+
+        pp.onNext(4);
+        pp.onComplete();
+
+        ts.assertResult(1, 2, 3, 4);
+    }
+
+    @Test
+    public void onSuccessSlowPath() {
+        final PublishSubject<Integer> pp = PublishSubject.create();
+        final SingleSubject<Integer> cs = SingleSubject.create();
+
+        TestObserver<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    cs.onSuccess(2);
+                }
+            }
+        });
+
+        pp.onNext(1);
+
+        pp.onNext(3);
+        pp.onComplete();
+
+        ts.assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void onErrorMainOverflow() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final AtomicReference<Observer<?>> subscriber = new AtomicReference<Observer<?>>();
+            TestObserver<Integer> ts = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> s) {
+                    s.onSubscribe(Disposables.empty());
+                    subscriber.set(s);
+                }
+            }
+            .mergeWith(Single.<Integer>error(new IOException()))
+            .test();
+
+            subscriber.get().onError(new TestException());
+
+            ts.assertFailure(IOException.class)
+            ;
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorOtherOverflow() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable.error(new IOException())
+            .mergeWith(Single.error(new TestException()))
+            .test()
+            .assertFailure(IOException.class)
+            ;
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void doubleOnSubscribeMain() {
+        TestHelper.checkDoubleOnSubscribeObservable(
+                new Function<Observable<Object>, Observable<Object>>() {
+                    @Override
+                    public Observable<Object> apply(Observable<Object> f)
+                            throws Exception {
+                        return f.mergeWith(Single.just(1));
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void isDisposed() {
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposables.empty());
+
+                assertFalse(((Disposable)observer).isDisposed());
+
+                observer.onNext(1);
+
+                assertTrue(((Disposable)observer).isDisposed());
+            }
+        }.mergeWith(Single.<Integer>just(1))
+        .take(1)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void onNextSlowPathCreateQueue() {
+        final PublishSubject<Integer> pp = PublishSubject.create();
+        final SingleSubject<Integer> cs = SingleSubject.create();
+
+        TestObserver<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    pp.onNext(2);
+                    pp.onNext(3);
+                }
+            }
+        });
+
+        cs.onSuccess(0);
+        pp.onNext(1);
+
+        pp.onNext(4);
+        pp.onComplete();
+
+        ts.assertResult(0, 1, 2, 3, 4);
+    }
+}

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1685,7 +1685,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void mergeWithNull() {
-        just1.mergeWith(null);
+        just1.mergeWith((ObservableSource<Integer>)null);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/tck/MergeWithCompletableTckTest.java
+++ b/src/test/java/io/reactivex/tck/MergeWithCompletableTckTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.*;
+
+@Test
+public class MergeWithCompletableTckTest extends BaseTck<Long> {
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        return
+            Flowable.rangeLong(1, elements)
+            .mergeWith(Completable.complete())
+        ;
+    }
+}

--- a/src/test/java/io/reactivex/tck/MergeWithMaybeEmptyTckTest.java
+++ b/src/test/java/io/reactivex/tck/MergeWithMaybeEmptyTckTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.*;
+
+@Test
+public class MergeWithMaybeEmptyTckTest extends BaseTck<Long> {
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        return
+            Flowable.rangeLong(1, elements)
+            .mergeWith(Maybe.<Long>empty())
+        ;
+    }
+}

--- a/src/test/java/io/reactivex/tck/MergeWithMaybeTckTest.java
+++ b/src/test/java/io/reactivex/tck/MergeWithMaybeTckTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.*;
+
+@Test
+public class MergeWithMaybeTckTest extends BaseTck<Long> {
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        if (elements == 0) {
+            return Flowable.<Long>empty()
+                    .mergeWith(Maybe.<Long>empty());
+        }
+        return
+            Flowable.rangeLong(1, elements - 1)
+            .mergeWith(Maybe.just(elements))
+        ;
+    }
+}

--- a/src/test/java/io/reactivex/tck/MergeWithSingleTckTest.java
+++ b/src/test/java/io/reactivex/tck/MergeWithSingleTckTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.tck;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.*;
+
+@Test
+public class MergeWithSingleTckTest extends BaseTck<Long> {
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        if (elements == 0) {
+            return Flowable.empty();
+        }
+        return
+            Flowable.rangeLong(1, elements - 1)
+            .mergeWith(Single.just(elements))
+        ;
+    }
+}


### PR DESCRIPTION
This PR adds specialized overloads to the `mergeWith` operator in `Flowable` and `Observable`.

If accepted, the marbles will be updated in a separate PR.

Related: #5350.