### PR TITLE
2.x: Add Flowable.switchMapCompletable{DelayError} operator

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletable.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Subscription;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Maps the upstream values into {@link CompletableSource}s, subscribes to the newer one while
+ * disposing the subscription to the previous {@code CompletableSource}, thus keeping at most one
+ * active {@code CompletableSource} running.
+ *
+ * @param <T> the upstream value type
+ * @since 2.1.11 - experimental
+ */
+@Experimental
+public final class FlowableSwitchMapCompletable<T> extends Completable {
+
+    final Flowable<T> source;
+
+    final Function<? super T, ? extends CompletableSource> mapper;
+
+    final boolean delayErrors;
+
+    public FlowableSwitchMapCompletable(Flowable<T> source,
+            Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors) {
+        this.source = source;
+        this.mapper = mapper;
+        this.delayErrors = delayErrors;
+    }
+
+    @Override
+    protected void subscribeActual(CompletableObserver s) {
+        source.subscribe(new SwitchMapCompletableObserver<T>(s, mapper, delayErrors));
+    }
+
+    static final class SwitchMapCompletableObserver<T> implements FlowableSubscriber<T>, Disposable {
+
+        final CompletableObserver downstream;
+
+        final Function<? super T, ? extends CompletableSource> mapper;
+
+        final boolean delayErrors;
+
+        final AtomicThrowable errors;
+
+        final AtomicReference<SwitchMapInnerObserver> inner;
+
+        static final SwitchMapInnerObserver INNER_DISPOSED = new SwitchMapInnerObserver(null);
+
+        volatile boolean done;
+
+        Subscription upstream;
+
+        SwitchMapCompletableObserver(CompletableObserver downstream,
+                Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+            this.delayErrors = delayErrors;
+            this.errors = new AtomicThrowable();
+            this.inner = new AtomicReference<SwitchMapInnerObserver>();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(upstream, s)) {
+                this.upstream = s;
+                downstream.onSubscribe(this);
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            CompletableSource c;
+
+            try {
+                c = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null CompletableSource");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                upstream.cancel();
+                onError(ex);
+                return;
+            }
+
+            SwitchMapInnerObserver o = new SwitchMapInnerObserver(this);
+
+            for (;;) {
+                SwitchMapInnerObserver current = inner.get();
+                if (current == INNER_DISPOSED) {
+                    break;
+                }
+                if (inner.compareAndSet(current, o)) {
+                    if (current != null) {
+                        current.dispose();
+                    }
+                    c.subscribe(o);
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (errors.addThrowable(t)) {
+                if (delayErrors) {
+                    onComplete();
+                } else {
+                    disposeInner();
+                    Throwable ex = errors.terminate();
+                    if (ex != ExceptionHelper.TERMINATED) {
+                        downstream.onError(ex);
+                    }
+                }
+            } else {
+                RxJavaPlugins.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            if (inner.get() == null) {
+                Throwable ex = errors.terminate();
+                if (ex == null) {
+                    downstream.onComplete();
+                } else {
+                    downstream.onError(ex);
+                }
+            }
+        }
+
+        void disposeInner() {
+            SwitchMapInnerObserver o = inner.getAndSet(INNER_DISPOSED);
+            if (o != null && o != INNER_DISPOSED) {
+                o.dispose();
+            }
+        }
+
+        @Override
+        public void dispose() {
+            upstream.cancel();
+            disposeInner();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return inner.get() == INNER_DISPOSED;
+        }
+
+        void innerError(SwitchMapInnerObserver sender, Throwable error) {
+            if (inner.compareAndSet(sender, null)) {
+                if (errors.addThrowable(error)) {
+                    if (delayErrors) {
+                        if (done) {
+                            Throwable ex = errors.terminate();
+                            downstream.onError(ex);
+                        }
+                    } else {
+                        dispose();
+                        Throwable ex = errors.terminate();
+                        if (ex != ExceptionHelper.TERMINATED) {
+                            downstream.onError(ex);
+                        }
+                    }
+                    return;
+                }
+            }
+            RxJavaPlugins.onError(error);
+        }
+
+        void innerComplete(SwitchMapInnerObserver sender) {
+            if (inner.compareAndSet(sender, null)) {
+                if (done) {
+                    Throwable ex = errors.terminate();
+                    if (ex == null) {
+                        downstream.onComplete();
+                    } else {
+                        downstream.onError(ex);
+                    }
+                }
+            }
+        }
+
+        static final class SwitchMapInnerObserver extends AtomicReference<Disposable>
+        implements CompletableObserver {
+
+            private static final long serialVersionUID = -8003404460084760287L;
+
+            final SwitchMapCompletableObserver<?> parent;
+
+            SwitchMapInnerObserver(SwitchMapCompletableObserver<?> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(this, d);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                parent.innerError(this, e);
+            }
+
+            @Override
+            public void onComplete() {
+                parent.innerComplete(this);
+            }
+
+            void dispose() {
+                DisposableHelper.dispose(this);
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
@@ -1,0 +1,389 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subjects.CompletableSubject;
+
+public class FlowableSwitchMapCompletableTest {
+
+    @Test
+    public void normal() {
+        Flowable.range(1, 10)
+        .switchMapCompletable(new Function<Integer, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Integer v) throws Exception {
+                return Completable.complete();
+            }
+        })
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void mainError() {
+        Flowable.<Integer>error(new TestException())
+        .switchMapCompletable(new Function<Integer, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Integer v) throws Exception {
+                return Completable.complete();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void innerError() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+        CompletableSubject cs = CompletableSubject.create();
+
+        TestObserver<Void> to = pp.switchMapCompletable(Functions.justFunction(cs))
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+        assertFalse(cs.hasObservers());
+
+        pp.onNext(1);
+
+        assertTrue(cs.hasObservers());
+
+        to.assertEmpty();
+
+        cs.onError(new TestException());
+
+        to.assertFailure(TestException.class);
+
+        assertFalse(pp.hasSubscribers());
+        assertFalse(cs.hasObservers());
+    }
+
+    @Test
+    public void switchOver() {
+        final CompletableSubject[] css = {
+                CompletableSubject.create(),
+                CompletableSubject.create()
+        };
+
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestObserver<Void> to = pp.switchMapCompletable(new Function<Integer, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Integer v) throws Exception {
+                return css[v];
+            }
+        })
+        .test();
+
+        to.assertEmpty();
+
+        pp.onNext(0);
+
+        assertTrue(css[0].hasObservers());
+
+        pp.onNext(1);
+
+        assertFalse(css[0].hasObservers());
+        assertTrue(css[1].hasObservers());
+
+        pp.onComplete();
+
+        to.assertEmpty();
+
+        assertTrue(css[1].hasObservers());
+
+        css[1].onComplete();
+
+        to.assertResult();
+    }
+
+    @Test
+    public void dispose() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+        CompletableSubject cs = CompletableSubject.create();
+
+        TestObserver<Void> to = pp.switchMapCompletable(Functions.justFunction(cs))
+        .test();
+
+        pp.onNext(1);
+
+        assertTrue(pp.hasSubscribers());
+        assertTrue(cs.hasObservers());
+
+        to.dispose();
+
+        assertFalse(pp.hasSubscribers());
+        assertFalse(cs.hasObservers());
+    }
+
+    @Test
+    public void checkDisposed() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+        CompletableSubject cs = CompletableSubject.create();
+
+        TestHelper.checkDisposed(pp.switchMapCompletable(Functions.justFunction(cs)));
+    }
+
+    @Test
+    public void checkBadSource() {
+        TestHelper.checkDoubleOnSubscribeFlowableToCompletable(new Function<Flowable<Object>, Completable>() {
+            @Override
+            public Completable apply(Flowable<Object> f) throws Exception {
+                return f.switchMapCompletable(Functions.justFunction(Completable.never()));
+            }
+        });
+    }
+
+    @Test
+    public void mapperCrash() {
+        Flowable.range(1, 5).switchMapCompletable(new Function<Integer, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Integer f) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapperCancels() {
+        final TestObserver<Void> to = new TestObserver<Void>();
+
+        Flowable.range(1, 5).switchMapCompletable(new Function<Integer, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Integer f) throws Exception {
+                to.cancel();
+                return Completable.complete();
+            }
+        })
+        .subscribe(to);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void onNextInnerCompleteRace() {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final CompletableSubject cs = CompletableSubject.create();
+
+            TestObserver<Void> to = pp.switchMapCompletable(Functions.justFunction(cs)).test();
+
+            pp.onNext(1);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    pp.onNext(2);
+                }
+            };
+
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    cs.onComplete();
+                }
+            };
+
+            TestHelper.race(r1, r2);
+
+            to.assertEmpty();
+        }
+    }
+
+    @Test
+    public void onNextInnerErrorRace() {
+        final TestException ex = new TestException();
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final PublishProcessor<Integer> pp = PublishProcessor.create();
+                final CompletableSubject cs = CompletableSubject.create();
+
+                TestObserver<Void> to = pp.switchMapCompletable(Functions.justFunction(cs)).test();
+
+                pp.onNext(1);
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        pp.onNext(2);
+                    }
+                };
+
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        cs.onError(ex);
+                    }
+                };
+
+                TestHelper.race(r1, r2);
+
+                to.assertError(new Predicate<Throwable>() {
+                    @Override
+                    public boolean test(Throwable e) throws Exception {
+                        return e instanceof TestException || e instanceof CompositeException;
+                    }
+                });
+
+                if (!errors.isEmpty()) {
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void onErrorInnerErrorRace() {
+        final TestException ex0 = new TestException();
+        final TestException ex = new TestException();
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final PublishProcessor<Integer> pp = PublishProcessor.create();
+                final CompletableSubject cs = CompletableSubject.create();
+
+                TestObserver<Void> to = pp.switchMapCompletable(Functions.justFunction(cs)).test();
+
+                pp.onNext(1);
+
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        pp.onError(ex0);
+                    }
+                };
+
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        cs.onError(ex);
+                    }
+                };
+
+                TestHelper.race(r1, r2);
+
+                to.assertError(new Predicate<Throwable>() {
+                    @Override
+                    public boolean test(Throwable e) throws Exception {
+                        return e instanceof TestException || e instanceof CompositeException;
+                    }
+                });
+
+                if (!errors.isEmpty()) {
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
+                }
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void innerErrorThenMainError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onError(new TestException("main"));
+                }
+            }
+            .switchMapCompletable(Functions.justFunction(Completable.error(new TestException("inner"))))
+            .test()
+            .assertFailureAndMessage(TestException.class, "inner");
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "main");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void innerErrorDelayed() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final CompletableSubject cs = CompletableSubject.create();
+
+        TestObserver<Void> to = pp.switchMapCompletableDelayError(Functions.justFunction(cs)).test();
+
+        pp.onNext(1);
+
+        cs.onError(new TestException());
+
+        to.assertEmpty();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onComplete();
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mainCompletesinnerErrorDelayed() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final CompletableSubject cs = CompletableSubject.create();
+
+        TestObserver<Void> to = pp.switchMapCompletableDelayError(Functions.justFunction(cs)).test();
+
+        pp.onNext(1);
+        pp.onComplete();
+
+        to.assertEmpty();
+
+        cs.onError(new TestException());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mainErrorDelayed() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+        final CompletableSubject cs = CompletableSubject.create();
+
+        TestObserver<Void> to = pp.switchMapCompletableDelayError(Functions.justFunction(cs)).test();
+
+        pp.onNext(1);
+
+        pp.onError(new TestException());
+
+        to.assertEmpty();
+
+        assertTrue(cs.hasObservers());
+
+        cs.onComplete();
+
+        to.assertFailure(TestException.class);
+    }
+}


### PR DESCRIPTION
This PR adds the `Flowable.switchMapCompletable` and `Flowable.switchMapCompletableDelayError` operators as requested by #4853.

The associated new marbles are:

![switchMapCompletable](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMapCompletable.f.png)

![switchMapCompletableDelayError](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMapCompletableDelayError.f.png)