### PR TITLE
2.x: Improve coverage and fix small mistakes/untaken paths in operators

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -888,7 +888,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     public static <T> Flowable<T> merge(Publisher<? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
         ObjectHelper.requireNonNull(sources, "source is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, MaybeToPublisher.instance(), false, maxConcurrency, Flowable.bufferSize()));
+        return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, MaybeToPublisher.instance(), false, maxConcurrency, 1));
     }
 
     /**
@@ -1222,12 +1222,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *         {@code source} Publisher
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> mergeDelayError(Publisher<? extends MaybeSource<? extends T>> sources) {
-        return Flowable.fromPublisher(sources).flatMap((Function)MaybeToPublisher.instance(), true);
+        return mergeDelayError(sources, Integer.MAX_VALUE);
     }
 
 
@@ -1267,7 +1266,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @Experimental
     public static <T> Flowable<T> mergeDelayError(Publisher<? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
-        return Flowable.fromPublisher(sources).flatMap((Function)MaybeToPublisher.instance(), true, maxConcurrency);
+        ObjectHelper.requireNonNull(sources, "source is null");
+        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
+        return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, MaybeToPublisher.instance(), true, maxConcurrency, 1));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -185,10 +185,10 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
         void removeInner(InnerSubscriber<T, U> inner) {
             for (;;) {
                 InnerSubscriber<?, ?>[] a = subscribers.get();
-                if (a == CANCELLED || a == EMPTY) {
+                int n = a.length;
+                if (n == 0) {
                     return;
                 }
-                int n = a.length;
                 int j = -1;
                 for (int i = 0; i < n; i++) {
                     if (a[i] == inner) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -57,7 +57,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
     public static <U, R> Flowable<R> multicastSelector(
             final Callable<? extends ConnectableFlowable<U>> connectableFactory,
             final Function<? super Flowable<U>, ? extends Publisher<R>> selector) {
-        return Flowable.unsafeCreate(new MultiCastPublisher<R, U>(connectableFactory, selector));
+        return new MulticastFlowable<R, U>(connectableFactory, selector);
     }
 
     /**
@@ -1100,17 +1100,17 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
         }
     }
 
-    static final class MultiCastPublisher<R, U> implements Publisher<R> {
+    static final class MulticastFlowable<R, U> extends Flowable<R> {
         private final Callable<? extends ConnectableFlowable<U>> connectableFactory;
         private final Function<? super Flowable<U>, ? extends Publisher<R>> selector;
 
-        MultiCastPublisher(Callable<? extends ConnectableFlowable<U>> connectableFactory, Function<? super Flowable<U>, ? extends Publisher<R>> selector) {
+        MulticastFlowable(Callable<? extends ConnectableFlowable<U>> connectableFactory, Function<? super Flowable<U>, ? extends Publisher<R>> selector) {
             this.connectableFactory = connectableFactory;
             this.selector = selector;
         }
 
         @Override
-        public void subscribe(Subscriber<? super R> child) {
+        protected void subscribeActual(Subscriber<? super R> child) {
             ConnectableFlowable<U> co;
             try {
                 co = ObjectHelper.requireNonNull(connectableFactory.call(), "The connectableFactory returned null");

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundary.java
@@ -93,6 +93,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
                         produced(1);
                     }
                 } else {
+                    s.cancel();
                     a.onError(new MissingBackpressureException("Could not deliver first window due to lack of requests"));
                     return;
                 }
@@ -254,11 +255,6 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
             }
         }
 
-        @Override
-        public boolean accept(Subscriber<? super Flowable<T>> a, Object v) {
-            // not used by this operator
-            return false;
-        }
     }
 
     static final class WindowBoundaryInnerSubscriber<T, B> extends DisposableSubscriber<B> {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -323,36 +323,22 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
     static final class OperatorWindowBoundaryOpenSubscriber<T, B> extends DisposableSubscriber<B> {
         final WindowBoundaryMainSubscriber<T, B, ?> parent;
 
-        boolean done;
-
         OperatorWindowBoundaryOpenSubscriber(WindowBoundaryMainSubscriber<T, B, ?> parent) {
             this.parent = parent;
         }
 
         @Override
         public void onNext(B t) {
-            if (done) {
-                return;
-            }
             parent.open(t);
         }
 
         @Override
         public void onError(Throwable t) {
-            if (done) {
-                RxJavaPlugins.onError(t);
-                return;
-            }
-            done = true;
             parent.error(t);
         }
 
         @Override
         public void onComplete() {
-            if (done) {
-                return;
-            }
-            done = true;
             parent.onComplete();
         }
     }
@@ -370,12 +356,8 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
 
         @Override
         public void onNext(V t) {
-            if (done) {
-                return;
-            }
-            done = true;
             cancel();
-            parent.close(this);
+            onComplete();
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
@@ -326,7 +326,6 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
             }
             done = true;
             parent.onComplete();
-//            parent.next();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowTimed.java
@@ -390,9 +390,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                             tm.dispose();
                             Disposable task = worker.schedulePeriodically(
                                     new ConsumerIndexHolder(producerIndex, this), timespan, timespan, unit);
-                            if (!timer.compareAndSet(tm, task)) {
-                                task.dispose();
-                            }
+                            timer.replace(task);
                         }
                     } else {
                         window = null;
@@ -549,9 +547,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
                                 Disposable task = worker.schedulePeriodically(
                                         new ConsumerIndexHolder(producerIndex, this), timespan, timespan, unit);
-                                if (!timer.compareAndSet(tm, task)) {
-                                    task.dispose();
-                                }
+                                timer.replace(task);
                             }
 
                         } else {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
@@ -199,24 +199,6 @@ public final class ObservableInternalHelper {
         }
     }
 
-    static final class RepeatWhenOuterHandler
-    implements Function<Observable<Notification<Object>>, ObservableSource<?>> {
-        private final Function<? super Observable<Object>, ? extends ObservableSource<?>> handler;
-
-        RepeatWhenOuterHandler(Function<? super Observable<Object>, ? extends ObservableSource<?>> handler) {
-            this.handler = handler;
-        }
-
-        @Override
-        public ObservableSource<?> apply(Observable<Notification<Object>> no) throws Exception {
-            return handler.apply(no.map(MapToInt.INSTANCE));
-        }
-    }
-
-    public static Function<Observable<Notification<Object>>, ObservableSource<?>> repeatWhenHandler(final Function<? super Observable<Object>, ? extends ObservableSource<?>> handler) {
-        return new RepeatWhenOuterHandler(handler);
-    }
-
     public static <T> Callable<ConnectableObservable<T>> replayCallable(final Observable<T> parent) {
         return new ReplayCallable<T>(parent);
     }
@@ -235,42 +217,6 @@ public final class ObservableInternalHelper {
 
     public static <T, R> Function<Observable<T>, ObservableSource<R>> replayFunction(final Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final Scheduler scheduler) {
         return new ReplayFunction<T, R>(selector, scheduler);
-    }
-
-    enum ErrorMapperFilter implements Function<Notification<Object>, Throwable>, Predicate<Notification<Object>> {
-        INSTANCE;
-
-        @Override
-        public Throwable apply(Notification<Object> t) throws Exception {
-            return t.getError();
-        }
-
-        @Override
-        public boolean test(Notification<Object> t) throws Exception {
-            return t.isOnError();
-        }
-    }
-
-    static final class RetryWhenInner
-    implements Function<Observable<Notification<Object>>, ObservableSource<?>> {
-        private final Function<? super Observable<Throwable>, ? extends ObservableSource<?>> handler;
-
-        RetryWhenInner(
-                Function<? super Observable<Throwable>, ? extends ObservableSource<?>> handler) {
-            this.handler = handler;
-        }
-
-        @Override
-        public ObservableSource<?> apply(Observable<Notification<Object>> no) throws Exception {
-            Observable<Throwable> map = no
-                    .takeWhile(ErrorMapperFilter.INSTANCE)
-                    .map(ErrorMapperFilter.INSTANCE);
-            return handler.apply(map);
-        }
-    }
-
-    public static <T> Function<Observable<Notification<Object>>, ObservableSource<?>> retryWhenHandler(final Function<? super Observable<Throwable>, ? extends ObservableSource<?>> handler) {
-        return new RetryWhenInner(handler);
     }
 
     static final class ZipIterableFunction<T, R>

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceSeedSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceSeedSingle.java
@@ -89,8 +89,8 @@ public final class ObservableReduceSeedSingle<T, R> extends Single<R> {
         @Override
         public void onError(Throwable e) {
             R v = value;
-            value = null;
             if (v != null) {
+                value = null;
                 actual.onError(e);
             } else {
                 RxJavaPlugins.onError(e);
@@ -100,8 +100,8 @@ public final class ObservableReduceSeedSingle<T, R> extends Single<R> {
         @Override
         public void onComplete() {
             R v = value;
-            value = null;
             if (v != null) {
+                value = null;
                 actual.onSuccess(v);
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -338,12 +338,8 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
 
         @Override
         public void onNext(V t) {
-            if (done) {
-                return;
-            }
-            done = true;
             dispose();
-            parent.close(this);
+            onComplete();
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
@@ -296,7 +296,6 @@ public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObserv
             }
             done = true;
             parent.onComplete();
-//            parent.next();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/schedulers/InstantPeriodicTask.java
+++ b/src/main/java/io/reactivex/internal/schedulers/InstantPeriodicTask.java
@@ -50,16 +50,14 @@ final class InstantPeriodicTask implements Callable<Void>, Disposable {
 
     @Override
     public Void call() throws Exception {
+        runner = Thread.currentThread();
         try {
-            runner = Thread.currentThread();
-            try {
-                task.run();
-                setRest(executor.submit(this));
-            } catch (Throwable ex) {
-                RxJavaPlugins.onError(ex);
-            }
-        } finally {
+            task.run();
+            setRest(executor.submit(this));
             runner = null;
+        } catch (Throwable ex) {
+            runner = null;
+            RxJavaPlugins.onError(ex);
         }
         return null;
     }
@@ -86,6 +84,7 @@ final class InstantPeriodicTask implements Callable<Void>, Disposable {
             Future<?> current = first.get();
             if (current == CANCELLED) {
                 f.cancel(runner != Thread.currentThread());
+                return;
             }
             if (first.compareAndSet(current, f)) {
                 return;
@@ -98,6 +97,7 @@ final class InstantPeriodicTask implements Callable<Void>, Disposable {
             Future<?> current = rest.get();
             if (current == CANCELLED) {
                 f.cancel(runner != Thread.currentThread());
+                return;
             }
             if (rest.compareAndSet(current, f)) {
                 return;

--- a/src/main/java/io/reactivex/internal/schedulers/ScheduledDirectPeriodicTask.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ScheduledDirectPeriodicTask.java
@@ -35,14 +35,12 @@ public final class ScheduledDirectPeriodicTask extends AbstractDirectTask implem
     public void run() {
         runner = Thread.currentThread();
         try {
-            try {
-                runnable.run();
-            } catch (Throwable ex) {
-                lazySet(FINISHED);
-                RxJavaPlugins.onError(ex);
-            }
-        } finally {
+            runnable.run();
             runner = null;
+        } catch (Throwable ex) {
+            runner = null;
+            lazySet(FINISHED);
+            RxJavaPlugins.onError(ex);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
@@ -28,8 +28,8 @@ import io.reactivex.annotations.Experimental;
 import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
-import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.processors.FlowableProcessor;
 import io.reactivex.processors.UnicastProcessor;
 
@@ -116,7 +116,7 @@ public class SchedulerWhen extends Scheduler implements Disposable {
         try {
             disposable = combine.apply(workerProcessor).subscribe();
         } catch (Throwable e) {
-            Exceptions.propagate(e);
+            throw ExceptionHelper.wrapOrThrow(e);
         }
     }
 
@@ -155,7 +155,7 @@ public class SchedulerWhen extends Scheduler implements Disposable {
     static final Disposable DISPOSED = Disposables.disposed();
 
     @SuppressWarnings("serial")
-    abstract static class ScheduledAction extends AtomicReference<Disposable>implements Disposable {
+    abstract static class ScheduledAction extends AtomicReference<Disposable> implements Disposable {
         ScheduledAction() {
             super(SUBSCRIBED);
         }

--- a/src/main/java/io/reactivex/internal/subscribers/QueueDrainSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/QueueDrainSubscriber.java
@@ -69,7 +69,7 @@ public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriber
         final Subscriber<? super V> s = actual;
         final SimplePlainQueue<U> q = queue;
 
-        if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
+        if (fastEnter()) {
             long r = requested.get();
             if (r != 0L) {
                 if (accept(s, value)) {
@@ -98,7 +98,7 @@ public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriber
         final Subscriber<? super V> s = actual;
         final SimplePlainQueue<U> q = queue;
 
-        if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
+        if (fastEnter()) {
             long r = requested.get();
             if (r != 0L) {
                 if (q.isEmpty()) {

--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -459,10 +459,10 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
     void remove(BehaviorSubscription<T> rs) {
         for (;;) {
             BehaviorSubscription<T>[] a = subscribers.get();
-            if (a == TERMINATED || a == EMPTY) {
+            int len = a.length;
+            if (len == 0) {
                 return;
             }
-            int len = a.length;
             int j = -1;
             for (int i = 0; i < len; i++) {
                 if (a[i] == rs) {

--- a/src/main/java/io/reactivex/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/subjects/BehaviorSubject.java
@@ -410,10 +410,10 @@ public final class BehaviorSubject<T> extends Subject<T> {
     void remove(BehaviorDisposable<T> rs) {
         for (;;) {
             BehaviorDisposable<T>[] a = subscribers.get();
-            if (a == TERMINATED || a == EMPTY) {
+            int len = a.length;
+            if (len == 0) {
                 return;
             }
-            int len = a.length;
             int j = -1;
             for (int i = 0; i < len; i++) {
                 if (a[i] == rs) {

--- a/src/test/java/io/reactivex/internal/observers/BlockingMultiObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/BlockingMultiObserverTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.observers;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.schedulers.Schedulers;
+
+public class BlockingMultiObserverTest {
+
+    @Test
+    public void dispose() {
+        BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+        bmo.dispose();
+
+        Disposable d = Disposables.empty();
+
+        bmo.onSubscribe(d);
+    }
+
+    @Test
+    public void blockingGetDefault() {
+        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+
+        Schedulers.single().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                bmo.onSuccess(1);
+            }
+        }, 100, TimeUnit.MILLISECONDS);
+
+        assertEquals(1, bmo.blockingGet(0).intValue());
+    }
+
+    @Test
+    public void blockingAwait() {
+        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+
+        Schedulers.single().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                bmo.onSuccess(1);
+            }
+        }, 100, TimeUnit.MILLISECONDS);
+
+        assertTrue(bmo.blockingAwait(1, TimeUnit.MINUTES));
+    }
+
+    @Test
+    public void blockingGetDefaultInterrupt() {
+        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+
+        Thread.currentThread().interrupt();
+        try {
+            bmo.blockingGet(0);
+            fail("Should have thrown");
+        } catch (RuntimeException ex) {
+            assertTrue(ex.getCause() instanceof InterruptedException);
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void blockingGetErrorInterrupt() {
+        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+
+        Thread.currentThread().interrupt();
+        try {
+            assertTrue(bmo.blockingGetError() instanceof InterruptedException);
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void blockingGetErrorTimeoutInterrupt() {
+        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+
+        Thread.currentThread().interrupt();
+        try {
+            bmo.blockingGetError(1, TimeUnit.MINUTES);
+            fail("Should have thrown");
+        } catch (RuntimeException ex) {
+            assertTrue(ex.getCause() instanceof InterruptedException);
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void blockingGetErrorDelayed() {
+        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+
+        Schedulers.single().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                bmo.onError(new TestException());
+            }
+        }, 100, TimeUnit.MILLISECONDS);
+
+        assertTrue(bmo.blockingGetError() instanceof TestException);
+    }
+
+    @Test
+    public void blockingGetErrorTimeoutDelayed() {
+        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+
+        Schedulers.single().scheduleDirect(new Runnable() {
+            @Override
+            public void run() {
+                bmo.onError(new TestException());
+            }
+        }, 100, TimeUnit.MILLISECONDS);
+
+        assertTrue(bmo.blockingGetError(1, TimeUnit.MINUTES) instanceof TestException);
+    }
+}

--- a/src/test/java/io/reactivex/internal/observers/DisposableLambdaObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/DisposableLambdaObserverTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.observers;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.Disposables;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class DisposableLambdaObserverTest {
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.doubleOnSubscribe(new DisposableLambdaObserver<Integer>(
+                new TestObserver<Integer>(), Functions.emptyConsumer(), Functions.EMPTY_ACTION
+        ));
+    }
+
+    @Test
+    public void disposeCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            DisposableLambdaObserver<Integer> o = new DisposableLambdaObserver<Integer>(
+                    new TestObserver<Integer>(), Functions.emptyConsumer(),
+                    new Action() {
+                        @Override
+                        public void run() throws Exception {
+                            throw new TestException();
+                        }
+                    }
+            );
+
+            o.onSubscribe(Disposables.empty());
+
+            assertFalse(o.isDisposed());
+
+            o.dispose();
+
+            assertTrue(o.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/observers/FullArbiterObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/FullArbiterObserverTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.observers;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.Disposables;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.disposables.ObserverFullArbiter;
+import io.reactivex.observers.TestObserver;
+
+public class FullArbiterObserverTest {
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        ObserverFullArbiter<Integer> fa = new ObserverFullArbiter<Integer>(to, null, 16);
+        FullArbiterObserver<Integer> fo = new FullArbiterObserver<Integer>(fa);
+        to.onSubscribe(fa);
+
+        TestHelper.doubleOnSubscribe(fo);
+    }
+
+    @Test
+    public void error() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        ObserverFullArbiter<Integer> fa = new ObserverFullArbiter<Integer>(to, null, 16);
+        FullArbiterObserver<Integer> fo = new FullArbiterObserver<Integer>(fa);
+        to.onSubscribe(fa);
+
+        fo.onSubscribe(Disposables.empty());
+        fo.onError(new TestException());
+
+        to.assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/internal/observers/QueueDrainObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/QueueDrainObserverTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.observers;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.observers.TestObserver;
+
+public class QueueDrainObserverTest {
+
+    static final QueueDrainObserver<Integer, Integer, Integer> createUnordered(TestObserver<Integer> to, final Disposable d) {
+        return new QueueDrainObserver<Integer, Integer, Integer>(to, new SpscArrayQueue<Integer>(4)) {
+            @Override
+            public void onNext(Integer t) {
+                fastPathEmit(t, false, d);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            public void onSubscribe(Disposable s) {
+            }
+
+            @Override
+            public void accept(Observer<? super Integer> a, Integer v) {
+                super.accept(a, v);
+                a.onNext(v);
+            }
+        };
+    }
+
+    static final QueueDrainObserver<Integer, Integer, Integer> createOrdered(TestObserver<Integer> to, final Disposable d) {
+        return new QueueDrainObserver<Integer, Integer, Integer>(to, new SpscArrayQueue<Integer>(4)) {
+            @Override
+            public void onNext(Integer t) {
+                fastPathOrderedEmit(t, false, d);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            public void onSubscribe(Disposable s) {
+            }
+
+            @Override
+            public void accept(Observer<? super Integer> a, Integer v) {
+                super.accept(a, v);
+                a.onNext(v);
+            }
+        };
+    }
+
+    @Test
+    public void unorderedSlowPath() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Disposable d = Disposables.empty();
+        QueueDrainObserver<Integer, Integer, Integer> qd = createUnordered(to, d);
+        to.onSubscribe(Disposables.empty());
+
+        qd.enter();
+        qd.onNext(1);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void orderedSlowPath() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Disposable d = Disposables.empty();
+        QueueDrainObserver<Integer, Integer, Integer> qd = createOrdered(to, d);
+        to.onSubscribe(Disposables.empty());
+
+        qd.enter();
+        qd.onNext(1);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void orderedSlowPathNonEmptyQueue() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Disposable d = Disposables.empty();
+        QueueDrainObserver<Integer, Integer, Integer> qd = createOrdered(to, d);
+        to.onSubscribe(Disposables.empty());
+
+        qd.queue.offer(0);
+        qd.onNext(1);
+
+        to.assertValuesOnly(0, 1);
+    }
+
+    @Test
+    public void unorderedOnNextRace() {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+
+            TestObserver<Integer> to = new TestObserver<Integer>();
+            Disposable d = Disposables.empty();
+            final QueueDrainObserver<Integer, Integer, Integer> qd = createUnordered(to, d);
+            to.onSubscribe(Disposables.empty());
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    qd.onNext(1);
+                }
+            };
+
+            TestHelper.race(r1, r1);
+
+            to.assertValuesOnly(1, 1);
+        }
+    }
+
+    @Test
+    public void orderedOnNextRace() {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+
+            TestObserver<Integer> to = new TestObserver<Integer>();
+            Disposable d = Disposables.empty();
+            final QueueDrainObserver<Integer, Integer, Integer> qd = createOrdered(to, d);
+            to.onSubscribe(Disposables.empty());
+
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    qd.onNext(1);
+                }
+            };
+
+            TestHelper.race(r1, r1);
+
+            to.assertValuesOnly(1, 1);
+        }
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -1755,4 +1755,16 @@ public class FlowableReplayTest {
         .test()
         .assertFailureAndMessage(NullPointerException.class, "The selector returned a null Publisher");
     }
+
+    @Test
+    public void multicastSelectorCallableConnectableCrash() {
+        FlowableReplay.multicastSelector(new Callable<ConnectableFlowable<Object>>() {
+            @Override
+            public ConnectableFlowable<Object> call() throws Exception {
+                throw new TestException();
+            }
+        }, Functions.<Flowable<Object>>identity())
+        .test()
+        .assertFailure(TestException.class);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
@@ -25,10 +25,10 @@ import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.Flowable;
 import io.reactivex.functions.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.subscribers.DefaultSubscriber;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.*;
 
 public class FlowableSingleTest {
 
@@ -760,11 +760,40 @@ public class FlowableSingleTest {
             }
         });
 
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
+            @Override
+            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
+                return o.singleOrError().toFlowable();
+            }
+        });
+
         TestHelper.checkDoubleOnSubscribeFlowableToMaybe(new Function<Flowable<Object>, MaybeSource<Object>>() {
             @Override
             public MaybeSource<Object> apply(Flowable<Object> o) throws Exception {
                 return o.singleElement();
             }
         });
+
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
+            @Override
+            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
+                return o.singleElement().toFlowable();
+            }
+        });
+    }
+
+    @Test
+    public void cancelAsFlowable() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp.singleOrError().toFlowable().test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.assertEmpty();
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeTest.java
@@ -98,4 +98,12 @@ public class MaybeMergeTest {
             .assertFailureAndMessage(TestException.class, "2", 0, 0);
         }
     }
+
+    @Test
+    public void scalar() {
+        Maybe.mergeDelayError(
+                Flowable.just(Maybe.just(1)))
+        .test()
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 
@@ -101,5 +102,13 @@ public class MaybeSwitchIfEmptySingleTest {
 
             TestHelper.race(r1, r2);
         }
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void source() {
+        assertSame(Maybe.empty(),
+                ((HasUpstreamMaybeSource)(Maybe.<Integer>empty().switchIfEmpty(Single.just(1)))).source()
+        );
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableHideTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableHideTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
 import io.reactivex.subjects.PublishSubject;
 
 public class ObservableHideTest {
@@ -42,6 +43,7 @@ public class ObservableHideTest {
         verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void testHidingError() {
         PublishSubject<Integer> src = PublishSubject.create();
@@ -59,5 +61,21 @@ public class ObservableHideTest {
         verify(o, never()).onNext(any());
         verify(o, never()).onComplete();
         verify(o).onError(any(TestException.class));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Observable<Object> o)
+                    throws Exception {
+                return o.hide();
+            }
+        });
+    }
+
+    @Test
+    public void disposed() {
+        TestHelper.checkDisposed(PublishSubject.create().hide());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableInternalHelperTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableInternalHelperTest.java
@@ -29,8 +29,6 @@ public class ObservableInternalHelperTest {
         assertNotNull(ObservableInternalHelper.MapToInt.values()[0]);
         assertNotNull(ObservableInternalHelper.MapToInt.valueOf("INSTANCE"));
 
-        assertNotNull(ObservableInternalHelper.ErrorMapperFilter.values()[0]);
-        assertNotNull(ObservableInternalHelper.ErrorMapperFilter.valueOf("INSTANCE"));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.*;
 import org.junit.Test;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
 
@@ -105,5 +106,13 @@ public class ObservableTakeLastOneTest {
                 return f.takeLast(1);
             }
         });
+    }
+
+    @Test
+    public void error() {
+        Observable.error(new TestException())
+        .takeLast(1)
+        .test()
+        .assertFailure(TestException.class);
     }
 }

--- a/src/test/java/io/reactivex/internal/schedulers/ExecutorSchedulerDelayedRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/ExecutorSchedulerDelayedRunnableTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.schedulers;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.schedulers.ExecutorScheduler.DelayedRunnable;
+
+public class ExecutorSchedulerDelayedRunnableTest {
+
+
+    @Test(expected = TestException.class)
+    public void delayedRunnableCrash() {
+        DelayedRunnable dl = new DelayedRunnable(new Runnable() {
+            @Override
+            public void run() {
+                throw new TestException();
+            }
+        });
+        dl.run();
+    }
+
+    @Test
+    public void dispose() {
+        final AtomicInteger count = new AtomicInteger();
+        DelayedRunnable dl = new DelayedRunnable(new Runnable() {
+            @Override
+            public void run() {
+                count.incrementAndGet();
+            }
+        });
+
+        dl.dispose();
+        dl.dispose();
+
+        dl.run();
+
+        assertEquals(0, count.get());
+    }
+}

--- a/src/test/java/io/reactivex/internal/schedulers/InstantPeriodicTaskTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/InstantPeriodicTaskTest.java
@@ -1,0 +1,277 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.internal.schedulers;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class InstantPeriodicTaskTest {
+
+    @Test
+    public void taskCrash() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+
+            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
+                @Override
+                public void run() {
+                    throw new TestException();
+                }
+            }, exec);
+
+            assertNull(task.call());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            exec.shutdownNow();
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void dispose() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+
+            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
+                @Override
+                public void run() {
+                    throw new TestException();
+                }
+            }, exec);
+
+            assertFalse(task.isDisposed());
+
+            task.dispose();
+
+            assertTrue(task.isDisposed());
+
+            task.dispose();
+
+            assertTrue(task.isDisposed());
+        } finally {
+            exec.shutdownNow();
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void dispose2() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+
+            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
+                @Override
+                public void run() {
+                    throw new TestException();
+                }
+            }, exec);
+
+            task.setFirst(new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null));
+            task.setRest(new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null));
+
+            assertFalse(task.isDisposed());
+
+            task.dispose();
+
+            assertTrue(task.isDisposed());
+
+            task.dispose();
+
+            assertTrue(task.isDisposed());
+        } finally {
+            exec.shutdownNow();
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void dispose2CurrentThread() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+
+            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
+                @Override
+                public void run() {
+                    throw new TestException();
+                }
+            }, exec);
+
+            task.runner = Thread.currentThread();
+
+            task.setFirst(new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null));
+            task.setRest(new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null));
+
+            assertFalse(task.isDisposed());
+
+            task.dispose();
+
+            assertTrue(task.isDisposed());
+
+            task.dispose();
+
+            assertTrue(task.isDisposed());
+        } finally {
+            exec.shutdownNow();
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void dispose3() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+
+            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
+                @Override
+                public void run() {
+                    throw new TestException();
+                }
+            }, exec);
+
+            task.dispose();
+
+            FutureTask<Void> f1 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+            task.setFirst(f1);
+
+            assertTrue(f1.isCancelled());
+
+            FutureTask<Void> f2 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+            task.setRest(f2);
+
+            assertTrue(f2.isCancelled());
+        } finally {
+            exec.shutdownNow();
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void disposeOnCurrentThread() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+
+            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
+                @Override
+                public void run() {
+                    throw new TestException();
+                }
+            }, exec);
+
+            task.runner = Thread.currentThread();
+
+            task.dispose();
+
+            FutureTask<Void> f1 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+            task.setFirst(f1);
+
+            assertTrue(f1.isCancelled());
+
+            FutureTask<Void> f2 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+            task.setRest(f2);
+
+            assertTrue(f2.isCancelled());
+        } finally {
+            exec.shutdownNow();
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void firstCancelRace() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+            for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+                final InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
+                    @Override
+                    public void run() {
+                        throw new TestException();
+                    }
+                }, exec);
+
+                final FutureTask<Void> f1 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        task.setFirst(f1);
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        task.dispose();
+                    }
+                };
+
+                TestHelper.race(r1, r2);
+
+                assertTrue(f1.isCancelled());
+                assertTrue(task.isDisposed());
+            }
+        } finally {
+            exec.shutdownNow();
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void restCancelRace() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+            for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+                final InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
+                    @Override
+                    public void run() {
+                        throw new TestException();
+                    }
+                }, exec);
+
+                final FutureTask<Void> f1 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        task.setRest(f1);
+                    }
+                };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        task.dispose();
+                    }
+                };
+
+                TestHelper.race(r1, r2);
+
+                assertTrue(f1.isCancelled());
+                assertTrue(task.isDisposed());
+            }
+        } finally {
+            exec.shutdownNow();
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/subscribers/QueueDrainSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/QueueDrainSubscriberTest.java
@@ -1,0 +1,336 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class QueueDrainSubscriberTest {
+
+    static final QueueDrainSubscriber<Integer, Integer, Integer> createUnordered(TestSubscriber<Integer> ts, final Disposable d) {
+        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<Integer>(4)) {
+            @Override
+            public void onNext(Integer t) {
+                fastPathEmitMax(t, false, d);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            public void onSubscribe(Subscription s) {
+            }
+
+            @Override
+            public boolean accept(Subscriber<? super Integer> a, Integer v) {
+                super.accept(a, v);
+                a.onNext(v);
+                return true;
+            }
+        };
+    }
+
+    static final QueueDrainSubscriber<Integer, Integer, Integer> createOrdered(TestSubscriber<Integer> ts, final Disposable d) {
+        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<Integer>(4)) {
+            @Override
+            public void onNext(Integer t) {
+                fastPathOrderedEmitMax(t, false, d);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            public void onSubscribe(Subscription s) {
+            }
+
+            @Override
+            public boolean accept(Subscriber<? super Integer> a, Integer v) {
+                super.accept(a, v);
+                a.onNext(v);
+                return true;
+            }
+        };
+    }
+
+    static final QueueDrainSubscriber<Integer, Integer, Integer> createUnorderedReject(TestSubscriber<Integer> ts, final Disposable d) {
+        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<Integer>(4)) {
+            @Override
+            public void onNext(Integer t) {
+                fastPathEmitMax(t, false, d);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            public void onSubscribe(Subscription s) {
+            }
+
+            @Override
+            public boolean accept(Subscriber<? super Integer> a, Integer v) {
+                super.accept(a, v);
+                a.onNext(v);
+                return false;
+            }
+        };
+    }
+
+    static final QueueDrainSubscriber<Integer, Integer, Integer> createOrderedReject(TestSubscriber<Integer> ts, final Disposable d) {
+        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<Integer>(4)) {
+            @Override
+            public void onNext(Integer t) {
+                fastPathOrderedEmitMax(t, false, d);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            public void onSubscribe(Subscription s) {
+            }
+
+            @Override
+            public boolean accept(Subscriber<? super Integer> a, Integer v) {
+                super.accept(a, v);
+                a.onNext(v);
+                return false;
+            }
+        };
+    }
+
+    @Test
+    public void unorderedFastPathNoRequest() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
+        Disposable d = Disposables.empty();
+        QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnordered(ts, d);
+        ts.onSubscribe(new BooleanSubscription());
+
+        qd.onNext(1);
+
+        ts.assertFailure(MissingBackpressureException.class);
+
+        assertTrue(d.isDisposed());
+    }
+
+    @Test
+    public void orderedFastPathNoRequest() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
+        Disposable d = Disposables.empty();
+        QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrdered(ts, d);
+        ts.onSubscribe(new BooleanSubscription());
+
+        qd.onNext(1);
+
+        ts.assertFailure(MissingBackpressureException.class);
+
+        assertTrue(d.isDisposed());
+    }
+
+    @Test
+    public void acceptBadRequest() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
+        Disposable d = Disposables.empty();
+        QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnordered(ts, d);
+        ts.onSubscribe(new BooleanSubscription());
+
+        assertTrue(qd.accept(ts, 0));
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            qd.requested(-1);
+            TestHelper.assertError(errors, 0, IllegalArgumentException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void unorderedFastPathRequest1() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        Disposable d = Disposables.empty();
+        QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnordered(ts, d);
+        ts.onSubscribe(new BooleanSubscription());
+
+        qd.requested(1);
+
+        qd.onNext(1);
+
+        ts.assertValuesOnly(1);
+    }
+
+    @Test
+    public void orderedFastPathRequest1() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        Disposable d = Disposables.empty();
+        QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrdered(ts, d);
+        ts.onSubscribe(new BooleanSubscription());
+
+        qd.requested(1);
+
+        qd.onNext(1);
+
+        ts.assertValuesOnly(1);
+    }
+
+    @Test
+    public void unorderedSlowPath() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        Disposable d = Disposables.empty();
+        QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnordered(ts, d);
+        ts.onSubscribe(new BooleanSubscription());
+
+        qd.enter();
+        qd.onNext(1);
+
+        ts.assertEmpty();
+    }
+
+    @Test
+    public void orderedSlowPath() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        Disposable d = Disposables.empty();
+        QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrdered(ts, d);
+        ts.onSubscribe(new BooleanSubscription());
+
+        qd.enter();
+        qd.onNext(1);
+
+        ts.assertEmpty();
+    }
+
+    @Test
+    public void orderedSlowPathNonEmptyQueue() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        Disposable d = Disposables.empty();
+        QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrdered(ts, d);
+        ts.onSubscribe(new BooleanSubscription());
+
+        qd.queue.offer(0);
+        qd.requested(2);
+        qd.onNext(1);
+
+        ts.assertValuesOnly(0, 1);
+    }
+
+    @Test
+    public void unorderedOnNextRace() {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+            Disposable d = Disposables.empty();
+            final QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnordered(ts, d);
+            ts.onSubscribe(new BooleanSubscription());
+
+            qd.requested(Long.MAX_VALUE);
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    qd.onNext(1);
+                }
+            };
+
+            TestHelper.race(r1, r1);
+
+            ts.assertValuesOnly(1, 1);
+        }
+    }
+
+    @Test
+    public void orderedOnNextRace() {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+            Disposable d = Disposables.empty();
+            final QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrdered(ts, d);
+            ts.onSubscribe(new BooleanSubscription());
+
+            qd.requested(Long.MAX_VALUE);
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    qd.onNext(1);
+                }
+            };
+
+            TestHelper.race(r1, r1);
+
+            ts.assertValuesOnly(1, 1);
+        }
+    }
+
+    @Test
+    public void unorderedFastPathReject() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        Disposable d = Disposables.empty();
+        QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnorderedReject(ts, d);
+        ts.onSubscribe(new BooleanSubscription());
+
+        qd.requested(1);
+
+        qd.onNext(1);
+
+        ts.assertValuesOnly(1);
+
+        assertEquals(1, qd.requested());
+    }
+
+    @Test
+    public void orderedFastPathReject() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        Disposable d = Disposables.empty();
+        QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrderedReject(ts, d);
+        ts.onSubscribe(new BooleanSubscription());
+
+        qd.requested(1);
+
+        qd.onNext(1);
+
+        ts.assertValuesOnly(1);
+
+        assertEquals(1, qd.requested());
+    }
+}


### PR DESCRIPTION
This PR improves the coverage of RxJava while adjusting some code paths and fixing other types of smaller bugs.

- Fix `Maybe.merge(Publisher)` to define a 1 element buffer only.
- Fix `Maybe.mergeDelayError(Publisher)` to use the dedicated `FlowableFlatMapPublisher` similar to the plain `merge()`.
- In `Flowable.flatMap`, checking for empty or cancelled arrays in `removeInner()` can be replaced with a length check.
- Make sure in `Flowable.reduce(seed, f)` the terminal events can't be called a second time if the reducer crashes.
- Turn the `FlowableReplay.MultiCastPublisher` into a `Flowable` and rename it to `MulticastFlowable`.
- Fix `FlowableWindowBoundary` not cancelling the upstream on a missing backpressure case, causing `NullPointerException`.
- Remove unused override of `accept()` in `FlowableWindowBoundary`.
- Remove the ineffective done flag from `OperatorWindowBoundaryOpenSubscriber`.
- Replace the timer CASs with the `replace()` call in `FlowableWindowTimed`.
- Remove the unused `RepeatWhen`, `ErrorMapperFilter` and `RetryWhen` components from `ObservableInternalHelper`.
- Make sure the value is cleared at most once in `ObservableReduceSeedSingle`.
- Simplify `ObservableWindowBoundarySelector`'s inner consumer's `onNext` handling.
- Simplify `FlowableWindowBoundarySelector`'s inner consumer's `onNext` handling.
- Inline the finally actions in `InstantPeriodicTask.call()`.
- Fix `InstantPeriodicTask.setFirst` and `setRest` to return from the loop when the task has been cancelled to prevent excess looping and overwriting the `CANCELLED` indicator.
- Inline the finally actions in `ScheduledDirectPeriodicTask.call()`.
- Slight adjustment of crash propagation in the `SchedulerWhen` constructor.
- In `BehaviorProcessor`, checking for empty or cancelled arrays in `remove()` can be replaced with a length check.
- In `BehaviorSubject`, checking for empty or cancelled arrays in `remove()` can be replaced with a length check.