### PR TITLE
2.x: Fix Javadoc warnings, links to the JDK types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,8 +91,10 @@ javadoc {
     options.addStringOption("doctitle").value = ""
     options.addStringOption("header").value = ""
 
-    options.links("http://docs.oracle.com/javase/7/docs/api/")
-    options.links("http://www.reactive-streams.org/reactive-streams-${reactiveStreamsVersion}-javadoc/")
+    options.links(
+        "https://docs.oracle.com/javase/7/docs/api/",
+        "http://www.reactive-streams.org/reactive-streams-${reactiveStreamsVersion}-javadoc/"
+    )
 
     if (JavaVersion.current().isJava7()) {
         // "./gradle/stylesheet.css" only supports Java 7

--- a/src/main/java/io/reactivex/CompletableObserver.java
+++ b/src/main/java/io/reactivex/CompletableObserver.java
@@ -28,7 +28,6 @@ import io.reactivex.disposables.Disposable;
  * Calling the {@code CompletableObserver}'s method must happen in a serialized fashion, that is, they must not
  * be invoked concurrently by multiple threads in an overlapping fashion and the invocation pattern must
  * adhere to the following protocol:
- * <p>
  * <pre><code>    onSubscribe (onError | onComplete)?</code></pre>
  * <p>
  * Subscribing a {@code CompletableObserver} to multiple {@code CompletableSource}s is not recommended. If such reuse

--- a/src/main/java/io/reactivex/MaybeObserver.java
+++ b/src/main/java/io/reactivex/MaybeObserver.java
@@ -28,7 +28,6 @@ import io.reactivex.disposables.Disposable;
  * Calling the {@code MaybeObserver}'s method must happen in a serialized fashion, that is, they must not
  * be invoked concurrently by multiple threads in an overlapping fashion and the invocation pattern must
  * adhere to the following protocol:
- * <p>
  * <pre><code>    onSubscribe (onSuccess | onError | onComplete)?</code></pre>
  * <p>
  * Note that unlike with the {@code Observable} protocol, {@link #onComplete()} is not called after the success item has been

--- a/src/main/java/io/reactivex/Observer.java
+++ b/src/main/java/io/reactivex/Observer.java
@@ -30,7 +30,6 @@ import io.reactivex.disposables.Disposable;
  * Calling the {@code Observer}'s method must happen in a serialized fashion, that is, they must not
  * be invoked concurrently by multiple threads in an overlapping fashion and the invocation pattern must
  * adhere to the following protocol:
- * <p>
  * <pre><code>    onSubscribe onNext* (onError | onComplete)?</code></pre>
  * <p>
  * Subscribing an {@code Observer} to multiple {@code ObservableSource}s is not recommended. If such reuse

--- a/src/main/java/io/reactivex/SingleObserver.java
+++ b/src/main/java/io/reactivex/SingleObserver.java
@@ -28,7 +28,6 @@ import io.reactivex.disposables.Disposable;
  * Calling the {@code SingleObserver}'s method must happen in a serialized fashion, that is, they must not
  * be invoked concurrently by multiple threads in an overlapping fashion and the invocation pattern must
  * adhere to the following protocol:
- * <p>
  * <pre><code>    onSubscribe (onSuccess | onError)?</code></pre>
  * <p>
  * Subscribing a {@code SingleObserver} to multiple {@code SingleSource}s is not recommended. If such reuse


### PR DESCRIPTION
The definition of multiple external links was wrong in `build.gradle` where the `options.links()` is actually defined as `String...` and multiple calls are not additional. This made the generated JavaDoc not have links to the JDK types. The fix now properly uses the varargs of the method. In addition, somehow the plain `http://` still wouldn't generate the proper links probably because they are redirected to `https://` for which the javadoc tool is not prepared.

In addition, 4 dangling `<p>` tags were showing up as warnings and have been removed.