### PR TITLE
2.x: Unify race test loop counts and invocations

### DIFF
--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -50,6 +50,19 @@ import io.reactivex.subscribers.TestSubscriber;
  */
 public enum TestHelper {
     ;
+
+    /**
+     * Number of times to loop a {@link #race(Runnable, Runnable)} invocation
+     * by default.
+     */
+    public static final int RACE_DEFAULT_LOOPS = 2500;
+
+    /**
+     * Number of times to loop a {@link #race(Runnable, Runnable)} invocation
+     * in tests with race conditions requiring more runs to check.
+     */
+    public static final int RACE_LONG_LOOPS = 10000;
+
     /**
      * Mocks a subscriber and prepares it to request Long.MAX_VALUE.
      * @param <T> the value type
@@ -344,6 +357,8 @@ public enum TestHelper {
      * <p>The method blocks until both have run to completion.
      * @param r1 the first runnable
      * @param r2 the second runnable
+     * @see #RACE_DEFAULT_LOOPS
+     * @see #RACE_LONG_LOOPS
      */
     public static void race(final Runnable r1, final Runnable r2) {
         race(r1, r2, Schedulers.single());
@@ -355,6 +370,8 @@ public enum TestHelper {
      * @param r1 the first runnable
      * @param r2 the second runnable
      * @param s the scheduler to use
+     * @see #RACE_DEFAULT_LOOPS
+     * @see #RACE_LONG_LOOPS
      */
     public static void race(final Runnable r1, final Runnable r2, Scheduler s) {
         final AtomicInteger count = new AtomicInteger(2);

--- a/src/test/java/io/reactivex/disposables/CompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/disposables/CompositeDisposableTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import io.reactivex.TestHelper;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Action;
-import io.reactivex.schedulers.Schedulers;
 
 public class CompositeDisposableTest {
 
@@ -443,7 +442,7 @@ public class CompositeDisposableTest {
 
     @Test
     public void disposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             Runnable run = new Runnable() {
@@ -453,13 +452,13 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void addRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             Runnable run = new Runnable() {
@@ -469,13 +468,13 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void addAllRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             Runnable run = new Runnable() {
@@ -485,13 +484,13 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void removeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -505,13 +504,13 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void deleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -525,13 +524,13 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void clearRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -545,13 +544,13 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void addDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             Runnable run = new Runnable() {
@@ -568,13 +567,13 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run2, Schedulers.io());
+            TestHelper.race(run, run2);
         }
     }
 
     @Test
     public void addAllDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             Runnable run = new Runnable() {
@@ -591,13 +590,13 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run2, Schedulers.io());
+            TestHelper.race(run, run2);
         }
     }
 
     @Test
     public void removeDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -618,13 +617,13 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run2, Schedulers.io());
+            TestHelper.race(run, run2);
         }
     }
 
     @Test
     public void deleteDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -645,13 +644,13 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run2, Schedulers.io());
+            TestHelper.race(run, run2);
         }
     }
 
     @Test
     public void clearDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -672,13 +671,13 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run2, Schedulers.io());
+            TestHelper.race(run, run2);
         }
     }
 
     @Test
     public void sizeDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -699,7 +698,7 @@ public class CompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run2, Schedulers.io());
+            TestHelper.race(run, run2);
         }
     }
 

--- a/src/test/java/io/reactivex/disposables/DisposablesTest.java
+++ b/src/test/java/io/reactivex/disposables/DisposablesTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.disposables;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -27,7 +28,6 @@ import io.reactivex.TestHelper;
 import io.reactivex.functions.Action;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 public class DisposablesTest {
 
@@ -123,7 +123,7 @@ public class DisposablesTest {
 
     @Test
     public void disposeRace() {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Disposable d = Disposables.empty();
 
             Runnable r = new Runnable() {
@@ -133,7 +133,7 @@ public class DisposablesTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.io());
+            TestHelper.race(r, r);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/disposables/ArrayCompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/ArrayCompositeDisposableTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.reactivex.TestHelper;
 import io.reactivex.disposables.*;
-import io.reactivex.schedulers.Schedulers;
 
 public class ArrayCompositeDisposableTest {
 
@@ -70,7 +69,7 @@ public class ArrayCompositeDisposableTest {
 
     @Test
     public void disposeRace() {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ArrayCompositeDisposable acd = new ArrayCompositeDisposable(2);
 
             Runnable r = new Runnable() {
@@ -80,13 +79,13 @@ public class ArrayCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.io());
+            TestHelper.race(r, r);
         }
     }
 
     @Test
     public void replaceRace() {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ArrayCompositeDisposable acd = new ArrayCompositeDisposable(2);
 
             Runnable r = new Runnable() {
@@ -96,13 +95,13 @@ public class ArrayCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.io());
+            TestHelper.race(r, r);
         }
     }
 
     @Test
     public void setRace() {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ArrayCompositeDisposable acd = new ArrayCompositeDisposable(2);
 
             Runnable r = new Runnable() {
@@ -112,7 +111,7 @@ public class ArrayCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.io());
+            TestHelper.race(r, r);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/disposables/CancellableDisposableTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/CancellableDisposableTest.java
@@ -24,7 +24,6 @@ import io.reactivex.TestHelper;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 public class CancellableDisposableTest {
 
@@ -84,7 +83,7 @@ public class CancellableDisposableTest {
     @Test
     public void disposeRace() {
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicInteger count = new AtomicInteger();
 
             Cancellable c = new Cancellable() {
@@ -103,7 +102,7 @@ public class CancellableDisposableTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.io());
+            TestHelper.race(r, r);
 
             assertEquals(1, count.get());
         }

--- a/src/test/java/io/reactivex/internal/disposables/DisposableHelperTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/DisposableHelperTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import io.reactivex.TestHelper;
 import io.reactivex.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 public class DisposableHelperTest {
     @Test
@@ -53,7 +52,7 @@ public class DisposableHelperTest {
 
     @Test
     public void disposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicReference<Disposable> d = new AtomicReference<Disposable>();
 
             Runnable r = new Runnable() {
@@ -63,13 +62,13 @@ public class DisposableHelperTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.io());
+            TestHelper.race(r, r);
         }
     }
 
     @Test
     public void setReplace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicReference<Disposable> d = new AtomicReference<Disposable>();
 
             Runnable r = new Runnable() {
@@ -79,13 +78,13 @@ public class DisposableHelperTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.io());
+            TestHelper.race(r, r);
         }
     }
 
     @Test
     public void setRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicReference<Disposable> d = new AtomicReference<Disposable>();
 
             Runnable r = new Runnable() {
@@ -95,7 +94,7 @@ public class DisposableHelperTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.io());
+            TestHelper.race(r, r);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/disposables/ListCompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/ListCompositeDisposableTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import io.reactivex.TestHelper;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
-import io.reactivex.schedulers.Schedulers;
 
 public class ListCompositeDisposableTest {
 
@@ -179,7 +178,7 @@ public class ListCompositeDisposableTest {
 
     @Test
     public void disposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             Runnable run = new Runnable() {
@@ -189,13 +188,13 @@ public class ListCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void addRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             Runnable run = new Runnable() {
@@ -205,13 +204,13 @@ public class ListCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void addAllRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             Runnable run = new Runnable() {
@@ -221,13 +220,13 @@ public class ListCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void removeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -241,13 +240,13 @@ public class ListCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void deleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -261,13 +260,13 @@ public class ListCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void clearRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -281,13 +280,13 @@ public class ListCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run, Schedulers.io());
+            TestHelper.race(run, run);
         }
     }
 
     @Test
     public void addDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             Runnable run = new Runnable() {
@@ -304,13 +303,13 @@ public class ListCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run2, Schedulers.io());
+            TestHelper.race(run, run2);
         }
     }
 
     @Test
     public void addAllDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             Runnable run = new Runnable() {
@@ -327,13 +326,13 @@ public class ListCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run2, Schedulers.io());
+            TestHelper.race(run, run2);
         }
     }
 
     @Test
     public void removeDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -354,13 +353,13 @@ public class ListCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run2, Schedulers.io());
+            TestHelper.race(run, run2);
         }
     }
 
     @Test
     public void deleteDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -381,13 +380,13 @@ public class ListCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run2, Schedulers.io());
+            TestHelper.race(run, run2);
         }
     }
 
     @Test
     public void clearDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposables.empty();
@@ -408,7 +407,7 @@ public class ListCompositeDisposableTest {
                 }
             };
 
-            TestHelper.race(run, run2, Schedulers.io());
+            TestHelper.race(run, run2);
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/observers/FutureObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/FutureObserverTest.java
@@ -154,7 +154,7 @@ public class FutureObserverTest {
 
     @Test
     public void cancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FutureSubscriber<Integer> fo = new FutureSubscriber<Integer>();
 
             Runnable r = new Runnable() {
@@ -164,7 +164,7 @@ public class FutureObserverTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
         }
     }
 
@@ -185,7 +185,7 @@ public class FutureObserverTest {
     public void onErrorCancelRace() {
         RxJavaPlugins.setErrorHandler(Functions.emptyConsumer());
         try {
-            for (int i = 0; i < 500; i++) {
+            for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
                 final FutureSubscriber<Integer> fo = new FutureSubscriber<Integer>();
 
                 final TestException ex = new TestException();
@@ -204,7 +204,7 @@ public class FutureObserverTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
             }
         } finally {
             RxJavaPlugins.reset();
@@ -213,7 +213,7 @@ public class FutureObserverTest {
 
     @Test
     public void onCompleteCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FutureSubscriber<Integer> fo = new FutureSubscriber<Integer>();
 
             if (i % 3 == 0) {
@@ -238,7 +238,7 @@ public class FutureObserverTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/observers/FutureSingleObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/FutureSingleObserverTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
 public class FutureSingleObserverTest {
@@ -66,7 +65,7 @@ public class FutureSingleObserverTest {
 
     @Test
     public void cancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Future<?> f = Single.never().toFuture();
 
             Runnable r = new Runnable() {
@@ -76,7 +75,7 @@ public class FutureSingleObserverTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
         }
     }
 
@@ -130,7 +129,7 @@ public class FutureSingleObserverTest {
 
     @Test
     public void onSuccessCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final Future<?> f = ps.single(-99).toFuture();
@@ -151,13 +150,13 @@ public class FutureSingleObserverTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void onErrorCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final Future<?> f = ps.single(-99).toFuture();
@@ -178,7 +177,7 @@ public class FutureSingleObserverTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableAmbTest.java
@@ -24,7 +24,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.*;
 
 public class CompletableAmbTest {
@@ -70,7 +69,7 @@ public class CompletableAmbTest {
 
     @Test
     public void innerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp0 = PublishProcessor.create();
@@ -95,7 +94,7 @@ public class CompletableAmbTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 
@@ -110,7 +109,7 @@ public class CompletableAmbTest {
 
     @Test
     public void nullSourceSuccessRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
@@ -134,7 +133,7 @@ public class CompletableAmbTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertError(errors, 0, NullPointerException.class);

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableCacheTest.java
@@ -168,7 +168,7 @@ public class CompletableCacheTest implements Consumer<Object>, Action {
 
     @Test
     public void subscribeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             PublishSubject<Integer> ps = PublishSubject.create();
 
             final Completable c = ps.ignoreElements().cache();
@@ -201,7 +201,7 @@ public class CompletableCacheTest implements Consumer<Object>, Action {
 
     @Test
     public void subscribeDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             PublishSubject<Integer> ps = PublishSubject.create();
 
             final Completable c = ps.ignoreElements().cache();

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
@@ -69,7 +69,7 @@ public class CompletableConcatTest {
 
     @Test
     public void errorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
@@ -100,7 +100,7 @@ public class CompletableConcatTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 
@@ -203,7 +203,7 @@ public class CompletableConcatTest {
         Completable[] a = new Completable[1024];
         Arrays.fill(a, Completable.complete());
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final Completable c = Completable.concatArray(a);
 
@@ -223,7 +223,7 @@ public class CompletableConcatTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
@@ -232,7 +232,7 @@ public class CompletableConcatTest {
         Completable[] a = new Completable[1024];
         Arrays.fill(a, Completable.complete());
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final Completable c = Completable.concat(Arrays.asList(a));
 
@@ -252,7 +252,7 @@ public class CompletableConcatTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeIterableTest.java
@@ -21,14 +21,13 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
 public class CompletableMergeIterableTest {
 
     @Test
     public void errorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishSubject<Integer> ps1 = PublishSubject.create();
@@ -52,7 +51,7 @@ public class CompletableMergeIterableTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
@@ -28,7 +28,6 @@ import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class CompletableMergeTest {
     @Test
@@ -192,7 +191,7 @@ public class CompletableMergeTest {
 
     @Test
     public void mainErrorInnerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -223,7 +222,7 @@ public class CompletableMergeTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 Throwable ex = to.errors().get(0);
                 if (ex instanceof CompositeException) {
@@ -247,7 +246,7 @@ public class CompletableMergeTest {
 
     @Test
     public void mainErrorInnerErrorDelayedRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
@@ -277,7 +276,7 @@ public class CompletableMergeTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertFailure(CompositeException.class);
 
@@ -446,7 +445,7 @@ public class CompletableMergeTest {
 
     @Test
     public void mergeArrayInnerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -472,7 +471,7 @@ public class CompletableMergeTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
@@ -106,7 +106,7 @@ public class CompletableTimeoutTest {
 
     @Test
     public void errorTimeoutRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
@@ -133,7 +133,7 @@ public class CompletableTimeoutTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertTerminated();
 

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
@@ -26,7 +26,6 @@ import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
 public class CompletableUsingTest {
@@ -440,7 +439,7 @@ public class CompletableUsingTest {
 
     @Test
     public void successDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
@@ -477,13 +476,13 @@ public class CompletableUsingTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void errorDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
@@ -520,13 +519,13 @@ public class CompletableUsingTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void emptyDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
@@ -562,7 +561,7 @@ public class CompletableUsingTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -567,7 +567,7 @@ public class FlowableAmbTest {
 
     @Test
     public void onNextRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps1 = PublishProcessor.create();
             final PublishProcessor<Integer> ps2 = PublishProcessor.create();
 
@@ -587,7 +587,7 @@ public class FlowableAmbTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertSubscribed().assertNoErrors()
             .assertNotComplete().assertValueCount(1);
@@ -596,7 +596,7 @@ public class FlowableAmbTest {
 
     @Test
     public void onCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps1 = PublishProcessor.create();
             final PublishProcessor<Integer> ps2 = PublishProcessor.create();
 
@@ -616,7 +616,7 @@ public class FlowableAmbTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertResult();
         }
@@ -624,7 +624,7 @@ public class FlowableAmbTest {
 
     @Test
     public void onErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps1 = PublishProcessor.create();
             final PublishProcessor<Integer> ps2 = PublishProcessor.create();
 
@@ -648,7 +648,7 @@ public class FlowableAmbTest {
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
             } finally {
                 RxJavaPlugins.reset();
             }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
@@ -345,7 +345,7 @@ public class FlowableBlockingTest {
 
     @Test
     public void blockinsSubscribeCancelAsync() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -1978,7 +1978,7 @@ public class FlowableBufferTest {
 
     @Test
     public void withTimeAndSizeCapacityRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestScheduler scheduler = new TestScheduler();
 
             final PublishProcessor<Object> ps = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -315,7 +315,7 @@ public class FlowableCacheTest {
 
     @Test
     public void subscribeEmitRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
             final Flowable<Integer> cache = ps.cache();
@@ -341,7 +341,7 @@ public class FlowableCacheTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to
             .awaitDone(5, TimeUnit.SECONDS)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1264,7 +1264,7 @@ public class FlowableCombineLatestTest {
 
     @Test
     public void onErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> ps1 = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -856,7 +856,7 @@ public class FlowableConcatMapEagerTest {
 
     @Test
     public void innerOuterRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> ps1 = PublishProcessor.create();
@@ -887,7 +887,7 @@ public class FlowableConcatMapEagerTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertSubscribed().assertNoValues().assertNotComplete();
 
@@ -966,7 +966,7 @@ public class FlowableConcatMapEagerTest {
 
     @Test
     public void nextCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps1 = PublishProcessor.create();
 
             final TestSubscriber<Integer> to = ps1.concatMapEager(new Function<Integer, Flowable<Integer>>() {
@@ -989,7 +989,7 @@ public class FlowableConcatMapEagerTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertEmpty();
         }
@@ -1136,7 +1136,7 @@ public class FlowableConcatMapEagerTest {
 
     @Test
     public void drainCancelRaceOnEmpty() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -27,7 +27,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableCreateTest {
@@ -480,14 +479,14 @@ public class FlowableCreateTest {
                         }
                     };
 
-                    TestHelper.race(r1, r2, Schedulers.single());
+                    TestHelper.race(r1, r2);
                 }
             }, m);
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
-                for (int i = 0; i < 500; i++) {
+                for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
                     source
                     .test()
                     .assertFailure(Throwable.class);
@@ -521,11 +520,11 @@ public class FlowableCreateTest {
                         }
                     };
 
-                    TestHelper.race(r1, r2, Schedulers.single());
+                    TestHelper.race(r1, r2);
                 }
             }, m);
 
-            for (int i = 0; i < 500; i++) {
+            for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
                 source
                 .test()
                 .assertResult();
@@ -589,7 +588,7 @@ public class FlowableCreateTest {
                         }
                     };
 
-                    TestHelper.race(r1, r2, Schedulers.single());
+                    TestHelper.race(r1, r2);
                 }
             }, m)
             .test()
@@ -783,18 +782,18 @@ public class FlowableCreateTest {
                     Runnable r1 = new Runnable() {
                         @Override
                         public void run() {
-                            for (int i = 0; i < 1000; i++) {
+                            for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
                                 f.onNext(1);
                             }
                         }
                     };
 
-                    TestHelper.race(r1, r1, Schedulers.single());
+                    TestHelper.race(r1, r1);
                 }
             }, m)
-            .take(1000)
+            .take(TestHelper.RACE_DEFAULT_LOOPS)
             .test()
-            .assertSubscribed().assertValueCount(1000).assertComplete().assertNoErrors();
+            .assertSubscribed().assertValueCount(TestHelper.RACE_DEFAULT_LOOPS).assertComplete().assertNoErrors();
         }
     }
 
@@ -825,7 +824,7 @@ public class FlowableCreateTest {
                         }
                     };
 
-                    TestHelper.race(r1, r2, Schedulers.single());
+                    TestHelper.race(r1, r2);
                 }
             }, m)
             .test()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -584,7 +584,7 @@ public class FlowableFlatMapMaybeTest {
 
     @Test
     public void requestCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> to = Flowable.just(1).concatWith(Flowable.<Integer>never())
             .flatMapMaybe(Functions.justFunction(Maybe.just(2))).test(0);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -470,7 +470,7 @@ public class FlowableFlatMapSingleTest {
 
     @Test
     public void requestCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> to = Flowable.just(1).concatWith(Flowable.<Integer>never())
             .flatMapSingle(Functions.justFunction(Single.just(2))).test(0);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -826,7 +826,7 @@ public class FlowableFlatMapTest {
 
     @Test
     public void innerCompleteCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps = PublishProcessor.create();
 
             final TestSubscriber<Integer> to = Flowable.merge(Flowable.just(ps)).test();
@@ -930,7 +930,7 @@ public class FlowableFlatMapTest {
 
     @Test
     public void cancelScalarDrainRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
@@ -962,7 +962,7 @@ public class FlowableFlatMapTest {
 
     @Test
     public void cancelDrainRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             for (int j = 1; j < 50; j += 5) {
                 List<Throwable> errors = TestHelper.trackPluginErrors();
                 try {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
@@ -722,7 +722,7 @@ public class FlowableFromIterableTest {
 
     @Test
     public void requestRaceConditional() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
             Runnable r = new Runnable() {
@@ -736,13 +736,13 @@ public class FlowableFromIterableTest {
             .filter(Functions.alwaysTrue())
             .subscribe(ts);
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
         }
     }
 
     @Test
     public void requestRaceConditional2() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
             Runnable r = new Runnable() {
@@ -756,13 +756,13 @@ public class FlowableFromIterableTest {
             .filter(Functions.alwaysFalse())
             .subscribe(ts);
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
         }
     }
 
     @Test
     public void requestCancelConditionalRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
             Runnable r1 = new Runnable() {
@@ -783,13 +783,13 @@ public class FlowableFromIterableTest {
             .filter(Functions.alwaysTrue())
             .subscribe(ts);
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void requestCancelConditionalRace2() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
             Runnable r1 = new Runnable() {
@@ -810,13 +810,13 @@ public class FlowableFromIterableTest {
             .filter(Functions.alwaysTrue())
             .subscribe(ts);
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void requestCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
             Runnable r1 = new Runnable() {
@@ -836,13 +836,13 @@ public class FlowableFromIterableTest {
             Flowable.fromIterable(Arrays.asList(1, 2, 3, 4))
             .subscribe(ts);
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void requestCancelRace2() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
             Runnable r1 = new Runnable() {
@@ -862,7 +862,7 @@ public class FlowableFromIterableTest {
             Flowable.fromIterable(Arrays.asList(1, 2, 3, 4))
             .subscribe(ts);
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
@@ -219,7 +219,7 @@ public class FlowableGenerateTest {
             }
         }, Functions.emptyConsumer());
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Object> ts = source.test(0L);
 
             Runnable r = new Runnable() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -30,7 +30,6 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableGroupJoinTest {
@@ -506,7 +505,7 @@ public class FlowableGroupJoinTest {
 
     @Test
     public void innerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Object> ps1 = PublishProcessor.create();
             final PublishProcessor<Object> ps2 = PublishProcessor.create();
 
@@ -553,7 +552,7 @@ public class FlowableGroupJoinTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertValueCount(1);
 
@@ -578,7 +577,7 @@ public class FlowableGroupJoinTest {
 
     @Test
     public void outerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Object> ps1 = PublishProcessor.create();
             final PublishProcessor<Object> ps2 = PublishProcessor.create();
 
@@ -626,7 +625,7 @@ public class FlowableGroupJoinTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertNoValues();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableLimitTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableLimitTest.java
@@ -190,7 +190,7 @@ public class FlowableLimitTest implements LongConsumer, Action {
 
     @Test
     public void requestRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = Flowable.range(1, 10)
                     .limit(5)
                     .test(0L);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -1740,7 +1740,7 @@ public class FlowableObserveOnTest {
 
     @Test
     public void backFusedCancelConditional() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
 
             final TestScheduler scheduler = new TestScheduler();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
@@ -427,7 +427,7 @@ public class FlowablePublishFunctionTest {
 
     @Test
     public void sourceSubscriptionDelayed() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(0L);
 
             Flowable.just(1)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -529,7 +529,7 @@ public class FlowablePublishTest {
 
     @Test
     public void addRemoveRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final ConnectableFlowable<Integer> co = Flowable.<Integer>empty().publish();
 
@@ -618,7 +618,7 @@ public class FlowablePublishTest {
 
     @Test
     public void nextCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final PublishProcessor<Integer> ps = PublishProcessor.create();
 
@@ -686,7 +686,7 @@ public class FlowablePublishTest {
 
     @Test
     public void subscribeDisconnectRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final PublishProcessor<Integer> ps = PublishProcessor.create();
 
@@ -768,7 +768,7 @@ public class FlowablePublishTest {
 
     @Test
     public void preNextConnect() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final ConnectableFlowable<Integer> co = Flowable.<Integer>empty().publish();
 
@@ -787,7 +787,7 @@ public class FlowablePublishTest {
 
     @Test
     public void connectRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final ConnectableFlowable<Integer> co = Flowable.<Integer>empty().publish();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -1305,7 +1305,7 @@ public class FlowableReplayTest {
 
     @Test
     public void connectRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> co = Flowable.range(1, 3).replay();
 
             Runnable r = new Runnable() {
@@ -1321,7 +1321,7 @@ public class FlowableReplayTest {
 
     @Test
     public void subscribeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> co = Flowable.range(1, 3).replay();
 
             final TestSubscriber<Integer> to1 = new TestSubscriber<Integer>();
@@ -1347,7 +1347,7 @@ public class FlowableReplayTest {
 
     @Test
     public void addRemoveRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> co = Flowable.range(1, 3).replay();
 
             final TestSubscriber<Integer> to1 = new TestSubscriber<Integer>();
@@ -1445,7 +1445,7 @@ public class FlowableReplayTest {
 
     @Test
     public void subscribeOnNextRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps = PublishProcessor.create();
 
             final ConnectableFlowable<Integer> co = ps.replay();
@@ -1474,7 +1474,7 @@ public class FlowableReplayTest {
 
     @Test
     public void unsubscribeOnNextRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps = PublishProcessor.create();
 
             final ConnectableFlowable<Integer> co = ps.replay();
@@ -1505,7 +1505,7 @@ public class FlowableReplayTest {
 
     @Test
     public void unsubscribeReplayRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> co = Flowable.range(1, 1000).replay();
 
             final TestSubscriber<Integer> to1 = new TestSubscriber<Integer>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -33,7 +33,6 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 
 public class FlowableRetryWithPredicateTest {
@@ -419,7 +418,7 @@ public class FlowableRetryWithPredicateTest {
 
     @Test
     public void retryDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps = PublishProcessor.create();
 
             final TestSubscriber<Integer> to = ps.retry(Functions.alwaysTrue()).test();
@@ -440,7 +439,7 @@ public class FlowableRetryWithPredicateTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertEmpty();
         }
@@ -467,7 +466,7 @@ public class FlowableRetryWithPredicateTest {
 
     @Test
     public void retryBiPredicateDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps = PublishProcessor.create();
 
             final TestSubscriber<Integer> to = ps.retry(new BiPredicate<Object, Object>() {
@@ -493,7 +492,7 @@ public class FlowableRetryWithPredicateTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertEmpty();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
@@ -338,7 +338,7 @@ public class FlowableSampleTest {
 
     @Test
     public void emitLastTimedRunCompleteRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestScheduler scheduler = new TestScheduler();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
@@ -386,7 +386,7 @@ public class FlowableSampleTest {
 
     @Test
     public void emitLastOtherRunCompleteRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final PublishProcessor<Integer> sampler = PublishProcessor.create();
 
@@ -417,7 +417,7 @@ public class FlowableSampleTest {
 
     @Test
     public void emitLastOtherCompleteCompleteRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final PublishProcessor<Integer> sampler = PublishProcessor.create();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScalarXMapTest.java
@@ -24,7 +24,6 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.subscriptions.*;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableScalarXMapTest {
@@ -212,7 +211,7 @@ public class FlowableScalarXMapTest {
 
     @Test
     public void scalarDisposableRunDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestSubscriber<Integer> to = new TestSubscriber<Integer>();
             final ScalarSubscription<Integer> sd = new ScalarSubscription<Integer>(to, 1);
             to.onSubscribe(sd);
@@ -231,7 +230,7 @@ public class FlowableScalarXMapTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -312,7 +312,7 @@ public class FlowableSequenceEqualTest {
 
     @Test
     public void onNextCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps = PublishProcessor.create();
 
             final TestObserver<Boolean> to = Flowable.sequenceEqual(Flowable.never(), ps).test();
@@ -339,7 +339,7 @@ public class FlowableSequenceEqualTest {
 
     @Test
     public void onNextCancelRaceObservable() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps = PublishProcessor.create();
 
             final TestSubscriber<Boolean> to = Flowable.sequenceEqual(Flowable.never(), ps).toFlowable().test();
@@ -414,7 +414,7 @@ public class FlowableSequenceEqualTest {
             }
         };
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
@@ -518,7 +518,7 @@ public class FlowableSequenceEqualTest {
             }
         };
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestObserver<Boolean> ts = new TestObserver<Boolean>();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
@@ -196,7 +196,7 @@ public class FlowableSkipLastTimedTest {
     @Test
     public void onNextDisposeRace() {
         TestScheduler scheduler = new TestScheduler();
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps = PublishProcessor.create();
 
             final TestSubscriber<Integer> to = ps.skipLast(1, TimeUnit.DAYS, scheduler).test();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -294,7 +294,7 @@ public class FlowableSubscribeOnTest {
 
     @Test
     public void deferredRequestRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -821,7 +821,7 @@ public class FlowableSwitchTest {
 
     @Test
     public void nextSourceErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
@@ -868,7 +868,7 @@ public class FlowableSwitchTest {
 
     @Test
     public void outerInnerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
@@ -917,7 +917,7 @@ public class FlowableSwitchTest {
 
     @Test
     public void nextCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps1 = PublishProcessor.create();
 
             final TestSubscriber<Integer> to = ps1.switchMap(new Function<Integer, Flowable<Integer>>() {
@@ -1114,7 +1114,7 @@ public class FlowableSwitchTest {
 
     @Test
     public void drainCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -291,7 +291,7 @@ public class FlowableTakeLastTimedTest {
 
     @Test
     public void cancelCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> ps = PublishProcessor.create();
 
             final TestSubscriber<Integer> to = ps.takeLast(1, TimeUnit.DAYS).test();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -523,7 +523,7 @@ public class FlowableTimeoutTests {
 
     @Test
     public void onNextOnTimeoutRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestScheduler sch = new TestScheduler();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
@@ -560,7 +560,7 @@ public class FlowableTimeoutTests {
 
     @Test
     public void onNextOnTimeoutRaceFallback() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestScheduler sch = new TestScheduler();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -549,7 +549,7 @@ public class FlowableTimeoutWithSelectorTest {
 
     @Test
     public void lateOnTimeoutError() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp = PublishProcessor.create();
@@ -603,7 +603,7 @@ public class FlowableTimeoutWithSelectorTest {
 
     @Test
     public void lateOnTimeoutFallbackRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp = PublishProcessor.create();
@@ -658,7 +658,7 @@ public class FlowableTimeoutWithSelectorTest {
 
     @Test
     public void onErrorOnTimeoutRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp = PublishProcessor.create();
@@ -713,7 +713,7 @@ public class FlowableTimeoutWithSelectorTest {
 
     @Test
     public void onECompleteOnTimeoutRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimerTest.java
@@ -304,7 +304,7 @@ public class FlowableTimerTest {
 
     @Test
     public void timerCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Long> ts = new TestSubscriber<Long>();
 
             final TestScheduler scheduler = new TestScheduler();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
@@ -392,7 +392,7 @@ public class FlowableToListTest {
 
     @Test
     public void onNextCancelRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final TestObserver<List<Integer>> ts = pp.toList().test();
 
@@ -415,7 +415,7 @@ public class FlowableToListTest {
 
     @Test
     public void onNextCancelRaceFlowable() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final TestSubscriber<List<Integer>> ts = pp.toList().toFlowable().test();
 
@@ -439,7 +439,7 @@ public class FlowableToListTest {
 
     @Test
     public void onCompleteCancelRaceFlowable() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final TestSubscriber<List<Integer>> ts = pp.toList().toFlowable().test();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -779,7 +779,7 @@ public class FlowableWithLatestFromTest {
 
     @Test
     public void otherOnSubscribeRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp0 = PublishProcessor.create();
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
@@ -822,7 +822,7 @@ public class FlowableWithLatestFromTest {
 
     @Test
     public void otherCompleteRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp0 = PublishProcessor.create();
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeAmbTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.maybe;
 
 import static org.junit.Assert.*;
+
 import java.util.*;
 
 import org.junit.Test;
@@ -23,7 +24,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class MaybeAmbTest {
 
@@ -71,7 +71,7 @@ public class MaybeAmbTest {
     @SuppressWarnings("unchecked")
     @Test
     public void innerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp0 = PublishProcessor.create();
@@ -96,7 +96,7 @@ public class MaybeAmbTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
@@ -24,7 +24,6 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class MaybeCacheTest {
@@ -224,7 +223,7 @@ public class MaybeCacheTest {
 
     @Test
     public void addAddRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final Maybe<Integer> source = pp.singleElement().cache();
@@ -236,13 +235,13 @@ public class MaybeCacheTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
         }
     }
 
     @Test
     public void removeRemoveRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final Maybe<Integer> source = pp.singleElement().cache();
@@ -264,7 +263,7 @@ public class MaybeCacheTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayTest.java
@@ -13,17 +13,17 @@
 
 package io.reactivex.internal.operators.maybe;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class MaybeConcatArrayTest {
@@ -83,7 +83,7 @@ public class MaybeConcatArrayTest {
     @SuppressWarnings("unchecked")
     @Test
     public void requestCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = Maybe.concatArray(Maybe.just(1), Maybe.just(2))
                     .test(0L);
 
@@ -101,14 +101,14 @@ public class MaybeConcatArrayTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void requestCancelRaceDelayError() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = Maybe.concatArrayDelayError(Maybe.just(1), Maybe.just(2))
                     .test(0L);
 
@@ -126,7 +126,7 @@ public class MaybeConcatArrayTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatIterableTest.java
@@ -24,7 +24,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.util.CrashingMappedIterable;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class MaybeConcatIterableTest {
@@ -61,7 +60,7 @@ public class MaybeConcatIterableTest {
     @SuppressWarnings("unchecked")
     @Test
     public void successCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
@@ -84,7 +83,7 @@ public class MaybeConcatIterableTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
@@ -403,7 +403,7 @@ public class MaybeFlatMapIterableFlowableTest {
         final Integer[] a = new Integer[1000];
         Arrays.fill(a, 1);
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             ps.onNext(1);
@@ -436,13 +436,13 @@ public class MaybeFlatMapIterableFlowableTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void cancelCreateInnerRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             ps.onNext(1);
@@ -470,7 +470,7 @@ public class MaybeFlatMapIterableFlowableTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeArrayTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.*;
 import java.util.*;
 
 import org.junit.Test;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
@@ -26,7 +26,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.operators.maybe.MaybeMergeArray.MergeMaybeObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subscribers.*;
 
@@ -133,7 +132,7 @@ public class MaybeMergeArrayTest {
     @SuppressWarnings("unchecked")
     @Test
     public void errorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
@@ -159,7 +158,7 @@ public class MaybeMergeArrayTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 ts.assertFailure(Throwable.class);
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
@@ -13,18 +13,15 @@
 
 package io.reactivex.internal.operators.maybe;
 
-import io.reactivex.Maybe;
-import io.reactivex.Single;
-import io.reactivex.TestHelper;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
-import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class MaybeSwitchIfEmptySingleTest {
 
@@ -83,7 +80,7 @@ public class MaybeSwitchIfEmptySingleTest {
 
     @Test
     public void emptyCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final TestObserver<Integer> ts = pp.singleElement().switchIfEmpty(Single.just(2)).test();
@@ -102,7 +99,7 @@ public class MaybeSwitchIfEmptySingleTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
@@ -22,7 +22,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class MaybeSwitchIfEmptyTest {
 
@@ -97,7 +96,7 @@ public class MaybeSwitchIfEmptyTest {
 
     @Test
     public void emptyCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final TestObserver<Integer> ts = pp.singleElement().switchIfEmpty(Maybe.just(2)).test();
@@ -116,7 +115,7 @@ public class MaybeSwitchIfEmptyTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
@@ -25,7 +25,6 @@ import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class MaybeTakeUntilPublisherTest {
 
@@ -118,7 +117,7 @@ public class MaybeTakeUntilPublisherTest {
 
     @Test
     public void onErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
@@ -143,7 +142,7 @@ public class MaybeTakeUntilPublisherTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 
@@ -160,7 +159,7 @@ public class MaybeTakeUntilPublisherTest {
 
     @Test
     public void onCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
@@ -179,7 +178,7 @@ public class MaybeTakeUntilPublisherTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertResult();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilTest.java
@@ -25,7 +25,6 @@ import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class MaybeTakeUntilTest {
 
@@ -146,7 +145,7 @@ public class MaybeTakeUntilTest {
 
     @Test
     public void onErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
@@ -171,7 +170,7 @@ public class MaybeTakeUntilTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 
@@ -188,7 +187,7 @@ public class MaybeTakeUntilTest {
 
     @Test
     public void onCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
@@ -207,7 +206,7 @@ public class MaybeTakeUntilTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertResult();
         }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimeoutPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimeoutPublisherTest.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.maybe;
 
 import static org.junit.Assert.*;
 
-import java.util.concurrent.*;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.Test;
 
@@ -25,7 +25,6 @@ import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.*;
 
 public class MaybeTimeoutPublisherTest {
 
@@ -157,7 +156,7 @@ public class MaybeTimeoutPublisherTest {
 
     @Test
     public void onErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -180,7 +179,7 @@ public class MaybeTimeoutPublisherTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
             } finally {
@@ -191,7 +190,7 @@ public class MaybeTimeoutPublisherTest {
 
     @Test
     public void onCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
@@ -210,7 +209,7 @@ public class MaybeTimeoutPublisherTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertSubscribed().assertNoValues();
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimeoutTest.java
@@ -276,7 +276,7 @@ public class MaybeTimeoutTest {
 
     @Test
     public void onErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -299,7 +299,7 @@ public class MaybeTimeoutTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
             } finally {
@@ -310,7 +310,7 @@ public class MaybeTimeoutTest {
 
     @Test
     public void onCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
@@ -329,7 +329,7 @@ public class MaybeTimeoutTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertSubscribed().assertNoValues();
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeUnsubscribeOnTest.java
@@ -103,7 +103,7 @@ public class MaybeUnsubscribeOnTest {
 
     @Test
     public void disposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final Disposable[] ds = { null };
@@ -137,7 +137,7 @@ public class MaybeUnsubscribeOnTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
@@ -26,7 +26,6 @@ import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
 public class MaybeUsingTest {
@@ -440,7 +439,7 @@ public class MaybeUsingTest {
 
     @Test
     public void successDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
@@ -477,13 +476,13 @@ public class MaybeUsingTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void errorDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
@@ -520,13 +519,13 @@ public class MaybeUsingTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void emptyDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
@@ -562,7 +561,7 @@ public class MaybeUsingTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipArrayTest.java
@@ -15,7 +15,7 @@ package io.reactivex.internal.operators.maybe;
 
 import static org.junit.Assert.*;
 
-import java.util.*;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -26,7 +26,6 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class MaybeZipArrayTest {
 
@@ -114,7 +113,7 @@ public class MaybeZipArrayTest {
 
     @Test
     public void innerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp0 = PublishProcessor.create();
@@ -139,7 +138,7 @@ public class MaybeZipArrayTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipIterableTest.java
@@ -27,7 +27,6 @@ import io.reactivex.internal.util.CrashingMappedIterable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class MaybeZipIterableTest {
 
@@ -115,7 +114,7 @@ public class MaybeZipIterableTest {
     @SuppressWarnings("unchecked")
     @Test
     public void innerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp0 = PublishProcessor.create();
@@ -141,7 +140,7 @@ public class MaybeZipIterableTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
@@ -271,7 +271,7 @@ public class ObservableAmbTest {
 
     @Test
     public void onNextRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps1 = PublishSubject.create();
             final PublishSubject<Integer> ps2 = PublishSubject.create();
 
@@ -291,7 +291,7 @@ public class ObservableAmbTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertSubscribed().assertNoErrors()
             .assertNotComplete().assertValueCount(1);
@@ -300,7 +300,7 @@ public class ObservableAmbTest {
 
     @Test
     public void onCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps1 = PublishSubject.create();
             final PublishSubject<Integer> ps2 = PublishSubject.create();
 
@@ -320,7 +320,7 @@ public class ObservableAmbTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertResult();
         }
@@ -328,7 +328,7 @@ public class ObservableAmbTest {
 
     @Test
     public void onErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps1 = PublishSubject.create();
             final PublishSubject<Integer> ps2 = PublishSubject.create();
 
@@ -352,7 +352,7 @@ public class ObservableAmbTest {
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
             } finally {
                 RxJavaPlugins.reset();
             }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -1404,7 +1404,7 @@ public class ObservableBufferTest {
 
     @Test
     public void withTimeAndSizeCapacityRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestScheduler scheduler = new TestScheduler();
 
             final PublishSubject<Object> ps = PublishSubject.create();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
@@ -318,7 +318,7 @@ public class ObservableCacheTest {
 
     @Test
     public void subscribeEmitRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.<Integer>create();
 
             final Observable<Integer> cache = ps.cache();
@@ -344,7 +344,7 @@ public class ObservableCacheTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to
             .awaitDone(5, TimeUnit.SECONDS)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
@@ -963,7 +963,7 @@ public class ObservableCombineLatestTest {
 
     @Test
     public void onErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishSubject<Integer> ps1 = PublishSubject.create();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletableTest.java
@@ -12,21 +12,19 @@
  */
 package io.reactivex.internal.operators.observable;
 
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
 import io.reactivex.*;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.disposables.Disposables;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subjects.PublishSubject;
-import io.reactivex.subjects.UnicastSubject;
-import org.junit.Test;
-
-import java.util.List;
-
-import static org.junit.Assert.assertTrue;
+import io.reactivex.subjects.*;
 
 public class ObservableConcatMapCompletableTest {
 
@@ -107,7 +105,7 @@ public class ObservableConcatMapCompletableTest {
 
     @Test
     public void onErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishSubject<Integer> ps1 = PublishSubject.create();
@@ -136,7 +134,7 @@ public class ObservableConcatMapCompletableTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -807,7 +807,7 @@ public class ObservableConcatMapEagerTest {
 
     @Test
     public void innerOuterRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishSubject<Integer> ps1 = PublishSubject.create();
@@ -838,7 +838,7 @@ public class ObservableConcatMapEagerTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertSubscribed().assertNoValues().assertNotComplete();
 
@@ -862,7 +862,7 @@ public class ObservableConcatMapEagerTest {
 
     @Test
     public void nextCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps1 = PublishSubject.create();
 
             final TestObserver<Integer> to = ps1.concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
@@ -885,7 +885,7 @@ public class ObservableConcatMapEagerTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertEmpty();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapTest.java
@@ -27,7 +27,6 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.*;
 
 public class ObservableConcatMapTest {
@@ -232,7 +231,7 @@ public class ObservableConcatMapTest {
 
     @Test
     public void onErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishSubject<Integer> ps1 = PublishSubject.create();
@@ -261,7 +260,7 @@ public class ObservableConcatMapTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
@@ -26,7 +26,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 public class ObservableCreateTest {
 
@@ -438,18 +437,18 @@ public class ObservableCreateTest {
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {
-                        for (int i = 0; i < 1000; i++) {
+                        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
                             f.onNext(1);
                         }
                     }
                 };
 
-                TestHelper.race(r1, r1, Schedulers.single());
+                TestHelper.race(r1, r1);
             }
         })
-        .take(1000)
+        .take(TestHelper.RACE_DEFAULT_LOOPS)
         .test()
-        .assertSubscribed().assertValueCount(1000).assertComplete().assertNoErrors();
+        .assertSubscribed().assertValueCount(TestHelper.RACE_DEFAULT_LOOPS).assertComplete().assertNoErrors();
     }
 
     @Test
@@ -478,7 +477,7 @@ public class ObservableCreateTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
             }
         })
         .test()
@@ -512,7 +511,7 @@ public class ObservableCreateTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
             }
         })
         .test()
@@ -546,14 +545,14 @@ public class ObservableCreateTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
             }
         });
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            for (int i = 0; i < 500; i++) {
+            for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
                 source
                 .test()
                 .assertFailure(Throwable.class);
@@ -585,11 +584,11 @@ public class ObservableCreateTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
             }
         });
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             source
             .test()
             .assertResult();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
@@ -694,7 +694,7 @@ public class ObservableFlatMapTest {
 
     @Test
     public void innerCompleteCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final TestObserver<Integer> to = Observable.merge(Observable.just(ps)).test();
@@ -789,7 +789,7 @@ public class ObservableFlatMapTest {
 
     @Test
     public void cancelScalarDrainRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
@@ -821,7 +821,7 @@ public class ObservableFlatMapTest {
 
     @Test
     public void cancelDrainRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             for (int j = 1; j < 50; j += 5) {
                 List<Throwable> errors = TestHelper.trackPluginErrors();
                 try {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupJoinTest.java
@@ -32,7 +32,6 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
 public class ObservableGroupJoinTest {
@@ -507,7 +506,7 @@ public class ObservableGroupJoinTest {
 
     @Test
     public void innerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Object> ps1 = PublishSubject.create();
             final PublishSubject<Object> ps2 = PublishSubject.create();
 
@@ -554,7 +553,7 @@ public class ObservableGroupJoinTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertValueCount(1);
 
@@ -579,7 +578,7 @@ public class ObservableGroupJoinTest {
 
     @Test
     public void outerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Object> ps1 = PublishSubject.create();
             final PublishSubject<Object> ps2 = PublishSubject.create();
 
@@ -627,7 +626,7 @@ public class ObservableGroupJoinTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertNoValues();
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -400,7 +400,7 @@ public class ObservablePublishTest {
 
     @Test
     public void preNextConnect() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final ConnectableObservable<Integer> co = Observable.<Integer>empty().publish();
 
@@ -419,7 +419,7 @@ public class ObservablePublishTest {
 
     @Test
     public void connectRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final ConnectableObservable<Integer> co = Observable.<Integer>empty().publish();
 
@@ -470,7 +470,7 @@ public class ObservablePublishTest {
 
     @Test
     public void addRemoveRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final ConnectableObservable<Integer> co = Observable.<Integer>empty().publish();
 
@@ -552,7 +552,7 @@ public class ObservablePublishTest {
 
     @Test
     public void nextCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
@@ -620,7 +620,7 @@ public class ObservablePublishTest {
 
     @Test
     public void subscribeDisconnectRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -1178,7 +1178,7 @@ public class ObservableReplayTest {
 
     @Test
     public void connectRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableObservable<Integer> co = Observable.range(1, 3).replay();
 
             Runnable r = new Runnable() {
@@ -1194,7 +1194,7 @@ public class ObservableReplayTest {
 
     @Test
     public void subscribeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableObservable<Integer> co = Observable.range(1, 3).replay();
 
             final TestObserver<Integer> to1 = new TestObserver<Integer>();
@@ -1220,7 +1220,7 @@ public class ObservableReplayTest {
 
     @Test
     public void addRemoveRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableObservable<Integer> co = Observable.range(1, 3).replay();
 
             final TestObserver<Integer> to1 = new TestObserver<Integer>();
@@ -1318,7 +1318,7 @@ public class ObservableReplayTest {
 
     @Test
     public void subscribeOnNextRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final ConnectableObservable<Integer> co = ps.replay();
@@ -1347,7 +1347,7 @@ public class ObservableReplayTest {
 
     @Test
     public void unsubscribeOnNextRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final ConnectableObservable<Integer> co = ps.replay();
@@ -1378,7 +1378,7 @@ public class ObservableReplayTest {
 
     @Test
     public void unsubscribeReplayRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableObservable<Integer> co = Observable.range(1, 1000).replay();
 
             final TestObserver<Integer> to1 = new TestObserver<Integer>();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -33,7 +33,6 @@ import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.*;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
 public class ObservableRetryWithPredicateTest {
@@ -390,7 +389,7 @@ public class ObservableRetryWithPredicateTest {
 
     @Test
     public void retryDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final TestObserver<Integer> to = ps.retry(Functions.alwaysTrue()).test();
@@ -411,7 +410,7 @@ public class ObservableRetryWithPredicateTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertEmpty();
         }
@@ -438,7 +437,7 @@ public class ObservableRetryWithPredicateTest {
 
     @Test
     public void retryBiPredicateDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final TestObserver<Integer> to = ps.retry(new BiPredicate<Object, Object>() {
@@ -464,7 +463,7 @@ public class ObservableRetryWithPredicateTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             to.assertEmpty();
         }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSampleTest.java
@@ -319,7 +319,7 @@ public class ObservableSampleTest {
 
     @Test
     public void emitLastTimedRunCompleteRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestScheduler scheduler = new TestScheduler();
 
             final PublishSubject<Integer> pp = PublishSubject.create();
@@ -367,7 +367,7 @@ public class ObservableSampleTest {
 
     @Test
     public void emitLastOtherRunCompleteRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> pp = PublishSubject.create();
             final PublishSubject<Integer> sampler = PublishSubject.create();
 
@@ -398,7 +398,7 @@ public class ObservableSampleTest {
 
     @Test
     public void emitLastOtherCompleteCompleteRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> pp = PublishSubject.create();
             final PublishSubject<Integer> sampler = PublishSubject.create();
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableScalarXMapTest.java
@@ -25,7 +25,6 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.operators.observable.ObservableScalarXMap.ScalarDisposable;
 import io.reactivex.observers.TestObserver;
-import io.reactivex.schedulers.Schedulers;
 
 public class ObservableScalarXMapTest {
 
@@ -214,7 +213,7 @@ public class ObservableScalarXMapTest {
 
     @Test
     public void scalarDisposableRunDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestObserver<Integer> to = new TestObserver<Integer>();
             final ScalarDisposable<Integer> sd = new ScalarDisposable<Integer>(to, 1);
             to.onSubscribe(sd);
@@ -233,7 +232,7 @@ public class ObservableScalarXMapTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
@@ -316,7 +316,7 @@ public class ObservableSequenceEqualTest {
 
     @Test
     public void onNextCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final TestObserver<Boolean> to = Observable.sequenceEqual(Observable.never(), ps).test();
@@ -343,7 +343,7 @@ public class ObservableSequenceEqualTest {
 
     @Test
     public void onNextCancelRaceObservable() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final TestObserver<Boolean> to = Observable.sequenceEqual(Observable.never(), ps).toObservable().test();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTimedTest.java
@@ -195,7 +195,7 @@ public class ObservableSkipLastTimedTest {
     @Test
     public void onNextDisposeRace() {
         TestScheduler scheduler = new TestScheduler();
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final TestObserver<Integer> to = ps.skipLast(1, TimeUnit.DAYS, scheduler).test();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
@@ -721,7 +721,7 @@ public class ObservableSwitchTest {
 
     @Test
     public void nextSourceErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
@@ -768,7 +768,7 @@ public class ObservableSwitchTest {
 
     @Test
     public void outerInnerErrorRace() {
-        for (int i = 0; i < 5000; i++) {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
@@ -819,7 +819,7 @@ public class ObservableSwitchTest {
 
     @Test
     public void nextCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps1 = PublishSubject.create();
 
             final TestObserver<Integer> to = ps1.switchMap(new Function<Integer, ObservableSource<Integer>>() {
@@ -989,7 +989,7 @@ public class ObservableSwitchTest {
 
     @Test
     public void outerInnerErrorRaceIgnoreDispose() {
-        for (int i = 0; i < 5000; i++) {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimedTest.java
@@ -254,7 +254,7 @@ public class ObservableTakeLastTimedTest {
 
     @Test
     public void cancelCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final TestObserver<Integer> to = ps.takeLast(1, TimeUnit.DAYS).test();

--- a/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
@@ -24,7 +24,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.*;
 
 public class SingleAmbTest {
@@ -134,7 +133,7 @@ public class SingleAmbTest {
 
     @Test
     public void nullSourceSuccessRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
@@ -159,7 +158,7 @@ public class SingleAmbTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertError(errors, 0, NullPointerException.class);
@@ -173,7 +172,7 @@ public class SingleAmbTest {
     @SuppressWarnings("unchecked")
     @Test
     public void multipleErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
@@ -199,7 +198,7 @@ public class SingleAmbTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);
@@ -213,7 +212,7 @@ public class SingleAmbTest {
     @SuppressWarnings("unchecked")
     @Test
     public void successErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
@@ -240,7 +239,7 @@ public class SingleAmbTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);

--- a/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
@@ -19,7 +19,6 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class SingleCacheTest {
 
@@ -41,7 +40,7 @@ public class SingleCacheTest {
 
     @Test
     public void addRemoveRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final Single<Integer> cached = pp.single(-99).cache();
@@ -62,7 +61,7 @@ public class SingleCacheTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowableTest.java
@@ -390,7 +390,7 @@ public class SingleFlatMapIterableFlowableTest {
         final Integer[] a = new Integer[1000];
         Arrays.fill(a, 1);
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             ps.onNext(1);
@@ -423,13 +423,13 @@ public class SingleFlatMapIterableFlowableTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void cancelCreateInnerRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             ps.onNext(1);
@@ -457,7 +457,7 @@ public class SingleFlatMapIterableFlowableTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
@@ -554,7 +554,7 @@ public class SingleFlatMapIterableFlowableTest {
         final Integer[] a = new Integer[1000];
         Arrays.fill(a, 1);
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             final TestSubscriber<Integer> ts = ps.singleOrError().flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
@@ -581,7 +581,7 @@ public class SingleFlatMapIterableFlowableTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
@@ -13,10 +13,11 @@
 
 package io.reactivex.internal.operators.single;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 import java.util.concurrent.CancellationException;
 
-import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.*;
@@ -24,7 +25,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class SingleTakeUntilTest {
 
@@ -223,7 +223,7 @@ public class SingleTakeUntilTest {
 
     @Test
     public void onErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
@@ -248,7 +248,7 @@ public class SingleTakeUntilTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTest.java
@@ -134,7 +134,7 @@ public class SingleTimeoutTest {
 
     @Test
     public void successTimeoutRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final SingleSubject<Integer> subj = SingleSubject.create();
             SingleSubject<Integer> fallback = SingleSubject.create();
 
@@ -172,7 +172,7 @@ public class SingleTimeoutTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
 
-            for (int i = 0; i < 1000; i++) {
+            for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
                 final SingleSubject<Integer> subj = SingleSubject.create();
                 SingleSubject<Integer> fallback = SingleSubject.create();
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleUnsubscribeOnTest.java
@@ -95,7 +95,7 @@ public class SingleUnsubscribeOnTest {
 
     @Test
     public void disposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final Disposable[] ds = { null };
@@ -124,7 +124,7 @@ public class SingleUnsubscribeOnTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
@@ -28,7 +28,6 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class SingleUsingTest {
 
@@ -220,7 +219,7 @@ public class SingleUsingTest {
 
     @Test
     public void successDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             Disposable d = Disposables.empty();
@@ -248,7 +247,7 @@ public class SingleUsingTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             assertTrue(d.isDisposed());
         }
@@ -295,7 +294,7 @@ public class SingleUsingTest {
 
     @Test
     public void errorDisposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             Disposable d = Disposables.empty();
@@ -323,7 +322,7 @@ public class SingleUsingTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             assertTrue(d.isDisposed());
         }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleZipArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleZipArrayTest.java
@@ -26,7 +26,6 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class SingleZipArrayTest {
 
@@ -114,7 +113,7 @@ public class SingleZipArrayTest {
 
     @Test
     public void innerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp0 = PublishProcessor.create();
@@ -139,7 +138,7 @@ public class SingleZipArrayTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleZipIterableTest.java
@@ -27,7 +27,6 @@ import io.reactivex.internal.util.CrashingMappedIterable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 
 public class SingleZipIterableTest {
 
@@ -115,7 +114,7 @@ public class SingleZipIterableTest {
     @SuppressWarnings("unchecked")
     @Test
     public void innerErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final PublishProcessor<Integer> pp0 = PublishProcessor.create();
@@ -141,7 +140,7 @@ public class SingleZipIterableTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 to.assertFailure(TestException.class);
 

--- a/src/test/java/io/reactivex/internal/schedulers/AbstractDirectTaskTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/AbstractDirectTaskTest.java
@@ -208,7 +208,7 @@ public class AbstractDirectTaskTest {
 
     @Test
     public void disposeSetFutureRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE) {
                 private static final long serialVersionUID = 208585707945686116L;
             };

--- a/src/test/java/io/reactivex/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/ScheduledRunnableTest.java
@@ -59,7 +59,7 @@ public class ScheduledRunnableTest {
 
     @Test
     public void setFutureCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             CompositeDisposable set = new CompositeDisposable();
             final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
             set.add(run);
@@ -88,7 +88,7 @@ public class ScheduledRunnableTest {
 
     @Test
     public void setFutureRunRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             CompositeDisposable set = new CompositeDisposable();
             final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
             set.add(run);
@@ -117,7 +117,7 @@ public class ScheduledRunnableTest {
 
     @Test
     public void disposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             CompositeDisposable set = new CompositeDisposable();
             final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
             set.add(run);
@@ -137,7 +137,7 @@ public class ScheduledRunnableTest {
 
     @Test
     public void runDispose() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             CompositeDisposable set = new CompositeDisposable();
             final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
             set.add(run);
@@ -260,7 +260,7 @@ public class ScheduledRunnableTest {
 
     @Test
     public void runFuture() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             CompositeDisposable set = new CompositeDisposable();
             final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
             set.add(run);
@@ -287,7 +287,7 @@ public class ScheduledRunnableTest {
 
     @Test
     public void syncWorkerCancelRace() {
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             final CompositeDisposable set = new CompositeDisposable();
             final AtomicBoolean interrupted = new AtomicBoolean();
             final AtomicInteger sync = new AtomicInteger(2);

--- a/src/test/java/io/reactivex/internal/schedulers/SchedulerMultiWorkerSupportTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/SchedulerMultiWorkerSupportTest.java
@@ -66,7 +66,7 @@ public class SchedulerMultiWorkerSupportTest {
 
     @Test
     public void distinctThreads() throws Exception {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final CompositeDisposable composite = new CompositeDisposable();
 

--- a/src/test/java/io/reactivex/internal/schedulers/SingleSchedulerTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/SingleSchedulerTest.java
@@ -68,7 +68,7 @@ public class SingleSchedulerTest extends AbstractSchedulerTests {
     @Test
     public void startRace() {
         final Scheduler s = new SingleScheduler();
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             s.shutdown();
 
             Runnable r1 = new Runnable() {

--- a/src/test/java/io/reactivex/internal/subscribers/FutureSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/FutureSubscriberTest.java
@@ -126,7 +126,7 @@ public class FutureSubscriberTest {
 
     @Test
     public void cancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FutureSubscriber<Integer> fs = new FutureSubscriber<Integer>();
 
             Runnable r = new Runnable() {
@@ -136,7 +136,7 @@ public class FutureSubscriberTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
         }
     }
 
@@ -155,7 +155,7 @@ public class FutureSubscriberTest {
 
     @Test
     public void onErrorCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FutureSubscriber<Integer> fs = new FutureSubscriber<Integer>();
 
             final TestException ex = new TestException();
@@ -174,13 +174,13 @@ public class FutureSubscriberTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void onCompleteCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FutureSubscriber<Integer> fs = new FutureSubscriber<Integer>();
 
             if (i % 3 == 0) {
@@ -205,7 +205,7 @@ public class FutureSubscriberTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/subscribers/SinglePostCompleteSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/SinglePostCompleteSubscriberTest.java
@@ -23,7 +23,7 @@ public class SinglePostCompleteSubscriberTest {
 
     @Test
     public void requestCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
             final SinglePostCompleteSubscriber<Integer, Integer> spc = new SinglePostCompleteSubscriber<Integer, Integer>(ts) {

--- a/src/test/java/io/reactivex/internal/subscriptions/ArrayCompositeSubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/ArrayCompositeSubscriptionTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.TestHelper;
-import io.reactivex.schedulers.Schedulers;
 
 public class ArrayCompositeSubscriptionTest {
 
@@ -94,7 +93,7 @@ public class ArrayCompositeSubscriptionTest {
 
     @Test
     public void disposeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ArrayCompositeSubscription ac = new ArrayCompositeSubscription(1000);
 
             Runnable r = new Runnable() {
@@ -104,13 +103,13 @@ public class ArrayCompositeSubscriptionTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
         }
     }
 
     @Test
     public void setReplaceRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ArrayCompositeSubscription ac = new ArrayCompositeSubscription(1);
 
             final BooleanSubscription s1 = new BooleanSubscription();
@@ -130,7 +129,7 @@ public class ArrayCompositeSubscriptionTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/subscriptions/DeferredScalarSubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/DeferredScalarSubscriptionTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.reactivex.TestHelper;
 import io.reactivex.internal.fuseable.QueueSubscription;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class DeferredScalarSubscriptionTest {
@@ -54,7 +53,7 @@ public class DeferredScalarSubscriptionTest {
 
     @Test
     public void completeCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(new TestSubscriber<Integer>());
 
             Runnable r1 = new Runnable() {
@@ -71,13 +70,13 @@ public class DeferredScalarSubscriptionTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void requestClearRace() {
-        for (int i = 0; i < 5000; i++) {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
             final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(ts);
@@ -98,7 +97,7 @@ public class DeferredScalarSubscriptionTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             if (ts.valueCount() >= 1) {
                 ts.assertValue(1);
@@ -108,7 +107,7 @@ public class DeferredScalarSubscriptionTest {
 
     @Test
     public void requestCancelRace() {
-        for (int i = 0; i < 5000; i++) {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
             final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(ts);
@@ -129,7 +128,7 @@ public class DeferredScalarSubscriptionTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             if (ts.valueCount() >= 1) {
                 ts.assertValue(1);

--- a/src/test/java/io/reactivex/internal/subscriptions/SubscriptionHelperTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/SubscriptionHelperTest.java
@@ -23,7 +23,6 @@ import org.reactivestreams.Subscription;
 
 import io.reactivex.TestHelper;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 public class SubscriptionHelperTest {
 
@@ -85,7 +84,7 @@ public class SubscriptionHelperTest {
 
     @Test
     public void cancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
 
             Runnable r = new Runnable() {
@@ -95,13 +94,13 @@ public class SubscriptionHelperTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
         }
     }
 
     @Test
     public void setRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
 
             final BooleanSubscription bs1 = new BooleanSubscription();
@@ -121,7 +120,7 @@ public class SubscriptionHelperTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             assertTrue(bs1.isCancelled() ^ bs2.isCancelled());
         }
@@ -129,7 +128,7 @@ public class SubscriptionHelperTest {
 
     @Test
     public void replaceRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
 
             final BooleanSubscription bs1 = new BooleanSubscription();
@@ -149,7 +148,7 @@ public class SubscriptionHelperTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             assertFalse(bs1.isCancelled());
             assertFalse(bs2.isCancelled());
@@ -192,7 +191,7 @@ public class SubscriptionHelperTest {
 
     @Test
     public void deferredRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
             final AtomicLong r = new AtomicLong();
 
@@ -224,7 +223,7 @@ public class SubscriptionHelperTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             assertSame(a, s.get());
             assertEquals(1, q.get());

--- a/src/test/java/io/reactivex/internal/util/BackpressureHelperTest.java
+++ b/src/test/java/io/reactivex/internal/util/BackpressureHelperTest.java
@@ -24,7 +24,6 @@ import org.junit.*;
 
 import io.reactivex.TestHelper;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 public class BackpressureHelperTest {
     @Ignore("BackpressureHelper is an enum")
@@ -85,7 +84,7 @@ public class BackpressureHelperTest {
     public void requestProduceRace() {
         final AtomicLong requested = new AtomicLong(1);
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -101,7 +100,7 @@ public class BackpressureHelperTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
@@ -109,7 +108,7 @@ public class BackpressureHelperTest {
     public void requestCancelProduceRace() {
         final AtomicLong requested = new AtomicLong(1);
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -125,7 +124,7 @@ public class BackpressureHelperTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/util/ExceptionHelperTest.java
+++ b/src/test/java/io/reactivex/internal/util/ExceptionHelperTest.java
@@ -13,14 +13,14 @@
 
 package io.reactivex.internal.util;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.TestHelper;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.schedulers.Schedulers;
 
 public class ExceptionHelperTest {
     @Test
@@ -30,7 +30,7 @@ public class ExceptionHelperTest {
 
     @Test
     public void addRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
 
@@ -43,7 +43,7 @@ public class ExceptionHelperTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/util/HalfSerializerObserverTest.java
+++ b/src/test/java/io/reactivex/internal/util/HalfSerializerObserverTest.java
@@ -23,7 +23,6 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.observers.TestObserver;
-import io.reactivex.schedulers.Schedulers;
 
 public class HalfSerializerObserverTest {
 
@@ -203,7 +202,7 @@ public class HalfSerializerObserverTest {
 
     @Test
     public void onNextOnCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final AtomicInteger wip = new AtomicInteger();
             final AtomicThrowable error = new AtomicThrowable();
@@ -225,7 +224,7 @@ public class HalfSerializerObserverTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertComplete().assertNoErrors();
 
@@ -235,7 +234,7 @@ public class HalfSerializerObserverTest {
 
     @Test
     public void onErrorOnCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final AtomicInteger wip = new AtomicInteger();
             final AtomicThrowable error = new AtomicThrowable();
@@ -260,7 +259,7 @@ public class HalfSerializerObserverTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             if (ts.completions() != 0) {
                 ts.assertResult();

--- a/src/test/java/io/reactivex/internal/util/HalfSerializerSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/util/HalfSerializerSubscriberTest.java
@@ -23,7 +23,6 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class HalfSerializerSubscriberTest {
@@ -209,7 +208,7 @@ public class HalfSerializerSubscriberTest {
 
     @Test
     public void onNextOnCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final AtomicInteger wip = new AtomicInteger();
             final AtomicThrowable error = new AtomicThrowable();
@@ -231,7 +230,7 @@ public class HalfSerializerSubscriberTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertComplete().assertNoErrors();
 
@@ -241,7 +240,7 @@ public class HalfSerializerSubscriberTest {
 
     @Test
     public void onErrorOnCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final AtomicInteger wip = new AtomicInteger();
             final AtomicThrowable error = new AtomicThrowable();
@@ -266,7 +265,7 @@ public class HalfSerializerSubscriberTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             if (ts.completions() != 0) {
                 ts.assertResult();

--- a/src/test/java/io/reactivex/internal/util/QueueDrainHelperTest.java
+++ b/src/test/java/io/reactivex/internal/util/QueueDrainHelperTest.java
@@ -123,7 +123,7 @@ public class QueueDrainHelperTest {
 
     @Test
     public void completeRequestRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
             final ArrayDeque<Integer> queue = new ArrayDeque<Integer>();
             final AtomicLong state = new AtomicLong();

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -2089,7 +2089,7 @@ public class MaybeTest {
     @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayFusedRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
@@ -2114,7 +2114,7 @@ public class MaybeTest {
                     pp2.onNext(1);
                     pp2.onComplete();
                 }
-            }, Schedulers.single());
+            });
 
             ts
             .awaitDone(5, TimeUnit.SECONDS)

--- a/src/test/java/io/reactivex/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SerializedObserverTest.java
@@ -1018,7 +1018,7 @@ public class SerializedObserverTest {
 
     @Test
     public void onCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestObserver<Integer> ts = new TestObserver<Integer>();
 
             final SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts);
@@ -1034,7 +1034,7 @@ public class SerializedObserverTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
 
             ts.awaitDone(5, TimeUnit.SECONDS)
             .assertResult();
@@ -1044,7 +1044,7 @@ public class SerializedObserverTest {
 
     @Test
     public void onNextOnCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestObserver<Integer> ts = new TestObserver<Integer>();
 
             final SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts);
@@ -1067,7 +1067,7 @@ public class SerializedObserverTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.awaitDone(5, TimeUnit.SECONDS)
             .assertNoErrors()
@@ -1080,7 +1080,7 @@ public class SerializedObserverTest {
 
     @Test
     public void onNextOnErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestObserver<Integer> ts = new TestObserver<Integer>();
 
             final SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts);
@@ -1105,7 +1105,7 @@ public class SerializedObserverTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.awaitDone(5, TimeUnit.SECONDS)
             .assertError(ex)
@@ -1118,7 +1118,7 @@ public class SerializedObserverTest {
 
     @Test
     public void onNextOnErrorRaceDelayError() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestObserver<Integer> ts = new TestObserver<Integer>();
 
             final SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts, true);
@@ -1143,7 +1143,7 @@ public class SerializedObserverTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.awaitDone(5, TimeUnit.SECONDS)
             .assertError(ex)
@@ -1180,7 +1180,7 @@ public class SerializedObserverTest {
 
     @Test
     public void onCompleteOnErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
@@ -1208,7 +1208,7 @@ public class SerializedObserverTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 ts.awaitDone(5, TimeUnit.SECONDS);
 

--- a/src/test/java/io/reactivex/parallel/ParallelRunOnTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelRunOnTest.java
@@ -163,7 +163,7 @@ public class ParallelRunOnTest {
 
     @Test
     public void nextCancelRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final TestSubscriber<Integer> ts = pp.parallel(1)
@@ -192,7 +192,7 @@ public class ParallelRunOnTest {
     @SuppressWarnings("unchecked")
     @Test
     public void nextCancelRaceBackpressured() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final TestSubscriber<Integer> ts = TestSubscriber.create(0L);
@@ -221,7 +221,7 @@ public class ParallelRunOnTest {
 
     @Test
     public void nextCancelRaceConditional() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final TestSubscriber<Integer> ts = pp.parallel(1)
@@ -251,7 +251,7 @@ public class ParallelRunOnTest {
     @SuppressWarnings("unchecked")
     @Test
     public void nextCancelRaceBackpressuredConditional() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final TestSubscriber<Integer> ts = TestSubscriber.create(0L);

--- a/src/test/java/io/reactivex/parallel/ParallelSortedJoinTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelSortedJoinTest.java
@@ -152,7 +152,7 @@ public class ParallelSortedJoinTest {
 
     @Test
     public void sortCancelRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ReplayProcessor<Integer> pp = ReplayProcessor.create();
             pp.onNext(1);
             pp.onNext(2);
@@ -181,7 +181,7 @@ public class ParallelSortedJoinTest {
 
     @Test
     public void sortCancelRace2() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ReplayProcessor<Integer> pp = ReplayProcessor.create();
             pp.onNext(1);
             pp.onNext(2);

--- a/src/test/java/io/reactivex/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/AsyncProcessorTest.java
@@ -13,27 +13,23 @@
 
 package io.reactivex.processors;
 
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.*;
+import org.mockito.*;
+import org.reactivestreams.Subscriber;
+
 import io.reactivex.TestHelper;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
-import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.SubscriberFusion;
-import io.reactivex.subscribers.TestSubscriber;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
-import org.reactivestreams.Subscriber;
-
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import io.reactivex.subscribers.*;
 
 public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
 
@@ -467,7 +463,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     public void cancelRace() {
         AsyncProcessor<Object> p = AsyncProcessor.create();
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Object> ts1 = p.test();
             final TestSubscriber<Object> ts2 = p.test();
 
@@ -485,14 +481,14 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void onErrorCancelRace() {
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AsyncProcessor<Object> p = AsyncProcessor.create();
 
             final TestSubscriber<Object> ts1 = p.test();
@@ -513,7 +509,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             if (ts1.errorCount() != 0) {
                 ts1.assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
@@ -636,7 +636,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void addRemoveRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorProcessor<Object> p = BehaviorProcessor.create();
 
             final TestSubscriber<Object> ts = p.test();
@@ -655,14 +655,14 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void subscribeOnNextRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorProcessor<Object> p = BehaviorProcessor.createDefault((Object)1);
 
             final TestSubscriber[] ts = { null };
@@ -681,7 +681,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             if (ts[0].valueCount() == 1) {
                 ts[0].assertValue(2).assertNoErrors().assertNotComplete();
@@ -759,7 +759,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void completeSubscribeRace() throws Exception {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorProcessor<Object> p = BehaviorProcessor.create();
 
             final TestSubscriber<Object> ts = new TestSubscriber<Object>();
@@ -786,7 +786,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void errorSubscribeRace() throws Exception {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorProcessor<Object> p = BehaviorProcessor.create();
 
             final TestSubscriber<Object> ts = new TestSubscriber<Object>();
@@ -815,7 +815,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test(timeout = 10000)
     public void subscriberCancelOfferRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorProcessor<Integer> pp = BehaviorProcessor.create();
 
             final TestSubscriber<Integer> ts = pp.test(1);
@@ -824,7 +824,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
                 @Override
                 public void run() {
                     for (int i = 0; i < 2; i++) {
-                        while (!pp.offer(i)) ;
+                        while (!pp.offer(i)) { }
                     }
                 }
             };

--- a/src/test/java/io/reactivex/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/PublishProcessorTest.java
@@ -576,7 +576,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     @Test
     public void terminateRace() throws Exception {
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             TestSubscriber<Integer> ts = pp.test();
@@ -588,7 +588,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(task, task, Schedulers.io());
+            TestHelper.race(task, task);
 
             ts
             .awaitDone(5, TimeUnit.SECONDS)
@@ -599,7 +599,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     @Test
     public void addRemoveRance() throws Exception {
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final TestSubscriber<Integer> ts = pp.test();
@@ -617,7 +617,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.io());
+            TestHelper.race(r1, r2);
         }
     }
 
@@ -680,7 +680,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test(timeout = 10000)
     public void subscriberCancelOfferRace() {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             final TestSubscriber<Integer> ts = pp.test(1);
@@ -689,7 +689,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
                 @Override
                 public void run() {
                     for (int i = 0; i < 2; i++) {
-                        while (!pp.offer(i)) ;
+                        while (!pp.offer(i)) { }
                     }
                 }
             };

--- a/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
@@ -1060,7 +1060,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void subscribeCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
             final ReplayProcessor<Integer> rp = ReplayProcessor.create();
@@ -1079,7 +1079,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
@@ -1097,7 +1097,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void subscribeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ReplayProcessor<Integer> rp = ReplayProcessor.create();
 
             Runnable r1 = new Runnable() {
@@ -1107,7 +1107,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(r1, r1, Schedulers.single());
+            TestHelper.race(r1, r1);
         }
     }
 
@@ -1126,7 +1126,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void cancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final ReplayProcessor<Integer> rp = ReplayProcessor.create();
             final TestSubscriber<Integer> ts1 = rp.test();
@@ -1146,7 +1146,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             assertFalse(rp.hasSubscribers());
         }
@@ -1182,7 +1182,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void replayRequestRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final ReplayProcessor<Integer> rp = ReplayProcessor.createWithTimeAndSize(1, TimeUnit.DAYS, Schedulers.single(), 2);
             final TestSubscriber<Integer> ts = rp.test(0L);
@@ -1201,7 +1201,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
@@ -1315,11 +1315,9 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         source.test().assertResult();
     }
 
-    int raceLoop = 10000;
-
     @Test
     public void unboundedRequestCompleteRace() {
-        for (int i = 0; i < raceLoop; i++) {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             final ReplayProcessor<Integer> source = ReplayProcessor.create();
 
             final TestSubscriber<Integer> ts = source.test(0);
@@ -1346,7 +1344,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void sizeRequestCompleteRace() {
-        for (int i = 0; i < raceLoop; i++) {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             final ReplayProcessor<Integer> source = ReplayProcessor.createWithSize(10);
 
             final TestSubscriber<Integer> ts = source.test(0);
@@ -1373,7 +1371,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void timedRequestCompleteRace() {
-        for (int i = 0; i < raceLoop; i++) {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             final ReplayProcessor<Integer> source = ReplayProcessor.createWithTime(2, TimeUnit.HOURS, Schedulers.single());
 
             final TestSubscriber<Integer> ts = source.test(0);
@@ -1400,7 +1398,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void timeAndSizeRequestCompleteRace() {
-        for (int i = 0; i < raceLoop; i++) {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             final ReplayProcessor<Integer> source = ReplayProcessor.createWithTimeAndSize(2, TimeUnit.HOURS, Schedulers.single(), 100);
 
             final TestSubscriber<Integer> ts = source.test(0);

--- a/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
@@ -23,7 +23,6 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class SerializedProcessorTest {
@@ -432,7 +431,7 @@ public class SerializedProcessorTest {
 
     @Test
     public void onNextOnNextRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FlowableProcessor<Integer> s = PublishProcessor.<Integer>create().toSerialized();
 
             TestSubscriber<Integer> ts = s.test();
@@ -451,7 +450,7 @@ public class SerializedProcessorTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertSubscribed().assertNoErrors().assertNotComplete()
             .assertValueSet(Arrays.asList(1, 2));
@@ -460,7 +459,7 @@ public class SerializedProcessorTest {
 
     @Test
     public void onNextOnErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FlowableProcessor<Integer> s = PublishProcessor.<Integer>create().toSerialized();
 
             TestSubscriber<Integer> ts = s.test();
@@ -481,7 +480,7 @@ public class SerializedProcessorTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertError(ex).assertNotComplete();
 
@@ -493,7 +492,7 @@ public class SerializedProcessorTest {
 
     @Test
     public void onNextOnCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FlowableProcessor<Integer> s = PublishProcessor.<Integer>create().toSerialized();
 
             TestSubscriber<Integer> ts = s.test();
@@ -512,7 +511,7 @@ public class SerializedProcessorTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertComplete().assertNoErrors();
 
@@ -524,7 +523,7 @@ public class SerializedProcessorTest {
 
     @Test
     public void onNextOnSubscribeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FlowableProcessor<Integer> s = PublishProcessor.<Integer>create().toSerialized();
 
             TestSubscriber<Integer> ts = s.test();
@@ -545,7 +544,7 @@ public class SerializedProcessorTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertValue(1).assertNotComplete().assertNoErrors();
         }
@@ -553,7 +552,7 @@ public class SerializedProcessorTest {
 
     @Test
     public void onCompleteOnSubscribeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FlowableProcessor<Integer> s = PublishProcessor.<Integer>create().toSerialized();
 
             TestSubscriber<Integer> ts = s.test();
@@ -574,7 +573,7 @@ public class SerializedProcessorTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertResult();
         }
@@ -582,7 +581,7 @@ public class SerializedProcessorTest {
 
     @Test
     public void onCompleteOnCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FlowableProcessor<Integer> s = PublishProcessor.<Integer>create().toSerialized();
 
             TestSubscriber<Integer> ts = s.test();
@@ -601,7 +600,7 @@ public class SerializedProcessorTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertResult();
         }
@@ -609,7 +608,7 @@ public class SerializedProcessorTest {
 
     @Test
     public void onErrorOnErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FlowableProcessor<Integer> s = PublishProcessor.<Integer>create().toSerialized();
 
             TestSubscriber<Integer> ts = s.test();
@@ -632,7 +631,7 @@ public class SerializedProcessorTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 ts.assertFailure(TestException.class);
 
@@ -645,7 +644,7 @@ public class SerializedProcessorTest {
 
     @Test
     public void onSubscribeOnSubscribeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FlowableProcessor<Integer> s = PublishProcessor.<Integer>create().toSerialized();
 
             TestSubscriber<Integer> ts = s.test();
@@ -667,7 +666,7 @@ public class SerializedProcessorTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertEmpty();
         }

--- a/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
@@ -13,22 +13,20 @@
 
 package io.reactivex.processors;
 
-import io.reactivex.Observable;
-import io.reactivex.TestHelper;
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.SubscriberFusion;
-import io.reactivex.subscribers.TestSubscriber;
-import org.junit.Test;
-
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.junit.Assert.*;
+import io.reactivex.subscribers.*;
 
 public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
 
@@ -188,7 +186,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void completeCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final int[] calls = { 0 };
             final UnicastProcessor<Object> up = UnicastProcessor.create(100, new Runnable() {
                 @Override
@@ -213,7 +211,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             assertEquals(1, calls[0]);
         }
@@ -296,7 +294,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void fusedDrainCancel() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final UnicastProcessor<Object> p = UnicastProcessor.create();
 
             final TestSubscriber<Object> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
@@ -317,7 +315,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 }

--- a/src/test/java/io/reactivex/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerTest.java
@@ -182,7 +182,7 @@ public class SchedulerTest {
     public void periodicDirectTaskRace() {
         final TestScheduler scheduler = new TestScheduler();
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Disposable d = scheduler.schedulePeriodicallyDirect(Functions.EMPTY_RUNNABLE, 1, 1, TimeUnit.MILLISECONDS);
 
             Runnable r1 = new Runnable() {
@@ -199,7 +199,7 @@ public class SchedulerTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.io());
+            TestHelper.race(r1, r2);
         }
 
     }

--- a/src/test/java/io/reactivex/subjects/AsyncSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/AsyncSubjectTest.java
@@ -29,7 +29,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.fuseable.QueueSubscription;
 import io.reactivex.observers.*;
-import io.reactivex.schedulers.Schedulers;
 
 public class AsyncSubjectTest extends SubjectTest<Integer> {
 
@@ -464,7 +463,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
     public void cancelRace() {
         AsyncSubject<Object> p = AsyncSubject.create();
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestObserver<Object> ts1 = p.test();
             final TestObserver<Object> ts2 = p.test();
 
@@ -482,14 +481,14 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void onErrorCancelRace() {
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AsyncSubject<Object> p = AsyncSubject.create();
 
             final TestObserver<Object> ts1 = p.test();
@@ -510,7 +509,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             if (ts1.errorCount() != 0) {
                 ts1.assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
@@ -630,7 +630,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void addRemoveRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorSubject<Object> p = BehaviorSubject.create();
 
             final TestObserver<Object> ts = p.test();
@@ -649,14 +649,14 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void subscribeOnNextRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorSubject<Object> p = BehaviorSubject.createDefault((Object)1);
 
             final TestObserver[] ts = { null };
@@ -675,7 +675,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             if (ts[0].valueCount() == 1) {
                 ts[0].assertValue(2).assertNoErrors().assertNotComplete();
@@ -718,7 +718,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void completeSubscribeRace() throws Exception {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorSubject<Object> p = BehaviorSubject.create();
 
             final TestObserver<Object> ts = new TestObserver<Object>();
@@ -745,7 +745,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void errorSubscribeRace() throws Exception {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorSubject<Object> p = BehaviorSubject.create();
 
             final TestObserver<Object> ts = new TestObserver<Object>();

--- a/src/test/java/io/reactivex/subjects/CompletableSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/CompletableSubjectTest.java
@@ -24,7 +24,6 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 public class CompletableSubjectTest {
 
@@ -205,7 +204,7 @@ public class CompletableSubjectTest {
 
     @Test
     public void addRemoveRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final CompletableSubject cs = CompletableSubject.create();
 
             final TestObserver<Void> to = cs.test();
@@ -223,7 +222,7 @@ public class CompletableSubjectTest {
                     to.cancel();
                 }
             };
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 }

--- a/src/test/java/io/reactivex/subjects/MaybeSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/MaybeSubjectTest.java
@@ -24,7 +24,6 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 public class MaybeSubjectTest {
 
@@ -251,7 +250,7 @@ public class MaybeSubjectTest {
 
     @Test
     public void addRemoveRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final MaybeSubject<Integer> ms = MaybeSubject.create();
 
             final TestObserver<Integer> to = ms.test();
@@ -269,7 +268,7 @@ public class MaybeSubjectTest {
                     to.cancel();
                 }
             };
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 }

--- a/src/test/java/io/reactivex/subjects/PublishSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/PublishSubjectTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.subjects;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
@@ -28,7 +29,6 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.observers.*;
-import io.reactivex.schedulers.Schedulers;
 
 public class PublishSubjectTest extends SubjectTest<Integer> {
 
@@ -563,7 +563,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     @Test
     public void terminateRace() throws Exception {
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> pp = PublishSubject.create();
 
             TestObserver<Integer> ts = pp.test();
@@ -575,7 +575,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(task, task, Schedulers.io());
+            TestHelper.race(task, task);
 
             ts
             .awaitDone(5, TimeUnit.SECONDS)
@@ -586,7 +586,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     @Test
     public void addRemoveRance() throws Exception {
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> pp = PublishSubject.create();
 
             final TestObserver<Integer> ts = pp.test();
@@ -604,14 +604,14 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.io());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void addTerminateRance() throws Exception {
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> pp = PublishSubject.create();
 
             Runnable r1 = new Runnable() {
@@ -627,14 +627,14 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.io());
+            TestHelper.race(r1, r2);
         }
     }
 
     @Test
     public void addCompleteRance() throws Exception {
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> pp = PublishSubject.create();
 
             final TestObserver<Integer> ts = new TestObserver<Integer>();
@@ -652,7 +652,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.io());
+            TestHelper.race(r1, r2);
 
             ts.awaitDone(5, TimeUnit.SECONDS)
             .assertResult();

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
@@ -970,7 +970,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void subscribeCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestObserver<Integer> ts = new TestObserver<Integer>();
 
             final ReplaySubject<Integer> rp = ReplaySubject.create();
@@ -989,7 +989,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 
@@ -1007,7 +1007,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void subscribeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ReplaySubject<Integer> rp = ReplaySubject.create();
 
             Runnable r1 = new Runnable() {
@@ -1017,7 +1017,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r1, Schedulers.single());
+            TestHelper.race(r1, r1);
         }
     }
 
@@ -1036,7 +1036,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void cancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final ReplaySubject<Integer> rp = ReplaySubject.create();
             final TestObserver<Integer> ts1 = rp.test();
@@ -1056,7 +1056,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             assertFalse(rp.hasObservers());
         }

--- a/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
@@ -25,7 +25,6 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 public class SerializedSubjectTest {
 
@@ -433,7 +432,7 @@ public class SerializedSubjectTest {
 
     @Test
     public void onNextOnNextRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
             TestObserver<Integer> ts = s.test();
@@ -452,7 +451,7 @@ public class SerializedSubjectTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertSubscribed().assertNoErrors().assertNotComplete()
             .assertValueSet(Arrays.asList(1, 2));
@@ -461,7 +460,7 @@ public class SerializedSubjectTest {
 
     @Test
     public void onNextOnErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
             TestObserver<Integer> ts = s.test();
@@ -482,7 +481,7 @@ public class SerializedSubjectTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertError(ex).assertNotComplete();
 
@@ -494,7 +493,7 @@ public class SerializedSubjectTest {
 
     @Test
     public void onNextOnCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
             TestObserver<Integer> ts = s.test();
@@ -513,7 +512,7 @@ public class SerializedSubjectTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertComplete().assertNoErrors();
 
@@ -525,7 +524,7 @@ public class SerializedSubjectTest {
 
     @Test
     public void onNextOnSubscribeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
             TestObserver<Integer> ts = s.test();
@@ -546,7 +545,7 @@ public class SerializedSubjectTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertValue(1).assertNotComplete().assertNoErrors();
         }
@@ -554,7 +553,7 @@ public class SerializedSubjectTest {
 
     @Test
     public void onCompleteOnSubscribeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
             TestObserver<Integer> ts = s.test();
@@ -575,7 +574,7 @@ public class SerializedSubjectTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertResult();
         }
@@ -583,7 +582,7 @@ public class SerializedSubjectTest {
 
     @Test
     public void onCompleteOnCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
             TestObserver<Integer> ts = s.test();
@@ -602,7 +601,7 @@ public class SerializedSubjectTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertResult();
         }
@@ -610,7 +609,7 @@ public class SerializedSubjectTest {
 
     @Test
     public void onErrorOnErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
             TestObserver<Integer> ts = s.test();
@@ -633,7 +632,7 @@ public class SerializedSubjectTest {
                     }
                 };
 
-                TestHelper.race(r1, r2, Schedulers.single());
+                TestHelper.race(r1, r2);
 
                 ts.assertFailure(TestException.class);
 
@@ -646,7 +645,7 @@ public class SerializedSubjectTest {
 
     @Test
     public void onSubscribeOnSubscribeRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
             TestObserver<Integer> ts = s.test();
@@ -668,7 +667,7 @@ public class SerializedSubjectTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.assertEmpty();
         }

--- a/src/test/java/io/reactivex/subjects/SingleSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/SingleSubjectTest.java
@@ -24,7 +24,6 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 public class SingleSubjectTest {
 
@@ -225,7 +224,7 @@ public class SingleSubjectTest {
 
     @Test
     public void addRemoveRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final SingleSubject<Integer> ss = SingleSubject.create();
 
             final TestObserver<Integer> to = ss.test();
@@ -243,7 +242,7 @@ public class SingleSubjectTest {
                     to.cancel();
                 }
             };
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 }

--- a/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.subjects;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -26,8 +27,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
-import static org.mockito.Mockito.mock;
 
 public class UnicastSubjectTest extends SubjectTest<Integer> {
 
@@ -223,7 +222,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void completeCancelRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final int[] calls = { 0 };
             final UnicastSubject<Object> up = UnicastSubject.create(100, new Runnable() {
                 @Override
@@ -248,7 +247,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             assertEquals(1, calls[0]);
         }
@@ -331,7 +330,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void fusedDrainCancel() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final UnicastSubject<Object> p = UnicastSubject.create();
 
             final TestObserver<Object> ts = ObserverFusion.newTest(QueueSubscription.ANY);
@@ -352,7 +351,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
         }
     }
 

--- a/src/test/java/io/reactivex/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SerializedSubscriberTest.java
@@ -1015,7 +1015,7 @@ public class SerializedSubscriberTest {
 
     @Test
     public void onCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
             final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
@@ -1031,7 +1031,7 @@ public class SerializedSubscriberTest {
                 }
             };
 
-            TestHelper.race(r, r, Schedulers.single());
+            TestHelper.race(r, r);
 
             ts.awaitDone(5, TimeUnit.SECONDS)
             .assertResult();
@@ -1041,7 +1041,7 @@ public class SerializedSubscriberTest {
 
     @Test
     public void onNextOnCompleteRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
             final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
@@ -1064,7 +1064,7 @@ public class SerializedSubscriberTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.awaitDone(5, TimeUnit.SECONDS)
             .assertNoErrors()
@@ -1077,7 +1077,7 @@ public class SerializedSubscriberTest {
 
     @Test
     public void onNextOnErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
             final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
@@ -1102,7 +1102,7 @@ public class SerializedSubscriberTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.awaitDone(5, TimeUnit.SECONDS)
             .assertError(ex)
@@ -1115,7 +1115,7 @@ public class SerializedSubscriberTest {
 
     @Test
     public void onNextOnErrorRaceDelayError() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
             final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts, true);
@@ -1140,7 +1140,7 @@ public class SerializedSubscriberTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.awaitDone(5, TimeUnit.SECONDS)
             .assertError(ex)
@@ -1177,7 +1177,7 @@ public class SerializedSubscriberTest {
 
     @Test
     public void onCompleteOnErrorRace() {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
             final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
@@ -1202,7 +1202,7 @@ public class SerializedSubscriberTest {
                 }
             };
 
-            TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2);
 
             ts.awaitDone(5, TimeUnit.SECONDS);
 


### PR DESCRIPTION
This PR replaces the individual race-test loop counts with global constants and removes the unnecessary custom `Scheduler` value from the invocations of `TestHelper.race()`.

The default loop count is now 2500 and should elimitate the +/- 0.1% coverage fluctuations.