### PR TITLE
Fix a race condition that may make OperatorMaterialize emit too many terminal notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
 - oraclejdk8
-sudo: false
+sudo: required
 # as per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 
 git:

--- a/src/main/java/rx/internal/operators/OperatorMaterialize.java
+++ b/src/main/java/rx/internal/operators/OperatorMaterialize.java
@@ -134,6 +134,7 @@ public final class OperatorMaterialize<T> implements Operator<Notification<T>, T
                     missed = true;
                     return;
                 }
+                busy = true;
             }
             // drain loop
             final AtomicLong localRequested = this.requested;


### PR DESCRIPTION
We're using RxJava 1.3.5 and one of our tests occasionally fails (very hard to reproduce). The test asserts that `anObservable.toBlocking.toList` (RxScala) expression throws a particular exception, because we expect the observable to be in error state by emitting a single `onError`. However, in rare cases, we observe that there is no exception thrown, and an empty list is returned instead. We verified that the problem is not the observable we use. The observable properly fires the `doOnError` handler prior to  the test assertion failure. Therefore we suspected something wrong happening in the `toBlocking.toList` conversion. I debugged that in fact this conversion uses `OperatorMaterialize` as a part of `BlockingOperatorToIterator`. 

I took a look at the `OperatorMaterialize` and found an obvious bug. The `busy` variable is never set to true anywhere, despite the comments showing the author of the code intended it to be true when the `drain` loop was running.

The PR fixes this problem by setting `busy` to true at the entry of the `drain` method. 

However I still have some doubts about the original code: 
- Why does `drain` have to be called from `requestMore`? Why isn't it enough to call it from `onCompleted` and `onError`? It looks like the `drain` logic does anything only if the `terminalNotification` is set, and it can be set only by `onCompleted` and `onError`.
- What is this `drain` logic supposed to do? Looks rather complex and the intent of it is not obvious. If we don't call it from `requestMore` then maybe we don't need the `drain` logic at all? Why not emit the terminal notifications directly from `onError` and `onCompleted` ?

Thanks,
Piotr Kołaczkowski