### PR TITLE
2.x: Perf measure of Flowable flatMap & flatMapCompletable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 def junitVersion = "4.12"
 def reactiveStreamsVersion = "1.0.2"
 def mockitoVersion = "2.1.0"
-def jmhLibVersion = "1.19"
+def jmhLibVersion = "1.20"
 def testNgVersion = "6.11"
 def guavaVersion = "24.0-jre"
 def jacocoVersion = "0.8.0"
@@ -201,6 +201,7 @@ jmh {
     jmhVersion = jmhLibVersion
     humanOutputFile = null
     includeTests = false
+    jvmArgsAppend = ["-Djmh.separateClasspathJAR=true"]
 
     if (project.hasProperty("jmh")) {
         include = ".*" + project.jmh + ".*"

--- a/src/jmh/java/io/reactivex/FlowableFlatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/FlowableFlatMapCompletablePerf.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.functions.Action;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.schedulers.Schedulers;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableFlatMapCompletablePerf implements Action {
+
+    @Param({"1", "10", "100", "1000", "10000", "100000", "1000000"})
+    int items;
+
+    @Param({"1", "8", "32", "128", "256"})
+    int maxConcurrency;
+
+    @Param({"1", "10", "100", "1000"})
+    int work;
+
+    Completable flatMapCompletable;
+
+    Flowable<Object> flatMap;
+
+    @Override
+    public void run() throws Exception {
+        Blackhole.consumeCPU(work);
+    }
+
+    @Setup
+    public void setup() {
+        Integer[] array = new Integer[items];
+        Arrays.fill(array, 777);
+
+        flatMapCompletable = Flowable.fromArray(array)
+                .flatMapCompletable(Functions.justFunction(Completable.fromAction(this).subscribeOn(Schedulers.computation())), false, maxConcurrency);
+
+        flatMap = Flowable.fromArray(array)
+                .flatMap(Functions.justFunction(Completable.fromAction(this).subscribeOn(Schedulers.computation()).toFlowable()), false, maxConcurrency);
+    }
+
+//    @Benchmark
+    public Object flatMap(Blackhole bh) {
+        return flatMap.subscribeWith(new PerfAsyncConsumer(bh)).await(items);
+    }
+
+    @Benchmark
+    public Object flatMapCompletable(Blackhole bh) {
+        return flatMapCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(items);
+    }
+}

--- a/src/jmh/java/io/reactivex/FlowableFlatMapCompletableSyncPerf.java
+++ b/src/jmh/java/io/reactivex/FlowableFlatMapCompletableSyncPerf.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.internal.functions.Functions;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableFlatMapCompletableSyncPerf {
+
+    @Param({"1", "10", "100", "1000", "10000", "100000", "1000000"})
+    int items;
+
+    @Param({"1", "8", "32", "128", "256"})
+    int maxConcurrency;
+
+    Completable flatMapCompletable;
+
+    Flowable<Object> flatMap;
+
+    @Setup
+    public void setup() {
+        Integer[] array = new Integer[items];
+        Arrays.fill(array, 777);
+
+        flatMapCompletable = Flowable.fromArray(array)
+                .flatMapCompletable(Functions.justFunction(Completable.complete()), false, maxConcurrency);
+
+        flatMap = Flowable.fromArray(array)
+                .flatMap(Functions.justFunction(Completable.complete().toFlowable()), false, maxConcurrency);
+    }
+
+    @Benchmark
+    public Object flatMap(Blackhole bh) {
+        return flatMap.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flatMapCompletable(Blackhole bh) {
+        return flatMapCompletable.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/PerfAsyncConsumer.java
+++ b/src/jmh/java/io/reactivex/PerfAsyncConsumer.java
@@ -68,8 +68,9 @@ SingleObserver<Object>, CompletableObserver, MaybeObserver<Object> {
     /**
      * Wait for the terminal signal.
      * @param count if less than 1001, a spin-wait is used
+     * @return this
      */
-    public void await(int count) {
+    public PerfAsyncConsumer await(int count) {
         if (count <= 1000) {
             while (getCount() != 0) { }
         } else {
@@ -79,6 +80,7 @@ SingleObserver<Object>, CompletableObserver, MaybeObserver<Object> {
                 throw new RuntimeException(ex);
             }
         }
+        return this;
     }
 
 }


### PR DESCRIPTION
This PR adds two benchmarks that measure the synchronous and asynchronous behavior of `Flowable.flatMap` and `Flowable.flatMapCompletable` when both are run with a `Completable` source.

Apart from the `item == 1` case, which is due to lack of scalar optimizations with `flatMapCompletable`, the `flatMapCompletable` is faster by a good margin:

![image](https://user-images.githubusercontent.com/1269832/37175444-de62c1fe-2319-11e8-90ce-1f0b0dbd661b.png)

I'd say the asynchronous use is slightly faster in general with `flatMapCompletable`:

![image](https://user-images.githubusercontent.com/1269832/37175490-fa38bd8e-2319-11e8-84ff-e01d1ec18129.png)

-----------

Originally, this PR started out as an attempt to optimize the inner consumer tracking in `flatMapCompletable` when the `maxConcurrency` is non-default by using a special containers for 1..8 instead of the `CompositeDisposable`. Unfortunately, this made it slightly slower in general (PR column):

![image](https://user-images.githubusercontent.com/1269832/37175604-4b4c8bb0-231a-11e8-8f28-a18b364c4d64.png)

The async benchmark is within +/- 3% most of the time, and generally inconclusive.

![image](https://user-images.githubusercontent.com/1269832/37175638-64e9e806-231a-11e8-8c42-682c53b986e7.png)

An additional test method was added to verify the new tracking classes, which is left as an additional mean to verify `flatMapCompletable`'s behavior in general.
