### PR TITLE
2.x: Fix Flowable.window(Publisher|Callable) upstream handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ def mockitoVersion = "2.1.0"
 def jmhLibVersion = "1.19"
 def testNgVersion = "6.11"
 def guavaVersion = "24.0-jre"
+def jacocoVersion = "0.8.0"
 // --------------------------------------
 
 repositories {
@@ -257,7 +258,7 @@ task testng(type: Test) {
 check.dependsOn testng 
 
 jacoco {
-    toolVersion = "0.7.9" // See http://www.eclemma.org/jacoco/.
+    toolVersion = jacocoVersion // See http://www.eclemma.org/jacoco/.
 }
 
 task GCandMem(dependsOn: "check") doLast {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
@@ -18,201 +18,224 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
-import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.fuseable.SimplePlainQueue;
 import io.reactivex.internal.queue.MpscLinkedQueue;
-import io.reactivex.internal.subscribers.QueueDrainSubscriber;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.internal.util.NotificationLite;
+import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.UnicastProcessor;
-import io.reactivex.subscribers.*;
+import io.reactivex.subscribers.DisposableSubscriber;
 
 public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowableWithUpstream<T, Flowable<T>> {
     final Callable<? extends Publisher<B>> other;
-    final int bufferSize;
+    final int capacityHint;
 
     public FlowableWindowBoundarySupplier(Flowable<T> source,
-            Callable<? extends Publisher<B>> other, int bufferSize) {
+            Callable<? extends Publisher<B>> other, int capacityHint) {
         super(source);
         this.other = other;
-        this.bufferSize = bufferSize;
+        this.capacityHint = capacityHint;
     }
 
     @Override
-    protected void subscribeActual(Subscriber<? super Flowable<T>> s) {
-        source.subscribe(new WindowBoundaryMainSubscriber<T, B>(
-                new SerializedSubscriber<Flowable<T>>(s), other, bufferSize));
+    protected void subscribeActual(Subscriber<? super Flowable<T>> subscriber) {
+        WindowBoundaryMainSubscriber<T, B> parent = new WindowBoundaryMainSubscriber<T, B>(subscriber, capacityHint, other);
+
+        source.subscribe(parent);
     }
 
     static final class WindowBoundaryMainSubscriber<T, B>
-    extends QueueDrainSubscriber<T, Object, Flowable<T>>
-    implements Subscription {
+    extends AtomicInteger
+    implements FlowableSubscriber<T>, Subscription, Runnable {
+
+        private static final long serialVersionUID = 2233020065421370272L;
+
+        final Subscriber<? super Flowable<T>> downstream;
+
+        final int capacityHint;
+
+        final AtomicReference<WindowBoundaryInnerSubscriber<T, B>> boundarySubscriber;
+
+        static final WindowBoundaryInnerSubscriber<Object, Object> BOUNDARY_DISPOSED = new WindowBoundaryInnerSubscriber<Object, Object>(null);
+
+        final AtomicInteger windows;
+
+        final MpscLinkedQueue<Object> queue;
+
+        final AtomicThrowable errors;
+
+        final AtomicBoolean stopWindows;
 
         final Callable<? extends Publisher<B>> other;
-        final int bufferSize;
 
-        Subscription s;
+        static final Object NEXT_WINDOW = new Object();
 
-        final AtomicReference<Disposable> boundary = new AtomicReference<Disposable>();
+        final AtomicLong requested;
+
+        Subscription upstream;
+
+        volatile boolean done;
 
         UnicastProcessor<T> window;
 
-        static final Object NEXT = new Object();
+        long emitted;
 
-        final AtomicLong windows = new AtomicLong();
-
-        WindowBoundaryMainSubscriber(Subscriber<? super Flowable<T>> actual, Callable<? extends Publisher<B>> other,
-                int bufferSize) {
-            super(actual, new MpscLinkedQueue<Object>());
+        WindowBoundaryMainSubscriber(Subscriber<? super Flowable<T>> downstream, int capacityHint, Callable<? extends Publisher<B>> other) {
+            this.downstream = downstream;
+            this.capacityHint = capacityHint;
+            this.boundarySubscriber = new AtomicReference<WindowBoundaryInnerSubscriber<T, B>>();
+            this.windows = new AtomicInteger(1);
+            this.queue = new MpscLinkedQueue<Object>();
+            this.errors = new AtomicThrowable();
+            this.stopWindows = new AtomicBoolean();
             this.other = other;
-            this.bufferSize = bufferSize;
-            windows.lazySet(1);
+            this.requested = new AtomicLong();
         }
 
         @Override
-        public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validate(this.s, s)) {
-                this.s = s;
-
-                Subscriber<? super Flowable<T>> a = actual;
-                a.onSubscribe(this);
-
-                if (cancelled) {
-                    return;
-                }
-
-                Publisher<B> p;
-
-                try {
-                    p = ObjectHelper.requireNonNull(other.call(), "The first window publisher supplied is null");
-                } catch (Throwable e) {
-                    Exceptions.throwIfFatal(e);
-                    s.cancel();
-                    a.onError(e);
-                    return;
-                }
-
-                UnicastProcessor<T> w = UnicastProcessor.<T>create(bufferSize);
-
-                long r = requested();
-                if (r != 0L) {
-                    a.onNext(w);
-                    if (r != Long.MAX_VALUE) {
-                        produced(1);
-                    }
-                } else {
-                    s.cancel();
-                    a.onError(new MissingBackpressureException("Could not deliver first window due to lack of requests"));
-                    return;
-                }
-
-                window = w;
-
-                WindowBoundaryInnerSubscriber<T, B> inner = new WindowBoundaryInnerSubscriber<T, B>(this);
-
-                if (boundary.compareAndSet(null, inner)) {
-                    windows.getAndIncrement();
-                    s.request(Long.MAX_VALUE);
-                    p.subscribe(inner);
-                }
+        public void onSubscribe(Subscription d) {
+            if (SubscriptionHelper.validate(upstream, d)) {
+                upstream = d;
+                downstream.onSubscribe(this);
+                queue.offer(NEXT_WINDOW);
+                drain();
+                d.request(Long.MAX_VALUE);
             }
         }
 
         @Override
         public void onNext(T t) {
-            if (done) {
-                return;
-            }
-            if (fastEnter()) {
-                UnicastProcessor<T> w = window;
-
-                w.onNext(t);
-
-                if (leave(-1) == 0) {
-                    return;
-                }
-            } else {
-                queue.offer(NotificationLite.next(t));
-                if (!enter()) {
-                    return;
-                }
-            }
-            drainLoop();
+            queue.offer(t);
+            drain();
         }
 
         @Override
-        public void onError(Throwable t) {
-            if (done) {
-                RxJavaPlugins.onError(t);
-                return;
+        public void onError(Throwable e) {
+            disposeBoundary();
+            if (errors.addThrowable(e)) {
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
             }
-            error = t;
-            done = true;
-            if (enter()) {
-                drainLoop();
-            }
-
-            if (windows.decrementAndGet() == 0) {
-                DisposableHelper.dispose(boundary);
-            }
-
-            actual.onError(t);
         }
 
         @Override
         public void onComplete() {
-            if (done) {
-                return;
-            }
+            disposeBoundary();
             done = true;
-            if (enter()) {
-                drainLoop();
-            }
-
-            if (windows.decrementAndGet() == 0) {
-                DisposableHelper.dispose(boundary);
-            }
-
-            actual.onComplete();
-
-        }
-
-        @Override
-        public void request(long n) {
-            requested(n);
+            drain();
         }
 
         @Override
         public void cancel() {
-            cancelled = true;
+            if (stopWindows.compareAndSet(false, true)) {
+                disposeBoundary();
+                if (windows.decrementAndGet() == 0) {
+                    upstream.cancel();
+                }
+            }
         }
 
-        void drainLoop() {
-            final SimplePlainQueue<Object> q = queue;
-            final Subscriber<? super Flowable<T>> a = actual;
+        @Override
+        public void request(long n) {
+            BackpressureHelper.add(requested, n);
+        }
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        void disposeBoundary() {
+            Disposable d = boundarySubscriber.getAndSet((WindowBoundaryInnerSubscriber)BOUNDARY_DISPOSED);
+            if (d != null && d != BOUNDARY_DISPOSED) {
+                d.dispose();
+            }
+        }
+
+        @Override
+        public void run() {
+            if (windows.decrementAndGet() == 0) {
+                upstream.cancel();
+            }
+        }
+
+        void innerNext(WindowBoundaryInnerSubscriber<T, B> sender) {
+            boundarySubscriber.compareAndSet(sender, null);
+            queue.offer(NEXT_WINDOW);
+            drain();
+        }
+
+        void innerError(Throwable e) {
+            upstream.cancel();
+            if (errors.addThrowable(e)) {
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        void innerComplete() {
+            upstream.cancel();
+            done = true;
+            drain();
+        }
+
+        @SuppressWarnings("unchecked")
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
             int missed = 1;
-            UnicastProcessor<T> w = window;
+            Subscriber<? super Flowable<T>> downstream = this.downstream;
+            MpscLinkedQueue<Object> queue = this.queue;
+            AtomicThrowable errors = this.errors;
+            long emitted = this.emitted;
+
             for (;;) {
 
                 for (;;) {
+                    if (windows.get() == 0) {
+                        queue.clear();
+                        window = null;
+                        return;
+                    }
+
+                    UnicastProcessor<T> w = window;
+
                     boolean d = done;
 
-                    Object o = q.poll();
+                    if (d && errors.get() != null) {
+                        queue.clear();
+                        Throwable ex = errors.terminate();
+                        if (w != null) {
+                            window = null;
+                            w.onError(ex);
+                        }
+                        downstream.onError(ex);
+                        return;
+                    }
 
-                    boolean empty = o == null;
+                    Object v = queue.poll();
+
+                    boolean empty = v == null;
 
                     if (d && empty) {
-                        DisposableHelper.dispose(boundary);
-                        Throwable e = error;
-                        if (e != null) {
-                            w.onError(e);
+                        Throwable ex = errors.terminate();
+                        if (ex == null) {
+                            if (w != null) {
+                                window = null;
+                                w.onComplete();
+                            }
+                            downstream.onComplete();
                         } else {
-                            w.onComplete();
+                            if (w != null) {
+                                window = null;
+                                w.onError(ex);
+                            }
+                            downstream.onError(ex);
                         }
                         return;
                     }
@@ -221,71 +244,55 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
                         break;
                     }
 
-                    if (o == NEXT) {
-                        w.onComplete();
-
-                        if (windows.decrementAndGet() == 0) {
-                            DisposableHelper.dispose(boundary);
-                            return;
-                        }
-
-                        if (cancelled) {
-                            continue;
-                        }
-
-                        Publisher<B> p;
-
-                        try {
-                            p = ObjectHelper.requireNonNull(other.call(), "The publisher supplied is null");
-                        } catch (Throwable e) {
-                            Exceptions.throwIfFatal(e);
-                            DisposableHelper.dispose(boundary);
-                            a.onError(e);
-                            return;
-                        }
-
-                        w = UnicastProcessor.<T>create(bufferSize);
-
-                        long r = requested();
-                        if (r != 0L) {
-                            windows.getAndIncrement();
-
-                            a.onNext(w);
-                            if (r != Long.MAX_VALUE) {
-                                produced(1);
-                            }
-                        } else {
-                            // don't emit new windows
-                            cancelled = true;
-                            a.onError(new MissingBackpressureException("Could not deliver new window due to lack of requests"));
-                            continue;
-                        }
-
-                        window = w;
-
-                        WindowBoundaryInnerSubscriber<T, B> b = new WindowBoundaryInnerSubscriber<T, B>(this);
-
-                        if (boundary.compareAndSet(boundary.get(), b)) {
-                            p.subscribe(b);
-                        }
-
+                    if (v != NEXT_WINDOW) {
+                        w.onNext((T)v);
                         continue;
                     }
 
-                    w.onNext(NotificationLite.<T>getValue(o));
+                    if (w != null) {
+                        window = null;
+                        w.onComplete();
+                    }
+
+                    if (!stopWindows.get()) {
+                        if (emitted != requested.get()) {
+                            w = UnicastProcessor.create(capacityHint, this);
+                            window = w;
+                            windows.getAndIncrement();
+
+                            Publisher<B> otherSource;
+
+                            try {
+                                otherSource = ObjectHelper.requireNonNull(other.call(), "The other Callable returned a null Publisher");
+                            } catch (Throwable ex) {
+                                Exceptions.throwIfFatal(ex);
+                                errors.addThrowable(ex);
+                                done = true;
+                                continue;
+                            }
+
+                            WindowBoundaryInnerSubscriber<T, B> bo = new WindowBoundaryInnerSubscriber<T, B>(this);
+
+                            if (boundarySubscriber.compareAndSet(null, bo)) {
+                                otherSource.subscribe(bo);
+
+                                emitted++;
+                                downstream.onNext(w);
+                            }
+                        } else {
+                            upstream.cancel();
+                            disposeBoundary();
+                            errors.addThrowable(new MissingBackpressureException("Could not deliver a window due to lack of requests"));
+                            done = true;
+                        }
+                    }
                 }
 
-                missed = leave(-missed);
+                this.emitted = emitted;
+                missed = addAndGet(-missed);
                 if (missed == 0) {
-                    return;
+                    break;
                 }
-            }
-        }
-
-        void next() {
-            queue.offer(NEXT);
-            if (enter()) {
-                drainLoop();
             }
         }
     }
@@ -305,8 +312,8 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
                 return;
             }
             done = true;
-            cancel();
-            parent.next();
+            dispose();
+            parent.innerNext(this);
         }
 
         @Override
@@ -316,7 +323,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
                 return;
             }
             done = true;
-            parent.onError(t);
+            parent.innerError(t);
         }
 
         @Override
@@ -325,7 +332,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
                 return;
             }
             done = true;
-            parent.onComplete();
+            parent.innerComplete();
         }
     }
 }


### PR DESCRIPTION
This PR fixes the upstream handling in `Flowable.window(Publisher)` and `Flowable.window(Callable<Publisher>)` operators to make sure if both the main output and the inner windows have been cancelled, the upstream is also cancelled.

Related: #5887, #5881.

In addition, the Jacoco code coverage has been updated to 0.8.0 mainly due to the [automatic filtering of difficult-to-impossible code paths](https://github.com/jacoco/jacoco/releases/tag/v0.8.0).