### PR TITLE
2.x: enhance test for groupBy with evicting map factory

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -1996,7 +1996,7 @@ public class FlowableGroupByTest {
                 //remove first
                 K k = list.get(0);
                 list.remove(0);
-                v = map.get(k);
+                v = map.remove(k);
             } else {
                 v = null;
             }
@@ -2014,16 +2014,20 @@ public class FlowableGroupByTest {
 
         @Override
         public V remove(Object key) {
+            list.remove(key);
             return map.remove(key);
         }
 
         @Override
         public void putAll(Map<? extends K, ? extends V> m) {
-            map.putAll(m);
+           for (Entry<? extends K, ? extends V> entry: m.entrySet()) {
+               put(entry.getKey(), entry.getValue()); 
+           }
         }
 
         @Override
         public void clear() {
+            list.clear();
             map.clear();
         }
 


### PR DESCRIPTION
Enhance `FlowableGroupByTest.SingleThreadEvictingHashMap` so that it actually evicts and be a bit defensive by supporting `putAll` and `clear` properly. No change to `src/main/java`.