### PR TITLE
2.x: Add Flowable.generateAsync to bridge 1-by-1 async APIs

### DIFF
--- a/src/main/java/io/reactivex/FlowableAsyncEmitter.java
+++ b/src/main/java/io/reactivex/FlowableAsyncEmitter.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import io.reactivex.annotations.Experimental;
+import io.reactivex.functions.Cancellable;
+
+/**
+ * Provides an API on top of the {@link Emitter} signals that allow
+ * setting and replacing a {@link Cancellable} resource to be cancelled
+ * when the associated flow is cancelled.
+ *
+ * @param <T> the value type of the items emitted via {@link #onNext(Object)}.
+ * @since 2.1.11 - experimental
+ */
+@Experimental
+public interface FlowableAsyncEmitter<T> extends Emitter<T> {
+
+    /**
+     * Sets the current {@link Cancellable} resource to the provided one
+     * and cancels the previous one if present.
+     * <p>
+     * If the underlying flow has been cancelled, the Cancellable
+     * provided will be cancelled immediately before returning false.
+     * @param c the new {@code Cancellable} to set
+     * @return if true, the operation was successful, if false,
+     *         the associated flow has been cancelled
+     */
+    boolean setCancellable(Cancellable c);
+
+    /**
+     * Sets the current {@link Cancellable} resource to the provided one.
+     * <p>
+     * If the underlying flow has been cancelled, the {@code Cancellable}
+     * provided will be cancelled immediately before returning false.
+     * <p>
+     * Unlike {@link #setCancellable(Cancellable)}, the previous
+     * {@code Cancellable} is not cancelled when returning false.
+     * @param c the new {@code Cancellable} to set
+     * @return if true, the operation was successful, if false,
+     *         the associated flow has been cancelled
+     */
+    boolean replaceCancellable(Cancellable c);
+
+    /**
+     * Returns true if the associated flow has been cancelled.
+     * @return true if the associated flow has been cancelled
+     */
+    boolean isCancelled();
+
+    /**
+     * The async logic may call this method to indicate the async
+     * API invocation didn't produce any items but it hasn't ended
+     * either, therefore, the generator can perform another
+     * API invocation immediately.
+     */
+    void onNothing();
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerateAsync.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerateAsync.java
@@ -1,0 +1,338 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.*;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Generates items by invoking a callback, for each downstream request one by one, that sets up an
+ * asynchronous call to some API that eventually responds with an item, an error or termination, while
+ * making sure there is only one such outstanding API call in progress and honoring the
+ * backpressure of the downstream.
+ *
+ * @param <T> the generated item type
+ * @param <S> the state associated with an individual subscription.
+ * @since 2.1.11 - experimental
+ */
+@Experimental
+public final class FlowableGenerateAsync<T, S> extends Flowable<T> {
+
+    final Callable<S> initialState;
+
+    final BiFunction<? super S, ? super FlowableAsyncEmitter<T>, ? extends S> asyncGenerator;
+
+    final Consumer<? super S> stateCleanup;
+
+    public FlowableGenerateAsync(Callable<S> initialState,
+            BiFunction<? super S, ? super FlowableAsyncEmitter<T>, ? extends S> asyncGenerator,
+            Consumer<? super S> stateCleanup) {
+        this.initialState = initialState;
+        this.asyncGenerator = asyncGenerator;
+        this.stateCleanup = stateCleanup;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        S state;
+
+        try {
+            state = initialState.call();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptySubscription.error(ex, s);
+            return;
+        }
+
+        GenerateAsyncSubscription<T, S> parent = new GenerateAsyncSubscription<T, S>(s, state, asyncGenerator, stateCleanup);
+        s.onSubscribe(parent);
+        parent.moveNext();
+    }
+
+    static final class GenerateAsyncSubscription<T, S>
+    extends AtomicInteger
+    implements Subscription, FlowableAsyncEmitter<T> {
+
+        private static final long serialVersionUID = -2460374219999425947L;
+
+        final Subscriber<? super T> downstream;
+
+        final AtomicInteger wip;
+
+        final AtomicLong requested;
+
+        final AtomicCancellable resource;
+
+        final BiFunction<? super S, ? super FlowableAsyncEmitter<T>, ? extends S> asyncGenerator;
+
+        final Consumer<? super S> stateCleanup;
+
+        final AtomicThrowable errors;
+
+        volatile S state;
+
+        T item;
+        volatile int itemState;
+
+        static final int ITEM_STATE_NOTHING_YET = 0;
+        static final int ITEM_STATE_HAS_VALUE = 1;
+        static final int ITEM_STATE_EMPTY = 2;
+        static final int ITEM_STATE_DONE = 4;
+        static final int ITEM_STATE_HAS_VALUE_DONE = ITEM_STATE_HAS_VALUE | ITEM_STATE_DONE;
+        static final int ITEM_STATE_EMPTY_DONE = ITEM_STATE_HAS_VALUE | ITEM_STATE_DONE;
+
+        volatile boolean done;
+
+        volatile boolean cancelled;
+
+        long emitted;
+
+        GenerateAsyncSubscription(Subscriber<? super T> downstream,
+                S state,
+                BiFunction<? super S, ? super FlowableAsyncEmitter<T>, ? extends S> asyncGenerator,
+                Consumer<? super S> stateCleanup) {
+            this.downstream = downstream;
+            this.state = state;
+            this.asyncGenerator = asyncGenerator;
+            this.stateCleanup = stateCleanup;
+            this.wip = new AtomicInteger();
+            this.requested = new AtomicLong();
+            this.resource = new AtomicCancellable();
+            this.errors = new AtomicThrowable();
+        }
+
+        @Override
+        public void request(long n) {
+            BackpressureHelper.add(requested, n);
+            drain();
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+            resource.cancel();
+            if (getAndIncrement() == 0) {
+                cleanup();
+            }
+        }
+
+        void cleanup() {
+            try {
+                stateCleanup.accept(state);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        @Override
+        public void onNext(T value) {
+            item = value;
+            itemState = ITEM_STATE_HAS_VALUE;
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            if (errors.addThrowable(error)) {
+                itemState |= ITEM_STATE_DONE;
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(error);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            itemState |= ITEM_STATE_DONE;
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void onNothing() {
+            item = null;
+            itemState = ITEM_STATE_EMPTY;
+            drain();
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
+
+        @Override
+        public boolean replaceCancellable(Cancellable c) {
+            return resource.replaceCancellable(c);
+        }
+
+        @Override
+        public boolean setCancellable(Cancellable c) {
+            return resource.setCancellable(c);
+        }
+
+        void moveNext() {
+            if (wip.getAndIncrement() == 0) {
+                do {
+                    if (cancelled) {
+                        return;
+                    }
+                    try {
+                        state = asyncGenerator.apply(state, this);
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        onError(ex);
+                        return;
+                    }
+                } while (wip.decrementAndGet() != 0);
+            }
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            Subscriber<? super T> downstream = this.downstream;
+            long emitted = this.emitted;
+            AtomicLong requested = this.requested;
+
+            for (;;) {
+
+                for (;;) {
+                    if (cancelled) {
+                        cleanup();
+                        return;
+                    }
+
+                    boolean d = done;
+                    int s = itemState;
+
+                    if (d && s == ITEM_STATE_DONE) {
+                        Throwable ex = errors.terminate();
+                        if (ex != null) {
+                            downstream.onError(ex);
+                        } else {
+                            downstream.onComplete();
+                        }
+                        resource.cancel();
+                        cleanup();
+                        return;
+                    }
+
+                    if ((s & ~ITEM_STATE_DONE) == ITEM_STATE_HAS_VALUE) {
+                        if (emitted != requested.get()) {
+                            T v = item;
+                            item = null;
+
+                            downstream.onNext(v);
+
+                            emitted++;
+
+                            if ((s & ITEM_STATE_DONE) != 0) {
+                                itemState = ITEM_STATE_DONE;
+                            } else {
+                                itemState = ITEM_STATE_NOTHING_YET;
+                                moveNext();
+                            }
+                        } else {
+                            break;
+                        }
+                    } else if ((s & ~ITEM_STATE_DONE) == ITEM_STATE_EMPTY) {
+                        if ((s & ITEM_STATE_DONE) != 0) {
+                            itemState = ITEM_STATE_DONE;
+                        } else {
+                            itemState = ITEM_STATE_NOTHING_YET;
+                            moveNext();
+                        }
+                    } else {
+                        break;
+                    }
+                }
+
+                this.emitted = emitted;
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+
+    static final class AtomicCancellable extends AtomicReference<Cancellable> {
+
+        private static final long serialVersionUID = -8193511349691432602L;
+
+        public boolean replaceCancellable(Cancellable c) {
+            for (;;) {
+                Cancellable curr = get();
+                if (curr == CANCELLED) {
+                    cancel(c);
+                    return false;
+                }
+                if (compareAndSet(curr, c)) {
+                    return true;
+                }
+            }
+        }
+
+        public boolean setCancellable(Cancellable c) {
+            for (;;) {
+                Cancellable curr = get();
+                if (curr == CANCELLED) {
+                    cancel(c);
+                    return false;
+                }
+                if (compareAndSet(curr, c)) {
+                    cancel(curr);
+                    return true;
+                }
+            }
+        }
+
+        void cancel() {
+            Cancellable c = getAndSet(CANCELLED);
+            cancel(c);
+        }
+
+        void cancel(Cancellable c) {
+            if (c != null) {
+                try {
+                    c.cancel();
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    RxJavaPlugins.onError(ex);
+                }
+            }
+        }
+
+        static final Cancellable CANCELLED = new Cancellable() {
+            @Override
+            public void cancel() throws Exception {
+            }
+        };
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerateAsync.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerateAsync.java
@@ -148,13 +148,20 @@ public final class FlowableGenerateAsync<T, S> extends Flowable<T> {
 
         @Override
         public void onNext(T value) {
-            item = value;
-            itemState = ITEM_STATE_HAS_VALUE;
-            drain();
+            if (value != null) {
+                item = value;
+                itemState = ITEM_STATE_HAS_VALUE;
+                drain();
+            } else {
+                onError(new NullPointerException("value is null"));
+            }
         }
 
         @Override
         public void onError(Throwable error) {
+            if (error == null) {
+                error = new NullPointerException("error is null");
+            }
             if (errors.addThrowable(error)) {
                 itemState |= ITEM_STATE_DONE;
                 done = true;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateAsyncTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateAsyncTest.java
@@ -650,7 +650,6 @@ public class FlowableGenerateAsyncTest {
         assertEquals(1, cleanup.get());
     }
 
-
     @Test
     public void empty() {
         final AtomicInteger cleanup = new AtomicInteger();
@@ -868,6 +867,72 @@ public class FlowableGenerateAsyncTest {
         ts.awaitDone(5, TimeUnit.SECONDS)
         .assertNoErrors()
         .assertComplete();
+        assertEquals(1, cleanup.get());
+    }
+
+
+    @Test
+    public void nullItem() {
+        final AtomicInteger cleanup = new AtomicInteger();
+
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return null;
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        emitter.onNext(null);
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test(0)
+        .assertFailure(NullPointerException.class);
+
+        assertEquals(1, cleanup.get());
+    }
+
+
+    @Test
+    public void nullThrowable() {
+        final AtomicInteger cleanup = new AtomicInteger();
+
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return null;
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        emitter.onError(null);
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test(0)
+        .assertFailure(NullPointerException.class);
+
         assertEquals(1, cleanup.get());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateAsyncTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateAsyncTest.java
@@ -1,0 +1,873 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.internal.operators.flowable.FlowableGenerateAsync.AtomicCancellable;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableGenerateAsyncTest {
+
+    static final class SyncRange {
+
+        final int max;
+
+        int index;
+
+        SyncRange(int start, int size) {
+            index = start;
+            max = start + size;
+        }
+
+        public Completable nextValue(Consumer<? super Integer> onValue) {
+            final int i = index;
+            if (i == max) {
+                return Completable.complete();
+            }
+            index = i + 1;
+            try {
+                onValue.accept(i);
+            } catch (Throwable ex) {
+                return Completable.error(ex);
+            }
+            return Completable.never();
+        }
+    }
+
+    static final class AsyncRange {
+
+        final int max;
+
+        int index;
+
+        AsyncRange(int start, int size) {
+            index = start;
+            max = start + size;
+        }
+
+        public Completable nextValue(final Consumer<? super Integer> onValue) {
+            final int i = index;
+            if (i == max) {
+                return Completable.complete();
+            }
+            index = i + 1;
+            return Completable.fromAction(new Action() {
+                @Override
+                public void run() throws Exception {
+                    onValue.accept(i);
+                }
+            })
+            .subscribeOn(Schedulers.single())
+            .mergeWith(Completable.never());
+        }
+    }
+
+    @Test
+    public void simple() {
+        final AtomicInteger cleanup = new AtomicInteger();
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return new SyncRange(1, 5);
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        Completable c = state.nextValue(new Consumer<Integer>() {
+                            @Override
+                            public void accept(Integer v) throws Exception {
+                                emitter.onNext(v);
+                            }
+                        });
+
+                        final Disposable d = c.subscribe(new Action() {
+                            @Override
+                            public void run() throws Exception {
+                                emitter.onComplete();
+                            }
+                        }, new Consumer<Throwable>() {
+                            @Override
+                            public void accept(Throwable e) throws Exception {
+                                emitter.onError(e);
+                            }
+                        });
+                        emitter.replaceCancellable(new Cancellable() {
+                            @Override
+                            public void cancel() throws Exception {
+                                d.dispose();
+                            }
+                        });
+
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, cleanup.get());
+    }
+
+    @Test
+    public void simpleEven() {
+        final AtomicInteger cleanup = new AtomicInteger();
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return new SyncRange(1, 12);
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        Completable c = state.nextValue(new Consumer<Integer>() {
+                            @Override
+                            public void accept(Integer v) throws Exception {
+                                if (v % 2 == 0) {
+                                    emitter.onNext(v);
+                                } else if (v == 11) {
+                                    emitter.onComplete();
+                                } else {
+                                    emitter.onNothing();
+                                }
+                            }
+                        });
+
+                        final Disposable d = c.subscribe(new Action() {
+                            @Override
+                            public void run() throws Exception {
+                                emitter.onComplete();
+                            }
+                        }, new Consumer<Throwable>() {
+                            @Override
+                            public void accept(Throwable e) throws Exception {
+                                emitter.onError(e);
+                            }
+                        });
+                        emitter.replaceCancellable(new Cancellable() {
+                            @Override
+                            public void cancel() throws Exception {
+                                d.dispose();
+                            }
+                        });
+
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test()
+        .assertResult(2, 4, 6, 8, 10);
+
+        assertEquals(1, cleanup.get());
+    }
+
+    @Test
+    public void error() {
+        final AtomicInteger cleanup = new AtomicInteger();
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return new SyncRange(1, 12);
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        Completable c = state.nextValue(new Consumer<Integer>() {
+                            @Override
+                            public void accept(Integer v) throws Exception {
+                                emitter.onError(new TestException());
+                            }
+                        });
+
+                        final Disposable d = c.subscribe(new Action() {
+                            @Override
+                            public void run() throws Exception {
+                                emitter.onComplete();
+                            }
+                        }, new Consumer<Throwable>() {
+                            @Override
+                            public void accept(Throwable e) throws Exception {
+                                emitter.onError(e);
+                            }
+                        });
+                        emitter.replaceCancellable(new Cancellable() {
+                            @Override
+                            public void cancel() throws Exception {
+                                d.dispose();
+                            }
+                        });
+
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, cleanup.get());
+    }
+
+    @Test
+    public void take() {
+        final AtomicBoolean cancelled1 = new AtomicBoolean();
+        final AtomicReference<FlowableAsyncEmitter<Integer>> emitterRef = new AtomicReference<FlowableAsyncEmitter<Integer>>();
+
+        final AtomicInteger cleanup = new AtomicInteger();
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return new SyncRange(1, 5);
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        cancelled1.set(emitter.isCancelled());
+                        emitterRef.set(emitter);
+                        Completable c = state.nextValue(new Consumer<Integer>() {
+                            @Override
+                            public void accept(Integer v) throws Exception {
+                                emitter.onNext(v);
+                            }
+                        });
+
+                        final Disposable d = c.subscribe(new Action() {
+                            @Override
+                            public void run() throws Exception {
+                                emitter.onComplete();
+                            }
+                        }, new Consumer<Throwable>() {
+                            @Override
+                            public void accept(Throwable e) throws Exception {
+                                emitter.onError(e);
+                            }
+                        });
+                        emitter.replaceCancellable(new Cancellable() {
+                            @Override
+                            public void cancel() throws Exception {
+                                d.dispose();
+                            }
+                        });
+
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .take(3)
+        .test()
+        .assertResult(1, 2, 3);
+
+        assertEquals(1, cleanup.get());
+
+        assertFalse(cancelled1.get());
+        assertTrue(emitterRef.get().isCancelled());
+    }
+
+    @Test
+    public void initialStateCrash() {
+        final AtomicInteger generator = new AtomicInteger();
+        final AtomicInteger cleanup = new AtomicInteger();
+
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        throw new TestException();
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        generator.incrementAndGet();
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(0, generator.get());
+        assertEquals(0, cleanup.get());
+    }
+
+    @Test
+    public void cancelledCancel() throws Exception {
+        FlowableGenerateAsync.AtomicCancellable.CANCELLED.cancel();
+    }
+
+    @Test
+    public void cancellableCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final AtomicInteger cleanup = new AtomicInteger();
+
+            Flowable.generateAsync(
+                    new Callable<SyncRange>() {
+                        @Override
+                        public SyncRange call() throws Exception {
+                            return null;
+                        }
+                    },
+                    new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                        @Override
+                        public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                                throws Exception {
+                            emitter.setCancellable(new Cancellable() {
+                                @Override
+                                public void cancel() throws Exception {
+                                    throw new TestException();
+                                }
+                            });
+                            emitter.onComplete();
+                            return state;
+                        }
+                    },
+                    new Consumer<SyncRange>() {
+                        @Override
+                        public void accept(SyncRange state) throws Exception {
+                            cleanup.incrementAndGet();
+                        }
+                    }
+            )
+            .test()
+            .assertResult();
+
+            assertEquals(1, cleanup.get());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void cleanupCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.generateAsync(
+                    new Callable<SyncRange>() {
+                        @Override
+                        public SyncRange call() throws Exception {
+                            return null;
+                        }
+                    },
+                    new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                        @Override
+                        public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                                throws Exception {
+                            emitter.onComplete();
+                            return state;
+                        }
+                    },
+                    new Consumer<SyncRange>() {
+                        @Override
+                        public void accept(SyncRange state) throws Exception {
+                            throw new TestException();
+                        }
+                    }
+            )
+            .test()
+            .assertResult();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void generatorCrash() {
+        final AtomicInteger cleanup = new AtomicInteger();
+
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return null;
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        throw new TestException();
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, cleanup.get());
+    }
+
+    @Test
+    public void doubleOnError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final AtomicInteger cleanup = new AtomicInteger();
+
+            Flowable.generateAsync(
+                    new Callable<SyncRange>() {
+                        @Override
+                        public SyncRange call() throws Exception {
+                            return null;
+                        }
+                    },
+                    new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                        @Override
+                        public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                                throws Exception {
+                            emitter.onError(new TestException("One"));
+                            emitter.onError(new TestException("Two"));
+                            return state;
+                        }
+                    },
+                    new Consumer<SyncRange>() {
+                        @Override
+                        public void accept(SyncRange state) throws Exception {
+                            cleanup.incrementAndGet();
+                        }
+                    }
+            )
+            .test()
+            .assertFailureAndMessage(TestException.class, "One");
+
+            assertEquals(1, cleanup.get());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "Two");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void never() {
+        final AtomicInteger cleanup = new AtomicInteger();
+
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return null;
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test()
+        .cancel();
+
+        assertEquals(1, cleanup.get());
+    }
+
+    @Test
+    public void onNextAlreadyAvailable() {
+        final AtomicInteger cleanup = new AtomicInteger();
+
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return null;
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        emitter.onNext(1);
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test(0)
+        .assertEmpty()
+        .requestMore(1)
+        .assertValue(1)
+        .requestMore(1)
+        .assertValues(1, 1)
+        .cancel();
+
+        assertEquals(1, cleanup.get());
+    }
+
+    @Test
+    public void onNextAlreadyAvailableAndComplete() {
+        final AtomicInteger cleanup = new AtomicInteger();
+
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return null;
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        emitter.onNext(1);
+                        emitter.onComplete();
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test(0)
+        .assertEmpty()
+        .requestMore(1)
+        .assertResult(1);
+
+        assertEquals(1, cleanup.get());
+    }
+
+    @Test
+    public void onNothingAndComplete() {
+        final AtomicInteger cleanup = new AtomicInteger();
+
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return null;
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        // in practice, there could be a request being serviced while
+                        // the following emitter.onNothing() is executing
+                        // after which the complete tags the state with it's done indicator
+                        ((FlowableGenerateAsync.GenerateAsyncSubscription<?, ?>)emitter).itemState = 2;
+                        emitter.onComplete();
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test()
+        .assertResult();
+
+        assertEquals(1, cleanup.get());
+    }
+
+
+    @Test
+    public void empty() {
+        final AtomicInteger cleanup = new AtomicInteger();
+
+        Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return null;
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        emitter.onComplete();
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test(0)
+        .assertResult();
+
+        assertEquals(1, cleanup.get());
+    }
+
+    @Test
+    public void atomicCancellableSetCancelled() {
+        final AtomicInteger calls = new AtomicInteger();
+
+        AtomicCancellable ac = new AtomicCancellable();
+        ac.cancel();
+
+        ac.setCancellable(new Cancellable() {
+            @Override
+            public void cancel() throws Exception {
+                calls.incrementAndGet();
+            }
+        });
+
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    public void setCancelRace() {
+        final AtomicCancellable ac = new AtomicCancellable();
+        final Cancellable c1 = new Cancellable() {
+            @Override
+            public void cancel() throws Exception {
+            }
+        };
+        final Cancellable c2 = new Cancellable() {
+            @Override
+            public void cancel() throws Exception {
+            }
+        };
+
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+
+            ac.set(null);
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    for (int i = 0; i < 10; i++) {
+                        ac.setCancellable(c1);
+                    }
+                }
+            };
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    for (int i = 0; i < 10; i++) {
+                        ac.replaceCancellable(c2);
+                    }
+                }
+            };
+
+            TestHelper.race(r1, r2);
+        }
+    }
+
+    @Test
+    public void backpressured() {
+        final AtomicInteger cleanup = new AtomicInteger();
+        TestSubscriber<Integer> ts = Flowable.generateAsync(
+                new Callable<SyncRange>() {
+                    @Override
+                    public SyncRange call() throws Exception {
+                        return new SyncRange(1, 1024);
+                    }
+                },
+                new BiFunction<SyncRange, FlowableAsyncEmitter<Integer>, SyncRange>() {
+                    @Override
+                    public SyncRange apply(SyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        Completable c = state.nextValue(new Consumer<Integer>() {
+                            @Override
+                            public void accept(Integer v) throws Exception {
+                                emitter.onNext(v);
+                            }
+                        });
+
+                        final Disposable d = c.subscribe(new Action() {
+                            @Override
+                            public void run() throws Exception {
+                                emitter.onComplete();
+                            }
+                        }, new Consumer<Throwable>() {
+                            @Override
+                            public void accept(Throwable e) throws Exception {
+                                emitter.onError(e);
+                            }
+                        });
+                        emitter.replaceCancellable(new Cancellable() {
+                            @Override
+                            public void cancel() throws Exception {
+                                d.dispose();
+                            }
+                        });
+
+                        return state;
+                    }
+                },
+                new Consumer<SyncRange>() {
+                    @Override
+                    public void accept(SyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test(0);
+
+        for (int i = 0; i < 1024; i++) {
+            ts.assertValueCount(i)
+            .assertNoErrors()
+            .assertNotComplete()
+            .requestMore(1)
+            .assertValueCount(i + 1)
+            .assertValueAt(i, i + 1)
+            .assertNoErrors();
+        }
+
+        ts.assertComplete();
+        assertEquals(1, cleanup.get());
+    }
+
+    @Test
+    public void asyncBbackpressured() {
+        final AtomicInteger cleanup = new AtomicInteger();
+        TestSubscriber<Integer> ts = Flowable.generateAsync(
+                new Callable<AsyncRange>() {
+                    @Override
+                    public AsyncRange call() throws Exception {
+                        return new AsyncRange(1, 256);
+                    }
+                },
+                new BiFunction<AsyncRange, FlowableAsyncEmitter<Integer>, AsyncRange>() {
+                    @Override
+                    public AsyncRange apply(AsyncRange state, final FlowableAsyncEmitter<Integer> emitter)
+                            throws Exception {
+                        Completable c = state.nextValue(new Consumer<Integer>() {
+                            @Override
+                            public void accept(Integer v) throws Exception {
+                                emitter.onNext(v);
+                            }
+                        });
+
+                        final Disposable d = c.subscribe(new Action() {
+                            @Override
+                            public void run() throws Exception {
+                                emitter.onComplete();
+                            }
+                        }, new Consumer<Throwable>() {
+                            @Override
+                            public void accept(Throwable e) throws Exception {
+                                emitter.onError(e);
+                            }
+                        });
+                        emitter.replaceCancellable(new Cancellable() {
+                            @Override
+                            public void cancel() throws Exception {
+                                d.dispose();
+                            }
+                        });
+
+                        return state;
+                    }
+                },
+                new Consumer<AsyncRange>() {
+                    @Override
+                    public void accept(AsyncRange state) throws Exception {
+                        cleanup.incrementAndGet();
+                    }
+                }
+        )
+        .test(0);
+
+        for (int i = 0; i < 256; i++) {
+            ts.assertValueCount(i)
+            .assertNoErrors()
+            .assertNotComplete()
+            .requestMore(1)
+            .awaitCount(i + 1)
+            .assertValueAt(i, i + 1)
+            .assertNoErrors();
+        }
+
+        ts.awaitDone(5, TimeUnit.SECONDS)
+        .assertNoErrors()
+        .assertComplete();
+        assertEquals(1, cleanup.get());
+    }
+}


### PR DESCRIPTION
This PR proposes a new source operator to bridge async APIs that can be repeatedly called to produce the next item (or terminate in some way) asynchronously and only call the API again once the result has been received and delivered to the downstream, while honoring the backpressure of the downstream. This means if the downstream stops requesting, the API won't be called until the latest result has been requested and consumed by the downstream.

The operator was inspired by [this StackOverflow](https://stackoverflow.com/questions/49059458/is-there-an-equivalent-of-project-reactors-flux-create-that-caters-for-push-p) question.

Example APIs could be [AsyncEnumerable](https://github.com/akarnokd/async-enumerable#async-enumerable) style, coroutine style or [async-await](https://github.com/electronicarts/ea-async).

There are no convenience overloads unlike `generate`, because these APIs likely require their interaction points created for each individual subscriber and otherwise should not be run from multiple subscriptions of the same Flowable.

(I'm still thinking about how a batched variant of this could be reasonably implemented. Batched means the downstream request is presented to the async preparation call and multiple items could be generated with a single API invocation. There are, however, complications such as controlling the request channel over multiple intermediate operators in between or how to detect and act on the case when there are fewer items delivered than requested and the API didn't indicate completion.)

The JavaDoc features the following example:

#### Example
Let's assume there is an async API with the following interface definition:

```java
interface AsyncAPI<T> extends AutoCloseable {

    CompletableFuture<Void> nextValue(Consumer<? super T> onValue);

}
```

When the call succeeds, the `onValue` is invoked with it. If there are no more items, the
` CompletableFuture`  returned by the last ` nextValue`  is completed (with ` null` ).
If there is an error, the same ` CompletableFuture`  is completed exceptionally. Each
` nextValue`  invocation creates a fresh ` CompletableFuture`  which can be cancelled
if necesary. ` nextValue`  should not be invoked again until the ` onValue`  callback
has been notified.

An instance of this API can be obtained on demand, thus the state of this operator consists of the
` AsyncAPI`  instance supplied for each individual {@code Subscriber}. The API can be transformed into
a ` Flowable`  as follows:

```java
Flowable<Integer> source = Flowable.<Integer, AsyncAPI<Integer>>generateAsync(

    // create a fresh API instance for each individual Subscriber
    () -> new AsyncAPIImpl<Integer>(),

    // this BiFunction will be called once the operator is ready to receive the next item
    // and will invoke it again only when that item is delivered via emitter.onNext()
    (state, emitter) -> {
        // issue the async API call
        CompletableFuture<Void> f = state.nextValue(

            // handle the value received
            value -> {

                // we have the option to signal that item
                if (value % 2 == 0) {
                    emitter.onNext(value);
                } else if (value == 101) {
                    // or stop altogether, which will also trigger a cleanup
                    emitter.onComplete();
                } else {
                    // or drop it and have the operator start a new call
                    emitter.onNothing();
                }
            }
        );

        // This API call may not produce further items or fail
        f.whenComplete((done, error) -> {
            // As per the CompletableFuture API, error != null is the error outcome,
            // done is always null due to the Void type
            if (error != null) {
                emitter.onError(error);
            } else {
                emitter.onComplete();
            }
        });

        // In case the downstream cancels, the current API call
        // should be cancelled as well
        emitter.replaceCancellable(() -> f.cancel(true));

        // some sources may want to create a fresh state object
        // after each invocation of this generator
        return state;
    },

    // cleanup the state object
    state -> { state.close(); }
);
```