### PR TITLE
2.x: Flowable.groupBy add overload with evicting map factory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ apply plugin: "me.champeau.gradle.jmh"
 apply plugin: "com.github.hierynomus.license"
 apply plugin: "com.jfrog.bintray"
 apply plugin: "com.jfrog.artifactory"
+apply plugin: "eclipse"
 
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
@@ -55,7 +56,7 @@ def reactiveStreamsVersion = "1.0.2"
 def mockitoVersion = "2.1.0"
 def jmhLibVersion = "1.19"
 def testNgVersion = "6.11"
-
+def guavaVersion = "24.0-jre"
 // --------------------------------------
 
 repositories {
@@ -73,6 +74,7 @@ dependencies {
 
     testImplementation "org.reactivestreams:reactive-streams-tck:$reactiveStreamsVersion"
     testImplementation "org.testng:testng:$testNgVersion"
+    testImplementation "com.google.guava:guava:$guavaVersion"
 }
 
 javadoc {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
@@ -14,7 +14,9 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
@@ -23,11 +25,13 @@ import io.reactivex.*;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.flowables.GroupedFlowable;
+import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.internal.util.EmptyComponent;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream<T, GroupedFlowable<K, V>> {
@@ -35,18 +39,42 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
     final Function<? super T, ? extends V> valueSelector;
     final int bufferSize;
     final boolean delayError;
+    final Function<? super Consumer<Object>, ? extends Map<K, Object>> mapFactory;
 
-    public FlowableGroupBy(Flowable<T> source, Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError) {
+    public FlowableGroupBy(Flowable<T> source, Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector, 
+            int bufferSize, boolean delayError, Function<? super Consumer<Object>, ? extends Map<K, Object>> mapFactory) {
         super(source);
         this.keySelector = keySelector;
         this.valueSelector = valueSelector;
         this.bufferSize = bufferSize;
         this.delayError = delayError;
+        this.mapFactory = mapFactory;
     }
 
     @Override
     protected void subscribeActual(Subscriber<? super GroupedFlowable<K, V>> s) {
-        source.subscribe(new GroupBySubscriber<T, K, V>(s, keySelector, valueSelector, bufferSize, delayError));
+
+        final Map<Object, GroupedUnicast<K, V>> groups;
+        final Queue<GroupedUnicast<K, V>> evictedGroups;
+
+        try {
+            if (mapFactory == null) {
+                evictedGroups = null;
+                groups = new ConcurrentHashMap<Object, GroupedUnicast<K, V>>();
+            } else {
+                evictedGroups = new ConcurrentLinkedQueue<GroupedUnicast<K, V>>();
+                Consumer<Object> evictionAction = (Consumer<Object>)(Consumer<?>) new EvictionAction<K, V>(evictedGroups);
+                groups = (Map<Object, GroupedUnicast<K,V>>)(Map<Object, ?>) mapFactory.apply(evictionAction);
+            }
+        } catch (Exception e) {
+            Exceptions.throwIfFatal(e);
+            s.onSubscribe(EmptyComponent.INSTANCE);
+            s.onError(e);
+            return;
+        }
+        GroupBySubscriber<T, K, V> subscriber =
+                new GroupBySubscriber<T, K, V>(s, keySelector, valueSelector, bufferSize, delayError, groups, evictedGroups);
+        source.subscribe(subscriber);
     }
 
     public static final class GroupBySubscriber<T, K, V>
@@ -62,6 +90,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         final boolean delayError;
         final Map<Object, GroupedUnicast<K, V>> groups;
         final SpscLinkedArrayQueue<GroupedFlowable<K, V>> queue;
+        final Queue<GroupedUnicast<K, V>> evictedGroups;
 
         static final Object NULL_KEY = new Object();
 
@@ -78,13 +107,16 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
 
         boolean outputFused;
 
-        public GroupBySubscriber(Subscriber<? super GroupedFlowable<K, V>> actual, Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError) {
+        public GroupBySubscriber(Subscriber<? super GroupedFlowable<K, V>> actual, Function<? super T, ? extends K> keySelector,
+                Function<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError,
+                Map<Object, GroupedUnicast<K, V>> groups, Queue<GroupedUnicast<K, V>> evictedGroups) {
             this.actual = actual;
             this.keySelector = keySelector;
             this.valueSelector = valueSelector;
             this.bufferSize = bufferSize;
             this.delayError = delayError;
-            this.groups = new ConcurrentHashMap<Object, GroupedUnicast<K, V>>();
+            this.groups = groups;
+            this.evictedGroups = evictedGroups;
             this.queue = new SpscLinkedArrayQueue<GroupedFlowable<K, V>>(bufferSize);
         }
 
@@ -144,6 +176,13 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             }
 
             group.onNext(v);
+            
+            if (evictedGroups != null) {
+                GroupedUnicast<K, V> evictedGroup;
+                while ((evictedGroup = evictedGroups.poll()) != null) {
+                    evictedGroup.onComplete();
+                }
+            }
 
             if (newGroup) {
                 q.offer(group);
@@ -161,7 +200,9 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
                 g.onError(t);
             }
             groups.clear();
-
+            if (evictedGroups != null) {
+                evictedGroups.clear();
+            }
             error = t;
             done = true;
             drain();
@@ -174,6 +215,9 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
                     g.onComplete();
                 }
                 groups.clear();
+                if (evictedGroups != null) {
+                    evictedGroups.clear();
+                }
                 done = true;
                 drain();
             }
@@ -369,6 +413,20 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         @Override
         public boolean isEmpty() {
             return queue.isEmpty();
+        }
+    }
+
+    static final class EvictionAction<K, V> implements Consumer<GroupedUnicast<K,V>> {
+
+        final Queue<GroupedUnicast<K, V>> evictedGroups;
+
+        EvictionAction(Queue<GroupedUnicast<K, V>> evictedGroups) {
+            this.evictedGroups = evictedGroups;
+        }
+
+        @Override
+        public void accept(GroupedUnicast<K,V> value) {
+            evictedGroups.offer(value);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -17,13 +17,19 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.subjects.PublishSubject;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.*;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
@@ -1841,5 +1847,241 @@ public class FlowableGroupByTest {
         })
         .test()
         .assertResult(1);
+    }
+    
+    @Test
+    public void mapFactoryThrows() {
+        final IOException ex = new IOException("boo");
+        Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory =  //
+                new Function<Consumer<Object>, Map<Integer, Object>>() {
+
+                    @Override
+                    public Map<Integer, Object> apply(final Consumer<Object> notify) throws Exception {
+                        throw ex;
+                    }
+                };
+        Flowable.just(1) 
+          .groupBy(Functions.<Integer>identity(), Functions.identity(), true, 16, evictingMapFactory) 
+          .test() 
+          .assertNoValues()
+          .assertError(ex);
+    }
+    
+    @Test
+    public void mapFactoryExpiryCompletesGroupedFlowable() {
+        final List<Integer> completed = new CopyOnWriteArrayList<Integer>();
+        Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory = createEvictingMapFactorySynchronousOnly(1);
+        PublishSubject<Integer> subject = PublishSubject.create();
+        TestSubscriber<Integer> ts = subject.toFlowable(BackpressureStrategy.BUFFER)
+                .groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), true, 16, evictingMapFactory)
+                .flatMap(addCompletedKey(completed))
+                .test();
+        subject.onNext(1);
+        subject.onNext(2);
+        subject.onNext(3);
+        ts.assertValues(1, 2, 3)
+          .assertNotTerminated();
+        assertEquals(Arrays.asList(1, 2), completed);
+        //ensure coverage of the code that clears the evicted queue
+        subject.onComplete();
+        ts.assertComplete();
+        ts.assertValueCount(3);
+    }
+    
+    private static final Function<Integer, Integer> mod5 = new Function<Integer, Integer>() {
+
+        @Override
+        public Integer apply(Integer n) throws Exception {
+            return n % 5;
+        }
+    };
+    
+    @Test
+    public void mapFactoryWithExpiringGuavaCacheDemonstrationCodeForUseInJavadoc() {
+        //javadoc will be a version of this using lambdas and without assertions
+        final List<Integer> completed = new CopyOnWriteArrayList<Integer>();
+        //size should be less than 5 to notice the effect
+        Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory = createEvictingMapFactoryGuava(3);
+        int numValues = 1000;
+        TestSubscriber<Integer> ts =
+            Flowable.range(1, numValues)
+                .groupBy(mod5, Functions.<Integer>identity(), true, 16, evictingMapFactory)
+                .flatMap(addCompletedKey(completed))
+                .test()
+                .assertComplete();
+        ts.assertValueCount(numValues);
+        //the exact eviction behaviour of the guava cache is not specified so we make some approximate tests
+        assertTrue(completed.size() > numValues *0.9);
+    }
+    
+    @Test
+    public void mapFactoryEvictionQueueClearedOnErrorCoverageOnly() {
+        Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory = createEvictingMapFactorySynchronousOnly(1);
+        PublishSubject<Integer> subject = PublishSubject.create();
+        TestSubscriber<Integer> ts = subject
+                .toFlowable(BackpressureStrategy.BUFFER)
+                .groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), true, 16, evictingMapFactory)
+                .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
+                        return g;
+                    }
+                })
+                .test();
+        RuntimeException ex = new RuntimeException();
+        //ensure coverage of the code that clears the evicted queue
+        subject.onError(ex);
+        ts.assertNoValues()
+          .assertError(ex);
+    }
+
+    private static Function<GroupedFlowable<Integer, Integer>, Publisher<? extends Integer>> addCompletedKey(
+            final List<Integer> completed) {
+        return new Function<GroupedFlowable<Integer, Integer>, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(final GroupedFlowable<Integer, Integer> g) throws Exception {
+                return g.doOnComplete(new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        completed.add(g.getKey());
+                    }
+                });
+            }
+        };
+    }
+
+    //not thread safe
+    private static final class SingleThreadEvictingHashMap<K,V> implements Map<K,V> {
+
+        private final List<K> list = new ArrayList<K>();
+        private final Map<K,V> map = new HashMap<K,V>();
+        private final int maxSize;
+        private final Consumer<V> evictedListener;
+
+        SingleThreadEvictingHashMap(int maxSize, Consumer<V> evictedListener) {
+            this.maxSize = maxSize;
+            this.evictedListener = evictedListener;
+        }
+
+        @Override
+        public int size() {
+            return map.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return map.isEmpty();
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return map.containsKey(key);
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+            return map.containsValue(value);
+        }
+
+        @Override
+        public V get(Object key) {
+            return map.get(key);
+        }
+
+        @Override
+        public V put(K key, V value) {
+            list.remove(key);
+            V v;
+            if (maxSize > 0 && list.size() == maxSize) {
+                //remove first
+                K k = list.get(0);
+                list.remove(0);
+                v = map.get(k);
+            } else {
+                v = null;
+            }
+            list.add(key);
+            V result = map.put(key, value);
+            if (v != null) {
+                try {
+                    evictedListener.accept(v);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public V remove(Object key) {
+            return map.remove(key);
+        }
+
+        @Override
+        public void putAll(Map<? extends K, ? extends V> m) {
+            map.putAll(m);
+        }
+
+        @Override
+        public void clear() {
+            map.clear();
+        }
+
+        @Override
+        public Set<K> keySet() {
+            return map.keySet();
+        }
+
+        @Override
+        public Collection<V> values() {
+            return map.values();
+        }
+
+        @Override
+        public Set<Entry<K, V>> entrySet() {
+            return map.entrySet();
+        }
+    }
+
+    private static Function<Consumer<Object>, Map<Integer, Object>> createEvictingMapFactoryGuava(final int maxSize) {
+        Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory =  //
+                new Function<Consumer<Object>, Map<Integer, Object>>(){
+
+            @Override
+            public Map<Integer, Object> apply(final Consumer<Object> notify) throws Exception {
+                return CacheBuilder.newBuilder() //
+                        .maximumSize(maxSize) //
+                        .removalListener(new RemovalListener<Integer, Object>() {
+                            @Override
+                            public void onRemoval(RemovalNotification<Integer,Object> notification) {
+                                try {
+                                    notify.accept(notification.getValue());
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }})
+                        .<Integer, Object> build()
+                        .asMap();
+            }};
+        return evictingMapFactory;
+    }
+
+    private static Function<Consumer<Object>, Map<Integer, Object>> createEvictingMapFactorySynchronousOnly(final int maxSize) {
+        Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory =  //
+                new Function<Consumer<Object>, Map<Integer, Object>>(){
+
+                    @Override
+                    public Map<Integer, Object> apply(final Consumer<Object> notify) throws Exception {
+                        return new SingleThreadEvictingHashMap<Integer,Object>(maxSize, new Consumer<Object>() {
+                                    @Override
+                                    public void accept(Object object) {
+                                        try {
+                                            notify.accept(object);
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }});
+                    }};
+        return evictingMapFactory;
     }
 }


### PR DESCRIPTION
As per discussion in #5763, this PR adds an overload for `Flowable.groupBy` that specifies an `evictingMapFactory`. 

An example of usage taken from the new javadoc:

```java
Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory = 
   notify ->
       CacheBuilder
         .newBuilder() 
         .maximumSize(3)
         .removalListener(entry -> { 
              try {
                  // emit the value not the key!
                  notify.accept(entry.getValue());
              } catch (Exception e) {
                  throw new RuntimeException(e);
              }
            })
         .<Integer, Object> build()
         .asMap();
         
 // Emit 1000 items but ensure that the
 // internal map never has more than 3 items in it           
 Flowable
   .range(1, 1000)
   // note that number of keys is 10
   .groupBy(x -> x % 10, x-> x, true, 16, evictingMapFactory)
   .flatMap(g -> g)
   .forEach(System.out::println);
```

Note that I based this operator on the 1.x version which I think may have a bug that goes as far as the signature of that method. The eviction consumer should not be given a key but rather the value from the map. I'll pursue the 1.x issue after dealing with this.
