### PR TITLE
Fix BlockingSingle.value() not unsubscribing after onSuccess and onError

### DIFF
--- a/src/main/java/rx/singles/BlockingSingle.java
+++ b/src/main/java/rx/singles/BlockingSingle.java
@@ -69,14 +69,22 @@ public final class BlockingSingle<T> {
         Subscription subscription = single.subscribe(new SingleSubscriber<T>() {
             @Override
             public void onSuccess(T value) {
-                returnItem.set(value);
-                latch.countDown();
+                try {
+                    returnItem.set(value);
+                    latch.countDown();
+                } finally {
+                    unsubscribe();
+                }
             }
 
             @Override
             public void onError(Throwable error) {
-                returnException.set(error);
-                latch.countDown();
+                try {
+                    returnException.set(error);
+                    latch.countDown();
+                } finally {
+                    unsubscribe();
+                }
             }
         });
 


### PR DESCRIPTION
Fix for the issue mentioned here: https://github.com/ReactiveX/RxJava/issues/5884

```BlockingSingle.value()``` was missing the unsubscribe() call to the created subscription. 
