### PR TITLE
2.x: Fix Flowable.singleOrError().toFlowable() not signalling NoSuchElementException

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleMaybe.java
@@ -36,7 +36,7 @@ public final class FlowableSingleMaybe<T> extends Maybe<T> implements FuseToFlow
 
     @Override
     public Flowable<T> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableSingle<T>(source, null));
+        return RxJavaPlugins.onAssembly(new FlowableSingle<T>(source, null, false));
     }
 
     static final class SingleElementSubscriber<T>

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleSingle.java
@@ -41,7 +41,7 @@ public final class FlowableSingleSingle<T> extends Single<T> implements FuseToFl
 
     @Override
     public Flowable<T> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableSingle<T>(source, defaultValue));
+        return RxJavaPlugins.onAssembly(new FlowableSingle<T>(source, defaultValue, true));
     }
 
     static final class SingleElementSubscriber<T>

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
@@ -796,4 +796,13 @@ public class FlowableSingleTest {
 
         assertFalse(pp.hasSubscribers());
     }
+
+    @Test
+    public void singleOrError() {
+        Flowable.empty()
+        .singleOrError()
+        .toFlowable()
+        .test()
+        .assertFailure(NoSuchElementException.class);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSingleTest.java
@@ -556,4 +556,13 @@ public class ObservableSingleTest {
             }
         });
     }
+
+    @Test
+    public void singleOrError() {
+        Observable.empty()
+        .singleOrError()
+        .toObservable()
+        .test()
+        .assertFailure(NoSuchElementException.class);
+    }
 }


### PR DESCRIPTION
When a `singleOrError` is followed by `toFlowable()`, the assembly process switches the `Flowable->Single` operator into a `Flowable->Flowable` operator implementing the `singleOrError` behavior (saving the back-and-forth type conversion). The backing implementation was shared with `singleElement` and as such, did not properly handle the `orError` case for an empty source. The PR fixes the lack of `NoSuchElementException` in this case.

Fixes #5903.

The `Observable` variant doesn't have such optimization but the test has been converted to make sure `Observable` is verified for this aspect in case the optimization is implemented with it in the future.