### PR TITLE
2.x: Fix excess item retention in the other replay components

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -806,6 +806,15 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
             truncateFinal();
         }
 
+        final void trimHead() {
+            Node head = get();
+            if (head.value != null) {
+                Node n = new Node(null, 0L);
+                n.lazySet(head.get());
+                set(n);
+            }
+        }
+
         @Override
         public final void replay(InnerSubscription<T> output) {
             synchronized (output) {
@@ -909,7 +918,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
          * based on its properties (i.e., truncate but the very last node).
          */
         void truncateFinal() {
-
+            trimHead();
         }
         /* test */ final  void collect(Collection<? super T> output) {
             Node n = getHead();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -619,6 +619,16 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
             // can't null out the head's value because of late replayers would see null
             setFirst(next);
         }
+
+        final void trimHead() {
+            Node head = get();
+            if (head.value != null) {
+                Node n = new Node(null);
+                n.lazySet(head.get());
+                set(n);
+            }
+        }
+
         /* test */ final void removeSome(int n) {
             Node head = get();
             while (n > 0) {
@@ -733,7 +743,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
          * based on its properties (i.e., truncate but the very last node).
          */
         void truncateFinal() {
-
+            trimHead();
         }
         /* test */ final  void collect(Collection<? super T> output) {
             Node n = getHead();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -1561,4 +1561,159 @@ public class ObservableReplayTest {
         .test()
         .assertFailureAndMessage(NullPointerException.class, "The connectableFactory returned a null ConnectableObservable");
     }
+
+    @Test
+    public void noHeadRetentionCompleteSize() {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        ObservableReplay<Integer> co = (ObservableReplay<Integer>)source
+                .replay(1);
+
+        co.connect();
+
+        BoundedReplayBuffer<Integer> buf = (BoundedReplayBuffer<Integer>)(co.current.get().buffer);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onComplete();
+
+        assertNull(buf.get().value);
+
+        Object o = buf.get();
+
+        buf.trimHead();
+
+        assertSame(o, buf.get());
+    }
+
+    @Test
+    public void noHeadRetentionErrorSize() {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        ObservableReplay<Integer> co = (ObservableReplay<Integer>)source
+                .replay(1);
+
+        co.connect();
+
+        BoundedReplayBuffer<Integer> buf = (BoundedReplayBuffer<Integer>)(co.current.get().buffer);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+
+        assertNull(buf.get().value);
+
+        Object o = buf.get();
+
+        buf.trimHead();
+
+        assertSame(o, buf.get());
+    }
+
+    @Test
+    public void noHeadRetentionSize() {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        ObservableReplay<Integer> co = (ObservableReplay<Integer>)source
+                .replay(1);
+
+        co.connect();
+
+        BoundedReplayBuffer<Integer> buf = (BoundedReplayBuffer<Integer>)(co.current.get().buffer);
+
+        source.onNext(1);
+        source.onNext(2);
+
+        assertNotNull(buf.get().value);
+
+        buf.trimHead();
+
+        assertNull(buf.get().value);
+
+        Object o = buf.get();
+
+        buf.trimHead();
+
+        assertSame(o, buf.get());
+    }
+
+    @Test
+    public void noHeadRetentionCompleteTime() {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        ObservableReplay<Integer> co = (ObservableReplay<Integer>)source
+                .replay(1, TimeUnit.MINUTES, Schedulers.computation());
+
+        co.connect();
+
+        BoundedReplayBuffer<Integer> buf = (BoundedReplayBuffer<Integer>)(co.current.get().buffer);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onComplete();
+
+        assertNull(buf.get().value);
+
+        Object o = buf.get();
+
+        buf.trimHead();
+
+        assertSame(o, buf.get());
+    }
+
+    @Test
+    public void noHeadRetentionErrorTime() {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        ObservableReplay<Integer> co = (ObservableReplay<Integer>)source
+                .replay(1, TimeUnit.MINUTES, Schedulers.computation());
+
+        co.connect();
+
+        BoundedReplayBuffer<Integer> buf = (BoundedReplayBuffer<Integer>)(co.current.get().buffer);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+
+        assertNull(buf.get().value);
+
+        Object o = buf.get();
+
+        buf.trimHead();
+
+        assertSame(o, buf.get());
+    }
+
+    @Test
+    public void noHeadRetentionTime() {
+        TestScheduler sch = new TestScheduler();
+
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        ObservableReplay<Integer> co = (ObservableReplay<Integer>)source
+                .replay(1, TimeUnit.MILLISECONDS, sch);
+
+        co.connect();
+
+        BoundedReplayBuffer<Integer> buf = (BoundedReplayBuffer<Integer>)(co.current.get().buffer);
+
+        source.onNext(1);
+
+        sch.advanceTimeBy(2, TimeUnit.MILLISECONDS);
+
+        source.onNext(2);
+
+        assertNotNull(buf.get().value);
+
+        buf.trimHead();
+
+        assertNull(buf.get().value);
+
+        Object o = buf.get();
+
+        buf.trimHead();
+
+        assertSame(o, buf.get());
+    }
 }


### PR DESCRIPTION
This is a follow-up PR to #5892 in order to avoid item retention in the head node. For the `ReplayProcessor`, the cleanup can be triggered with `cleanupBuffer`. For the `replay()` operators, such trigger is not possible. However, the terminal events will perform the cleanup internally at least.