### PR TITLE
2.x: Cleanup test local variable names

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -2286,9 +2286,9 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<Void> test() {
-        TestObserver<Void> ts = new TestObserver<Void>();
-        subscribe(ts);
-        return ts;
+        TestObserver<Void> to = new TestObserver<Void>();
+        subscribe(to);
+        return to;
     }
 
     /**
@@ -2305,12 +2305,12 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<Void> test(boolean cancelled) {
-        TestObserver<Void> ts = new TestObserver<Void>();
+        TestObserver<Void> to = new TestObserver<Void>();
 
         if (cancelled) {
-            ts.cancel();
+            to.cancel();
         }
-        subscribe(ts);
-        return ts;
+        subscribe(to);
+        return to;
     }
 }

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -4496,9 +4496,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<T> test() {
-        TestObserver<T> ts = new TestObserver<T>();
-        subscribe(ts);
-        return ts;
+        TestObserver<T> to = new TestObserver<T>();
+        subscribe(to);
+        return to;
     }
 
     /**
@@ -4514,13 +4514,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<T> test(boolean cancelled) {
-        TestObserver<T> ts = new TestObserver<T>();
+        TestObserver<T> to = new TestObserver<T>();
 
         if (cancelled) {
-            ts.cancel();
+            to.cancel();
         }
 
-        subscribe(ts);
-        return ts;
+        subscribe(to);
+        return to;
     }
 }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -15079,9 +15079,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<T> test() { // NoPMD
-        TestObserver<T> ts = new TestObserver<T>();
-        subscribe(ts);
-        return ts;
+        TestObserver<T> to = new TestObserver<T>();
+        subscribe(to);
+        return to;
     }
 
     /**
@@ -15099,11 +15099,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<T> test(boolean dispose) { // NoPMD
-        TestObserver<T> ts = new TestObserver<T>();
+        TestObserver<T> to = new TestObserver<T>();
         if (dispose) {
-            ts.dispose();
+            to.dispose();
         }
-        subscribe(ts);
-        return ts;
+        subscribe(to);
+        return to;
     }
 }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -3654,9 +3654,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<T> test() {
-        TestObserver<T> ts = new TestObserver<T>();
-        subscribe(ts);
-        return ts;
+        TestObserver<T> to = new TestObserver<T>();
+        subscribe(to);
+        return to;
     }
 
     /**
@@ -3673,14 +3673,14 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<T> test(boolean cancelled) {
-        TestObserver<T> ts = new TestObserver<T>();
+        TestObserver<T> to = new TestObserver<T>();
 
         if (cancelled) {
-            ts.cancel();
+            to.cancel();
         }
 
-        subscribe(ts);
-        return ts;
+        subscribe(to);
+        return to;
     }
 
     private static <T> Single<T> toSingle(Flowable<T> source) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -64,13 +64,13 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      * Child Subscribers will observe the events of the ConnectableObservable on the
      * specified scheduler.
      * @param <T> the value type
-     * @param co the ConnectableFlowable to wrap
+     * @param cf the ConnectableFlowable to wrap
      * @param scheduler the target scheduler
      * @return the new ConnectableObservable instance
      */
-    public static <T> ConnectableFlowable<T> observeOn(final ConnectableFlowable<T> co, final Scheduler scheduler) {
-        final Flowable<T> observable = co.observeOn(scheduler);
-        return RxJavaPlugins.onAssembly(new ConnectableFlowableReplay<T>(co, observable));
+    public static <T> ConnectableFlowable<T> observeOn(final ConnectableFlowable<T> cf, final Scheduler scheduler) {
+        final Flowable<T> observable = cf.observeOn(scheduler);
+        return RxJavaPlugins.onAssembly(new ConnectableFlowableReplay<T>(cf, observable));
     }
 
     /**
@@ -1100,9 +1100,9 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
 
         @Override
         protected void subscribeActual(Subscriber<? super R> child) {
-            ConnectableFlowable<U> co;
+            ConnectableFlowable<U> cf;
             try {
-                co = ObjectHelper.requireNonNull(connectableFactory.call(), "The connectableFactory returned null");
+                cf = ObjectHelper.requireNonNull(connectableFactory.call(), "The connectableFactory returned null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 EmptySubscription.error(e, child);
@@ -1111,7 +1111,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
 
             Publisher<R> observable;
             try {
-                observable = ObjectHelper.requireNonNull(selector.apply(co), "The selector returned a null Publisher");
+                observable = ObjectHelper.requireNonNull(selector.apply(cf), "The selector returned a null Publisher");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 EmptySubscription.error(e, child);
@@ -1122,7 +1122,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
 
             observable.subscribe(srw);
 
-            co.connect(new DisposableConsumer(srw));
+            cf.connect(new DisposableConsumer(srw));
         }
 
         final class DisposableConsumer implements Consumer<Disposable> {
@@ -1140,17 +1140,17 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
     }
 
     static final class ConnectableFlowableReplay<T> extends ConnectableFlowable<T> {
-        private final ConnectableFlowable<T> co;
+        private final ConnectableFlowable<T> cf;
         private final Flowable<T> observable;
 
-        ConnectableFlowableReplay(ConnectableFlowable<T> co, Flowable<T> observable) {
-            this.co = co;
+        ConnectableFlowableReplay(ConnectableFlowable<T> cf, Flowable<T> observable) {
+            this.cf = cf;
             this.observable = observable;
         }
 
         @Override
         public void connect(Consumer<? super Disposable> connection) {
-            co.connect(connection);
+            cf.connect(connection);
         }
 
         @Override

--- a/src/main/java/io/reactivex/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/observers/TestObserver.java
@@ -18,8 +18,8 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.disposables.DisposableHelper;
-import io.reactivex.internal.fuseable.QueueDisposable;
-import io.reactivex.internal.util.*;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.util.ExceptionHelper;
 
 /**
  * An Observer that records events and allows making assertions about them.
@@ -309,9 +309,9 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
 
     static String fusionModeToString(int mode) {
         switch (mode) {
-        case QueueDisposable.NONE : return "NONE";
-        case QueueDisposable.SYNC : return "SYNC";
-        case QueueDisposable.ASYNC : return "ASYNC";
+        case QueueFuseable.NONE : return "NONE";
+        case QueueFuseable.SYNC : return "SYNC";
+        case QueueFuseable.ASYNC : return "ASYNC";
         default: return "Unknown(" + mode + ")";
         }
     }

--- a/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
+++ b/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.io.*;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+/**
+ * Checks for commonly copy-pasted but not-renamed local variables in unit tests.
+ * <ul>
+ * <li>{@code TestSubscriber} named as {@code to*}</li>
+ * <li>{@code TestObserver} named as {@code ts*}</li>
+ * <li>{@code PublishProcessor} named as {@code ps*}</li>
+ * <li>{@code PublishSubject} named as {@code pp*}</li>
+ * </ul>
+ */
+public class CheckLocalVariablesInTests {
+
+    static void findPattern(String pattern) throws Exception {
+        File f = MaybeNo2Dot0Since.findSource("Flowable");
+        if (f == null) {
+            System.out.println("Unable to find sources of RxJava");
+            return;
+        }
+
+        Queue<File> dirs = new ArrayDeque<File>();
+
+        StringBuilder fail = new StringBuilder();
+        fail.append("The following code pattern was found: ").append(pattern).append("\n");
+
+        File parent = f.getParentFile();
+
+        dirs.offer(new File(parent.getAbsolutePath().replace('\\', '/').replace("src/main/java", "src/test/java")));
+
+        Pattern p = Pattern.compile(pattern);
+
+        int total = 0;
+
+        while (!dirs.isEmpty()) {
+            f = dirs.poll();
+
+            File[] list = f.listFiles();
+            if (list != null && list.length != 0) {
+
+                for (File u : list) {
+                    if (u.isDirectory()) {
+                        dirs.offer(u);
+                    } else {
+                        String fname = u.getName();
+                        if (fname.endsWith(".java")) {
+
+                            int lineNum = 0;
+                            BufferedReader in = new BufferedReader(new FileReader(u));
+                            try {
+                                for (;;) {
+                                    String line = in.readLine();
+                                    if (line != null) {
+                                        lineNum++;
+
+                                        line = line.trim();
+
+                                        if (!line.startsWith("//") && !line.startsWith("*")) {
+                                            if (p.matcher(line).find()) {
+                                                fail
+                                                .append(fname)
+                                                .append("#L").append(lineNum)
+                                                .append("    ").append(line)
+                                                .append("\n");
+                                                total++;
+                                            }
+                                        }
+                                    } else {
+                                        break;
+                                    }
+                                }
+                            } finally {
+                                in.close();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (total != 0) {
+            fail.append("Found ")
+            .append(total)
+            .append(" instances");
+            System.out.println(fail);
+            throw new AssertionError(fail.toString());
+        }
+    }
+
+    @Test
+    public void testSubscriberAsTo() throws Exception {
+        findPattern("TestSubscriber<.*>\\s+to");
+    }
+
+    @Test
+    public void testObserverAsTs() throws Exception {
+        findPattern("TestObserver<.*>\\s+ts");
+    }
+
+    @Test
+    public void publishSubjectAsPp() throws Exception {
+        findPattern("PublishSubject<.*>\\s+pp");
+    }
+
+    @Test
+    public void publishProcessorAsPs() throws Exception {
+        findPattern("PublishProcessor<.*>\\s+ps");
+    }
+
+    @Test
+    public void behaviorProcessorAsBs() throws Exception {
+        findPattern("BehaviorProcessor<.*>\\s+bs");
+    }
+
+    @Test
+    public void behaviorSubjectAsBp() throws Exception {
+        findPattern("BehaviorSubject<.*>\\s+bp");
+    }
+
+    @Test
+    public void connectableFlowableAsCo() throws Exception {
+        findPattern("ConnectableFlowable<.*>\\s+co(0-9|\\b)");
+    }
+
+    @Test
+    public void connectableObservableAsCf() throws Exception {
+        findPattern("ConnectableObservable<.*>\\s+cf(0-9|\\b)");
+    }
+
+    @Test
+    public void queueDisposableInsteadOfQueueFuseable() throws Exception {
+        findPattern("QueueDisposable\\.(NONE|SYNC|ASYNC|ANY|BOUNDARY)");
+    }
+
+    @Test
+    public void queueSubscriptionInsteadOfQueueFuseable() throws Exception {
+        findPattern("QueueSubscription\\.(NONE|SYNC|ASYNC|ANY|BOUNDARY)");
+    }
+
+    @Test
+    public void singleSourceAsMs() throws Exception {
+        findPattern("SingleSource<.*>\\s+ms");
+    }
+
+    @Test
+    public void singleSourceAsCs() throws Exception {
+        findPattern("SingleSource<.*>\\s+cs");
+    }
+
+    @Test
+    public void maybeSourceAsSs() throws Exception {
+        findPattern("MaybeSource<.*>\\s+ss");
+    }
+
+    @Test
+    public void maybeSourceAsCs() throws Exception {
+        findPattern("MaybeSource<.*>\\s+cs");
+    }
+
+    @Test
+    public void completableSourceAsSs() throws Exception {
+        findPattern("CompletableSource<.*>\\s+ss");
+    }
+
+    @Test
+    public void completableSourceAsMs() throws Exception {
+        findPattern("CompletableSource<.*>\\s+ms");
+    }
+}

--- a/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
+++ b/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
@@ -183,4 +183,9 @@ public class CheckLocalVariablesInTests {
     public void completableSourceAsMs() throws Exception {
         findPattern("CompletableSource<.*>\\s+ms");
     }
+
+    @Test
+    public void observableAsC() throws Exception {
+        findPattern("Observable<.*>\\s+c\\b");
+    }
 }

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -217,8 +217,8 @@ public enum TestHelper {
         }
     }
 
-    public static void assertError(TestObserver<?> ts, int index, Class<? extends Throwable> clazz) {
-        Throwable ex = ts.errors().get(0);
+    public static void assertError(TestObserver<?> to, int index, Class<? extends Throwable> clazz) {
+        Throwable ex = to.errors().get(0);
         try {
             if (ex instanceof CompositeException) {
                 CompositeException ce = (CompositeException) ex;
@@ -244,8 +244,8 @@ public enum TestHelper {
         }
     }
 
-    public static void assertError(TestObserver<?> ts, int index, Class<? extends Throwable> clazz, String message) {
-        Throwable ex = ts.errors().get(0);
+    public static void assertError(TestObserver<?> to, int index, Class<? extends Throwable> clazz, String message) {
+        Throwable ex = to.errors().get(0);
         if (ex instanceof CompositeException) {
             CompositeException ce = (CompositeException) ex;
             List<Throwable> cel = ce.getExceptions();
@@ -514,14 +514,14 @@ public enum TestHelper {
     public static <T> Consumer<TestObserver<T>> observerSingleNot(final T value) {
         return new Consumer<TestObserver<T>>() {
             @Override
-            public void accept(TestObserver<T> ts) throws Exception {
-                ts
+            public void accept(TestObserver<T> to) throws Exception {
+                to
                 .assertSubscribed()
                 .assertValueCount(1)
                 .assertNoErrors()
                 .assertComplete();
 
-                T v = ts.values().get(0);
+                T v = to.values().get(0);
                 assertNotEquals(value, v);
             }
         };
@@ -2271,16 +2271,16 @@ public enum TestHelper {
     /**
      * Check if the TestSubscriber has a CompositeException with the specified class
      * of Throwables in the given order.
-     * @param ts the TestSubscriber instance
+     * @param to the TestSubscriber instance
      * @param classes the array of expected Throwables inside the Composite
      */
-    public static void assertCompositeExceptions(TestObserver<?> ts, Class<? extends Throwable>... classes) {
-        ts
+    public static void assertCompositeExceptions(TestObserver<?> to, Class<? extends Throwable>... classes) {
+        to
         .assertSubscribed()
         .assertError(CompositeException.class)
         .assertNotComplete();
 
-        List<Throwable> list = compositeList(ts.errors().get(0));
+        List<Throwable> list = compositeList(to.errors().get(0));
 
         assertEquals(classes.length, list.size());
 
@@ -2292,18 +2292,18 @@ public enum TestHelper {
     /**
      * Check if the TestSubscriber has a CompositeException with the specified class
      * of Throwables in the given order.
-     * @param ts the TestSubscriber instance
+     * @param to the TestSubscriber instance
      * @param classes the array of subsequent Class and String instances representing the
      * expected Throwable class and the expected error message
      */
     @SuppressWarnings("unchecked")
-    public static void assertCompositeExceptions(TestObserver<?> ts, Object... classes) {
-        ts
+    public static void assertCompositeExceptions(TestObserver<?> to, Object... classes) {
+        to
         .assertSubscribed()
         .assertError(CompositeException.class)
         .assertNotComplete();
 
-        List<Throwable> list = compositeList(ts.errors().get(0));
+        List<Throwable> list = compositeList(to.errors().get(0));
 
         assertEquals(classes.length, list.size());
 
@@ -2357,9 +2357,9 @@ public enum TestHelper {
                         QueueDisposable<Object> qd = (QueueDisposable<Object>) d;
                         state[0] = true;
 
-                        int m = qd.requestFusion(QueueDisposable.ANY);
+                        int m = qd.requestFusion(QueueFuseable.ANY);
 
-                        if (m != QueueDisposable.NONE) {
+                        if (m != QueueFuseable.NONE) {
                             state[1] = true;
 
                             state[2] = qd.isEmpty();
@@ -2423,9 +2423,9 @@ public enum TestHelper {
                         QueueSubscription<Object> qd = (QueueSubscription<Object>) d;
                         state[0] = true;
 
-                        int m = qd.requestFusion(QueueSubscription.ANY);
+                        int m = qd.requestFusion(QueueFuseable.ANY);
 
-                        if (m != QueueSubscription.NONE) {
+                        if (m != QueueFuseable.NONE) {
                             state[1] = true;
 
                             state[2] = qd.isEmpty();
@@ -2481,11 +2481,11 @@ public enum TestHelper {
 
     /**
      * Returns an expanded error list of the given test consumer.
-     * @param to the test consumer instance
+     * @param ts the test consumer instance
      * @return the list
      */
-    public static List<Throwable> errorList(TestSubscriber<?> to) {
-        return compositeList(to.errors().get(0));
+    public static List<Throwable> errorList(TestSubscriber<?> ts) {
+        return compositeList(ts.errors().get(0));
     }
 
     /**
@@ -2557,23 +2557,23 @@ public enum TestHelper {
 
             if (o instanceof Publisher) {
                 Publisher<?> os = (Publisher<?>) o;
-                TestSubscriber<Object> to = new TestSubscriber<Object>();
+                TestSubscriber<Object> ts = new TestSubscriber<Object>();
 
-                os.subscribe(to);
+                os.subscribe(ts);
 
-                to.awaitDone(5, TimeUnit.SECONDS);
+                ts.awaitDone(5, TimeUnit.SECONDS);
 
-                to.assertSubscribed();
+                ts.assertSubscribed();
 
                 if (expected != null) {
-                    to.assertValues(expected);
+                    ts.assertValues(expected);
                 }
                 if (error) {
-                    to.assertError(TestException.class)
+                    ts.assertError(TestException.class)
                     .assertErrorMessage("error")
                     .assertNotComplete();
                 } else {
-                    to.assertNoErrors().assertComplete();
+                    ts.assertNoErrors().assertComplete();
                 }
             }
 
@@ -2716,23 +2716,23 @@ public enum TestHelper {
 
             if (o instanceof Publisher) {
                 Publisher<?> os = (Publisher<?>) o;
-                TestSubscriber<Object> to = new TestSubscriber<Object>();
+                TestSubscriber<Object> ts = new TestSubscriber<Object>();
 
-                os.subscribe(to);
+                os.subscribe(ts);
 
-                to.awaitDone(5, TimeUnit.SECONDS);
+                ts.awaitDone(5, TimeUnit.SECONDS);
 
-                to.assertSubscribed();
+                ts.assertSubscribed();
 
                 if (expected != null) {
-                    to.assertValues(expected);
+                    ts.assertValues(expected);
                 }
                 if (error) {
-                    to.assertError(TestException.class)
+                    ts.assertError(TestException.class)
                     .assertErrorMessage("error")
                     .assertNotComplete();
                 } else {
-                    to.assertNoErrors().assertComplete();
+                    ts.assertNoErrors().assertComplete();
                 }
             }
 

--- a/src/test/java/io/reactivex/XFlatMapTest.java
+++ b/src/test/java/io/reactivex/XFlatMapTest.java
@@ -154,7 +154,7 @@ public class XFlatMapTest {
     public void flowableCompletable() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Void> ts = Flowable.just(1)
+            TestObserver<Void> to = Flowable.just(1)
             .subscribeOn(Schedulers.io())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
@@ -167,13 +167,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -217,7 +217,7 @@ public class XFlatMapTest {
     public void observableFlowable() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Integer> ts = Observable.just(1)
+            TestObserver<Integer> to = Observable.just(1)
             .subscribeOn(Schedulers.io())
             .flatMap(new Function<Integer, Observable<Integer>>() {
                 @Override
@@ -230,13 +230,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -248,7 +248,7 @@ public class XFlatMapTest {
     public void observerSingle() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Integer> ts = Observable.just(1)
+            TestObserver<Integer> to = Observable.just(1)
             .subscribeOn(Schedulers.io())
             .flatMapSingle(new Function<Integer, Single<Integer>>() {
                 @Override
@@ -261,13 +261,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -279,7 +279,7 @@ public class XFlatMapTest {
     public void observerMaybe() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Integer> ts = Observable.just(1)
+            TestObserver<Integer> to = Observable.just(1)
             .subscribeOn(Schedulers.io())
             .flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
                 @Override
@@ -292,13 +292,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -310,7 +310,7 @@ public class XFlatMapTest {
     public void observerCompletable() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Void> ts = Observable.just(1)
+            TestObserver<Void> to = Observable.just(1)
             .subscribeOn(Schedulers.io())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
@@ -323,13 +323,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -341,7 +341,7 @@ public class XFlatMapTest {
     public void observerCompletable2() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Void> ts = Observable.just(1)
+            TestObserver<Void> to = Observable.just(1)
             .subscribeOn(Schedulers.io())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
@@ -355,13 +355,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -373,7 +373,7 @@ public class XFlatMapTest {
     public void singleSingle() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Integer> ts = Single.just(1)
+            TestObserver<Integer> to = Single.just(1)
             .subscribeOn(Schedulers.io())
             .flatMap(new Function<Integer, Single<Integer>>() {
                 @Override
@@ -386,13 +386,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -404,7 +404,7 @@ public class XFlatMapTest {
     public void singleMaybe() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Integer> ts = Single.just(1)
+            TestObserver<Integer> to = Single.just(1)
             .subscribeOn(Schedulers.io())
             .flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
                 @Override
@@ -417,13 +417,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -435,7 +435,7 @@ public class XFlatMapTest {
     public void singleCompletable() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Void> ts = Single.just(1)
+            TestObserver<Void> to = Single.just(1)
             .subscribeOn(Schedulers.io())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
@@ -448,13 +448,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -466,7 +466,7 @@ public class XFlatMapTest {
     public void singleCompletable2() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Integer> ts = Single.just(1)
+            TestObserver<Integer> to = Single.just(1)
             .subscribeOn(Schedulers.io())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
@@ -480,13 +480,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -498,7 +498,7 @@ public class XFlatMapTest {
     public void maybeSingle() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Integer> ts = Maybe.just(1)
+            TestObserver<Integer> to = Maybe.just(1)
             .subscribeOn(Schedulers.io())
             .flatMapSingle(new Function<Integer, Single<Integer>>() {
                 @Override
@@ -511,13 +511,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -529,7 +529,7 @@ public class XFlatMapTest {
     public void maybeMaybe() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Integer> ts = Maybe.just(1)
+            TestObserver<Integer> to = Maybe.just(1)
             .subscribeOn(Schedulers.io())
             .flatMap(new Function<Integer, Maybe<Integer>>() {
                 @Override
@@ -542,13 +542,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -560,7 +560,7 @@ public class XFlatMapTest {
     public void maybeCompletable() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Void> ts = Maybe.just(1)
+            TestObserver<Void> to = Maybe.just(1)
             .subscribeOn(Schedulers.io())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
@@ -573,13 +573,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {
@@ -591,7 +591,7 @@ public class XFlatMapTest {
     public void maybeCompletable2() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Void> ts = Maybe.just(1)
+            TestObserver<Void> to = Maybe.just(1)
             .subscribeOn(Schedulers.io())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
@@ -605,13 +605,13 @@ public class XFlatMapTest {
 
             cb.await();
 
-            beforeCancelSleep(ts);
+            beforeCancelSleep(to);
 
-            ts.cancel();
+            to.cancel();
 
             Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+            to.assertEmpty();
 
             assertTrue(errors.toString(), errors.isEmpty());
         } finally {

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -2599,24 +2599,24 @@ public class CompletableTest {
 
     @Test(timeout = 5000)
     public void subscribeObserverNormal() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
-        normal.completable.toObservable().subscribe(ts);
+        normal.completable.toObservable().subscribe(to);
 
-        ts.assertComplete();
-        ts.assertNoValues();
-        ts.assertNoErrors();
+        to.assertComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
     }
 
     @Test(timeout = 5000)
     public void subscribeObserverError() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
-        error.completable.toObservable().subscribe(ts);
+        error.completable.toObservable().subscribe(to);
 
-        ts.assertNotComplete();
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
+        to.assertNotComplete();
+        to.assertNoValues();
+        to.assertError(TestException.class);
     }
 
     @Test(timeout = 5000)
@@ -2978,12 +2978,12 @@ public class CompletableTest {
 
     @Test(timeout = 5000)
     public void ambArrayOneFires() {
-        PublishProcessor<Object> ps1 = PublishProcessor.create();
-        PublishProcessor<Object> ps2 = PublishProcessor.create();
+        PublishProcessor<Object> pp1 = PublishProcessor.create();
+        PublishProcessor<Object> pp2 = PublishProcessor.create();
 
-        Completable c1 = Completable.fromPublisher(ps1);
+        Completable c1 = Completable.fromPublisher(pp1);
 
-        Completable c2 = Completable.fromPublisher(ps2);
+        Completable c2 = Completable.fromPublisher(pp2);
 
         Completable c = Completable.ambArray(c1, c2);
 
@@ -2996,25 +2996,25 @@ public class CompletableTest {
             }
         });
 
-        Assert.assertTrue("First subject no subscribers", ps1.hasSubscribers());
-        Assert.assertTrue("Second subject no subscribers", ps2.hasSubscribers());
+        Assert.assertTrue("First subject no subscribers", pp1.hasSubscribers());
+        Assert.assertTrue("Second subject no subscribers", pp2.hasSubscribers());
 
-        ps1.onComplete();
+        pp1.onComplete();
 
-        Assert.assertFalse("First subject has subscribers", ps1.hasSubscribers());
-        Assert.assertFalse("Second subject has subscribers", ps2.hasSubscribers());
+        Assert.assertFalse("First subject has subscribers", pp1.hasSubscribers());
+        Assert.assertFalse("Second subject has subscribers", pp2.hasSubscribers());
 
         Assert.assertTrue("Not completed", complete.get());
     }
 
     @Test(timeout = 5000)
     public void ambArrayOneFiresError() {
-        PublishProcessor<Object> ps1 = PublishProcessor.create();
-        PublishProcessor<Object> ps2 = PublishProcessor.create();
+        PublishProcessor<Object> pp1 = PublishProcessor.create();
+        PublishProcessor<Object> pp2 = PublishProcessor.create();
 
-        Completable c1 = Completable.fromPublisher(ps1);
+        Completable c1 = Completable.fromPublisher(pp1);
 
-        Completable c2 = Completable.fromPublisher(ps2);
+        Completable c2 = Completable.fromPublisher(pp2);
 
         Completable c = Completable.ambArray(c1, c2);
 
@@ -3027,25 +3027,25 @@ public class CompletableTest {
             }
         });
 
-        Assert.assertTrue("First subject no subscribers", ps1.hasSubscribers());
-        Assert.assertTrue("Second subject no subscribers", ps2.hasSubscribers());
+        Assert.assertTrue("First subject no subscribers", pp1.hasSubscribers());
+        Assert.assertTrue("Second subject no subscribers", pp2.hasSubscribers());
 
-        ps1.onError(new TestException());
+        pp1.onError(new TestException());
 
-        Assert.assertFalse("First subject has subscribers", ps1.hasSubscribers());
-        Assert.assertFalse("Second subject has subscribers", ps2.hasSubscribers());
+        Assert.assertFalse("First subject has subscribers", pp1.hasSubscribers());
+        Assert.assertFalse("Second subject has subscribers", pp2.hasSubscribers());
 
         Assert.assertTrue("Not completed", complete.get() instanceof TestException);
     }
 
     @Test(timeout = 5000)
     public void ambArraySecondFires() {
-        PublishProcessor<Object> ps1 = PublishProcessor.create();
-        PublishProcessor<Object> ps2 = PublishProcessor.create();
+        PublishProcessor<Object> pp1 = PublishProcessor.create();
+        PublishProcessor<Object> pp2 = PublishProcessor.create();
 
-        Completable c1 = Completable.fromPublisher(ps1);
+        Completable c1 = Completable.fromPublisher(pp1);
 
-        Completable c2 = Completable.fromPublisher(ps2);
+        Completable c2 = Completable.fromPublisher(pp2);
 
         Completable c = Completable.ambArray(c1, c2);
 
@@ -3058,25 +3058,25 @@ public class CompletableTest {
             }
         });
 
-        Assert.assertTrue("First subject no subscribers", ps1.hasSubscribers());
-        Assert.assertTrue("Second subject no subscribers", ps2.hasSubscribers());
+        Assert.assertTrue("First subject no subscribers", pp1.hasSubscribers());
+        Assert.assertTrue("Second subject no subscribers", pp2.hasSubscribers());
 
-        ps2.onComplete();
+        pp2.onComplete();
 
-        Assert.assertFalse("First subject has subscribers", ps1.hasSubscribers());
-        Assert.assertFalse("Second subject has subscribers", ps2.hasSubscribers());
+        Assert.assertFalse("First subject has subscribers", pp1.hasSubscribers());
+        Assert.assertFalse("Second subject has subscribers", pp2.hasSubscribers());
 
         Assert.assertTrue("Not completed", complete.get());
     }
 
     @Test(timeout = 5000)
     public void ambArraySecondFiresError() {
-        PublishProcessor<Object> ps1 = PublishProcessor.create();
-        PublishProcessor<Object> ps2 = PublishProcessor.create();
+        PublishProcessor<Object> pp1 = PublishProcessor.create();
+        PublishProcessor<Object> pp2 = PublishProcessor.create();
 
-        Completable c1 = Completable.fromPublisher(ps1);
+        Completable c1 = Completable.fromPublisher(pp1);
 
-        Completable c2 = Completable.fromPublisher(ps2);
+        Completable c2 = Completable.fromPublisher(pp2);
 
         Completable c = Completable.ambArray(c1, c2);
 
@@ -3089,13 +3089,13 @@ public class CompletableTest {
             }
         });
 
-        Assert.assertTrue("First subject no subscribers", ps1.hasSubscribers());
-        Assert.assertTrue("Second subject no subscribers", ps2.hasSubscribers());
+        Assert.assertTrue("First subject no subscribers", pp1.hasSubscribers());
+        Assert.assertTrue("Second subject no subscribers", pp2.hasSubscribers());
 
-        ps2.onError(new TestException());
+        pp2.onError(new TestException());
 
-        Assert.assertFalse("First subject has subscribers", ps1.hasSubscribers());
-        Assert.assertFalse("Second subject has subscribers", ps2.hasSubscribers());
+        Assert.assertFalse("First subject has subscribers", pp1.hasSubscribers());
+        Assert.assertFalse("Second subject has subscribers", pp2.hasSubscribers());
 
         Assert.assertTrue("Not completed", complete.get() instanceof TestException);
     }
@@ -3199,12 +3199,12 @@ public class CompletableTest {
 
     @Test(timeout = 5000)
     public void ambWithArrayOneFires() {
-        PublishProcessor<Object> ps1 = PublishProcessor.create();
-        PublishProcessor<Object> ps2 = PublishProcessor.create();
+        PublishProcessor<Object> pp1 = PublishProcessor.create();
+        PublishProcessor<Object> pp2 = PublishProcessor.create();
 
-        Completable c1 = Completable.fromPublisher(ps1);
+        Completable c1 = Completable.fromPublisher(pp1);
 
-        Completable c2 = Completable.fromPublisher(ps2);
+        Completable c2 = Completable.fromPublisher(pp2);
 
         Completable c = c1.ambWith(c2);
 
@@ -3217,25 +3217,25 @@ public class CompletableTest {
             }
         });
 
-        Assert.assertTrue("First subject no subscribers", ps1.hasSubscribers());
-        Assert.assertTrue("Second subject no subscribers", ps2.hasSubscribers());
+        Assert.assertTrue("First subject no subscribers", pp1.hasSubscribers());
+        Assert.assertTrue("Second subject no subscribers", pp2.hasSubscribers());
 
-        ps1.onComplete();
+        pp1.onComplete();
 
-        Assert.assertFalse("First subject has subscribers", ps1.hasSubscribers());
-        Assert.assertFalse("Second subject has subscribers", ps2.hasSubscribers());
+        Assert.assertFalse("First subject has subscribers", pp1.hasSubscribers());
+        Assert.assertFalse("Second subject has subscribers", pp2.hasSubscribers());
 
         Assert.assertTrue("Not completed", complete.get());
     }
 
     @Test(timeout = 5000)
     public void ambWithArrayOneFiresError() {
-        PublishProcessor<Object> ps1 = PublishProcessor.create();
-        PublishProcessor<Object> ps2 = PublishProcessor.create();
+        PublishProcessor<Object> pp1 = PublishProcessor.create();
+        PublishProcessor<Object> pp2 = PublishProcessor.create();
 
-        Completable c1 = Completable.fromPublisher(ps1);
+        Completable c1 = Completable.fromPublisher(pp1);
 
-        Completable c2 = Completable.fromPublisher(ps2);
+        Completable c2 = Completable.fromPublisher(pp2);
 
         Completable c = c1.ambWith(c2);
 
@@ -3248,25 +3248,25 @@ public class CompletableTest {
             }
         });
 
-        Assert.assertTrue("First subject no subscribers", ps1.hasSubscribers());
-        Assert.assertTrue("Second subject no subscribers", ps2.hasSubscribers());
+        Assert.assertTrue("First subject no subscribers", pp1.hasSubscribers());
+        Assert.assertTrue("Second subject no subscribers", pp2.hasSubscribers());
 
-        ps1.onError(new TestException());
+        pp1.onError(new TestException());
 
-        Assert.assertFalse("First subject has subscribers", ps1.hasSubscribers());
-        Assert.assertFalse("Second subject has subscribers", ps2.hasSubscribers());
+        Assert.assertFalse("First subject has subscribers", pp1.hasSubscribers());
+        Assert.assertFalse("Second subject has subscribers", pp2.hasSubscribers());
 
         Assert.assertTrue("Not completed", complete.get() instanceof TestException);
     }
 
     @Test(timeout = 5000)
     public void ambWithArraySecondFires() {
-        PublishProcessor<Object> ps1 = PublishProcessor.create();
-        PublishProcessor<Object> ps2 = PublishProcessor.create();
+        PublishProcessor<Object> pp1 = PublishProcessor.create();
+        PublishProcessor<Object> pp2 = PublishProcessor.create();
 
-        Completable c1 = Completable.fromPublisher(ps1);
+        Completable c1 = Completable.fromPublisher(pp1);
 
-        Completable c2 = Completable.fromPublisher(ps2);
+        Completable c2 = Completable.fromPublisher(pp2);
 
         Completable c = c1.ambWith(c2);
 
@@ -3279,25 +3279,25 @@ public class CompletableTest {
             }
         });
 
-        Assert.assertTrue("First subject no subscribers", ps1.hasSubscribers());
-        Assert.assertTrue("Second subject no subscribers", ps2.hasSubscribers());
+        Assert.assertTrue("First subject no subscribers", pp1.hasSubscribers());
+        Assert.assertTrue("Second subject no subscribers", pp2.hasSubscribers());
 
-        ps2.onComplete();
+        pp2.onComplete();
 
-        Assert.assertFalse("First subject has subscribers", ps1.hasSubscribers());
-        Assert.assertFalse("Second subject has subscribers", ps2.hasSubscribers());
+        Assert.assertFalse("First subject has subscribers", pp1.hasSubscribers());
+        Assert.assertFalse("Second subject has subscribers", pp2.hasSubscribers());
 
         Assert.assertTrue("Not completed", complete.get());
     }
 
     @Test(timeout = 5000)
     public void ambWithArraySecondFiresError() {
-        PublishProcessor<Object> ps1 = PublishProcessor.create();
-        PublishProcessor<Object> ps2 = PublishProcessor.create();
+        PublishProcessor<Object> pp1 = PublishProcessor.create();
+        PublishProcessor<Object> pp2 = PublishProcessor.create();
 
-        Completable c1 = Completable.fromPublisher(ps1);
+        Completable c1 = Completable.fromPublisher(pp1);
 
-        Completable c2 = Completable.fromPublisher(ps2);
+        Completable c2 = Completable.fromPublisher(pp2);
 
         Completable c = c1.ambWith(c2);
 
@@ -3310,13 +3310,13 @@ public class CompletableTest {
             }
         });
 
-        Assert.assertTrue("First subject no subscribers", ps1.hasSubscribers());
-        Assert.assertTrue("Second subject no subscribers", ps2.hasSubscribers());
+        Assert.assertTrue("First subject no subscribers", pp1.hasSubscribers());
+        Assert.assertTrue("Second subject no subscribers", pp2.hasSubscribers());
 
-        ps2.onError(new TestException());
+        pp2.onError(new TestException());
 
-        Assert.assertFalse("First subject has subscribers", ps1.hasSubscribers());
-        Assert.assertFalse("Second subject has subscribers", ps2.hasSubscribers());
+        Assert.assertFalse("First subject has subscribers", pp1.hasSubscribers());
+        Assert.assertFalse("Second subject has subscribers", pp2.hasSubscribers());
 
         Assert.assertTrue("Not completed", complete.get() instanceof TestException);
     }
@@ -3404,16 +3404,16 @@ public class CompletableTest {
                     }
                 }));
 
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
-        c.subscribe(ts);
+        c.subscribe(to);
 
         Assert.assertTrue("Did not start with other", run.get());
         normal.assertSubscriptions(1);
 
-        ts.assertValue(1);
-        ts.assertComplete();
-        ts.assertNoErrors();
+        to.assertValue(1);
+        to.assertComplete();
+        to.assertNoErrors();
     }
 
     @Test(timeout = 5000)
@@ -3421,15 +3421,15 @@ public class CompletableTest {
         Observable<Object> c = normal.completable
                 .startWith(Observable.error(new TestException()));
 
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
-        c.subscribe(ts);
+        c.subscribe(to);
 
         normal.assertSubscriptions(0);
 
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertError(TestException.class);
+        to.assertNotComplete();
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -3395,7 +3395,7 @@ public class CompletableTest {
     @Test(timeout = 5000)
     public void startWithObservableNormal() {
         final AtomicBoolean run = new AtomicBoolean();
-        Observable<Object> c = normal.completable
+        Observable<Object> o = normal.completable
                 .startWith(Observable.fromCallable(new Callable<Object>() {
                     @Override
                     public Object call() throws Exception {
@@ -3406,7 +3406,7 @@ public class CompletableTest {
 
         TestObserver<Object> to = new TestObserver<Object>();
 
-        c.subscribe(to);
+        o.subscribe(to);
 
         Assert.assertTrue("Did not start with other", run.get());
         normal.assertSubscriptions(1);
@@ -3418,12 +3418,12 @@ public class CompletableTest {
 
     @Test(timeout = 5000)
     public void startWithObservableError() {
-        Observable<Object> c = normal.completable
+        Observable<Object> o = normal.completable
                 .startWith(Observable.error(new TestException()));
 
         TestObserver<Object> to = new TestObserver<Object>();
 
-        c.subscribe(to);
+        o.subscribe(to);
 
         normal.assertSubscriptions(0);
 

--- a/src/test/java/io/reactivex/flowable/FlowableFuseableTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableFuseableTest.java
@@ -17,8 +17,8 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import io.reactivex.Flowable;
-import io.reactivex.internal.fuseable.QueueSubscription;
-import io.reactivex.subscribers.*;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.subscribers.SubscriberFusion;
 
 public class FlowableFuseableTest {
 
@@ -26,8 +26,8 @@ public class FlowableFuseableTest {
     public void syncRange() {
 
         Flowable.range(1, 10)
-        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueFuseable.ANY, false))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -37,8 +37,8 @@ public class FlowableFuseableTest {
     public void syncArray() {
 
         Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
-        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueFuseable.ANY, false))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -48,8 +48,8 @@ public class FlowableFuseableTest {
     public void syncIterable() {
 
         Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
-        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueFuseable.ANY, false))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -59,9 +59,9 @@ public class FlowableFuseableTest {
     public void syncRangeHidden() {
 
         Flowable.range(1, 10).hide()
-        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueFuseable.ANY, false))
         .assertOf(SubscriberFusion.<Integer>assertNotFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -71,9 +71,9 @@ public class FlowableFuseableTest {
     public void syncArrayHidden() {
         Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
         .hide()
-        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueFuseable.ANY, false))
         .assertOf(SubscriberFusion.<Integer>assertNotFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -83,9 +83,9 @@ public class FlowableFuseableTest {
     public void syncIterableHidden() {
         Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
         .hide()
-        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueFuseable.ANY, false))
         .assertOf(SubscriberFusion.<Integer>assertNotFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();

--- a/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
@@ -749,11 +749,11 @@ public class FlowableSubscriberTest {
 
     @Test
     public void methodTestCancelled() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.test(Long.MAX_VALUE, true);
+        pp.test(Long.MAX_VALUE, true);
 
-        assertFalse(ps.hasSubscribers());
+        assertFalse(pp.hasSubscribers());
     }
 
     @Test
@@ -767,11 +767,11 @@ public class FlowableSubscriberTest {
 
     @Test
     public void methodTestNoCancel() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.test(Long.MAX_VALUE, false);
+        pp.test(Long.MAX_VALUE, false);
 
-        assertTrue(ps.hasSubscribers());
+        assertTrue(pp.hasSubscribers());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/disposables/EmptyDisposableTest.java
+++ b/src/test/java/io/reactivex/internal/disposables/EmptyDisposableTest.java
@@ -14,10 +14,11 @@
 package io.reactivex.internal.disposables;
 
 import static org.junit.Assert.*;
+
 import org.junit.Test;
 
 import io.reactivex.TestHelper;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 
 public class EmptyDisposableTest {
 
@@ -28,8 +29,8 @@ public class EmptyDisposableTest {
 
     @Test
     public void asyncFusion() {
-        assertEquals(QueueDisposable.NONE, EmptyDisposable.INSTANCE.requestFusion(QueueDisposable.SYNC));
-        assertEquals(QueueDisposable.ASYNC, EmptyDisposable.INSTANCE.requestFusion(QueueDisposable.ASYNC));
+        assertEquals(QueueFuseable.NONE, EmptyDisposable.INSTANCE.requestFusion(QueueFuseable.SYNC));
+        assertEquals(QueueFuseable.ASYNC, EmptyDisposable.INSTANCE.requestFusion(QueueFuseable.ASYNC));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/observers/DeferredScalarObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/DeferredScalarObserverTest.java
@@ -20,8 +20,7 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.internal.fuseable.QueueDisposable;
-import io.reactivex.internal.observers.DeferredScalarObserver;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.observers.*;
 
 public class DeferredScalarObserverTest {
@@ -106,7 +105,7 @@ public class DeferredScalarObserverTest {
 
     @Test
     public void fused() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         TakeFirst source = new TakeFirst(to);
 
@@ -115,7 +114,7 @@ public class DeferredScalarObserverTest {
         source.onSubscribe(d);
 
         to.assertOf(ObserverFusion.<Integer>assertFuseable());
-        to.assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC));
+        to.assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC));
 
         source.onNext(1);
         source.onNext(1);
@@ -129,7 +128,7 @@ public class DeferredScalarObserverTest {
 
     @Test
     public void fusedReject() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.SYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.SYNC);
 
         TakeFirst source = new TakeFirst(to);
 
@@ -138,7 +137,7 @@ public class DeferredScalarObserverTest {
         source.onSubscribe(d);
 
         to.assertOf(ObserverFusion.<Integer>assertFuseable());
-        to.assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.NONE));
+        to.assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.NONE));
 
         source.onNext(1);
         source.onNext(1);
@@ -168,7 +167,7 @@ public class DeferredScalarObserverTest {
 
     @Test
     public void nonfusedTerminateMore() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.NONE);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.NONE);
 
         TakeLast source = new TakeLast(to);
 
@@ -186,7 +185,7 @@ public class DeferredScalarObserverTest {
 
     @Test
     public void nonfusedError() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.NONE);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.NONE);
 
         TakeLast source = new TakeLast(to);
 
@@ -204,7 +203,7 @@ public class DeferredScalarObserverTest {
 
     @Test
     public void fusedTerminateMore() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         TakeLast source = new TakeLast(to);
 
@@ -222,7 +221,7 @@ public class DeferredScalarObserverTest {
 
     @Test
     public void fusedError() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         TakeLast source = new TakeLast(to);
 
@@ -240,7 +239,7 @@ public class DeferredScalarObserverTest {
 
     @Test
     public void disposed() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.NONE);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.NONE);
 
         TakeLast source = new TakeLast(to);
 
@@ -295,7 +294,7 @@ public class DeferredScalarObserverTest {
 
     @Test
     public void fusedEmpty() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         TakeLast source = new TakeLast(to);
 
@@ -310,7 +309,7 @@ public class DeferredScalarObserverTest {
 
     @Test
     public void nonfusedEmpty() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.NONE);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.NONE);
 
         TakeLast source = new TakeLast(to);
 
@@ -335,7 +334,7 @@ public class DeferredScalarObserverTest {
             public void onSubscribe(Disposable d) {
                 this.d = (QueueDisposable<Integer>)d;
                 to.onSubscribe(d);
-                this.d.requestFusion(QueueDisposable.ANY);
+                this.d.requestFusion(QueueFuseable.ANY);
             }
 
             @Override
@@ -385,7 +384,7 @@ public class DeferredScalarObserverTest {
             public void onSubscribe(Disposable d) {
                 this.d = (QueueDisposable<Integer>)d;
                 to.onSubscribe(d);
-                this.d.requestFusion(QueueDisposable.ANY);
+                this.d.requestFusion(QueueFuseable.ANY);
             }
 
             @Override
@@ -414,7 +413,7 @@ public class DeferredScalarObserverTest {
 
     @Test
     public void offerThrow() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.NONE);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.NONE);
 
         TakeLast source = new TakeLast(to);
 
@@ -433,7 +432,7 @@ public class DeferredScalarObserverTest {
             public void onSubscribe(Disposable d) {
                 this.d = (QueueDisposable<Integer>)d;
                 to.onSubscribe(d);
-                this.d.requestFusion(QueueDisposable.ANY);
+                this.d.requestFusion(QueueFuseable.ANY);
             }
 
             @Override

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableCacheTest.java
@@ -85,50 +85,50 @@ public class CompletableCacheTest implements Consumer<Object>, Action {
     public void crossDispose() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserver<Void> ts1 = new TestObserver<Void>();
+        final TestObserver<Void> to1 = new TestObserver<Void>();
 
-        final TestObserver<Void> ts2 = new TestObserver<Void>() {
+        final TestObserver<Void> to2 = new TestObserver<Void>() {
             @Override
             public void onComplete() {
                 super.onComplete();
-                ts1.cancel();
+                to1.cancel();
             }
         };
 
         Completable c = ps.ignoreElements().cache();
 
-        c.subscribe(ts2);
-        c.subscribe(ts1);
+        c.subscribe(to2);
+        c.subscribe(to1);
 
         ps.onComplete();
 
-        ts1.assertEmpty();
-        ts2.assertResult();
+        to1.assertEmpty();
+        to2.assertResult();
     }
 
     @Test
     public void crossDisposeOnError() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserver<Void> ts1 = new TestObserver<Void>();
+        final TestObserver<Void> to1 = new TestObserver<Void>();
 
-        final TestObserver<Void> ts2 = new TestObserver<Void>() {
+        final TestObserver<Void> to2 = new TestObserver<Void>() {
             @Override
             public void onError(Throwable ex) {
                 super.onError(ex);
-                ts1.cancel();
+                to1.cancel();
             }
         };
 
         Completable c = ps.ignoreElements().cache();
 
-        c.subscribe(ts2);
-        c.subscribe(ts1);
+        c.subscribe(to2);
+        c.subscribe(to1);
 
         ps.onError(new TestException());
 
-        ts1.assertEmpty();
-        ts2.assertFailure(TestException.class);
+        to1.assertEmpty();
+        to2.assertFailure(TestException.class);
     }
 
     @Test
@@ -139,31 +139,31 @@ public class CompletableCacheTest implements Consumer<Object>, Action {
 
         assertFalse(ps.hasObservers());
 
-        TestObserver<Void> ts1 = c.test();
+        TestObserver<Void> to1 = c.test();
 
         assertTrue(ps.hasObservers());
 
-        ts1.cancel();
+        to1.cancel();
 
         assertTrue(ps.hasObservers());
 
-        TestObserver<Void> ts2 = c.test();
+        TestObserver<Void> to2 = c.test();
 
-        TestObserver<Void> ts3 = c.test();
-        ts3.cancel();
+        TestObserver<Void> to3 = c.test();
+        to3.cancel();
 
-        TestObserver<Void> ts4 = c.test(true);
-        ts3.cancel();
+        TestObserver<Void> to4 = c.test(true);
+        to3.cancel();
 
         ps.onComplete();
 
-        ts1.assertEmpty();
+        to1.assertEmpty();
 
-        ts2.assertResult();
+        to2.assertResult();
 
-        ts3.assertEmpty();
+        to3.assertEmpty();
 
-        ts4.assertEmpty();
+        to4.assertEmpty();
     }
 
     @Test
@@ -173,20 +173,20 @@ public class CompletableCacheTest implements Consumer<Object>, Action {
 
             final Completable c = ps.ignoreElements().cache();
 
-            final TestObserver<Void> ts1 = new TestObserver<Void>();
+            final TestObserver<Void> to1 = new TestObserver<Void>();
 
-            final TestObserver<Void> ts2 = new TestObserver<Void>();
+            final TestObserver<Void> to2 = new TestObserver<Void>();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    c.subscribe(ts1);
+                    c.subscribe(to1);
                 }
             };
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    c.subscribe(ts2);
+                    c.subscribe(to2);
                 }
             };
 
@@ -194,8 +194,8 @@ public class CompletableCacheTest implements Consumer<Object>, Action {
 
             ps.onComplete();
 
-            ts1.assertResult();
-            ts2.assertResult();
+            to1.assertResult();
+            to2.assertResult();
         }
     }
 
@@ -206,20 +206,20 @@ public class CompletableCacheTest implements Consumer<Object>, Action {
 
             final Completable c = ps.ignoreElements().cache();
 
-            final TestObserver<Void> ts1 = c.test();
+            final TestObserver<Void> to1 = c.test();
 
-            final TestObserver<Void> ts2 = new TestObserver<Void>();
+            final TestObserver<Void> to2 = new TestObserver<Void>();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ts1.cancel();
+                    to1.cancel();
                 }
             };
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    c.subscribe(ts2);
+                    c.subscribe(to2);
                 }
             };
 
@@ -227,8 +227,8 @@ public class CompletableCacheTest implements Consumer<Object>, Action {
 
             ps.onComplete();
 
-            ts1.assertEmpty();
-            ts2.assertResult();
+            to1.assertEmpty();
+            to2.assertResult();
         }
     }
 
@@ -236,31 +236,31 @@ public class CompletableCacheTest implements Consumer<Object>, Action {
     public void doubleDispose() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserver<Void> ts = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<Void>();
 
         ps.ignoreElements().cache()
         .subscribe(new CompletableObserver() {
 
             @Override
             public void onSubscribe(Disposable d) {
-                ts.onSubscribe(EmptyDisposable.INSTANCE);
+                to.onSubscribe(EmptyDisposable.INSTANCE);
                 d.dispose();
                 d.dispose();
             }
 
             @Override
             public void onComplete() {
-                ts.onComplete();
+                to.onComplete();
             }
 
             @Override
             public void onError(Throwable e) {
-                ts.onError(e);
+                to.onError(e);
             }
         });
 
         ps.onComplete();
 
-        ts.assertEmpty();
+        to.assertEmpty();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
@@ -73,30 +73,30 @@ public class CompletableConcatTest {
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
-                final PublishProcessor<Integer> ps1 = PublishProcessor.create();
-                final PublishProcessor<Integer> ps2 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-                TestObserver<Void> to = Completable.concat(ps1.map(new Function<Integer, Completable>() {
+                TestObserver<Void> to = Completable.concat(pp1.map(new Function<Integer, Completable>() {
                     @Override
                     public Completable apply(Integer v) throws Exception {
-                        return ps2.ignoreElements();
+                        return pp2.ignoreElements();
                     }
                 })).test();
 
-                ps1.onNext(1);
+                pp1.onNext(1);
 
                 final TestException ex = new TestException();
 
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {
-                        ps1.onError(ex);
+                        pp1.onError(ex);
                     }
                 };
                 Runnable r2 = new Runnable() {
                     @Override
                     public void run() {
-                        ps2.onError(ex);
+                        pp2.onError(ex);
                     }
                 };
 

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeOnTest.java
@@ -35,13 +35,13 @@ public class CompletableSubscribeOnTest {
         try {
             TestScheduler scheduler = new TestScheduler();
 
-            TestObserver<Void> ts = Completable.complete()
+            TestObserver<Void> to = Completable.complete()
             .subscribeOn(scheduler)
             .test();
 
             scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-            ts.assertResult();
+            to.assertResult();
 
             assertTrue(list.toString(), list.isEmpty());
         } finally {

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableTimerTest.java
@@ -38,7 +38,7 @@ public class CompletableTimerTest {
         try {
             for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
-                TestObserver<Void> ts = Completable.timer(1, TimeUnit.MILLISECONDS, s)
+                TestObserver<Void> to = Completable.timer(1, TimeUnit.MILLISECONDS, s)
                 .doOnComplete(new Action() {
                     @Override
                     public void run() throws Exception {
@@ -53,7 +53,7 @@ public class CompletableTimerTest {
 
                 Thread.sleep(500);
 
-                ts.cancel();
+                to.cancel();
 
                 Thread.sleep(500);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
@@ -146,40 +146,40 @@ public class FlowableAllTest {
     @Test
     @Ignore("No backpressure in Single")
     public void testBackpressureIfNoneRequestedNoneShouldBeDelivered() {
-        TestObserver<Boolean> ts = new TestObserver<Boolean>();
+        TestObserver<Boolean> to = new TestObserver<Boolean>();
         Flowable.empty().all(new Predicate<Object>() {
             @Override
             public boolean test(Object t1) {
                 return false;
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertNotComplete();
     }
 
     @Test
     public void testBackpressureIfOneRequestedOneShouldBeDelivered() {
-        TestObserver<Boolean> ts = new TestObserver<Boolean>();
+        TestObserver<Boolean> to = new TestObserver<Boolean>();
 
         Flowable.empty().all(new Predicate<Object>() {
             @Override
             public boolean test(Object t) {
                 return false;
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertTerminated();
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertTerminated();
+        to.assertNoErrors();
+        to.assertComplete();
 
-        ts.assertValue(true);
+        to.assertValue(true);
     }
 
     @Test
     public void testPredicateThrowsExceptionAndValueInCauseMessage() {
-        TestObserver<Boolean> ts = new TestObserver<Boolean>();
+        TestObserver<Boolean> to = new TestObserver<Boolean>();
 
         final IllegalArgumentException ex = new IllegalArgumentException();
 
@@ -189,12 +189,12 @@ public class FlowableAllTest {
                 throw ex;
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertTerminated();
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(ex);
+        to.assertTerminated();
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(ex);
         // FIXME need to decide about adding the value that probably caused the crash in some way
 //        assertTrue(ex.getCause().getMessage().contains("Boo!"));
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -353,20 +353,20 @@ public class FlowableAmbTest {
     @SuppressWarnings("unchecked")
     @Test
     public void ambIterable() {
-        PublishProcessor<Integer> ps1 = PublishProcessor.create();
-        PublishProcessor<Integer> ps2 = PublishProcessor.create();
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        Flowable.amb(Arrays.asList(ps1, ps2)).subscribe(ts);
+        Flowable.amb(Arrays.asList(pp1, pp2)).subscribe(ts);
 
         ts.assertNoValues();
 
-        ps1.onNext(1);
-        ps1.onComplete();
+        pp1.onNext(1);
+        pp1.onComplete();
 
-        assertFalse(ps1.hasSubscribers());
-        assertFalse(ps2.hasSubscribers());
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
 
         ts.assertValue(1);
         ts.assertNoErrors();
@@ -376,20 +376,20 @@ public class FlowableAmbTest {
     @SuppressWarnings("unchecked")
     @Test
     public void ambIterable2() {
-        PublishProcessor<Integer> ps1 = PublishProcessor.create();
-        PublishProcessor<Integer> ps2 = PublishProcessor.create();
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        Flowable.amb(Arrays.asList(ps1, ps2)).subscribe(ts);
+        Flowable.amb(Arrays.asList(pp1, pp2)).subscribe(ts);
 
         ts.assertNoValues();
 
-        ps2.onNext(2);
-        ps2.onComplete();
+        pp2.onNext(2);
+        pp2.onComplete();
 
-        assertFalse(ps1.hasSubscribers());
-        assertFalse(ps2.hasSubscribers());
+        assertFalse(pp1.hasSubscribers());
+        assertFalse(pp2.hasSubscribers());
 
         ts.assertValue(2);
         ts.assertNoErrors();
@@ -568,28 +568,28 @@ public class FlowableAmbTest {
     @Test
     public void onNextRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps1 = PublishProcessor.create();
-            final PublishProcessor<Integer> ps2 = PublishProcessor.create();
+            final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+            final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
             @SuppressWarnings("unchecked")
-            TestSubscriber<Integer> to = Flowable.ambArray(ps1, ps2).test();
+            TestSubscriber<Integer> ts = Flowable.ambArray(pp1, pp2).test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ps1.onNext(1);
+                    pp1.onNext(1);
                 }
             };
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ps2.onNext(1);
+                    pp2.onNext(1);
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            to.assertSubscribed().assertNoErrors()
+            ts.assertSubscribed().assertNoErrors()
             .assertNotComplete().assertValueCount(1);
         }
     }
@@ -597,52 +597,52 @@ public class FlowableAmbTest {
     @Test
     public void onCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps1 = PublishProcessor.create();
-            final PublishProcessor<Integer> ps2 = PublishProcessor.create();
+            final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+            final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
             @SuppressWarnings("unchecked")
-            TestSubscriber<Integer> to = Flowable.ambArray(ps1, ps2).test();
+            TestSubscriber<Integer> ts = Flowable.ambArray(pp1, pp2).test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ps1.onComplete();
+                    pp1.onComplete();
                 }
             };
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ps2.onComplete();
+                    pp2.onComplete();
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            to.assertResult();
+            ts.assertResult();
         }
     }
 
     @Test
     public void onErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps1 = PublishProcessor.create();
-            final PublishProcessor<Integer> ps2 = PublishProcessor.create();
+            final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+            final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
             @SuppressWarnings("unchecked")
-            TestSubscriber<Integer> to = Flowable.ambArray(ps1, ps2).test();
+            TestSubscriber<Integer> ts = Flowable.ambArray(pp1, pp2).test();
 
             final Throwable ex = new TestException();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ps1.onError(ex);
+                    pp1.onError(ex);
                 }
             };
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ps2.onError(ex);
+                    pp2.onError(ex);
                 }
             };
 
@@ -653,7 +653,7 @@ public class FlowableAmbTest {
                 RxJavaPlugins.reset();
             }
 
-            to.assertFailure(TestException.class);
+            ts.assertFailure(TestException.class);
             if (!errors.isEmpty()) {
                 TestHelper.assertUndeliverable(errors, 0, TestException.class);
             }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
@@ -239,7 +239,7 @@ public class FlowableAnyTest {
     @Test
     @Ignore("Single doesn't do backpressure")
     public void testBackpressureIfNoneRequestedNoneShouldBeDelivered() {
-        TestObserver<Boolean> ts = new TestObserver<Boolean>();
+        TestObserver<Boolean> to = new TestObserver<Boolean>();
 
         Flowable.just(1).any(new Predicate<Integer>() {
             @Override
@@ -247,32 +247,32 @@ public class FlowableAnyTest {
                 return true;
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertNotComplete();
     }
 
     @Test
     public void testBackpressureIfOneRequestedOneShouldBeDelivered() {
-        TestObserver<Boolean> ts = new TestObserver<Boolean>();
+        TestObserver<Boolean> to = new TestObserver<Boolean>();
         Flowable.just(1).any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertTerminated();
-        ts.assertNoErrors();
-        ts.assertComplete();
-        ts.assertValue(true);
+        to.assertTerminated();
+        to.assertNoErrors();
+        to.assertComplete();
+        to.assertValue(true);
     }
 
     @Test
     public void testPredicateThrowsExceptionAndValueInCauseMessage() {
-        TestObserver<Boolean> ts = new TestObserver<Boolean>();
+        TestObserver<Boolean> to = new TestObserver<Boolean>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
         Flowable.just("Boo!").any(new Predicate<String>() {
@@ -280,12 +280,12 @@ public class FlowableAnyTest {
             public boolean test(String v) {
                 throw ex;
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertTerminated();
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(ex);
+        to.assertTerminated();
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(ex);
         // FIXME value as last cause?
 //        assertTrue(ex.getCause().getMessage().contains("Boo!"));
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAutoConnectTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAutoConnectTest.java
@@ -23,10 +23,10 @@ public class FlowableAutoConnectTest {
 
     @Test
     public void autoConnectImmediately() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.publish().autoConnect(0);
+        pp.publish().autoConnect(0);
 
-        assertTrue(ps.hasSubscribers());
+        assertTrue(pp.hasSubscribers());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
@@ -291,12 +291,12 @@ public class FlowableBlockingTest {
 
     @Test
     public void onCompleteDelayed() {
-        TestSubscriber<Object> to = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<Object>();
 
         Flowable.empty().delay(100, TimeUnit.MILLISECONDS)
-        .blockingSubscribe(to);
+        .blockingSubscribe(ts);
 
-        to.assertResult();
+        ts.assertResult();
     }
 
     @Test
@@ -306,24 +306,24 @@ public class FlowableBlockingTest {
 
     @Test
     public void disposeUpFront() {
-        TestSubscriber<Object> to = new TestSubscriber<Object>();
-        to.dispose();
-        Flowable.just(1).blockingSubscribe(to);
+        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        ts.dispose();
+        Flowable.just(1).blockingSubscribe(ts);
 
-        to.assertEmpty();
+        ts.assertEmpty();
     }
 
     @SuppressWarnings("rawtypes")
     @Test
     public void delayed() throws Exception {
-        final TestSubscriber<Object> to = new TestSubscriber<Object>();
+        final TestSubscriber<Object> ts = new TestSubscriber<Object>();
         final Subscriber[] s = { null };
 
         Schedulers.single().scheduleDirect(new Runnable() {
             @SuppressWarnings("unchecked")
             @Override
             public void run() {
-                to.dispose();
+                ts.dispose();
                 s[0].onNext(1);
             }
         }, 200, TimeUnit.MILLISECONDS);
@@ -334,13 +334,13 @@ public class FlowableBlockingTest {
                 observer.onSubscribe(new BooleanSubscription());
                 s[0] = observer;
             }
-        }.blockingSubscribe(to);
+        }.blockingSubscribe(ts);
 
-        while (!to.isDisposed()) {
+        while (!ts.isDisposed()) {
             Thread.sleep(100);
         }
 
-        to.assertEmpty();
+        ts.assertEmpty();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -1100,29 +1100,29 @@ public class FlowableBufferTest {
     @Test
     public void timeAndSkipOverlap() {
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<List<Integer>> ts = TestSubscriber.create();
 
-        ps.buffer(2, 1, TimeUnit.SECONDS, scheduler).subscribe(ts);
+        pp.buffer(2, 1, TimeUnit.SECONDS, scheduler).subscribe(ts);
 
-        ps.onNext(1);
-
-        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-
-        ps.onNext(2);
+        pp.onNext(1);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        ps.onNext(3);
+        pp.onNext(2);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        ps.onNext(4);
+        pp.onNext(3);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        ps.onComplete();
+        pp.onNext(4);
+
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        pp.onComplete();
 
         ts.assertValues(
                 Arrays.asList(1, 2),
@@ -1140,29 +1140,29 @@ public class FlowableBufferTest {
     @Test
     public void timeAndSkipSkip() {
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<List<Integer>> ts = TestSubscriber.create();
 
-        ps.buffer(2, 3, TimeUnit.SECONDS, scheduler).subscribe(ts);
+        pp.buffer(2, 3, TimeUnit.SECONDS, scheduler).subscribe(ts);
 
-        ps.onNext(1);
-
-        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-
-        ps.onNext(2);
+        pp.onNext(1);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        ps.onNext(3);
+        pp.onNext(2);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        ps.onNext(4);
+        pp.onNext(3);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        ps.onComplete();
+        pp.onNext(4);
+
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        pp.onComplete();
 
         ts.assertValues(
                 Arrays.asList(1, 2),
@@ -1185,29 +1185,29 @@ public class FlowableBufferTest {
         });
 
         try {
-            PublishProcessor<Integer> ps = PublishProcessor.create();
+            PublishProcessor<Integer> pp = PublishProcessor.create();
 
             TestSubscriber<List<Integer>> ts = TestSubscriber.create();
 
-            ps.buffer(2, 1, TimeUnit.SECONDS).subscribe(ts);
+            pp.buffer(2, 1, TimeUnit.SECONDS).subscribe(ts);
 
-            ps.onNext(1);
-
-            scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-
-            ps.onNext(2);
+            pp.onNext(1);
 
             scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-            ps.onNext(3);
+            pp.onNext(2);
 
             scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-            ps.onNext(4);
+            pp.onNext(3);
 
             scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-            ps.onComplete();
+            pp.onNext(4);
+
+            scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+            pp.onComplete();
 
             ts.assertValues(
                     Arrays.asList(1, 2),
@@ -1236,29 +1236,29 @@ public class FlowableBufferTest {
 
         try {
 
-            PublishProcessor<Integer> ps = PublishProcessor.create();
+            PublishProcessor<Integer> pp = PublishProcessor.create();
 
             TestSubscriber<List<Integer>> ts = TestSubscriber.create();
 
-            ps.buffer(2, 3, TimeUnit.SECONDS).subscribe(ts);
+            pp.buffer(2, 3, TimeUnit.SECONDS).subscribe(ts);
 
-            ps.onNext(1);
-
-            scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-
-            ps.onNext(2);
+            pp.onNext(1);
 
             scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-            ps.onNext(3);
+            pp.onNext(2);
 
             scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-            ps.onNext(4);
+            pp.onNext(3);
 
             scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-            ps.onComplete();
+            pp.onNext(4);
+
+            scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+
+            pp.onComplete();
 
             ts.assertValues(
                     Arrays.asList(1, 2),
@@ -1849,9 +1849,9 @@ public class FlowableBufferTest {
     public void bufferTimedExactSupplierCrash() {
         TestScheduler scheduler = new TestScheduler();
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> to = ps
+        TestSubscriber<List<Integer>> ts = pp
         .buffer(1, TimeUnit.MILLISECONDS, scheduler, 1, new Callable<List<Integer>>() {
             int calls;
             @Override
@@ -1864,13 +1864,13 @@ public class FlowableBufferTest {
         }, true)
         .test();
 
-        ps.onNext(1);
+        pp.onNext(1);
 
         scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
-        ps.onNext(2);
+        pp.onNext(2);
 
-        to
+        ts
         .assertFailure(TestException.class, Arrays.asList(1));
     }
 
@@ -1879,15 +1879,15 @@ public class FlowableBufferTest {
     public void bufferTimedExactBoundedError() {
         TestScheduler scheduler = new TestScheduler();
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> to = ps
+        TestSubscriber<List<Integer>> ts = pp
         .buffer(1, TimeUnit.MILLISECONDS, scheduler, 1, Functions.<Integer>createArrayList(16), true)
         .test();
 
-        ps.onError(new TestException());
+        pp.onError(new TestException());
 
-        to
+        ts
         .assertFailure(TestException.class);
     }
 
@@ -1981,19 +1981,19 @@ public class FlowableBufferTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestScheduler scheduler = new TestScheduler();
 
-            final PublishProcessor<Object> ps = PublishProcessor.create();
+            final PublishProcessor<Object> pp = PublishProcessor.create();
 
-            TestSubscriber<List<Object>> ts = ps.buffer(1, TimeUnit.SECONDS, scheduler, 5).test();
+            TestSubscriber<List<Object>> ts = pp.buffer(1, TimeUnit.SECONDS, scheduler, 5).test();
 
-            ps.onNext(1);
-            ps.onNext(2);
-            ps.onNext(3);
-            ps.onNext(4);
+            pp.onNext(1);
+            pp.onNext(2);
+            pp.onNext(3);
+            pp.onNext(4);
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ps.onNext(5);
+                    pp.onNext(5);
                 }
             };
 
@@ -2006,7 +2006,7 @@ public class FlowableBufferTest {
 
             TestHelper.race(r1, r2);
 
-            ps.onComplete();
+            pp.onComplete();
 
             int items = 0;
             for (List<Object> o : ts.values()) {
@@ -2456,7 +2456,7 @@ public class FlowableBufferTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> b = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> to = pp.buffer(b, new Callable<List<Integer>>() {
+        TestSubscriber<List<Integer>> ts = pp.buffer(b, new Callable<List<Integer>>() {
             int calls;
             @Override
             public List<Integer> call() throws Exception {
@@ -2469,7 +2469,7 @@ public class FlowableBufferTest {
 
         b.onNext(1);
 
-        to.assertFailure(TestException.class);
+        ts.assertFailure(TestException.class);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -316,18 +316,18 @@ public class FlowableCacheTest {
     @Test
     public void subscribeEmitRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps = PublishProcessor.<Integer>create();
+            final PublishProcessor<Integer> pp = PublishProcessor.<Integer>create();
 
-            final Flowable<Integer> cache = ps.cache();
+            final Flowable<Integer> cache = pp.cache();
 
             cache.test();
 
-            final TestSubscriber<Integer> to = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    cache.subscribe(to);
+                    cache.subscribe(ts);
                 }
             };
 
@@ -335,15 +335,15 @@ public class FlowableCacheTest {
                 @Override
                 public void run() {
                     for (int j = 0; j < 500; j++) {
-                        ps.onNext(j);
+                        pp.onNext(j);
                     }
-                    ps.onComplete();
+                    pp.onComplete();
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            to
+            ts
             .awaitDone(5, TimeUnit.SECONDS)
             .assertSubscribed().assertValueCount(500).assertComplete().assertNoErrors();
         }
@@ -351,22 +351,22 @@ public class FlowableCacheTest {
 
     @Test
     public void observers() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
-        FlowableCache<Integer> cache = (FlowableCache<Integer>)Flowable.range(1, 5).concatWith(ps).cache();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+        FlowableCache<Integer> cache = (FlowableCache<Integer>)Flowable.range(1, 5).concatWith(pp).cache();
 
         assertFalse(cache.hasSubscribers());
 
         assertEquals(0, cache.cachedEventCount());
 
-        TestSubscriber<Integer> to = cache.test();
+        TestSubscriber<Integer> ts = cache.test();
 
         assertTrue(cache.hasSubscribers());
 
         assertEquals(5, cache.cachedEventCount());
 
-        ps.onComplete();
+        pp.onComplete();
 
-        to.assertResult(1, 2, 3, 4, 5);
+        ts.assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
@@ -460,33 +460,33 @@ public class FlowableCacheTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Flowable<Integer> cache = Flowable.range(1, 500).cache();
 
-            final TestSubscriber<Integer> to1 = new TestSubscriber<Integer>();
-            final TestSubscriber<Integer> to2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    cache.subscribe(to1);
+                    cache.subscribe(ts1);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    cache.subscribe(to2);
+                    cache.subscribe(ts2);
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            to1
+            ts1
             .awaitDone(5, TimeUnit.SECONDS)
             .assertSubscribed()
             .assertValueCount(500)
             .assertComplete()
             .assertNoErrors();
 
-            to2
+            ts2
             .awaitDone(5, TimeUnit.SECONDS)
             .assertSubscribed()
             .assertValueCount(500)
@@ -498,31 +498,31 @@ public class FlowableCacheTest {
     @Test
     public void subscribeCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps = PublishProcessor.<Integer>create();
+            final PublishProcessor<Integer> pp = PublishProcessor.<Integer>create();
 
-            final Flowable<Integer> cache = ps.cache();
+            final Flowable<Integer> cache = pp.cache();
 
             cache.test();
 
-            final TestSubscriber<Integer> to = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    cache.subscribe(to);
+                    cache.subscribe(ts);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ps.onComplete();
+                    pp.onComplete();
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            to
+            ts
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCastTest.java
@@ -56,17 +56,17 @@ public class FlowableCastTest {
     @Test
     public void castCrashUnsubscribes() {
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<String> ts = TestSubscriber.create();
 
-        ps.cast(String.class).subscribe(ts);
+        pp.cast(String.class).subscribe(ts);
 
-        Assert.assertTrue("Not subscribed?", ps.hasSubscribers());
+        Assert.assertTrue("Not subscribed?", pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        Assert.assertFalse("Subscribed?", ps.hasSubscribers());
+        Assert.assertFalse("Subscribed?", pp.hasSubscribers());
 
         ts.assertError(ClassCastException.class);
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1242,14 +1242,14 @@ public class FlowableCombineLatestTest {
 
     @Test
     public void cancelWhileSubscribing() {
-        final TestSubscriber<Object> to = new TestSubscriber<Object>();
+        final TestSubscriber<Object> ts = new TestSubscriber<Object>();
 
         Flowable.combineLatest(
                 Flowable.just(1)
                 .doOnNext(new Consumer<Integer>() {
                     @Override
                     public void accept(Integer v) throws Exception {
-                        to.cancel();
+                        ts.cancel();
                     }
                 }),
                 Flowable.never(),
@@ -1259,7 +1259,7 @@ public class FlowableCombineLatestTest {
                 return a;
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
     }
 
     @Test
@@ -1267,10 +1267,10 @@ public class FlowableCombineLatestTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                final PublishProcessor<Integer> ps1 = PublishProcessor.create();
-                final PublishProcessor<Integer> ps2 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-                TestSubscriber<Integer> to = Flowable.combineLatest(ps1, ps2, new BiFunction<Integer, Integer, Integer>() {
+                TestSubscriber<Integer> ts = Flowable.combineLatest(pp1, pp2, new BiFunction<Integer, Integer, Integer>() {
                     @Override
                     public Integer apply(Integer a, Integer b) throws Exception {
                         return a;
@@ -1283,30 +1283,30 @@ public class FlowableCombineLatestTest {
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {
-                        ps1.onError(ex1);
+                        pp1.onError(ex1);
                     }
                 };
                 Runnable r2 = new Runnable() {
                     @Override
                     public void run() {
-                        ps2.onError(ex2);
+                        pp2.onError(ex2);
                     }
                 };
 
                 TestHelper.race(r1, r2);
 
-                if (to.errorCount() != 0) {
-                    if (to.errors().get(0) instanceof CompositeException) {
-                        to.assertSubscribed()
+                if (ts.errorCount() != 0) {
+                    if (ts.errors().get(0) instanceof CompositeException) {
+                        ts.assertSubscribed()
                         .assertNotComplete()
                         .assertNoValues();
 
-                        for (Throwable e : TestHelper.errorList(to)) {
+                        for (Throwable e : TestHelper.errorList(ts)) {
                             assertTrue(e.toString(), e instanceof TestException);
                         }
 
                     } else {
-                        to.assertFailure(TestException.class);
+                        ts.assertFailure(TestException.class);
                     }
                 }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -800,7 +800,7 @@ public class FlowableCreateTest {
     @Test
     public void serializedConcurrentOnNextOnComplete() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            TestSubscriber<Object> to = Flowable.create(new FlowableOnSubscribe<Object>() {
+            TestSubscriber<Object> ts = Flowable.create(new FlowableOnSubscribe<Object>() {
                 @Override
                 public void subscribe(FlowableEmitter<Object> e) throws Exception {
                     final FlowableEmitter<Object> f = e.serialize();
@@ -831,7 +831,7 @@ public class FlowableCreateTest {
             .assertSubscribed().assertComplete()
             .assertNoErrors();
 
-            int c = to.valueCount();
+            int c = ts.valueCount();
             assertTrue("" + c, c >= 100);
         }
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
@@ -422,36 +422,36 @@ public class FlowableDebounceTest {
 
     @Test
     public void disposeInOnNext() {
-        final TestSubscriber<Integer> to = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
         BehaviorProcessor.createDefault(1)
         .debounce(new Function<Integer, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Integer o) throws Exception {
-                to.cancel();
+                ts.cancel();
                 return Flowable.never();
             }
         })
-        .subscribeWith(to)
+        .subscribeWith(ts)
         .assertEmpty();
 
-        assertTrue(to.isDisposed());
+        assertTrue(ts.isDisposed());
     }
 
     @Test
     public void disposedInOnComplete() {
-        final TestSubscriber<Integer> to = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
         new Flowable<Integer>() {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
-                to.cancel();
+                ts.cancel();
                 subscriber.onComplete();
             }
         }
         .debounce(Functions.justFunction(Flowable.never()))
-        .subscribeWith(to)
+        .subscribeWith(ts)
         .assertEmpty();
     }
 
@@ -459,7 +459,7 @@ public class FlowableDebounceTest {
     public void emitLate() {
         final AtomicReference<Subscriber<? super Integer>> ref = new AtomicReference<Subscriber<? super Integer>>();
 
-        TestSubscriber<Integer> to = Flowable.range(1, 2)
+        TestSubscriber<Integer> ts = Flowable.range(1, 2)
         .debounce(new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer o) throws Exception {
@@ -479,7 +479,7 @@ public class FlowableDebounceTest {
 
         ref.get().onNext(1);
 
-        to
+        ts
         .assertResult(2);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
@@ -768,17 +768,17 @@ public class FlowableDelayTest {
     public void testErrorRunsBeforeOnNext() {
         TestScheduler test = new TestScheduler();
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        ps.delay(1, TimeUnit.SECONDS, test).subscribe(ts);
+        pp.delay(1, TimeUnit.SECONDS, test).subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
         test.advanceTimeBy(500, TimeUnit.MILLISECONDS);
 
-        ps.onError(new TestException());
+        pp.onError(new TestException());
 
         test.advanceTimeBy(1, TimeUnit.SECONDS);
 
@@ -789,7 +789,7 @@ public class FlowableDelayTest {
 
     @Test
     public void testDelaySupplierSimple() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
         Flowable<Integer> source = Flowable.range(1, 5);
 
@@ -798,7 +798,7 @@ public class FlowableDelayTest {
         source.delaySubscription(Flowable.defer(new Callable<Publisher<Integer>>() {
             @Override
             public Publisher<Integer> call() {
-                return ps;
+                return pp;
             }
         })).subscribe(ts);
 
@@ -806,7 +806,7 @@ public class FlowableDelayTest {
         ts.assertNoErrors();
         ts.assertNotComplete();
 
-        ps.onNext(1);
+        pp.onNext(1);
 
         ts.assertValues(1, 2, 3, 4, 5);
         ts.assertComplete();
@@ -815,7 +815,7 @@ public class FlowableDelayTest {
 
     @Test
     public void testDelaySupplierCompletes() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
         Flowable<Integer> source = Flowable.range(1, 5);
 
@@ -824,7 +824,7 @@ public class FlowableDelayTest {
         source.delaySubscription(Flowable.defer(new Callable<Publisher<Integer>>() {
             @Override
             public Publisher<Integer> call() {
-                return ps;
+                return pp;
             }
         })).subscribe(ts);
 
@@ -833,7 +833,7 @@ public class FlowableDelayTest {
         ts.assertNotComplete();
 
         // FIXME should this complete the source instead of consuming it?
-        ps.onComplete();
+        pp.onComplete();
 
         ts.assertValues(1, 2, 3, 4, 5);
         ts.assertComplete();
@@ -842,7 +842,7 @@ public class FlowableDelayTest {
 
     @Test
     public void testDelaySupplierErrors() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
         Flowable<Integer> source = Flowable.range(1, 5);
 
@@ -851,7 +851,7 @@ public class FlowableDelayTest {
         source.delaySubscription(Flowable.defer(new Callable<Publisher<Integer>>() {
             @Override
             public Publisher<Integer> call() {
-                return ps;
+                return pp;
             }
         })).subscribe(ts);
 
@@ -859,7 +859,7 @@ public class FlowableDelayTest {
         ts.assertNoErrors();
         ts.assertNotComplete();
 
-        ps.onError(new TestException());
+        pp.onError(new TestException());
 
         ts.assertNoValues();
         ts.assertNotComplete();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
@@ -143,29 +143,29 @@ public class FlowableDistinctTest {
 
     @Test
     public void fusedSync() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.just(1, 1, 2, 1, 3, 2, 4, 5, 4)
         .distinct()
-        .subscribe(to);
+        .subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.SYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void fusedAsync() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> us = UnicastProcessor.create();
 
         us
         .distinct()
-        .subscribe(to);
+        .subscribe(ts);
 
         TestHelper.emit(us, 1, 1, 2, 1, 3, 2, 4, 5, 4);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.ASYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
@@ -182,9 +182,9 @@ public class FlowableDistinctUntilChangedTest {
                 return a.equals(b);
             }
         })
-        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueFuseable.ANY, false))
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult(1, 2, 3, 2, 4, 1, 2);
     }
 
@@ -203,9 +203,9 @@ public class FlowableDistinctUntilChangedTest {
                 return true;
             }
         })
-        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueSubscription.ANY, false))
+        .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueFuseable.ANY, false))
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult(1, 2, 3, 2, 4, 1, 2);
     }
 
@@ -272,7 +272,7 @@ public class FlowableDistinctUntilChangedTest {
 
     @Test
     public void fused() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.just(1, 2, 2, 3, 3, 4, 5)
         .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
@@ -281,17 +281,17 @@ public class FlowableDistinctUntilChangedTest {
                 return a.equals(b);
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
-        to.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueDisposable.SYNC))
+        ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult(1, 2, 3, 4, 5)
         ;
     }
 
     @Test
     public void fusedAsync() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
@@ -302,12 +302,12 @@ public class FlowableDistinctUntilChangedTest {
                 return a.equals(b);
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
         TestHelper.emit(up, 1, 2, 2, 3, 3, 4, 5);
 
-        to.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC))
+        ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2, 3, 4, 5)
         ;
     }
@@ -438,7 +438,7 @@ public class FlowableDistinctUntilChangedTest {
 
     @Test
     public void conditionalFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.just(1, 2, 1, 3, 3, 4, 3, 5, 5)
         .distinctUntilChanged()
@@ -450,13 +450,13 @@ public class FlowableDistinctUntilChangedTest {
         })
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.SYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.SYNC)
         .assertResult(2, 4);
     }
 
     @Test
     public void conditionalAsyncFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
         up
@@ -472,7 +472,7 @@ public class FlowableDistinctUntilChangedTest {
 
         TestHelper.emit(up, 1, 2, 1, 3, 3, 4, 3, 5, 5);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.ASYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC)
         .assertResult(2, 4);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNextTest.java
@@ -23,7 +23,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.subscribers.*;
 
@@ -88,13 +88,13 @@ public class FlowableDoAfterNextTest {
 
     @Test
     public void syncFused() {
-        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueSubscription.SYNC);
+        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Flowable.range(1, 5)
         .doAfterNext(afterNext)
         .subscribe(ts0);
 
-        SubscriberFusion.assertFusion(ts0, QueueSubscription.SYNC)
+        SubscriberFusion.assertFusion(ts0, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
@@ -102,13 +102,13 @@ public class FlowableDoAfterNextTest {
 
     @Test
     public void asyncFusedRejected() {
-        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueSubscription.ASYNC);
+        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueFuseable.ASYNC);
 
         Flowable.range(1, 5)
         .doAfterNext(afterNext)
         .subscribe(ts0);
 
-        SubscriberFusion.assertFusion(ts0, QueueSubscription.NONE)
+        SubscriberFusion.assertFusion(ts0, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
@@ -116,7 +116,7 @@ public class FlowableDoAfterNextTest {
 
     @Test
     public void asyncFused() {
-        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueSubscription.ASYNC);
+        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueFuseable.ASYNC);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
@@ -126,7 +126,7 @@ public class FlowableDoAfterNextTest {
         .doAfterNext(afterNext)
         .subscribe(ts0);
 
-        SubscriberFusion.assertFusion(ts0, QueueSubscription.ASYNC)
+        SubscriberFusion.assertFusion(ts0, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
@@ -183,14 +183,14 @@ public class FlowableDoAfterNextTest {
 
     @Test
     public void syncFusedConditional() {
-        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueSubscription.SYNC);
+        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Flowable.range(1, 5)
         .doAfterNext(afterNext)
         .filter(Functions.alwaysTrue())
         .subscribe(ts0);
 
-        SubscriberFusion.assertFusion(ts0, QueueSubscription.SYNC)
+        SubscriberFusion.assertFusion(ts0, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
@@ -198,14 +198,14 @@ public class FlowableDoAfterNextTest {
 
     @Test
     public void asyncFusedRejectedConditional() {
-        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueSubscription.ASYNC);
+        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueFuseable.ASYNC);
 
         Flowable.range(1, 5)
         .doAfterNext(afterNext)
         .filter(Functions.alwaysTrue())
         .subscribe(ts0);
 
-        SubscriberFusion.assertFusion(ts0, QueueSubscription.NONE)
+        SubscriberFusion.assertFusion(ts0, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
@@ -213,7 +213,7 @@ public class FlowableDoAfterNextTest {
 
     @Test
     public void asyncFusedConditional() {
-        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueSubscription.ASYNC);
+        TestSubscriber<Integer> ts0 = SubscriberFusion.newTest(QueueFuseable.ASYNC);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
@@ -224,7 +224,7 @@ public class FlowableDoAfterNextTest {
         .filter(Functions.alwaysTrue())
         .subscribe(ts0);
 
-        SubscriberFusion.assertFusion(ts0, QueueSubscription.ASYNC)
+        SubscriberFusion.assertFusion(ts0, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoFinallyTest.java
@@ -24,7 +24,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.subscribers.*;
@@ -97,13 +97,13 @@ public class FlowableDoFinallyTest implements Action {
 
     @Test
     public void syncFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.SYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Flowable.range(1, 5)
         .doFinally(this)
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.SYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -111,13 +111,13 @@ public class FlowableDoFinallyTest implements Action {
 
     @Test
     public void syncFusedBoundary() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.SYNC | QueueSubscription.BOUNDARY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC | QueueFuseable.BOUNDARY);
 
         Flowable.range(1, 5)
         .doFinally(this)
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -125,7 +125,7 @@ public class FlowableDoFinallyTest implements Action {
 
     @Test
     public void asyncFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ASYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ASYNC);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -134,7 +134,7 @@ public class FlowableDoFinallyTest implements Action {
         .doFinally(this)
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.ASYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -142,7 +142,7 @@ public class FlowableDoFinallyTest implements Action {
 
     @Test
     public void asyncFusedBoundary() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ASYNC | QueueSubscription.BOUNDARY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ASYNC | QueueFuseable.BOUNDARY);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -151,7 +151,7 @@ public class FlowableDoFinallyTest implements Action {
         .doFinally(this)
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -205,14 +205,14 @@ public class FlowableDoFinallyTest implements Action {
 
     @Test
     public void syncFusedConditional() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.SYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Flowable.range(1, 5)
         .doFinally(this)
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.SYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -220,13 +220,13 @@ public class FlowableDoFinallyTest implements Action {
 
     @Test
     public void nonFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.SYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Flowable.range(1, 5).hide()
         .doFinally(this)
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -234,14 +234,14 @@ public class FlowableDoFinallyTest implements Action {
 
     @Test
     public void nonFusedConditional() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.SYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Flowable.range(1, 5).hide()
         .doFinally(this)
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -249,14 +249,14 @@ public class FlowableDoFinallyTest implements Action {
 
     @Test
     public void syncFusedBoundaryConditional() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.SYNC | QueueSubscription.BOUNDARY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC | QueueFuseable.BOUNDARY);
 
         Flowable.range(1, 5)
         .doFinally(this)
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -264,7 +264,7 @@ public class FlowableDoFinallyTest implements Action {
 
     @Test
     public void asyncFusedConditional() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ASYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ASYNC);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -274,7 +274,7 @@ public class FlowableDoFinallyTest implements Action {
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.ASYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -282,7 +282,7 @@ public class FlowableDoFinallyTest implements Action {
 
     @Test
     public void asyncFusedBoundaryConditional() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ASYNC | QueueSubscription.BOUNDARY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ASYNC | QueueFuseable.BOUNDARY);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -292,7 +292,7 @@ public class FlowableDoFinallyTest implements Action {
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -357,7 +357,7 @@ public class FlowableDoFinallyTest implements Action {
                 @SuppressWarnings("unchecked")
                 QueueSubscription<Integer> qs = (QueueSubscription<Integer>)s;
 
-                qs.requestFusion(QueueSubscription.ANY);
+                qs.requestFusion(QueueFuseable.ANY);
 
                 assertFalse(qs.isEmpty());
 
@@ -404,7 +404,7 @@ public class FlowableDoFinallyTest implements Action {
                 @SuppressWarnings("unchecked")
                 QueueSubscription<Integer> qs = (QueueSubscription<Integer>)s;
 
-                qs.requestFusion(QueueSubscription.ANY);
+                qs.requestFusion(QueueFuseable.ANY);
 
                 assertFalse(qs.isEmpty());
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
@@ -504,7 +504,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void fused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -524,7 +524,7 @@ public class FlowableDoOnEachTest {
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(5, call[0]);
@@ -533,7 +533,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void fusedOnErrorCrash() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0 };
 
@@ -553,7 +553,7 @@ public class FlowableDoOnEachTest {
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertFailure(TestException.class);
 
         assertEquals(0, call[0]);
@@ -561,7 +561,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void fusedConditional() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -582,7 +582,7 @@ public class FlowableDoOnEachTest {
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(5, call[0]);
@@ -591,7 +591,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void fusedOnErrorCrashConditional() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0 };
 
@@ -612,7 +612,7 @@ public class FlowableDoOnEachTest {
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertFailure(TestException.class);
 
         assertEquals(0, call[0]);
@@ -620,7 +620,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void fusedAsync() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -644,7 +644,7 @@ public class FlowableDoOnEachTest {
         TestHelper.emit(up, 1, 2, 3, 4, 5);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(5, call[0]);
@@ -653,7 +653,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void fusedAsyncConditional() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -678,7 +678,7 @@ public class FlowableDoOnEachTest {
         TestHelper.emit(up, 1, 2, 3, 4, 5);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(5, call[0]);
@@ -687,7 +687,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void fusedAsyncConditional2() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -712,7 +712,7 @@ public class FlowableDoOnEachTest {
         TestHelper.emit(up, 1, 2, 3, 4, 5);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(5, call[0]);
@@ -736,7 +736,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void doOnNextDoOnErrorFused() {
-        ConnectableFlowable<Integer> co = Flowable.just(1)
+        ConnectableFlowable<Integer> cf = Flowable.just(1)
         .doOnNext(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
@@ -751,8 +751,8 @@ public class FlowableDoOnEachTest {
         })
         .publish();
 
-        TestSubscriber<Integer> ts = co.test();
-        co.connect();
+        TestSubscriber<Integer> ts = cf.test();
+        cf.connect();
 
         ts.assertFailure(CompositeException.class);
 
@@ -762,7 +762,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void doOnNextDoOnErrorCombinedFused() {
-        ConnectableFlowable<Integer> co = Flowable.just(1)
+        ConnectableFlowable<Integer> cf = Flowable.just(1)
                 .compose(new FlowableTransformer<Integer, Integer>() {
                     @Override
                     public Publisher<Integer> apply(Flowable<Integer> v) {
@@ -787,8 +787,8 @@ public class FlowableDoOnEachTest {
                 })
         .publish();
 
-        TestSubscriber<Integer> ts = co.test();
-        co.connect();
+        TestSubscriber<Integer> ts = cf.test();
+        cf.connect();
 
         ts.assertFailure(CompositeException.class);
 
@@ -798,7 +798,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void doOnNextDoOnErrorFused2() {
-        ConnectableFlowable<Integer> co = Flowable.just(1)
+        ConnectableFlowable<Integer> cf = Flowable.just(1)
         .doOnNext(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
@@ -819,8 +819,8 @@ public class FlowableDoOnEachTest {
         })
         .publish();
 
-        TestSubscriber<Integer> ts = co.test();
-        co.connect();
+        TestSubscriber<Integer> ts = cf.test();
+        cf.connect();
 
         ts.assertFailure(CompositeException.class);
 
@@ -831,7 +831,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void doOnNextDoOnErrorFusedConditional() {
-        ConnectableFlowable<Integer> co = Flowable.just(1)
+        ConnectableFlowable<Integer> cf = Flowable.just(1)
         .doOnNext(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
@@ -847,8 +847,8 @@ public class FlowableDoOnEachTest {
         .filter(Functions.alwaysTrue())
         .publish();
 
-        TestSubscriber<Integer> ts = co.test();
-        co.connect();
+        TestSubscriber<Integer> ts = cf.test();
+        cf.connect();
 
         ts.assertFailure(CompositeException.class);
 
@@ -858,7 +858,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void doOnNextDoOnErrorFusedConditional2() {
-        ConnectableFlowable<Integer> co = Flowable.just(1)
+        ConnectableFlowable<Integer> cf = Flowable.just(1)
         .doOnNext(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
@@ -880,8 +880,8 @@ public class FlowableDoOnEachTest {
         .filter(Functions.alwaysTrue())
         .publish();
 
-        TestSubscriber<Integer> ts = co.test();
-        co.connect();
+        TestSubscriber<Integer> ts = cf.test();
+        cf.connect();
 
         ts.assertFailure(CompositeException.class);
 
@@ -892,7 +892,7 @@ public class FlowableDoOnEachTest {
 
     @Test
     public void doOnNextDoOnErrorCombinedFusedConditional() {
-        ConnectableFlowable<Integer> co = Flowable.just(1)
+        ConnectableFlowable<Integer> cf = Flowable.just(1)
                 .compose(new FlowableTransformer<Integer, Integer>() {
                     @Override
                     public Publisher<Integer> apply(Flowable<Integer> v) {
@@ -918,8 +918,8 @@ public class FlowableDoOnEachTest {
         .filter(Functions.alwaysTrue())
         .publish();
 
-        TestSubscriber<Integer> ts = co.test();
-        co.connect();
+        TestSubscriber<Integer> ts = cf.test();
+        cf.connect();
 
         ts.assertFailure(CompositeException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFilterTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFilterTest.java
@@ -181,22 +181,22 @@ public class FlowableFilterTest {
     @Test
     public void functionCrashUnsubscribes() {
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        ps.filter(new Predicate<Integer>() {
+        pp.filter(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 throw new TestException();
             }
         }).subscribe(ts);
 
-        Assert.assertTrue("Not subscribed?", ps.hasSubscribers());
+        Assert.assertTrue("Not subscribed?", pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        Assert.assertFalse("Subscribed?", ps.hasSubscribers());
+        Assert.assertFalse("Subscribed?", pp.hasSubscribers());
 
         ts.assertError(TestException.class);
     }
@@ -245,7 +245,7 @@ public class FlowableFilterTest {
 
     @Test
     public void conditionalFusedSync() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 5)
         .filter(Functions.alwaysTrue())
@@ -253,13 +253,13 @@ public class FlowableFilterTest {
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void conditionalFusedSync2() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 5)
         .filter(Functions.alwaysFalse())
@@ -267,13 +267,13 @@ public class FlowableFilterTest {
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult();
     }
 
     @Test
     public void conditionalFusedAsync() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
@@ -290,13 +290,13 @@ public class FlowableFilterTest {
         up.onComplete();
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void conditionalFusedNoneAsync() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
@@ -313,13 +313,13 @@ public class FlowableFilterTest {
         up.onComplete();
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult();
     }
 
     @Test
     public void conditionalFusedNoneAsync2() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
@@ -336,7 +336,7 @@ public class FlowableFilterTest {
         up.onComplete();
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult();
     }
 
@@ -415,33 +415,33 @@ public class FlowableFilterTest {
 
     @Test
     public void syncFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 5)
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void syncNoneFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 5)
         .filter(Functions.alwaysFalse())
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult();
     }
 
     @Test
     public void syncNoneFused2() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 5)
         .filter(Functions.alwaysFalse())
@@ -449,7 +449,7 @@ public class FlowableFilterTest {
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult();
     }
 
@@ -563,7 +563,7 @@ public class FlowableFilterTest {
 
     @Test
     public void fusedSync() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 5)
         .filter(new Predicate<Integer>() {
@@ -572,15 +572,15 @@ public class FlowableFilterTest {
                 return v % 2 == 0;
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.SYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.SYNC)
         .assertResult(2, 4);
     }
 
     @Test
     public void fusedAsync() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> us = UnicastProcessor.create();
 
@@ -591,17 +591,17 @@ public class FlowableFilterTest {
                 return v % 2 == 0;
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
         TestHelper.emit(us, 1, 2, 3, 4, 5);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.ASYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC)
         .assertResult(2, 4);
     }
 
     @Test
     public void fusedReject() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY | QueueDisposable.BOUNDARY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
 
         Flowable.range(1, 5)
         .filter(new Predicate<Integer>() {
@@ -610,9 +610,9 @@ public class FlowableFilterTest {
                 return v % 2 == 0;
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(2, 4);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
@@ -49,9 +49,9 @@ public class FlowableFlatMapCompletableTest {
 
     @Test
     public void mapperThrowsFlowable() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = ps
+        TestSubscriber<Integer> ts = pp
         .flatMapCompletable(new Function<Integer, CompletableSource>() {
             @Override
             public CompletableSource apply(Integer v) throws Exception {
@@ -60,20 +60,20 @@ public class FlowableFlatMapCompletableTest {
         }).<Integer>toFlowable()
         .test();
 
-        assertTrue(ps.hasSubscribers());
+        assertTrue(pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertFailure(TestException.class);
+        ts.assertFailure(TestException.class);
 
-        assertFalse(ps.hasSubscribers());
+        assertFalse(pp.hasSubscribers());
     }
 
     @Test
     public void mapperReturnsNullFlowable() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = ps
+        TestSubscriber<Integer> ts = pp
         .flatMapCompletable(new Function<Integer, CompletableSource>() {
             @Override
             public CompletableSource apply(Integer v) throws Exception {
@@ -82,13 +82,13 @@ public class FlowableFlatMapCompletableTest {
         }).<Integer>toFlowable()
         .test();
 
-        assertTrue(ps.hasSubscribers());
+        assertTrue(pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertFailure(NullPointerException.class);
+        ts.assertFailure(NullPointerException.class);
 
-        assertFalse(ps.hasSubscribers());
+        assertFalse(pp.hasSubscribers());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class FlowableFlatMapCompletableTest {
 
     @Test
     public void normalDelayErrorAllFlowable() {
-        TestSubscriber<Integer> to = Flowable.range(1, 10).concatWith(Flowable.<Integer>error(new TestException()))
+        TestSubscriber<Integer> ts = Flowable.range(1, 10).concatWith(Flowable.<Integer>error(new TestException()))
         .flatMapCompletable(new Function<Integer, CompletableSource>() {
             @Override
             public CompletableSource apply(Integer v) throws Exception {
@@ -144,7 +144,7 @@ public class FlowableFlatMapCompletableTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
 
         for (int i = 0; i < 11; i++) {
             TestHelper.assertError(errors, i, TestException.class);
@@ -153,7 +153,7 @@ public class FlowableFlatMapCompletableTest {
 
     @Test
     public void normalDelayInnerErrorAllFlowable() {
-        TestSubscriber<Integer> to = Flowable.range(1, 10)
+        TestSubscriber<Integer> ts = Flowable.range(1, 10)
         .flatMapCompletable(new Function<Integer, CompletableSource>() {
             @Override
             public CompletableSource apply(Integer v) throws Exception {
@@ -163,7 +163,7 @@ public class FlowableFlatMapCompletableTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
 
         for (int i = 0; i < 10; i++) {
             TestHelper.assertError(errors, i, TestException.class);
@@ -186,7 +186,7 @@ public class FlowableFlatMapCompletableTest {
 
     @Test
     public void fusedFlowable() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 10)
         .flatMapCompletable(new Function<Integer, CompletableSource>() {
@@ -195,11 +195,11 @@ public class FlowableFlatMapCompletableTest {
                 return Completable.complete();
             }
         }).<Integer>toFlowable()
-        .subscribe(to);
+        .subscribe(ts);
 
-        to
+        ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult();
     }
 
@@ -218,9 +218,9 @@ public class FlowableFlatMapCompletableTest {
 
     @Test
     public void mapperThrows() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Void> to = ps
+        TestObserver<Void> to = pp
         .flatMapCompletable(new Function<Integer, CompletableSource>() {
             @Override
             public CompletableSource apply(Integer v) throws Exception {
@@ -229,20 +229,20 @@ public class FlowableFlatMapCompletableTest {
         })
         .test();
 
-        assertTrue(ps.hasSubscribers());
+        assertTrue(pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
         to.assertFailure(TestException.class);
 
-        assertFalse(ps.hasSubscribers());
+        assertFalse(pp.hasSubscribers());
     }
 
     @Test
     public void mapperReturnsNull() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Void> to = ps
+        TestObserver<Void> to = pp
         .flatMapCompletable(new Function<Integer, CompletableSource>() {
             @Override
             public CompletableSource apply(Integer v) throws Exception {
@@ -251,13 +251,13 @@ public class FlowableFlatMapCompletableTest {
         })
         .test();
 
-        assertTrue(ps.hasSubscribers());
+        assertTrue(pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
         to.assertFailure(NullPointerException.class);
 
-        assertFalse(ps.hasSubscribers());
+        assertFalse(pp.hasSubscribers());
     }
 
     @Test
@@ -341,7 +341,7 @@ public class FlowableFlatMapCompletableTest {
 
     @Test
     public void fused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 10)
         .flatMapCompletable(new Function<Integer, CompletableSource>() {
@@ -355,7 +355,7 @@ public class FlowableFlatMapCompletableTest {
 
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -123,9 +123,9 @@ public class FlowableFlatMapMaybeTest {
 
     @Test
     public void mapperThrowsFlowable() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = ps
+        TestSubscriber<Integer> ts = pp
         .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v) throws Exception {
@@ -134,20 +134,20 @@ public class FlowableFlatMapMaybeTest {
         })
         .test();
 
-        assertTrue(ps.hasSubscribers());
+        assertTrue(pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertFailure(TestException.class);
+        ts.assertFailure(TestException.class);
 
-        assertFalse(ps.hasSubscribers());
+        assertFalse(pp.hasSubscribers());
     }
 
     @Test
     public void mapperReturnsNullFlowable() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = ps
+        TestSubscriber<Integer> ts = pp
         .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v) throws Exception {
@@ -156,18 +156,18 @@ public class FlowableFlatMapMaybeTest {
         })
         .test();
 
-        assertTrue(ps.hasSubscribers());
+        assertTrue(pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertFailure(NullPointerException.class);
+        ts.assertFailure(NullPointerException.class);
 
-        assertFalse(ps.hasSubscribers());
+        assertFalse(pp.hasSubscribers());
     }
 
     @Test
     public void normalDelayErrorAll() {
-        TestSubscriber<Integer> to = Flowable.range(1, 10).concatWith(Flowable.<Integer>error(new TestException()))
+        TestSubscriber<Integer> ts = Flowable.range(1, 10).concatWith(Flowable.<Integer>error(new TestException()))
         .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v) throws Exception {
@@ -177,7 +177,7 @@ public class FlowableFlatMapMaybeTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
 
         for (int i = 0; i < 11; i++) {
             TestHelper.assertError(errors, i, TestException.class);
@@ -352,46 +352,46 @@ public class FlowableFlatMapMaybeTest {
 
     @Test
     public void successError() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = Flowable.range(1, 2)
+        TestSubscriber<Integer> ts = Flowable.range(1, 2)
         .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v) throws Exception {
                 if (v == 2) {
-                    return ps.singleElement();
+                    return pp.singleElement();
                 }
                 return Maybe.error(new TestException());
             }
         }, true, Integer.MAX_VALUE)
         .test();
 
-        ps.onNext(1);
-        ps.onComplete();
+        pp.onNext(1);
+        pp.onComplete();
 
-        to
+        ts
         .assertFailure(TestException.class, 1);
     }
 
     @Test
     public void completeError() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = Flowable.range(1, 2)
+        TestSubscriber<Integer> ts = Flowable.range(1, 2)
         .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v) throws Exception {
                 if (v == 2) {
-                    return ps.singleElement();
+                    return pp.singleElement();
                 }
                 return Maybe.error(new TestException());
             }
         }, true, Integer.MAX_VALUE)
         .test();
 
-        ps.onComplete();
+        pp.onComplete();
 
-        to
+        ts
         .assertFailure(TestException.class);
     }
 
@@ -451,72 +451,72 @@ public class FlowableFlatMapMaybeTest {
 
     @Test
     public void emissionQueueTrigger() {
-        final PublishProcessor<Integer> ps1 = PublishProcessor.create();
-        final PublishProcessor<Integer> ps2 = PublishProcessor.create();
+        final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
                 if (t == 1) {
-                    ps2.onNext(2);
-                    ps2.onComplete();
+                    pp2.onNext(2);
+                    pp2.onComplete();
                 }
             }
         };
 
-        Flowable.just(ps1, ps2)
+        Flowable.just(pp1, pp2)
                 .flatMapMaybe(new Function<PublishProcessor<Integer>, MaybeSource<Integer>>() {
                     @Override
                     public MaybeSource<Integer> apply(PublishProcessor<Integer> v) throws Exception {
                         return v.singleElement();
                     }
                 })
-        .subscribe(to);
+        .subscribe(ts);
 
-        ps1.onNext(1);
-        ps1.onComplete();
+        pp1.onNext(1);
+        pp1.onComplete();
 
-        to.assertResult(1, 2);
+        ts.assertResult(1, 2);
     }
 
     @Test
     public void emissionQueueTrigger2() {
-        final PublishProcessor<Integer> ps1 = PublishProcessor.create();
-        final PublishProcessor<Integer> ps2 = PublishProcessor.create();
-        final PublishProcessor<Integer> ps3 = PublishProcessor.create();
+        final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        final PublishProcessor<Integer> pp2 = PublishProcessor.create();
+        final PublishProcessor<Integer> pp3 = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
                 if (t == 1) {
-                    ps2.onNext(2);
-                    ps2.onComplete();
+                    pp2.onNext(2);
+                    pp2.onComplete();
                 }
             }
         };
 
-        Flowable.just(ps1, ps2, ps3)
+        Flowable.just(pp1, pp2, pp3)
                 .flatMapMaybe(new Function<PublishProcessor<Integer>, MaybeSource<Integer>>() {
                     @Override
                     public MaybeSource<Integer> apply(PublishProcessor<Integer> v) throws Exception {
                         return v.singleElement();
                     }
                 })
-        .subscribe(to);
+        .subscribe(ts);
 
-        ps1.onNext(1);
-        ps1.onComplete();
+        pp1.onNext(1);
+        pp1.onComplete();
 
-        ps3.onComplete();
+        pp3.onComplete();
 
-        to.assertResult(1, 2);
+        ts.assertResult(1, 2);
     }
 
     @Test
     public void disposeInner() {
-        final TestSubscriber<Object> to = new TestSubscriber<Object>();
+        final TestSubscriber<Object> ts = new TestSubscriber<Object>();
 
         Flowable.just(1).flatMapMaybe(new Function<Integer, MaybeSource<Object>>() {
             @Override
@@ -528,30 +528,30 @@ public class FlowableFlatMapMaybeTest {
 
                         assertFalse(((Disposable)observer).isDisposed());
 
-                        to.dispose();
+                        ts.dispose();
 
                         assertTrue(((Disposable)observer).isDisposed());
                     }
                 };
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
-        to
+        ts
         .assertEmpty();
     }
 
     @Test
     public void innerSuccessCompletesAfterMain() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = Flowable.just(1).flatMapMaybe(Functions.justFunction(ps.singleElement()))
+        TestSubscriber<Integer> ts = Flowable.just(1).flatMapMaybe(Functions.justFunction(pp.singleElement()))
         .test();
 
-        ps.onNext(2);
-        ps.onComplete();
+        pp.onNext(2);
+        pp.onComplete();
 
-        to
+        ts
         .assertResult(2);
     }
 
@@ -585,19 +585,19 @@ public class FlowableFlatMapMaybeTest {
     @Test
     public void requestCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> to = Flowable.just(1).concatWith(Flowable.<Integer>never())
+            final TestSubscriber<Integer> ts = Flowable.just(1).concatWith(Flowable.<Integer>never())
             .flatMapMaybe(Functions.justFunction(Maybe.just(2))).test(0);
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    to.request(1);
+                    ts.request(1);
                 }
             };
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -656,11 +656,11 @@ public class FlowableFlatMapTest {
     @Test
     public void castCrashUnsubscribes() {
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        ps.flatMap(new Function<Integer, Publisher<Integer>>() {
+        pp.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer t) {
                 throw new TestException();
@@ -672,11 +672,11 @@ public class FlowableFlatMapTest {
             }
         }).subscribe(ts);
 
-        Assert.assertTrue("Not subscribed?", ps.hasSubscribers());
+        Assert.assertTrue("Not subscribed?", pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        Assert.assertFalse("Subscribed?", ps.hasSubscribers());
+        Assert.assertFalse("Subscribed?", pp.hasSubscribers());
 
         ts.assertError(TestException.class);
     }
@@ -780,68 +780,68 @@ public class FlowableFlatMapTest {
 
     @Test
     public void scalarReentrant() {
-        final PublishProcessor<Flowable<Integer>> ps = PublishProcessor.create();
+        final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
                 if (t == 1) {
-                    ps.onNext(Flowable.just(2));
+                    pp.onNext(Flowable.just(2));
                 }
             }
         };
 
-        Flowable.merge(ps)
-        .subscribe(to);
+        Flowable.merge(pp)
+        .subscribe(ts);
 
-        ps.onNext(Flowable.just(1));
-        ps.onComplete();
+        pp.onNext(Flowable.just(1));
+        pp.onComplete();
 
-        to.assertResult(1, 2);
+        ts.assertResult(1, 2);
     }
 
     @Test
     public void scalarReentrant2() {
-        final PublishProcessor<Flowable<Integer>> ps = PublishProcessor.create();
+        final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
                 if (t == 1) {
-                    ps.onNext(Flowable.just(2));
+                    pp.onNext(Flowable.just(2));
                 }
             }
         };
 
-        Flowable.merge(ps, 2)
-        .subscribe(to);
+        Flowable.merge(pp, 2)
+        .subscribe(ts);
 
-        ps.onNext(Flowable.just(1));
-        ps.onComplete();
+        pp.onNext(Flowable.just(1));
+        pp.onComplete();
 
-        to.assertResult(1, 2);
+        ts.assertResult(1, 2);
     }
 
     @Test
     public void innerCompleteCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps = PublishProcessor.create();
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestSubscriber<Integer> to = Flowable.merge(Flowable.just(ps)).test();
+            final TestSubscriber<Integer> ts = Flowable.merge(Flowable.just(pp)).test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ps.onComplete();
+                    pp.onComplete();
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
 
@@ -870,7 +870,7 @@ public class FlowableFlatMapTest {
 
     @Test
     public void fusedInnerThrows2() {
-        TestSubscriber<Integer> to = Flowable.range(1, 2).hide()
+        TestSubscriber<Integer> ts = Flowable.range(1, 2).hide()
         .flatMap(new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer v) throws Exception {
@@ -885,7 +885,7 @@ public class FlowableFlatMapTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.errorList(to);
+        List<Throwable> errors = TestHelper.errorList(ts);
 
         TestHelper.assertError(errors, 0, TestException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -26,7 +26,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.operators.flowable.FlowableFlattenIterable.FlattenIterableSubscriber;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.internal.util.ExceptionHelper;
@@ -395,9 +395,9 @@ public class FlowableFlattenIterableTest {
             }
         };
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps
+        pp
         .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
             public Iterable<Integer> apply(Integer v) {
@@ -406,13 +406,13 @@ public class FlowableFlattenIterableTest {
         })
         .subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
         ts.assertNoValues();
         ts.assertError(TestException.class);
         ts.assertNotComplete();
 
-        Assert.assertFalse("PublishProcessor has Subscribers?!", ps.hasSubscribers());
+        Assert.assertFalse("PublishProcessor has Subscribers?!", pp.hasSubscribers());
     }
 
     @Test
@@ -498,9 +498,9 @@ public class FlowableFlattenIterableTest {
             }
         };
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps
+        pp
         .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
             public Iterable<Integer> apply(Integer v) {
@@ -510,13 +510,13 @@ public class FlowableFlattenIterableTest {
         .take(1)
         .subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
         ts.assertValue(1);
         ts.assertNoErrors();
         ts.assertComplete();
 
-        Assert.assertFalse("PublishProcessor has Subscribers?!", ps.hasSubscribers());
+        Assert.assertFalse("PublishProcessor has Subscribers?!", pp.hasSubscribers());
         Assert.assertEquals(1, counter.get());
     }
 
@@ -617,7 +617,7 @@ public class FlowableFlattenIterableTest {
                 @SuppressWarnings("unchecked")
                 QueueSubscription<Integer> qs = (QueueSubscription<Integer>)s;
 
-                assertEquals(QueueSubscription.SYNC, qs.requestFusion(QueueSubscription.ANY));
+                assertEquals(QueueFuseable.SYNC, qs.requestFusion(QueueFuseable.ANY));
 
                 try {
                     assertFalse("Source reports being empty!", qs.isEmpty());
@@ -672,7 +672,7 @@ public class FlowableFlattenIterableTest {
 
     @Test
     public void mixedInnerSource() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.just(1, 2, 3)
         .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
@@ -686,13 +686,13 @@ public class FlowableFlattenIterableTest {
         })
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.SYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.SYNC)
         .assertResult(1, 2, 1, 2);
     }
 
     @Test
     public void mixedInnerSource2() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.just(1, 2, 3)
         .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
@@ -706,13 +706,13 @@ public class FlowableFlattenIterableTest {
         })
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.SYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.SYNC)
         .assertResult(1, 2);
     }
 
     @Test
     public void fusionRejected() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.just(1, 2, 3).hide()
         .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
@@ -723,7 +723,7 @@ public class FlowableFlattenIterableTest {
         })
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1, 2, 1, 2, 1, 2);
     }
 
@@ -745,7 +745,7 @@ public class FlowableFlattenIterableTest {
                 @SuppressWarnings("unchecked")
                 QueueSubscription<Integer> qs = (QueueSubscription<Integer>)s;
 
-                assertEquals(QueueSubscription.SYNC, qs.requestFusion(QueueSubscription.ANY));
+                assertEquals(QueueFuseable.SYNC, qs.requestFusion(QueueFuseable.ANY));
 
                 try {
                     assertFalse("Source reports being empty!", qs.isEmpty());
@@ -1085,16 +1085,16 @@ public class FlowableFlattenIterableTest {
 
         f.onSubscribe(new BooleanSubscription());
 
-        f.fusionMode = QueueSubscription.NONE;
+        f.fusionMode = QueueFuseable.NONE;
 
-        assertEquals(QueueSubscription.NONE, f.requestFusion(QueueSubscription.SYNC));
+        assertEquals(QueueFuseable.NONE, f.requestFusion(QueueFuseable.SYNC));
 
-        assertEquals(QueueSubscription.NONE, f.requestFusion(QueueSubscription.ASYNC));
+        assertEquals(QueueFuseable.NONE, f.requestFusion(QueueFuseable.ASYNC));
 
-        f.fusionMode = QueueSubscription.SYNC;
+        f.fusionMode = QueueFuseable.SYNC;
 
-        assertEquals(QueueSubscription.SYNC, f.requestFusion(QueueSubscription.SYNC));
+        assertEquals(QueueFuseable.SYNC, f.requestFusion(QueueFuseable.SYNC));
 
-        assertEquals(QueueSubscription.NONE, f.requestFusion(QueueSubscription.ASYNC));
+        assertEquals(QueueFuseable.NONE, f.requestFusion(QueueFuseable.ASYNC));
 }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
@@ -551,7 +551,7 @@ public class FlowableFromIterableTest {
 
     @Test
     public void fusionWithConcatMap() {
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
         Flowable.fromIterable(Arrays.asList(1, 2, 3, 4)).concatMap(
         new Function<Integer, Flowable  <Integer>>() {
@@ -559,11 +559,11 @@ public class FlowableFromIterableTest {
             public Flowable<Integer> apply(Integer v) {
                 return Flowable.range(v, 2);
             }
-        }).subscribe(to);
+        }).subscribe(ts);
 
-        to.assertValues(1, 2, 2, 3, 3, 4, 4, 5);
-        to.assertNoErrors();
-        to.assertComplete();
+        ts.assertValues(1, 2, 2, 3, 3, 4, 4, 5);
+        ts.assertNoErrors();
+        ts.assertComplete();
     }
 
     @Test
@@ -868,12 +868,12 @@ public class FlowableFromIterableTest {
 
     @Test
     public void fusionRejected() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ASYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ASYNC);
 
         Flowable.fromIterable(Arrays.asList(1, 2, 3))
-        .subscribe(to);
+        .subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1, 2, 3);
     }
 
@@ -886,7 +886,7 @@ public class FlowableFromIterableTest {
                 @SuppressWarnings("unchecked")
                 QueueSubscription<Integer> qd = (QueueSubscription<Integer>)d;
 
-                qd.requestFusion(QueueSubscription.ANY);
+                qd.requestFusion(QueueFuseable.ANY);
 
                 try {
                     assertEquals(1, qd.poll().intValue());
@@ -932,7 +932,7 @@ public class FlowableFromIterableTest {
 
     @Test
     public void hasNextCancels() {
-        final TestSubscriber<Integer> to = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
         Flowable.fromIterable(new Iterable<Integer>() {
             @Override
@@ -943,7 +943,7 @@ public class FlowableFromIterableTest {
                     @Override
                     public boolean hasNext() {
                         if (++count == 2) {
-                            to.cancel();
+                            ts.cancel();
                         }
                         return true;
                     }
@@ -960,9 +960,9 @@ public class FlowableFromIterableTest {
                 };
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
-        to.assertValue(1)
+        ts.assertValue(1)
         .assertNoErrors()
         .assertNotComplete();
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -508,25 +508,25 @@ public class FlowableGroupJoinTest {
     @Test
     public void innerErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Object> ps1 = PublishProcessor.create();
-            final PublishProcessor<Object> ps2 = PublishProcessor.create();
+            final PublishProcessor<Object> pp1 = PublishProcessor.create();
+            final PublishProcessor<Object> pp2 = PublishProcessor.create();
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
-                TestSubscriber<Flowable<Integer>> to = Flowable.just(1)
+                TestSubscriber<Flowable<Integer>> ts = Flowable.just(1)
                 .groupJoin(
                     Flowable.just(2).concatWith(Flowable.<Integer>never()),
                     new Function<Integer, Flowable<Object>>() {
                         @Override
                         public Flowable<Object> apply(Integer left) throws Exception {
-                            return ps1;
+                            return pp1;
                         }
                     },
                     new Function<Integer, Flowable<Object>>() {
                         @Override
                         public Flowable<Object> apply(Integer right) throws Exception {
-                            return ps2;
+                            return pp2;
                         }
                     },
                     new BiFunction<Integer, Flowable<Integer>, Flowable<Integer>>() {
@@ -544,28 +544,28 @@ public class FlowableGroupJoinTest {
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {
-                        ps1.onError(ex1);
+                        pp1.onError(ex1);
                     }
                 };
                 Runnable r2 = new Runnable() {
                     @Override
                     public void run() {
-                        ps2.onError(ex2);
+                        pp2.onError(ex2);
                     }
                 };
 
                 TestHelper.race(r1, r2);
 
-                to.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertValueCount(1);
+                ts.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertValueCount(1);
 
-                Throwable exc = to.errors().get(0);
+                Throwable exc = ts.errors().get(0);
 
                 if (exc instanceof CompositeException) {
                     List<Throwable> es = TestHelper.compositeList(exc);
                     TestHelper.assertError(es, 0, TestException.class);
                     TestHelper.assertError(es, 1, TestException.class);
                 } else {
-                    to.assertError(TestException.class);
+                    ts.assertError(TestException.class);
                 }
 
                 if (!errors.isEmpty()) {
@@ -580,15 +580,15 @@ public class FlowableGroupJoinTest {
     @Test
     public void outerErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Object> ps1 = PublishProcessor.create();
-            final PublishProcessor<Object> ps2 = PublishProcessor.create();
+            final PublishProcessor<Object> pp1 = PublishProcessor.create();
+            final PublishProcessor<Object> pp2 = PublishProcessor.create();
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
-                TestSubscriber<Object> to = ps1
+                TestSubscriber<Object> ts = pp1
                 .groupJoin(
-                    ps2,
+                    pp2,
                     new Function<Object, Flowable<Object>>() {
                         @Override
                         public Flowable<Object> apply(Object left) throws Exception {
@@ -617,28 +617,28 @@ public class FlowableGroupJoinTest {
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {
-                        ps1.onError(ex1);
+                        pp1.onError(ex1);
                     }
                 };
                 Runnable r2 = new Runnable() {
                     @Override
                     public void run() {
-                        ps2.onError(ex2);
+                        pp2.onError(ex2);
                     }
                 };
 
                 TestHelper.race(r1, r2);
 
-                to.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertNoValues();
+                ts.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertNoValues();
 
-                Throwable exc = to.errors().get(0);
+                Throwable exc = ts.errors().get(0);
 
                 if (exc instanceof CompositeException) {
                     List<Throwable> es = TestHelper.compositeList(exc);
                     TestHelper.assertError(es, 0, TestException.class);
                     TestHelper.assertError(es, 1, TestException.class);
                 } else {
-                    to.assertError(TestException.class);
+                    ts.assertError(TestException.class);
                 }
 
                 if (!errors.isEmpty()) {
@@ -652,12 +652,12 @@ public class FlowableGroupJoinTest {
 
     @Test
     public void rightEmission() {
-        final PublishProcessor<Object> ps1 = PublishProcessor.create();
-        final PublishProcessor<Object> ps2 = PublishProcessor.create();
+        final PublishProcessor<Object> pp1 = PublishProcessor.create();
+        final PublishProcessor<Object> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Object> to = ps1
+        TestSubscriber<Object> ts = pp1
         .groupJoin(
-            ps2,
+            pp2,
             new Function<Object, Flowable<Object>>() {
                 @Override
                 public Flowable<Object> apply(Object left) throws Exception {
@@ -680,14 +680,14 @@ public class FlowableGroupJoinTest {
         .flatMap(Functions.<Flowable<Object>>identity())
         .test();
 
-        ps2.onNext(2);
+        pp2.onNext(2);
 
-        ps1.onNext(1);
-        ps1.onComplete();
+        pp1.onNext(1);
+        pp1.onComplete();
 
-        ps2.onComplete();
+        pp2.onComplete();
 
-        to.assertResult(2);
+        ts.assertResult(2);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -18,12 +18,12 @@ import static org.junit.Assert.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.observers.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.*;
@@ -174,22 +174,22 @@ public class FlowableIgnoreElementsTest {
 
     @Test
     public void testCompletedOk() {
-        TestObserver<Object> ts = new TestObserver<Object>();
-        Flowable.range(1, 10).ignoreElements().subscribe(ts);
-        ts.assertNoErrors();
-        ts.assertNoValues();
-        ts.assertTerminated();
+        TestObserver<Object> to = new TestObserver<Object>();
+        Flowable.range(1, 10).ignoreElements().subscribe(to);
+        to.assertNoErrors();
+        to.assertNoValues();
+        to.assertTerminated();
     }
 
     @Test
     public void testErrorReceived() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
         TestException ex = new TestException("boo");
-        Flowable.error(ex).ignoreElements().subscribe(ts);
-        ts.assertNoValues();
-        ts.assertTerminated();
-        ts.assertError(TestException.class);
-        ts.assertErrorMessage("boo");
+        Flowable.error(ex).ignoreElements().subscribe(to);
+        to.assertNoValues();
+        to.assertTerminated();
+        to.assertError(TestException.class);
+        to.assertErrorMessage("boo");
     }
 
     @Test
@@ -252,13 +252,13 @@ public class FlowableIgnoreElementsTest {
 
     @Test
     public void fused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.just(1).hide().ignoreElements().<Integer>toFlowable()
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
@@ -339,9 +339,9 @@ public class FlowableJoinTest {
 
     @Test
     public void rightClose() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = ps.join(Flowable.just(2),
+        TestSubscriber<Integer> ts = pp.join(Flowable.just(2),
                 Functions.justFunction(Flowable.never()),
                 Functions.justFunction(Flowable.empty()),
                 new BiFunction<Integer, Integer, Integer>() {
@@ -353,16 +353,16 @@ public class FlowableJoinTest {
         .test()
         .assertEmpty();
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertEmpty();
+        ts.assertEmpty();
     }
 
     @Test
     public void resultSelectorThrows2() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = ps.join(
+        TestSubscriber<Integer> ts = pp.join(
                 Flowable.just(2),
                 Functions.justFunction(Flowable.never()),
                 Functions.justFunction(Flowable.never()),
@@ -374,10 +374,10 @@ public class FlowableJoinTest {
                 })
         .test();
 
-        ps.onNext(1);
-        ps.onComplete();
+        pp.onNext(1);
+        pp.onComplete();
 
-        to.assertFailure(TestException.class);
+        ts.assertFailure(TestException.class);
     }
 
     @Test
@@ -417,7 +417,7 @@ public class FlowableJoinTest {
             @SuppressWarnings("rawtypes")
             final Subscriber[] o = { null };
 
-            TestSubscriber<Integer> to = Flowable.just(1)
+            TestSubscriber<Integer> ts = Flowable.just(1)
             .join(Flowable.just(2),
                     Functions.justFunction(Flowable.never()),
                     Functions.justFunction(new Flowable<Integer>() {
@@ -438,7 +438,7 @@ public class FlowableJoinTest {
 
             o[0].onError(new TestException("Second"));
 
-            to
+            ts
             .assertFailureAndMessage(TestException.class, "First");
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapNotificationTest.java
@@ -104,9 +104,9 @@ public class FlowableMapNotificationTest {
     public void noBackpressure() {
         TestSubscriber<Object> ts = TestSubscriber.create(0L);
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        new FlowableMapNotification<Integer, Integer>(ps,
+        new FlowableMapNotification<Integer, Integer>(pp,
                 new Function<Integer, Integer>() {
                     @Override
                     public Integer apply(Integer item) {
@@ -131,10 +131,10 @@ public class FlowableMapNotificationTest {
         ts.assertNoErrors();
         ts.assertNotComplete();
 
-        ps.onNext(1);
-        ps.onNext(2);
-        ps.onNext(3);
-        ps.onComplete();
+        pp.onNext(1);
+        pp.onNext(2);
+        pp.onNext(3);
+        pp.onComplete();
 
         ts.assertNoValues();
         ts.assertNoErrors();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
@@ -339,22 +339,22 @@ public class FlowableMapTest {
     @Test
     public void functionCrashUnsubscribes() {
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        ps.map(new Function<Integer, Integer>() {
+        pp.map(new Function<Integer, Integer>() {
             @Override
             public Integer apply(Integer v) {
                 throw new TestException();
             }
         }).subscribe(ts);
 
-        Assert.assertTrue("Not subscribed?", ps.hasSubscribers());
+        Assert.assertTrue("Not subscribed?", pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        Assert.assertFalse("Subscribed?", ps.hasSubscribers());
+        Assert.assertFalse("Subscribed?", pp.hasSubscribers());
 
         ts.assertError(TestException.class);
     }
@@ -418,7 +418,7 @@ public class FlowableMapTest {
 
     @Test
     public void mapFilterFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 2)
         .map(new Function<Integer, Integer>() {
@@ -436,13 +436,13 @@ public class FlowableMapTest {
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult(2, 3);
     }
 
     @Test
     public void mapFilterFusedHidden() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 2).hide()
         .map(new Function<Integer, Integer>() {
@@ -460,7 +460,7 @@ public class FlowableMapTest {
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertResult(2, 3);
     }
 
@@ -496,7 +496,7 @@ public class FlowableMapTest {
 
     @Test
     public void mapFilterMapperCrashFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 2).hide()
         .map(new Function<Integer, Integer>() {
@@ -514,7 +514,7 @@ public class FlowableMapTest {
         .subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertFailure(TestException.class);
     }
 
@@ -556,7 +556,7 @@ public class FlowableMapTest {
 
     @Test
     public void mapFilterFused2() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
@@ -580,7 +580,7 @@ public class FlowableMapTest {
         up.onComplete();
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(2, 3);
     }
 
@@ -638,41 +638,41 @@ public class FlowableMapTest {
 
     @Test
     public void fusedSync() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 5)
         .map(Functions.<Integer>identity())
-        .subscribe(to);
+        .subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.SYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void fusedAsync() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> us = UnicastProcessor.create();
 
         us
         .map(Functions.<Integer>identity())
-        .subscribe(to);
+        .subscribe(ts);
 
         TestHelper.emit(us, 1, 2, 3, 4, 5);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.ASYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void fusedReject() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY | QueueDisposable.BOUNDARY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
 
         Flowable.range(1, 5)
         .map(Functions.<Integer>identity())
-        .subscribe(to);
+        .subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -604,22 +604,22 @@ public class FlowableMergeDelayErrorTest {
     public void iterableMaxConcurrent() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        PublishProcessor<Integer> ps1 = PublishProcessor.create();
-        PublishProcessor<Integer> ps2 = PublishProcessor.create();
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        Flowable.mergeDelayError(Arrays.asList(ps1, ps2), 1).subscribe(ts);
+        Flowable.mergeDelayError(Arrays.asList(pp1, pp2), 1).subscribe(ts);
 
-        assertTrue("ps1 has no subscribers?!", ps1.hasSubscribers());
-        assertFalse("ps2 has subscribers?!", ps2.hasSubscribers());
+        assertTrue("ps1 has no subscribers?!", pp1.hasSubscribers());
+        assertFalse("ps2 has subscribers?!", pp2.hasSubscribers());
 
-        ps1.onNext(1);
-        ps1.onComplete();
+        pp1.onNext(1);
+        pp1.onComplete();
 
-        assertFalse("ps1 has subscribers?!", ps1.hasSubscribers());
-        assertTrue("ps2 has no subscribers?!", ps2.hasSubscribers());
+        assertFalse("ps1 has subscribers?!", pp1.hasSubscribers());
+        assertTrue("ps2 has no subscribers?!", pp2.hasSubscribers());
 
-        ps2.onNext(2);
-        ps2.onComplete();
+        pp2.onNext(2);
+        pp2.onComplete();
 
         ts.assertValues(1, 2);
         ts.assertNoErrors();
@@ -631,22 +631,22 @@ public class FlowableMergeDelayErrorTest {
     public void iterableMaxConcurrentError() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        PublishProcessor<Integer> ps1 = PublishProcessor.create();
-        PublishProcessor<Integer> ps2 = PublishProcessor.create();
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        Flowable.mergeDelayError(Arrays.asList(ps1, ps2), 1).subscribe(ts);
+        Flowable.mergeDelayError(Arrays.asList(pp1, pp2), 1).subscribe(ts);
 
-        assertTrue("ps1 has no subscribers?!", ps1.hasSubscribers());
-        assertFalse("ps2 has subscribers?!", ps2.hasSubscribers());
+        assertTrue("ps1 has no subscribers?!", pp1.hasSubscribers());
+        assertFalse("ps2 has subscribers?!", pp2.hasSubscribers());
 
-        ps1.onNext(1);
-        ps1.onError(new TestException());
+        pp1.onNext(1);
+        pp1.onError(new TestException());
 
-        assertFalse("ps1 has subscribers?!", ps1.hasSubscribers());
-        assertTrue("ps2 has no subscribers?!", ps2.hasSubscribers());
+        assertFalse("ps1 has subscribers?!", pp1.hasSubscribers());
+        assertTrue("ps2 has no subscribers?!", pp2.hasSubscribers());
 
-        ps2.onNext(2);
-        ps2.onError(new TestException());
+        pp2.onNext(2);
+        pp2.onError(new TestException());
 
         ts.assertValues(1, 2);
         ts.assertError(CompositeException.class);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -1494,22 +1494,22 @@ public class FlowableMergeTest {
     public void mergeArrayMaxConcurrent() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        PublishProcessor<Integer> ps1 = PublishProcessor.create();
-        PublishProcessor<Integer> ps2 = PublishProcessor.create();
+        PublishProcessor<Integer> pp1 = PublishProcessor.create();
+        PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        Flowable.mergeArray(1, 128, new Flowable[] { ps1, ps2 }).subscribe(ts);
+        Flowable.mergeArray(1, 128, new Flowable[] { pp1, pp2 }).subscribe(ts);
 
-        assertTrue("ps1 has no subscribers?!", ps1.hasSubscribers());
-        assertFalse("ps2 has subscribers?!", ps2.hasSubscribers());
+        assertTrue("ps1 has no subscribers?!", pp1.hasSubscribers());
+        assertFalse("ps2 has subscribers?!", pp2.hasSubscribers());
 
-        ps1.onNext(1);
-        ps1.onComplete();
+        pp1.onNext(1);
+        pp1.onComplete();
 
-        assertFalse("ps1 has subscribers?!", ps1.hasSubscribers());
-        assertTrue("ps2 has no subscribers?!", ps2.hasSubscribers());
+        assertFalse("ps1 has subscribers?!", pp1.hasSubscribers());
+        assertTrue("ps2 has no subscribers?!", pp2.hasSubscribers());
 
-        ps2.onNext(2);
-        ps2.onComplete();
+        pp2.onNext(2);
+        pp2.onComplete();
 
         ts.assertValues(1, 2);
         ts.assertNoErrors();
@@ -1571,15 +1571,15 @@ public class FlowableMergeTest {
                 new FlowableFlatMap.MergeSubscriber<Publisher<Integer>, Integer>(ts, Functions.<Publisher<Integer>>identity(), false, 128, 128);
         ms.onSubscribe(new BooleanSubscription());
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ms.onNext(ps);
+        ms.onNext(pp);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
         BackpressureHelper.add(ms.requested, 2);
 
-        ps.onNext(2);
+        pp.onNext(2);
 
         ms.drain();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -1006,7 +1006,7 @@ public class FlowableObserveOnTest {
 
     @Test
     public void conditionalConsumerFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 5)
         .observeOn(Schedulers.single())
@@ -1020,14 +1020,14 @@ public class FlowableObserveOnTest {
 
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(2, 4);
     }
 
     @Test
     public void conditionalConsumerFusedReject() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.SYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Flowable.range(1, 5)
         .observeOn(Schedulers.single())
@@ -1041,7 +1041,7 @@ public class FlowableObserveOnTest {
 
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(2, 4);
     }
@@ -1071,7 +1071,7 @@ public class FlowableObserveOnTest {
 
     @Test
     public void conditionalConsumerFusedAsync() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
@@ -1094,14 +1094,14 @@ public class FlowableObserveOnTest {
 
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(2, 4);
     }
 
     @Test
     public void conditionalConsumerHidden() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 5).hide()
         .observeOn(Schedulers.single())
@@ -1115,14 +1115,14 @@ public class FlowableObserveOnTest {
 
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(2, 4);
     }
 
     @Test
     public void conditionalConsumerBarrier() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 5)
         .map(Functions.<Integer>identity())
@@ -1137,7 +1137,7 @@ public class FlowableObserveOnTest {
 
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(2, 4);
     }
@@ -1162,7 +1162,7 @@ public class FlowableObserveOnTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestScheduler scheduler = new TestScheduler();
-            TestSubscriber<Integer> to = new Flowable<Integer>() {
+            TestSubscriber<Integer> ts = new Flowable<Integer>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> observer) {
                     observer.onSubscribe(new BooleanSubscription());
@@ -1177,7 +1177,7 @@ public class FlowableObserveOnTest {
 
             scheduler.triggerActions();
 
-            to.assertResult();
+            ts.assertResult();
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
@@ -1198,11 +1198,11 @@ public class FlowableObserveOnTest {
     public void inputAsyncFused() {
         UnicastProcessor<Integer> us = UnicastProcessor.create();
 
-        TestSubscriber<Integer> to = us.observeOn(Schedulers.single()).test();
+        TestSubscriber<Integer> ts = us.observeOn(Schedulers.single()).test();
 
         TestHelper.emit(us, 1, 2, 3, 4, 5);
 
-        to
+        ts
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5);
     }
@@ -1211,11 +1211,11 @@ public class FlowableObserveOnTest {
     public void inputAsyncFusedError() {
         UnicastProcessor<Integer> us = UnicastProcessor.create();
 
-        TestSubscriber<Integer> to = us.observeOn(Schedulers.single()).test();
+        TestSubscriber<Integer> ts = us.observeOn(Schedulers.single()).test();
 
         us.onError(new TestException());
 
-        to
+        ts
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
     }
@@ -1224,77 +1224,77 @@ public class FlowableObserveOnTest {
     public void inputAsyncFusedErrorDelayed() {
         UnicastProcessor<Integer> us = UnicastProcessor.create();
 
-        TestSubscriber<Integer> to = us.observeOn(Schedulers.single(), true).test();
+        TestSubscriber<Integer> ts = us.observeOn(Schedulers.single(), true).test();
 
         us.onError(new TestException());
 
-        to
+        ts
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
     }
 
     @Test
     public void outputFused() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 5).hide()
         .observeOn(Schedulers.single())
-        .subscribe(to);
+        .subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueSubscription.ASYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC)
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void outputFusedReject() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueSubscription.SYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Flowable.range(1, 5).hide()
         .observeOn(Schedulers.single())
-        .subscribe(to);
+        .subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueSubscription.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void inputOutputAsyncFusedError() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> us = UnicastProcessor.create();
 
         us.observeOn(Schedulers.single())
-        .subscribe(to);
+        .subscribe(ts);
 
         us.onError(new TestException());
 
-        to
+        ts
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
 
-        SubscriberFusion.assertFusion(to, QueueSubscription.ASYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC)
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
     }
 
     @Test
     public void inputOutputAsyncFusedErrorDelayed() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> us = UnicastProcessor.create();
 
         us.observeOn(Schedulers.single(), true)
-        .subscribe(to);
+        .subscribe(ts);
 
         us.onError(new TestException());
 
-        to
+        ts
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
 
-        SubscriberFusion.assertFusion(to, QueueSubscription.ASYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC)
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
     }
@@ -1312,7 +1312,7 @@ public class FlowableObserveOnTest {
             @Override
             public void onSubscribe(Subscription d) {
                 this.d = d;
-                ((QueueSubscription<?>)d).requestFusion(QueueSubscription.ANY);
+                ((QueueSubscription<?>)d).requestFusion(QueueFuseable.ANY);
             }
 
             @Override
@@ -1712,14 +1712,14 @@ public class FlowableObserveOnTest {
 
     @Test
     public void backFusedConditional() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 100).hide()
         .observeOn(ImmediateThinScheduler.INSTANCE)
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.ASYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC)
         .assertValueCount(100)
         .assertComplete()
         .assertNoErrors();
@@ -1727,21 +1727,21 @@ public class FlowableObserveOnTest {
 
     @Test
     public void backFusedErrorConditional() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.<Integer>error(new TestException())
         .observeOn(ImmediateThinScheduler.INSTANCE)
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.ASYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC)
         .assertFailure(TestException.class);
     }
 
     @Test
     public void backFusedCancelConditional() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+            final TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
             final TestScheduler scheduler = new TestScheduler();
 
@@ -1766,7 +1766,7 @@ public class FlowableObserveOnTest {
 
             TestHelper.race(r1, r2);
 
-            SubscriberFusion.assertFusion(ts, QueueSubscription.ASYNC);
+            SubscriberFusion.assertFusion(ts, QueueFuseable.ASYNC);
 
             if (ts.valueCount() != 0) {
                 ts.assertResult(1);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -24,7 +24,7 @@ import org.reactivestreams.*;
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
@@ -249,23 +249,23 @@ public class FlowableOnBackpressureBufferTest {
 
     @Test
     public void fusedNormal() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.range(1, 10).onBackpressureBuffer().subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-          .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+          .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
           .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
 
     @Test
     public void fusedError() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Flowable.<Integer>error(new TestException()).onBackpressureBuffer().subscribe(ts);
 
         ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
-          .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+          .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
           .assertFailure(TestException.class);
     }
 
@@ -300,11 +300,11 @@ public class FlowableOnBackpressureBufferTest {
 
     @Test
     public void fusionRejected() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.SYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Flowable.<Integer>never().onBackpressureBuffer().subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertEmpty();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
@@ -222,15 +222,15 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
     public void normalBackpressure() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.onErrorResumeNext(Flowable.range(3, 2)).subscribe(ts);
+        pp.onErrorResumeNext(Flowable.range(3, 2)).subscribe(ts);
 
         ts.request(2);
 
-        ps.onNext(1);
-        ps.onNext(2);
-        ps.onError(new TestException("Forced failure"));
+        pp.onNext(1);
+        pp.onNext(2);
+        pp.onError(new TestException("Forced failure"));
 
         ts.assertValues(1, 2);
         ts.assertNoErrors();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
@@ -352,9 +352,9 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
     public void normalBackpressure() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.onErrorResumeNext(new Function<Throwable, Flowable<Integer>>() {
+        pp.onErrorResumeNext(new Function<Throwable, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Throwable v) {
                 return Flowable.range(3, 2);
@@ -363,9 +363,9 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
 
         ts.request(2);
 
-        ps.onNext(1);
-        ps.onNext(2);
-        ps.onError(new TestException("Forced failure"));
+        pp.onNext(1);
+        pp.onNext(2);
+        pp.onError(new TestException("Forced failure"));
 
         ts.assertValues(1, 2);
         ts.assertNoErrors();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
@@ -218,9 +218,9 @@ public class FlowableOnErrorReturnTest {
     public void normalBackpressure() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.onErrorReturn(new Function<Throwable, Integer>() {
+        pp.onErrorReturn(new Function<Throwable, Integer>() {
             @Override
             public Integer apply(Throwable e) {
                 return 3;
@@ -229,9 +229,9 @@ public class FlowableOnErrorReturnTest {
 
         ts.request(2);
 
-        ps.onNext(1);
-        ps.onNext(2);
-        ps.onError(new TestException("Forced failure"));
+        pp.onNext(1);
+        pp.onNext(2);
+        pp.onError(new TestException("Forced failure"));
 
         ts.assertValues(1, 2);
         ts.assertNoErrors();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaFlowableTest.java
@@ -267,15 +267,15 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
     public void normalBackpressure() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.onExceptionResumeNext(Flowable.range(3, 2)).subscribe(ts);
+        pp.onExceptionResumeNext(Flowable.range(3, 2)).subscribe(ts);
 
         ts.request(2);
 
-        ps.onNext(1);
-        ps.onNext(2);
-        ps.onError(new TestException("Forced failure"));
+        pp.onNext(1);
+        pp.onNext(2);
+        pp.onError(new TestException("Forced failure"));
 
         ts.assertValues(1, 2);
         ts.assertNoErrors();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
@@ -84,17 +84,17 @@ public class FlowablePublishFunctionTest {
     public void canBeCancelled() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
+        pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Flowable<Integer> o) {
                 return Flowable.concat(o.take(5), o.takeLast(5));
             }
         }).subscribe(ts);
 
-        ps.onNext(1);
-        ps.onNext(2);
+        pp.onNext(1);
+        pp.onNext(2);
 
         ts.assertValues(1, 2);
         ts.assertNoErrors();
@@ -102,7 +102,7 @@ public class FlowablePublishFunctionTest {
 
         ts.cancel();
 
-        Assert.assertFalse("Source has subscribers?", ps.hasSubscribers());
+        Assert.assertFalse("Source has subscribers?", pp.hasSubscribers());
     }
 
     @Test
@@ -120,22 +120,22 @@ public class FlowablePublishFunctionTest {
     public void takeCompletes() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
+        pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Flowable<Integer> o) {
                 return o.take(1);
             }
         }).subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
         ts.assertValues(1);
         ts.assertNoErrors();
         ts.assertComplete();
 
-        Assert.assertFalse("Source has subscribers?", ps.hasSubscribers());
+        Assert.assertFalse("Source has subscribers?", pp.hasSubscribers());
 
     }
 
@@ -151,9 +151,9 @@ public class FlowablePublishFunctionTest {
             }
         };
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
+        pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Flowable<Integer> o) {
                 return o.take(1);
@@ -167,54 +167,54 @@ public class FlowablePublishFunctionTest {
     public void takeCompletesUnsafe() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
+        pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Flowable<Integer> o) {
                 return o.take(1);
             }
         }).subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
         ts.assertValues(1);
         ts.assertNoErrors();
         ts.assertComplete();
 
-        Assert.assertFalse("Source has subscribers?", ps.hasSubscribers());
+        Assert.assertFalse("Source has subscribers?", pp.hasSubscribers());
     }
 
     @Test
     public void directCompletesUnsafe() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
+        pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Flowable<Integer> o) {
                 return o;
             }
         }).subscribe(ts);
 
-        ps.onNext(1);
-        ps.onComplete();
+        pp.onNext(1);
+        pp.onComplete();
 
         ts.assertValues(1);
         ts.assertNoErrors();
         ts.assertComplete();
 
-        Assert.assertFalse("Source has subscribers?", ps.hasSubscribers());
+        Assert.assertFalse("Source has subscribers?", pp.hasSubscribers());
     }
 
     @Test
     public void overflowMissingBackpressureException() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
+        pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Flowable<Integer> o) {
                 return o;
@@ -222,7 +222,7 @@ public class FlowablePublishFunctionTest {
         }).subscribe(ts);
 
         for (int i = 0; i < Flowable.bufferSize() * 2; i++) {
-            ps.onNext(i);
+            pp.onNext(i);
         }
 
         ts.assertNoValues();
@@ -231,16 +231,16 @@ public class FlowablePublishFunctionTest {
 
         Assert.assertEquals("Could not emit value due to lack of requests",
                 ts.errors().get(0).getMessage());
-        Assert.assertFalse("Source has subscribers?", ps.hasSubscribers());
+        Assert.assertFalse("Source has subscribers?", pp.hasSubscribers());
     }
 
     @Test
     public void overflowMissingBackpressureExceptionDelayed() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        new FlowablePublishMulticast<Integer, Integer>(ps, new Function<Flowable<Integer>, Flowable<Integer>>() {
+        new FlowablePublishMulticast<Integer, Integer>(pp, new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Flowable<Integer> o) {
                 return o;
@@ -248,7 +248,7 @@ public class FlowablePublishFunctionTest {
         }, Flowable.bufferSize(), true).subscribe(ts);
 
         for (int i = 0; i < Flowable.bufferSize() * 2; i++) {
-            ps.onNext(i);
+            pp.onNext(i);
         }
 
         ts.request(Flowable.bufferSize());
@@ -258,7 +258,7 @@ public class FlowablePublishFunctionTest {
         ts.assertNotComplete();
 
         Assert.assertEquals("Could not emit value due to lack of requests", ts.errors().get(0).getMessage());
-        Assert.assertFalse("Source has subscribers?", ps.hasSubscribers());
+        Assert.assertFalse("Source has subscribers?", pp.hasSubscribers());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -254,12 +254,12 @@ public class FlowablePublishTest {
     @Test
     public void testConnectWithNoSubscriber() {
         TestScheduler scheduler = new TestScheduler();
-        ConnectableFlowable<Long> co = Flowable.interval(10, 10, TimeUnit.MILLISECONDS, scheduler).take(3).publish();
-        co.connect();
+        ConnectableFlowable<Long> cf = Flowable.interval(10, 10, TimeUnit.MILLISECONDS, scheduler).take(3).publish();
+        cf.connect();
         // Emit 0
         scheduler.advanceTimeBy(15, TimeUnit.MILLISECONDS);
         TestSubscriber<Long> subscriber = new TestSubscriber<Long>();
-        co.subscribe(subscriber);
+        cf.subscribe(subscriber);
         // Emit 1 and 2
         scheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS);
         subscriber.assertValues(1L, 2L);
@@ -401,8 +401,8 @@ public class FlowablePublishTest {
 
     @Test
     public void syncFusedObserveOn() {
-        ConnectableFlowable<Integer> co = Flowable.range(0, 1000).publish();
-        Flowable<Integer> obs = co.observeOn(Schedulers.computation());
+        ConnectableFlowable<Integer> cf = Flowable.range(0, 1000).publish();
+        Flowable<Integer> obs = cf.observeOn(Schedulers.computation());
         for (int i = 0; i < 1000; i++) {
             for (int j = 1; j < 6; j++) {
                 List<TestSubscriber<Integer>> tss = new ArrayList<TestSubscriber<Integer>>();
@@ -412,7 +412,7 @@ public class FlowablePublishTest {
                     obs.subscribe(ts);
                 }
 
-                Disposable s = co.connect();
+                Disposable s = cf.connect();
 
                 for (TestSubscriber<Integer> ts : tss) {
                     ts.awaitDone(5, TimeUnit.SECONDS)
@@ -428,8 +428,8 @@ public class FlowablePublishTest {
 
     @Test
     public void syncFusedObserveOn2() {
-        ConnectableFlowable<Integer> co = Flowable.range(0, 1000).publish();
-        Flowable<Integer> obs = co.observeOn(ImmediateThinScheduler.INSTANCE);
+        ConnectableFlowable<Integer> cf = Flowable.range(0, 1000).publish();
+        Flowable<Integer> obs = cf.observeOn(ImmediateThinScheduler.INSTANCE);
         for (int i = 0; i < 1000; i++) {
             for (int j = 1; j < 6; j++) {
                 List<TestSubscriber<Integer>> tss = new ArrayList<TestSubscriber<Integer>>();
@@ -439,7 +439,7 @@ public class FlowablePublishTest {
                     obs.subscribe(ts);
                 }
 
-                Disposable s = co.connect();
+                Disposable s = cf.connect();
 
                 for (TestSubscriber<Integer> ts : tss) {
                     ts.awaitDone(5, TimeUnit.SECONDS)
@@ -455,17 +455,17 @@ public class FlowablePublishTest {
 
     @Test
     public void asyncFusedObserveOn() {
-        ConnectableFlowable<Integer> co = Flowable.range(0, 1000).observeOn(ImmediateThinScheduler.INSTANCE).publish();
+        ConnectableFlowable<Integer> cf = Flowable.range(0, 1000).observeOn(ImmediateThinScheduler.INSTANCE).publish();
         for (int i = 0; i < 1000; i++) {
             for (int j = 1; j < 6; j++) {
                 List<TestSubscriber<Integer>> tss = new ArrayList<TestSubscriber<Integer>>();
                 for (int k = 1; k < j; k++) {
                     TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
                     tss.add(ts);
-                    co.subscribe(ts);
+                    cf.subscribe(ts);
                 }
 
-                Disposable s = co.connect();
+                Disposable s = cf.connect();
 
                 for (TestSubscriber<Integer> ts : tss) {
                     ts.awaitDone(5, TimeUnit.SECONDS)
@@ -481,8 +481,8 @@ public class FlowablePublishTest {
 
     @Test
     public void testObserveOn() {
-        ConnectableFlowable<Integer> co = Flowable.range(0, 1000).hide().publish();
-        Flowable<Integer> obs = co.observeOn(Schedulers.computation());
+        ConnectableFlowable<Integer> cf = Flowable.range(0, 1000).hide().publish();
+        Flowable<Integer> obs = cf.observeOn(Schedulers.computation());
         for (int i = 0; i < 1000; i++) {
             for (int j = 1; j < 6; j++) {
                 List<TestSubscriber<Integer>> tss = new ArrayList<TestSubscriber<Integer>>();
@@ -492,7 +492,7 @@ public class FlowablePublishTest {
                     obs.subscribe(ts);
                 }
 
-                Disposable s = co.connect();
+                Disposable s = cf.connect();
 
                 for (TestSubscriber<Integer> ts : tss) {
                     ts.awaitDone(5, TimeUnit.SECONDS)
@@ -515,9 +515,9 @@ public class FlowablePublishTest {
 
     @Test
     public void connectThrows() {
-        ConnectableFlowable<Integer> co = Flowable.<Integer>empty().publish();
+        ConnectableFlowable<Integer> cf = Flowable.<Integer>empty().publish();
         try {
-            co.connect(new Consumer<Disposable>() {
+            cf.connect(new Consumer<Disposable>() {
                 @Override
                 public void accept(Disposable s) throws Exception {
                     throw new TestException();
@@ -532,23 +532,23 @@ public class FlowablePublishTest {
     public void addRemoveRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            final ConnectableFlowable<Integer> co = Flowable.<Integer>empty().publish();
+            final ConnectableFlowable<Integer> cf = Flowable.<Integer>empty().publish();
 
-            final TestSubscriber<Integer> to = co.test();
+            final TestSubscriber<Integer> ts = cf.test();
 
-            final TestSubscriber<Integer> to2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    co.subscribe(to2);
+                    cf.subscribe(ts2);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
 
@@ -558,9 +558,9 @@ public class FlowablePublishTest {
 
     @Test
     public void disposeOnArrival() {
-        ConnectableFlowable<Integer> co = Flowable.<Integer>empty().publish();
+        ConnectableFlowable<Integer> cf = Flowable.<Integer>empty().publish();
 
-        co.test(Long.MAX_VALUE, true).assertEmpty();
+        cf.test(Long.MAX_VALUE, true).assertEmpty();
     }
 
     @Test
@@ -579,65 +579,65 @@ public class FlowablePublishTest {
 
     @Test
     public void empty() {
-        ConnectableFlowable<Integer> co = Flowable.<Integer>empty().publish();
+        ConnectableFlowable<Integer> cf = Flowable.<Integer>empty().publish();
 
-        co.connect();
+        cf.connect();
     }
 
     @Test
     public void take() {
-        ConnectableFlowable<Integer> co = Flowable.range(1, 2).publish();
+        ConnectableFlowable<Integer> cf = Flowable.range(1, 2).publish();
 
-        TestSubscriber<Integer> to = co.take(1).test();
+        TestSubscriber<Integer> ts = cf.take(1).test();
 
-        co.connect();
+        cf.connect();
 
-        to.assertResult(1);
+        ts.assertResult(1);
     }
 
     @Test
     public void just() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ConnectableFlowable<Integer> co = ps.publish();
+        ConnectableFlowable<Integer> cf = pp.publish();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
-                ps.onComplete();
+                pp.onComplete();
             }
         };
 
-        co.subscribe(to);
-        co.connect();
+        cf.subscribe(ts);
+        cf.connect();
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertResult(1);
+        ts.assertResult(1);
     }
 
     @Test
     public void nextCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            final PublishProcessor<Integer> ps = PublishProcessor.create();
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final ConnectableFlowable<Integer> co = ps.publish();
+            final ConnectableFlowable<Integer> cf = pp.publish();
 
-            final TestSubscriber<Integer> to = co.test();
+            final TestSubscriber<Integer> ts = cf.test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ps.onNext(1);
+                    pp.onNext(1);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
 
@@ -675,9 +675,9 @@ public class FlowablePublishTest {
     public void noErrorLoss() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            ConnectableFlowable<Object> co = Flowable.error(new TestException()).publish();
+            ConnectableFlowable<Object> cf = Flowable.error(new TestException()).publish();
 
-            co.connect();
+            cf.connect();
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
@@ -689,12 +689,12 @@ public class FlowablePublishTest {
     public void subscribeDisconnectRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            final PublishProcessor<Integer> ps = PublishProcessor.create();
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final ConnectableFlowable<Integer> co = ps.publish();
+            final ConnectableFlowable<Integer> cf = pp.publish();
 
-            final Disposable d = co.connect();
-            final TestSubscriber<Integer> to = new TestSubscriber<Integer>();
+            final Disposable d = cf.connect();
+            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -706,7 +706,7 @@ public class FlowablePublishTest {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    co.subscribe(to);
+                    cf.subscribe(ts);
                 }
             };
 
@@ -716,9 +716,9 @@ public class FlowablePublishTest {
 
     @Test
     public void selectorDisconnectsIndependentSource() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
+        pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
                 return Flowable.range(1, 2);
@@ -727,7 +727,7 @@ public class FlowablePublishTest {
         .test()
         .assertResult(1, 2);
 
-        assertFalse(ps.hasSubscribers());
+        assertFalse(pp.hasSubscribers());
     }
 
     @Test(timeout = 5000)
@@ -753,9 +753,9 @@ public class FlowablePublishTest {
 
     @Test
     public void selectorInnerError() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
+        pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
                 return Flowable.error(new TestException());
@@ -764,21 +764,21 @@ public class FlowablePublishTest {
         .test()
         .assertFailure(TestException.class);
 
-        assertFalse(ps.hasSubscribers());
+        assertFalse(pp.hasSubscribers());
     }
 
     @Test
     public void preNextConnect() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            final ConnectableFlowable<Integer> co = Flowable.<Integer>empty().publish();
+            final ConnectableFlowable<Integer> cf = Flowable.<Integer>empty().publish();
 
-            co.connect();
+            cf.connect();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    co.test();
+                    cf.test();
                 }
             };
 
@@ -790,12 +790,12 @@ public class FlowablePublishTest {
     public void connectRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            final ConnectableFlowable<Integer> co = Flowable.<Integer>empty().publish();
+            final ConnectableFlowable<Integer> cf = Flowable.<Integer>empty().publish();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    co.connect();
+                    cf.connect();
                 }
             };
 
@@ -902,7 +902,7 @@ public class FlowablePublishTest {
 
             final AtomicReference<Disposable> ref = new AtomicReference<Disposable>();
 
-            final ConnectableFlowable<Integer> co = new Flowable<Integer>() {
+            final ConnectableFlowable<Integer> cf = new Flowable<Integer>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -910,7 +910,7 @@ public class FlowablePublishTest {
                 }
             }.publish();
 
-            co.connect();
+            cf.connect();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -927,7 +927,7 @@ public class FlowablePublishTest {
     public void removeNotPresent() {
         final AtomicReference<PublishSubscriber<Integer>> ref = new AtomicReference<PublishSubscriber<Integer>>();
 
-        final ConnectableFlowable<Integer> co = new Flowable<Integer>() {
+        final ConnectableFlowable<Integer> cf = new Flowable<Integer>() {
             @Override
             @SuppressWarnings("unchecked")
             protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -936,7 +936,7 @@ public class FlowablePublishTest {
             }
         }.publish();
 
-        co.connect();
+        cf.connect();
 
         ref.get().add(new InnerSubscriber<Integer>(new TestSubscriber<Integer>()));
         ref.get().remove(null);
@@ -945,9 +945,9 @@ public class FlowablePublishTest {
     @Test
     @Ignore("publish() keeps consuming the upstream if there are no subscribers, 3.x should change this")
     public void subscriberSwap() {
-        final ConnectableFlowable<Integer> co = Flowable.range(1, 5).publish();
+        final ConnectableFlowable<Integer> cf = Flowable.range(1, 5).publish();
 
-        co.connect();
+        cf.connect();
 
         TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() {
             @Override
@@ -958,12 +958,12 @@ public class FlowablePublishTest {
             }
         };
 
-        co.subscribe(ts1);
+        cf.subscribe(ts1);
 
         ts1.assertResult(1);
 
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(0);
-        co.subscribe(ts2);
+        cf.subscribe(ts2);
 
         ts2
         .assertEmpty()
@@ -973,7 +973,7 @@ public class FlowablePublishTest {
 
     @Test
     public void subscriberLiveSwap() {
-        final ConnectableFlowable<Integer> co = Flowable.range(1, 5).publish();
+        final ConnectableFlowable<Integer> cf = Flowable.range(1, 5).publish();
 
         final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(0);
 
@@ -983,13 +983,13 @@ public class FlowablePublishTest {
                 super.onNext(t);
                 cancel();
                 onComplete();
-                co.subscribe(ts2);
+                cf.subscribe(ts2);
             }
         };
 
-        co.subscribe(ts1);
+        cf.subscribe(ts1);
 
-        co.connect();
+        cf.connect();
 
         ts1.assertResult(1);
 
@@ -1261,13 +1261,13 @@ public class FlowablePublishTest {
     public void publishCancelOneAsync2() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ConnectableFlowable<Integer> co = pp.publish();
+        ConnectableFlowable<Integer> cf = pp.publish();
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
 
         final AtomicReference<InnerSubscriber<Integer>> ref = new AtomicReference<InnerSubscriber<Integer>>();
 
-        co.subscribe(new FlowableSubscriber<Integer>() {
+        cf.subscribe(new FlowableSubscriber<Integer>() {
             @SuppressWarnings("unchecked")
             @Override
             public void onSubscribe(Subscription s) {
@@ -1291,9 +1291,9 @@ public class FlowablePublishTest {
                 ts1.onComplete();
             }
         });
-        TestSubscriber<Integer> ts2 = co.test();
+        TestSubscriber<Integer> ts2 = cf.test();
 
-        co.connect();
+        cf.connect();
 
         ref.get().set(Long.MIN_VALUE);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
@@ -26,7 +26,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.subscribers.*;
 
 public class FlowableRangeLongTest {
@@ -290,21 +290,21 @@ public class FlowableRangeLongTest {
 
     @Test
     public void fused() {
-        TestSubscriber<Long> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Long> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
-        Flowable.rangeLong(1, 2).subscribe(to);
+        Flowable.rangeLong(1, 2).subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.SYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.SYNC)
         .assertResult(1L, 2L);
     }
 
     @Test
     public void fusedReject() {
-        TestSubscriber<Long> to = SubscriberFusion.newTest(QueueDisposable.ASYNC);
+        TestSubscriber<Long> ts = SubscriberFusion.newTest(QueueFuseable.ASYNC);
 
-        Flowable.rangeLong(1, 2).subscribe(to);
+        Flowable.rangeLong(1, 2).subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1L, 2L);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
@@ -26,7 +26,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.subscribers.*;
 
 public class FlowableRangeTest {
@@ -283,12 +283,12 @@ public class FlowableRangeTest {
 
     @Test
     public void requestWrongFusion() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ASYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ASYNC);
 
         Flowable.range(1, 5)
-        .subscribe(to);
+        .subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
     }
 
@@ -301,21 +301,21 @@ public class FlowableRangeTest {
 
     @Test
     public void fused() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
-        Flowable.range(1, 2).subscribe(to);
+        Flowable.range(1, 2).subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.SYNC)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.SYNC)
         .assertResult(1, 2);
     }
 
     @Test
     public void fusedReject() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ASYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ASYNC);
 
-        Flowable.range(1, 2).subscribe(to);
+        Flowable.range(1, 2).subscribe(ts);
 
-        SubscriberFusion.assertFusion(to, QueueDisposable.NONE)
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE)
         .assertResult(1, 2);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -775,18 +775,18 @@ public class FlowableRefCountTest {
 
     @Test
     public void replayIsUnsubscribed() {
-        ConnectableFlowable<Integer> co = Flowable.just(1)
+        ConnectableFlowable<Integer> cf = Flowable.just(1)
         .replay();
 
-        assertTrue(((Disposable)co).isDisposed());
+        assertTrue(((Disposable)cf).isDisposed());
 
-        Disposable s = co.connect();
+        Disposable s = cf.connect();
 
-        assertFalse(((Disposable)co).isDisposed());
+        assertFalse(((Disposable)cf).isDisposed());
 
         s.dispose();
 
-        assertTrue(((Disposable)co).isDisposed());
+        assertTrue(((Disposable)cf).isDisposed());
     }
 
     static final class BadFlowableSubscribe extends ConnectableFlowable<Object> {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -46,14 +46,14 @@ public class FlowableReplayTest {
     public void testBufferedReplay() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        ConnectableFlowable<Integer> co = source.replay(3);
-        co.connect();
+        ConnectableFlowable<Integer> cf = source.replay(3);
+        cf.connect();
 
         {
             Subscriber<Object> observer1 = TestHelper.mockSubscriber();
             InOrder inOrder = inOrder(observer1);
 
-            co.subscribe(observer1);
+            cf.subscribe(observer1);
 
             source.onNext(1);
             source.onNext(2);
@@ -76,7 +76,7 @@ public class FlowableReplayTest {
             Subscriber<Object> observer1 = TestHelper.mockSubscriber();
             InOrder inOrder = inOrder(observer1);
 
-            co.subscribe(observer1);
+            cf.subscribe(observer1);
 
             inOrder.verify(observer1, times(1)).onNext(2);
             inOrder.verify(observer1, times(1)).onNext(3);
@@ -91,14 +91,14 @@ public class FlowableReplayTest {
     public void testBufferedWindowReplay() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         TestScheduler scheduler = new TestScheduler();
-        ConnectableFlowable<Integer> co = source.replay(3, 100, TimeUnit.MILLISECONDS, scheduler);
-        co.connect();
+        ConnectableFlowable<Integer> cf = source.replay(3, 100, TimeUnit.MILLISECONDS, scheduler);
+        cf.connect();
 
         {
             Subscriber<Object> observer1 = TestHelper.mockSubscriber();
             InOrder inOrder = inOrder(observer1);
 
-            co.subscribe(observer1);
+            cf.subscribe(observer1);
 
             source.onNext(1);
             scheduler.advanceTimeBy(10, TimeUnit.MILLISECONDS);
@@ -128,7 +128,7 @@ public class FlowableReplayTest {
             Subscriber<Object> observer1 = TestHelper.mockSubscriber();
             InOrder inOrder = inOrder(observer1);
 
-            co.subscribe(observer1);
+            cf.subscribe(observer1);
 
             inOrder.verify(observer1, times(1)).onNext(4);
             inOrder.verify(observer1, times(1)).onNext(5);
@@ -143,14 +143,14 @@ public class FlowableReplayTest {
 
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        ConnectableFlowable<Integer> co = source.replay(100, TimeUnit.MILLISECONDS, scheduler);
-        co.connect();
+        ConnectableFlowable<Integer> cf = source.replay(100, TimeUnit.MILLISECONDS, scheduler);
+        cf.connect();
 
         {
             Subscriber<Object> observer1 = TestHelper.mockSubscriber();
             InOrder inOrder = inOrder(observer1);
 
-            co.subscribe(observer1);
+            cf.subscribe(observer1);
 
             source.onNext(1);
             scheduler.advanceTimeBy(60, TimeUnit.MILLISECONDS);
@@ -174,7 +174,7 @@ public class FlowableReplayTest {
             Subscriber<Object> observer1 = TestHelper.mockSubscriber();
             InOrder inOrder = inOrder(observer1);
 
-            co.subscribe(observer1);
+            cf.subscribe(observer1);
             inOrder.verify(observer1, never()).onNext(3);
 
             inOrder.verify(observer1, times(1)).onComplete();
@@ -371,14 +371,14 @@ public class FlowableReplayTest {
     public void testBufferedReplayError() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        ConnectableFlowable<Integer> co = source.replay(3);
-        co.connect();
+        ConnectableFlowable<Integer> cf = source.replay(3);
+        cf.connect();
 
         {
             Subscriber<Object> observer1 = TestHelper.mockSubscriber();
             InOrder inOrder = inOrder(observer1);
 
-            co.subscribe(observer1);
+            cf.subscribe(observer1);
 
             source.onNext(1);
             source.onNext(2);
@@ -402,7 +402,7 @@ public class FlowableReplayTest {
             Subscriber<Object> observer1 = TestHelper.mockSubscriber();
             InOrder inOrder = inOrder(observer1);
 
-            co.subscribe(observer1);
+            cf.subscribe(observer1);
 
             inOrder.verify(observer1, times(1)).onNext(2);
             inOrder.verify(observer1, times(1)).onNext(3);
@@ -419,14 +419,14 @@ public class FlowableReplayTest {
 
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        ConnectableFlowable<Integer> co = source.replay(100, TimeUnit.MILLISECONDS, scheduler);
-        co.connect();
+        ConnectableFlowable<Integer> cf = source.replay(100, TimeUnit.MILLISECONDS, scheduler);
+        cf.connect();
 
         {
             Subscriber<Object> observer1 = TestHelper.mockSubscriber();
             InOrder inOrder = inOrder(observer1);
 
-            co.subscribe(observer1);
+            cf.subscribe(observer1);
 
             source.onNext(1);
             scheduler.advanceTimeBy(60, TimeUnit.MILLISECONDS);
@@ -450,7 +450,7 @@ public class FlowableReplayTest {
             Subscriber<Object> observer1 = TestHelper.mockSubscriber();
             InOrder inOrder = inOrder(observer1);
 
-            co.subscribe(observer1);
+            cf.subscribe(observer1);
             inOrder.verify(observer1, never()).onNext(3);
 
             inOrder.verify(observer1, times(1)).onError(any(RuntimeException.class));
@@ -807,17 +807,17 @@ public class FlowableReplayTest {
                         requested.addAndGet(t);
                     }
                 });
-        ConnectableFlowable<Integer> co = source.replay();
+        ConnectableFlowable<Integer> cf = source.replay();
 
         TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(10L);
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(90L);
 
-        co.subscribe(ts1);
-        co.subscribe(ts2);
+        cf.subscribe(ts1);
+        cf.subscribe(ts2);
 
         ts2.request(10);
 
-        co.connect();
+        cf.connect();
 
         ts1.assertValueCount(10);
         ts1.assertNotTerminated();
@@ -838,17 +838,17 @@ public class FlowableReplayTest {
                         requested.addAndGet(t);
                     }
                 });
-        ConnectableFlowable<Integer> co = source.replay(50);
+        ConnectableFlowable<Integer> cf = source.replay(50);
 
         TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(10L);
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(90L);
 
-        co.subscribe(ts1);
-        co.subscribe(ts2);
+        cf.subscribe(ts1);
+        cf.subscribe(ts2);
 
         ts2.request(10);
 
-        co.connect();
+        cf.connect();
 
         ts1.assertValueCount(10);
         ts1.assertNotTerminated();
@@ -1306,12 +1306,12 @@ public class FlowableReplayTest {
     @Test
     public void connectRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final ConnectableFlowable<Integer> co = Flowable.range(1, 3).replay();
+            final ConnectableFlowable<Integer> cf = Flowable.range(1, 3).replay();
 
             Runnable r = new Runnable() {
                 @Override
                 public void run() {
-                    co.connect();
+                    cf.connect();
                 }
             };
 
@@ -1322,22 +1322,22 @@ public class FlowableReplayTest {
     @Test
     public void subscribeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final ConnectableFlowable<Integer> co = Flowable.range(1, 3).replay();
+            final ConnectableFlowable<Integer> cf = Flowable.range(1, 3).replay();
 
-            final TestSubscriber<Integer> to1 = new TestSubscriber<Integer>();
-            final TestSubscriber<Integer> to2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    co.subscribe(to1);
+                    cf.subscribe(ts1);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    co.subscribe(to2);
+                    cf.subscribe(ts2);
                 }
             };
 
@@ -1348,24 +1348,24 @@ public class FlowableReplayTest {
     @Test
     public void addRemoveRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final ConnectableFlowable<Integer> co = Flowable.range(1, 3).replay();
+            final ConnectableFlowable<Integer> cf = Flowable.range(1, 3).replay();
 
-            final TestSubscriber<Integer> to1 = new TestSubscriber<Integer>();
-            final TestSubscriber<Integer> to2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
 
-            co.subscribe(to1);
+            cf.subscribe(ts1);
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    to1.cancel();
+                    ts1.cancel();
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    co.subscribe(to2);
+                    cf.subscribe(ts2);
                 }
             };
 
@@ -1384,12 +1384,12 @@ public class FlowableReplayTest {
 
     @Test
     public void cancelOnArrival2() {
-        ConnectableFlowable<Integer> co = PublishProcessor.<Integer>create()
+        ConnectableFlowable<Integer> cf = PublishProcessor.<Integer>create()
         .replay(Integer.MAX_VALUE);
 
-        co.test();
+        cf.test();
 
-        co
+        cf
         .autoConnect()
         .test(Long.MAX_VALUE, true)
         .assertEmpty();
@@ -1397,11 +1397,11 @@ public class FlowableReplayTest {
 
     @Test
     public void connectConsumerThrows() {
-        ConnectableFlowable<Integer> co = Flowable.range(1, 2)
+        ConnectableFlowable<Integer> cf = Flowable.range(1, 2)
         .replay();
 
         try {
-            co.connect(new Consumer<Disposable>() {
+            cf.connect(new Consumer<Disposable>() {
                 @Override
                 public void accept(Disposable t) throws Exception {
                     throw new TestException();
@@ -1412,11 +1412,11 @@ public class FlowableReplayTest {
             // expected
         }
 
-        co.test().assertEmpty().cancel();
+        cf.test().assertEmpty().cancel();
 
-        co.connect();
+        cf.connect();
 
-        co.test().assertResult(1, 2);
+        cf.test().assertResult(1, 2);
     }
 
     @Test
@@ -1446,16 +1446,16 @@ public class FlowableReplayTest {
     @Test
     public void subscribeOnNextRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps = PublishProcessor.create();
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final ConnectableFlowable<Integer> co = ps.replay();
+            final ConnectableFlowable<Integer> cf = pp.replay();
 
-            final TestSubscriber<Integer> to1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    co.subscribe(to1);
+                    cf.subscribe(ts1);
                 }
             };
 
@@ -1463,7 +1463,7 @@ public class FlowableReplayTest {
                 @Override
                 public void run() {
                     for (int j = 0; j < 1000; j++) {
-                        ps.onNext(j);
+                        pp.onNext(j);
                     }
                 }
             };
@@ -1475,18 +1475,18 @@ public class FlowableReplayTest {
     @Test
     public void unsubscribeOnNextRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps = PublishProcessor.create();
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final ConnectableFlowable<Integer> co = ps.replay();
+            final ConnectableFlowable<Integer> cf = pp.replay();
 
-            final TestSubscriber<Integer> to1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
 
-            co.subscribe(to1);
+            cf.subscribe(ts1);
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    to1.dispose();
+                    ts1.dispose();
                 }
             };
 
@@ -1494,7 +1494,7 @@ public class FlowableReplayTest {
                 @Override
                 public void run() {
                     for (int j = 0; j < 1000; j++) {
-                        ps.onNext(j);
+                        pp.onNext(j);
                     }
                 }
             };
@@ -1506,23 +1506,23 @@ public class FlowableReplayTest {
     @Test
     public void unsubscribeReplayRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final ConnectableFlowable<Integer> co = Flowable.range(1, 1000).replay();
+            final ConnectableFlowable<Integer> cf = Flowable.range(1, 1000).replay();
 
-            final TestSubscriber<Integer> to1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
 
-            co.connect();
+            cf.connect();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    co.subscribe(to1);
+                    cf.subscribe(ts1);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    to1.dispose();
+                    ts1.dispose();
                 }
             };
 
@@ -1532,90 +1532,90 @@ public class FlowableReplayTest {
 
     @Test
     public void reentrantOnNext() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
-                    ps.onNext(2);
-                    ps.onComplete();
+                    pp.onNext(2);
+                    pp.onComplete();
                 }
                 super.onNext(t);
             }
         };
 
-        ps.replay().autoConnect().subscribe(to);
+        pp.replay().autoConnect().subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertResult(1, 2);
+        ts.assertResult(1, 2);
     }
 
     @Test
     public void reentrantOnNextBound() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
-                    ps.onNext(2);
-                    ps.onComplete();
+                    pp.onNext(2);
+                    pp.onComplete();
                 }
                 super.onNext(t);
             }
         };
 
-        ps.replay(10).autoConnect().subscribe(to);
+        pp.replay(10).autoConnect().subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertResult(1, 2);
+        ts.assertResult(1, 2);
     }
 
     @Test
     public void reentrantOnNextCancel() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
-                    ps.onNext(2);
+                    pp.onNext(2);
                     cancel();
                 }
                 super.onNext(t);
             }
         };
 
-        ps.replay().autoConnect().subscribe(to);
+        pp.replay().autoConnect().subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertValues(1);
+        ts.assertValues(1);
     }
 
     @Test
     public void reentrantOnNextCancelBounded() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
-                    ps.onNext(2);
+                    pp.onNext(2);
                     cancel();
                 }
                 super.onNext(t);
             }
         };
 
-        ps.replay(10).autoConnect().subscribe(to);
+        pp.replay(10).autoConnect().subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertValues(1);
+        ts.assertValues(1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -392,7 +392,7 @@ public class FlowableRetryWithPredicateTest {
     @Test
     public void predicateThrows() {
 
-        TestSubscriber<Object> to = Flowable.error(new TestException("Outer"))
+        TestSubscriber<Object> ts = Flowable.error(new TestException("Outer"))
         .retry(new Predicate<Throwable>() {
             @Override
             public boolean test(Throwable e) throws Exception {
@@ -402,7 +402,7 @@ public class FlowableRetryWithPredicateTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");
@@ -419,36 +419,36 @@ public class FlowableRetryWithPredicateTest {
     @Test
     public void retryDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps = PublishProcessor.create();
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestSubscriber<Integer> to = ps.retry(Functions.alwaysTrue()).test();
+            final TestSubscriber<Integer> ts = pp.retry(Functions.alwaysTrue()).test();
 
             final TestException ex = new TestException();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ps.onError(ex);
+                    pp.onError(ex);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            to.assertEmpty();
+            ts.assertEmpty();
         }
     }
 
     @Test
     public void bipredicateThrows() {
 
-        TestSubscriber<Object> to = Flowable.error(new TestException("Outer"))
+        TestSubscriber<Object> ts = Flowable.error(new TestException("Outer"))
         .retry(new BiPredicate<Integer, Throwable>() {
             @Override
             public boolean test(Integer n, Throwable e) throws Exception {
@@ -458,7 +458,7 @@ public class FlowableRetryWithPredicateTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");
@@ -467,9 +467,9 @@ public class FlowableRetryWithPredicateTest {
     @Test
     public void retryBiPredicateDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps = PublishProcessor.create();
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestSubscriber<Integer> to = ps.retry(new BiPredicate<Object, Object>() {
+            final TestSubscriber<Integer> ts = pp.retry(new BiPredicate<Object, Object>() {
                 @Override
                 public boolean test(Object t1, Object t2) throws Exception {
                     return true;
@@ -481,20 +481,20 @@ public class FlowableRetryWithPredicateTest {
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ps.onError(ex);
+                    pp.onError(ex);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            to.assertEmpty();
+            ts.assertEmpty();
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScalarXMapTest.java
@@ -178,9 +178,9 @@ public class FlowableScalarXMapTest {
 
     @Test
     public void scalarDisposableStateCheck() {
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>();
-        ScalarSubscription<Integer> sd = new ScalarSubscription<Integer>(to, 1);
-        to.onSubscribe(sd);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ScalarSubscription<Integer> sd = new ScalarSubscription<Integer>(ts, 1);
+        ts.onSubscribe(sd);
 
         assertFalse(sd.isCancelled());
 
@@ -192,7 +192,7 @@ public class FlowableScalarXMapTest {
 
         assertTrue(sd.isEmpty());
 
-        to.assertResult(1);
+        ts.assertResult(1);
 
         try {
             sd.offer(1);
@@ -212,9 +212,9 @@ public class FlowableScalarXMapTest {
     @Test
     public void scalarDisposableRunDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestSubscriber<Integer> to = new TestSubscriber<Integer>();
-            final ScalarSubscription<Integer> sd = new ScalarSubscription<Integer>(to, 1);
-            to.onSubscribe(sd);
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            final ScalarSubscription<Integer> sd = new ScalarSubscription<Integer>(ts, 1);
+            ts.onSubscribe(sd);
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -313,9 +313,9 @@ public class FlowableSequenceEqualTest {
     @Test
     public void onNextCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps = PublishProcessor.create();
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestObserver<Boolean> to = Flowable.sequenceEqual(Flowable.never(), ps).test();
+            final TestObserver<Boolean> to = Flowable.sequenceEqual(Flowable.never(), pp).test();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -327,7 +327,7 @@ public class FlowableSequenceEqualTest {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ps.onNext(1);
+                    pp.onNext(1);
                 }
             };
 
@@ -340,27 +340,27 @@ public class FlowableSequenceEqualTest {
     @Test
     public void onNextCancelRaceObservable() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps = PublishProcessor.create();
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestSubscriber<Boolean> to = Flowable.sequenceEqual(Flowable.never(), ps).toFlowable().test();
+            final TestSubscriber<Boolean> ts = Flowable.sequenceEqual(Flowable.never(), pp).toFlowable().test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ps.onNext(1);
+                    pp.onNext(1);
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            to.assertEmpty();
+            ts.assertEmpty();
         }
     }
 
@@ -519,14 +519,14 @@ public class FlowableSequenceEqualTest {
         };
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestObserver<Boolean> ts = new TestObserver<Boolean>();
+            final TestObserver<Boolean> to = new TestObserver<Boolean>();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
             boolean swap = (i & 1) == 0;
 
             Flowable.sequenceEqual(swap ? pp : neverNever, swap ? neverNever : pp)
-            .subscribe(ts);
+            .subscribe(to);
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -538,13 +538,13 @@ public class FlowableSequenceEqualTest {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            ts.assertEmpty();
+            to.assertEmpty();
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
@@ -197,21 +197,21 @@ public class FlowableSkipLastTimedTest {
     public void onNextDisposeRace() {
         TestScheduler scheduler = new TestScheduler();
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps = PublishProcessor.create();
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestSubscriber<Integer> to = ps.skipLast(1, TimeUnit.DAYS, scheduler).test();
+            final TestSubscriber<Integer> ts = pp.skipLast(1, TimeUnit.DAYS, scheduler).test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ps.onComplete();
+                    pp.onComplete();
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -723,27 +723,27 @@ public class FlowableSwitchTest {
 
     @Test
     public void switchOnNextDelayErrorWithError() {
-        PublishProcessor<Flowable<Integer>> ps = PublishProcessor.create();
+        PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Flowable.switchOnNextDelayError(ps).test();
+        TestSubscriber<Integer> ts = Flowable.switchOnNextDelayError(pp).test();
 
-        ps.onNext(Flowable.just(1));
-        ps.onNext(Flowable.<Integer>error(new TestException()));
-        ps.onNext(Flowable.range(2, 4));
-        ps.onComplete();
+        pp.onNext(Flowable.just(1));
+        pp.onNext(Flowable.<Integer>error(new TestException()));
+        pp.onNext(Flowable.range(2, 4));
+        pp.onComplete();
 
         ts.assertFailure(TestException.class, 1, 2, 3, 4, 5);
     }
 
     @Test
     public void switchOnNextDelayErrorBufferSize() {
-        PublishProcessor<Flowable<Integer>> ps = PublishProcessor.create();
+        PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Flowable.switchOnNextDelayError(ps, 2).test();
+        TestSubscriber<Integer> ts = Flowable.switchOnNextDelayError(pp, 2).test();
 
-        ps.onNext(Flowable.just(1));
-        ps.onNext(Flowable.range(2, 4));
-        ps.onComplete();
+        pp.onNext(Flowable.just(1));
+        pp.onNext(Flowable.range(2, 4));
+        pp.onComplete();
 
         ts.assertResult(1, 2, 3, 4, 5);
     }
@@ -825,14 +825,14 @@ public class FlowableSwitchTest {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
-                final PublishProcessor<Integer> ps1 = PublishProcessor.create();
-                final PublishProcessor<Integer> ps2 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-                ps1.switchMap(new Function<Integer, Flowable<Integer>>() {
+                pp1.switchMap(new Function<Integer, Flowable<Integer>>() {
                     @Override
                     public Flowable<Integer> apply(Integer v) throws Exception {
                         if (v == 1) {
-                            return ps2;
+                            return pp2;
                         }
                         return Flowable.never();
                     }
@@ -842,7 +842,7 @@ public class FlowableSwitchTest {
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {
-                        ps1.onNext(2);
+                        pp1.onNext(2);
                     }
                 };
 
@@ -851,7 +851,7 @@ public class FlowableSwitchTest {
                 Runnable r2 = new Runnable() {
                     @Override
                     public void run() {
-                        ps2.onError(ex);
+                        pp2.onError(ex);
                     }
                 };
 
@@ -872,14 +872,14 @@ public class FlowableSwitchTest {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
-                final PublishProcessor<Integer> ps1 = PublishProcessor.create();
-                final PublishProcessor<Integer> ps2 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-                ps1.switchMap(new Function<Integer, Flowable<Integer>>() {
+                pp1.switchMap(new Function<Integer, Flowable<Integer>>() {
                     @Override
                     public Flowable<Integer> apply(Integer v) throws Exception {
                         if (v == 1) {
-                            return ps2;
+                            return pp2;
                         }
                         return Flowable.never();
                     }
@@ -891,7 +891,7 @@ public class FlowableSwitchTest {
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {
-                        ps1.onError(ex1);
+                        pp1.onError(ex1);
                     }
                 };
 
@@ -900,7 +900,7 @@ public class FlowableSwitchTest {
                 Runnable r2 = new Runnable() {
                     @Override
                     public void run() {
-                        ps2.onError(ex2);
+                        pp2.onError(ex2);
                     }
                 };
 
@@ -918,9 +918,9 @@ public class FlowableSwitchTest {
     @Test
     public void nextCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps1 = PublishProcessor.create();
+            final PublishProcessor<Integer> pp1 = PublishProcessor.create();
 
-            final TestSubscriber<Integer> to = ps1.switchMap(new Function<Integer, Flowable<Integer>>() {
+            final TestSubscriber<Integer> ts = pp1.switchMap(new Function<Integer, Flowable<Integer>>() {
                 @Override
                 public Flowable<Integer> apply(Integer v) throws Exception {
                     return Flowable.never();
@@ -931,14 +931,14 @@ public class FlowableSwitchTest {
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ps1.onNext(2);
+                    pp1.onNext(2);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
 
@@ -1024,44 +1024,44 @@ public class FlowableSwitchTest {
 
     @Test
     public void innerCompletesReentrant() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
-                ps.onComplete();
+                pp.onComplete();
             }
         };
 
         Flowable.just(1).hide()
-        .switchMap(Functions.justFunction(ps))
-        .subscribe(to);
+        .switchMap(Functions.justFunction(pp))
+        .subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertResult(1);
+        ts.assertResult(1);
     }
 
     @Test
     public void innerErrorsReentrant() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
-                ps.onError(new TestException());
+                pp.onError(new TestException());
             }
         };
 
         Flowable.just(1).hide()
-        .switchMap(Functions.justFunction(ps))
-        .subscribe(to);
+        .switchMap(Functions.justFunction(pp))
+        .subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        to.assertFailure(TestException.class, 1);
+        ts.assertFailure(TestException.class, 1);
     }
 
     @Test
@@ -1159,7 +1159,7 @@ public class FlowableSwitchTest {
         final PublishProcessor<Integer> main = PublishProcessor.create();
         final PublishProcessor<Integer> inner = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = main.switchMap(Functions.justFunction(inner))
+        TestSubscriber<Integer> ts = main.switchMap(Functions.justFunction(inner))
         .test();
 
         assertTrue(main.hasSubscribers());
@@ -1172,6 +1172,6 @@ public class FlowableSwitchTest {
 
         assertFalse(inner.hasSubscribers());
 
-        to.assertFailure(TestException.class);
+        ts.assertFailure(TestException.class);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -208,19 +208,19 @@ public class FlowableTakeLastTimedTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        ps.takeLast(1000, TimeUnit.MILLISECONDS, scheduler).subscribe(ts);
+        pp.takeLast(1000, TimeUnit.MILLISECONDS, scheduler).subscribe(ts);
 
-        ps.onNext(1);
+        pp.onNext(1);
         scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
-        ps.onNext(2);
+        pp.onNext(2);
         scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
-        ps.onNext(3);
+        pp.onNext(3);
         scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
-        ps.onNext(4);
+        pp.onNext(4);
         scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
-        ps.onComplete();
+        pp.onComplete();
         scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
 
         ts.assertNoValues();
@@ -292,21 +292,21 @@ public class FlowableTakeLastTimedTest {
     @Test
     public void cancelCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> ps = PublishProcessor.create();
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestSubscriber<Integer> to = ps.takeLast(1, TimeUnit.DAYS).test();
+            final TestSubscriber<Integer> ts = pp.takeLast(1, TimeUnit.DAYS).test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ps.onComplete();
+                    pp.onComplete();
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -480,36 +480,36 @@ public class FlowableTimeoutTests {
 
     @Test
     public void timedTake() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = ps.timeout(1, TimeUnit.DAYS)
+        TestSubscriber<Integer> ts = pp.timeout(1, TimeUnit.DAYS)
         .take(1)
         .test();
 
-        assertTrue(ps.hasSubscribers());
+        assertTrue(pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        assertFalse(ps.hasSubscribers());
+        assertFalse(pp.hasSubscribers());
 
-        to.assertResult(1);
+        ts.assertResult(1);
     }
 
     @Test
     public void timedFallbackTake() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = ps.timeout(1, TimeUnit.DAYS, Flowable.just(2))
+        TestSubscriber<Integer> ts = pp.timeout(1, TimeUnit.DAYS, Flowable.just(2))
         .take(1)
         .test();
 
-        assertTrue(ps.hasSubscribers());
+        assertTrue(pp.hasSubscribers());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        assertFalse(ps.hasSubscribers());
+        assertFalse(pp.hasSubscribers());
 
-        to.assertResult(1);
+        ts.assertResult(1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -416,13 +416,13 @@ public class FlowableTimeoutWithSelectorTest {
     public void emptyInner() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = pp
+        TestSubscriber<Integer> ts = pp
         .timeout(Functions.justFunction(Flowable.empty()))
         .test();
 
         pp.onNext(1);
 
-        to.assertFailure(TimeoutException.class, 1);
+        ts.assertFailure(TimeoutException.class, 1);
     }
 
     @Test
@@ -431,7 +431,7 @@ public class FlowableTimeoutWithSelectorTest {
         try {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            TestSubscriber<Integer> to = pp
+            TestSubscriber<Integer> ts = pp
             .timeout(Functions.justFunction(new Flowable<Integer>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> observer) {
@@ -446,7 +446,7 @@ public class FlowableTimeoutWithSelectorTest {
 
             pp.onNext(1);
 
-            to.assertFailureAndMessage(TestException.class, "First", 1);
+            ts.assertFailureAndMessage(TestException.class, "First", 1);
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
@@ -460,7 +460,7 @@ public class FlowableTimeoutWithSelectorTest {
         try {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            TestSubscriber<Integer> to = pp
+            TestSubscriber<Integer> ts = pp
             .timeout(Functions.justFunction(new Flowable<Integer>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> observer) {
@@ -475,7 +475,7 @@ public class FlowableTimeoutWithSelectorTest {
 
             pp.onNext(1);
 
-            to.assertFailureAndMessage(TestException.class, "First", 1);
+            ts.assertFailureAndMessage(TestException.class, "First", 1);
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
         } finally {
@@ -515,7 +515,7 @@ public class FlowableTimeoutWithSelectorTest {
     public void selectorTake() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = pp
+        TestSubscriber<Integer> ts = pp
         .timeout(Functions.justFunction(Flowable.never()))
         .take(1)
         .test();
@@ -526,14 +526,14 @@ public class FlowableTimeoutWithSelectorTest {
 
         assertFalse(pp.hasSubscribers());
 
-        to.assertResult(1);
+        ts.assertResult(1);
     }
 
     @Test
     public void selectorFallbackTake() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = pp
+        TestSubscriber<Integer> ts = pp
         .timeout(Functions.justFunction(Flowable.never()), Flowable.just(2))
         .take(1)
         .test();
@@ -544,7 +544,7 @@ public class FlowableTimeoutWithSelectorTest {
 
         assertFalse(pp.hasSubscribers());
 
-        to.assertResult(1);
+        ts.assertResult(1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
@@ -231,25 +231,25 @@ public class FlowableToListTest {
     @Ignore("Single doesn't do backpressure")
     public void testBackpressureHonored() {
         Single<List<Integer>> w = Flowable.just(1, 2, 3, 4, 5).toList();
-        TestObserver<List<Integer>> ts = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
 
-        w.subscribe(ts);
+        w.subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
-
-//        ts.request(1);
-
-        ts.assertValue(Arrays.asList(1, 2, 3, 4, 5));
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertNotComplete();
 
 //        ts.request(1);
 
-        ts.assertValue(Arrays.asList(1, 2, 3, 4, 5));
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValue(Arrays.asList(1, 2, 3, 4, 5));
+        to.assertNoErrors();
+        to.assertComplete();
+
+//        ts.request(1);
+
+        to.assertValue(Arrays.asList(1, 2, 3, 4, 5));
+        to.assertNoErrors();
+        to.assertComplete();
     }
     @Test(timeout = 2000)
     @Ignore("PublishProcessor no longer emits without requests so this test fails due to the race of onComplete and request")
@@ -264,8 +264,8 @@ public class FlowableToListTest {
                 Single<List<Integer>> sorted = source.toList();
 
                 final CyclicBarrier cb = new CyclicBarrier(2);
-                final TestObserver<List<Integer>> ts = new TestObserver<List<Integer>>();
-                sorted.subscribe(ts);
+                final TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
+                sorted.subscribe(to);
 
                 w.schedule(new Runnable() {
                     @Override
@@ -277,10 +277,10 @@ public class FlowableToListTest {
                 source.onNext(1);
                 await(cb);
                 source.onComplete();
-                ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
-                ts.assertTerminated();
-                ts.assertNoErrors();
-                ts.assertValue(Arrays.asList(1));
+                to.awaitTerminalEvent(1, TimeUnit.SECONDS);
+                to.assertTerminated();
+                to.assertNoErrors();
+                to.assertValue(Arrays.asList(1));
             }
         } finally {
             w.dispose();
@@ -395,7 +395,7 @@ public class FlowableToListTest {
     public void onNextCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
-            final TestObserver<List<Integer>> ts = pp.toList().test();
+            final TestObserver<List<Integer>> to = pp.toList().test();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -406,7 +406,7 @@ public class FlowableToListTest {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
@@ -204,25 +204,25 @@ public class FlowableToSortedListTest {
     @Ignore("Single doesn't do backpressure")
     public void testBackpressureHonored() {
         Single<List<Integer>> w = Flowable.just(1, 3, 2, 5, 4).toSortedList();
-        TestObserver<List<Integer>> ts = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
 
-        w.subscribe(ts);
+        w.subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
-
-//        ts.request(1);
-
-        ts.assertValue(Arrays.asList(1, 2, 3, 4, 5));
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertNotComplete();
 
 //        ts.request(1);
 
-        ts.assertValue(Arrays.asList(1, 2, 3, 4, 5));
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValue(Arrays.asList(1, 2, 3, 4, 5));
+        to.assertNoErrors();
+        to.assertComplete();
+
+//        ts.request(1);
+
+        to.assertValue(Arrays.asList(1, 2, 3, 4, 5));
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test(timeout = 2000)
@@ -238,8 +238,8 @@ public class FlowableToSortedListTest {
                 Single<List<Integer>> sorted = source.toSortedList();
 
                 final CyclicBarrier cb = new CyclicBarrier(2);
-                final TestObserver<List<Integer>> ts = new TestObserver<List<Integer>>();
-                sorted.subscribe(ts);
+                final TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
+                sorted.subscribe(to);
                 w.schedule(new Runnable() {
                     @Override
                     public void run() {
@@ -250,10 +250,10 @@ public class FlowableToSortedListTest {
                 source.onNext(1);
                 await(cb);
                 source.onComplete();
-                ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
-                ts.assertTerminated();
-                ts.assertNoErrors();
-                ts.assertValue(Arrays.asList(1));
+                to.awaitTerminalEvent(1, TimeUnit.SECONDS);
+                to.assertTerminated();
+                to.assertNoErrors();
+                to.assertValue(Arrays.asList(1));
             }
         } finally {
             w.dispose();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
@@ -525,7 +525,7 @@ public class FlowableUsingTest {
 
     @Test
     public void supplierDisposerCrash() {
-        TestSubscriber<Object> to = Flowable.using(new Callable<Object>() {
+        TestSubscriber<Object> ts = Flowable.using(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
                 return 1;
@@ -544,7 +544,7 @@ public class FlowableUsingTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
 
         TestHelper.assertError(errors, 0, TestException.class, "First");
         TestHelper.assertError(errors, 1, TestException.class, "Second");
@@ -552,7 +552,7 @@ public class FlowableUsingTest {
 
     @Test
     public void eagerOnErrorDisposerCrash() {
-        TestSubscriber<Object> to = Flowable.using(new Callable<Object>() {
+        TestSubscriber<Object> ts = Flowable.using(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
                 return 1;
@@ -571,7 +571,7 @@ public class FlowableUsingTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
 
         TestHelper.assertError(errors, 0, TestException.class, "First");
         TestHelper.assertError(errors, 1, TestException.class, "Second");

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -474,13 +474,13 @@ public class FlowableWindowWithFlowableTest {
 
     @Test
     public void boundaryOnError() {
-        TestSubscriber<Object> to = Flowable.error(new TestException())
+        TestSubscriber<Object> ts = Flowable.error(new TestException())
         .window(Flowable.never())
         .flatMap(Functions.<Flowable<Object>>identity(), true)
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
 
         TestHelper.assertError(errors, 0, TestException.class);
     }
@@ -534,7 +534,7 @@ public class FlowableWindowWithFlowableTest {
     public void reentrant() {
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -552,11 +552,11 @@ public class FlowableWindowWithFlowableTest {
                 return v;
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
         ps.onNext(1);
 
-        to
+        ts
         .awaitDone(1, TimeUnit.SECONDS)
         .assertResult(1, 2);
     }
@@ -565,7 +565,7 @@ public class FlowableWindowWithFlowableTest {
     public void reentrantCallable() {
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -593,11 +593,11 @@ public class FlowableWindowWithFlowableTest {
                 return v;
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
         ps.onNext(1);
 
-        to
+        ts
         .awaitDone(1, TimeUnit.SECONDS)
         .assertResult(1, 2);
     }
@@ -738,7 +738,7 @@ public class FlowableWindowWithFlowableTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = source.window(boundary)
+        TestSubscriber<Integer> ts = source.window(boundary)
         .take(1)
         .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
@@ -754,7 +754,7 @@ public class FlowableWindowWithFlowableTest {
         assertFalse("source not disposed", source.hasSubscribers());
         assertFalse("boundary not disposed", boundary.hasSubscribers());
 
-        to.assertResult(1);
+        ts.assertResult(1);
     }
 
 
@@ -764,7 +764,7 @@ public class FlowableWindowWithFlowableTest {
         try {
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-            TestSubscriber<Flowable<Object>> to = Flowable.error(new TestException("main"))
+            TestSubscriber<Flowable<Object>> ts = Flowable.error(new TestException("main"))
             .window(new Flowable<Object>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> observer) {
@@ -774,7 +774,7 @@ public class FlowableWindowWithFlowableTest {
             })
             .test();
 
-            to
+            ts
             .assertValueCount(1)
             .assertError(TestException.class)
             .assertErrorMessage("main")
@@ -798,7 +798,7 @@ public class FlowableWindowWithFlowableTest {
                 final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
                 final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-                TestSubscriber<Flowable<Object>> to = new Flowable<Object>() {
+                TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                     @Override
                     protected void subscribeActual(Subscriber<? super Object> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -829,7 +829,7 @@ public class FlowableWindowWithFlowableTest {
 
                 TestHelper.race(r1, r2);
 
-                to
+                ts
                 .assertValueCount(1)
                 .assertTerminated();
 
@@ -848,7 +848,7 @@ public class FlowableWindowWithFlowableTest {
             final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-            TestSubscriber<Flowable<Object>> to = new Flowable<Object>() {
+            TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> observer) {
                     observer.onSubscribe(new BooleanSubscription());
@@ -879,7 +879,7 @@ public class FlowableWindowWithFlowableTest {
 
             TestHelper.race(r1, r2);
 
-            to
+            ts
             .assertValueCount(2)
             .assertNotComplete()
             .assertNoErrors();
@@ -891,7 +891,7 @@ public class FlowableWindowWithFlowableTest {
         final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
         final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-        TestSubscriber<Flowable<Object>> to = new Flowable<Object>() {
+        TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
             @Override
             protected void subscribeActual(Subscriber<? super Object> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -907,13 +907,13 @@ public class FlowableWindowWithFlowableTest {
         })
         .test();
 
-        to.assertValueCount(1)
+        ts.assertValueCount(1)
         .assertNotTerminated()
         .cancel();
 
         ref.get().onNext(1);
 
-        to.assertValueCount(1)
+        ts.assertValueCount(1)
         .assertNotTerminated();
     }
 
@@ -923,7 +923,7 @@ public class FlowableWindowWithFlowableTest {
             final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-            final TestSubscriber<Flowable<Object>> to = new Flowable<Object>() {
+            final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                  @Override
                  protected void subscribeActual(Subscriber<? super Object> observer) {
                      observer.onSubscribe(new BooleanSubscription());
@@ -956,7 +956,7 @@ public class FlowableWindowWithFlowableTest {
              Runnable r1 = new Runnable() {
                  @Override
                  public void run() {
-                     to.cancel();
+                     ts.cancel();
                  }
              };
              Runnable r2 = new Runnable() {
@@ -980,7 +980,7 @@ public class FlowableWindowWithFlowableTest {
            final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
            final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-           final TestSubscriber<Flowable<Object>> to = new Flowable<Object>() {
+           final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                @Override
                protected void subscribeActual(Subscriber<? super Object> observer) {
                    observer.onSubscribe(new BooleanSubscription());
@@ -1013,7 +1013,7 @@ public class FlowableWindowWithFlowableTest {
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
             Runnable r2 = new Runnable() {
@@ -1045,7 +1045,7 @@ public class FlowableWindowWithFlowableTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = source.window(Functions.justCallable(boundary))
+        TestSubscriber<Integer> ts = source.window(Functions.justCallable(boundary))
         .take(1)
         .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
@@ -1061,7 +1061,7 @@ public class FlowableWindowWithFlowableTest {
         assertFalse("source not disposed", source.hasSubscribers());
         assertFalse("boundary not disposed", boundary.hasSubscribers());
 
-        to.assertResult(1);
+        ts.assertResult(1);
     }
 
     @Test
@@ -1070,7 +1070,7 @@ public class FlowableWindowWithFlowableTest {
         try {
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-            TestSubscriber<Flowable<Object>> to = Flowable.error(new TestException("main"))
+            TestSubscriber<Flowable<Object>> ts = Flowable.error(new TestException("main"))
             .window(Functions.justCallable(new Flowable<Object>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> observer) {
@@ -1080,7 +1080,7 @@ public class FlowableWindowWithFlowableTest {
             }))
             .test();
 
-            to
+            ts
             .assertValueCount(1)
             .assertError(TestException.class)
             .assertErrorMessage("main")
@@ -1104,7 +1104,7 @@ public class FlowableWindowWithFlowableTest {
                 final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
                 final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-                TestSubscriber<Flowable<Object>> to = new Flowable<Object>() {
+                TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                     @Override
                     protected void subscribeActual(Subscriber<? super Object> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -1135,7 +1135,7 @@ public class FlowableWindowWithFlowableTest {
 
                 TestHelper.race(r1, r2);
 
-                to
+                ts
                 .assertValueCount(1)
                 .assertTerminated();
 
@@ -1154,7 +1154,7 @@ public class FlowableWindowWithFlowableTest {
             final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-            TestSubscriber<Flowable<Object>> to = new Flowable<Object>() {
+            TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> observer) {
                     observer.onSubscribe(new BooleanSubscription());
@@ -1185,7 +1185,7 @@ public class FlowableWindowWithFlowableTest {
 
             TestHelper.race(r1, r2);
 
-            to
+            ts
             .assertValueCount(2)
             .assertNotComplete()
             .assertNoErrors();
@@ -1197,7 +1197,7 @@ public class FlowableWindowWithFlowableTest {
         final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
         final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-        TestSubscriber<Flowable<Object>> to = new Flowable<Object>() {
+        TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
             @Override
             protected void subscribeActual(Subscriber<? super Object> observer) {
                 observer.onSubscribe(new BooleanSubscription());
@@ -1213,13 +1213,13 @@ public class FlowableWindowWithFlowableTest {
         }))
         .test();
 
-        to.assertValueCount(1)
+        ts.assertValueCount(1)
         .assertNotTerminated()
         .cancel();
 
         ref.get().onNext(1);
 
-        to.assertValueCount(1)
+        ts.assertValueCount(1)
         .assertNotTerminated();
     }
 
@@ -1229,7 +1229,7 @@ public class FlowableWindowWithFlowableTest {
             final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-            final TestSubscriber<Flowable<Object>> to = new Flowable<Object>() {
+            final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                  @Override
                  protected void subscribeActual(Subscriber<? super Object> observer) {
                      observer.onSubscribe(new BooleanSubscription());
@@ -1262,7 +1262,7 @@ public class FlowableWindowWithFlowableTest {
              Runnable r1 = new Runnable() {
                  @Override
                  public void run() {
-                     to.cancel();
+                     ts.cancel();
                  }
              };
              Runnable r2 = new Runnable() {
@@ -1288,7 +1288,7 @@ public class FlowableWindowWithFlowableTest {
                 final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
                 final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
-                final TestSubscriber<Flowable<Object>> to = new Flowable<Object>() {
+                final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                     @Override
                     protected void subscribeActual(Subscriber<? super Object> observer) {
                         observer.onSubscribe(new BooleanSubscription());
@@ -1330,7 +1330,7 @@ public class FlowableWindowWithFlowableTest {
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {
-                        to.cancel();
+                        ts.cancel();
                     }
                 };
                 Runnable r2 = new Runnable() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -269,7 +269,7 @@ public class FlowableWindowWithStartEndFlowableTest {
     public void reentrant() {
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -287,11 +287,11 @@ public class FlowableWindowWithStartEndFlowableTest {
                 return v;
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
         ps.onNext(1);
 
-        to
+        ts
         .awaitDone(1, TimeUnit.SECONDS)
         .assertResult(1, 2);
     }
@@ -312,7 +312,7 @@ public class FlowableWindowWithStartEndFlowableTest {
         PublishProcessor<Integer> start = PublishProcessor.create();
         final PublishProcessor<Integer> end = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = source.window(start, new Function<Integer, Flowable<Integer>>() {
+        TestSubscriber<Integer> ts = source.window(start, new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer v) throws Exception {
                 return end;
@@ -339,7 +339,7 @@ public class FlowableWindowWithStartEndFlowableTest {
 
         TestHelper.emit(source, 7, 8);
 
-        to.assertResult(1, 2, 3, 4, 5, 5, 6, 6, 7, 8);
+        ts.assertResult(1, 2, 3, 4, 5, 5, 6, 6, 7, 8);
     }
 
     @Test
@@ -348,7 +348,7 @@ public class FlowableWindowWithStartEndFlowableTest {
         PublishProcessor<Integer> start = PublishProcessor.create();
         final PublishProcessor<Integer> end = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = source.window(start, new Function<Integer, Flowable<Integer>>() {
+        TestSubscriber<Integer> ts = source.window(start, new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer v) throws Exception {
                 return end;
@@ -359,7 +359,7 @@ public class FlowableWindowWithStartEndFlowableTest {
 
         start.onError(new TestException());
 
-        to.assertFailure(TestException.class);
+        ts.assertFailure(TestException.class);
 
         assertFalse("Source has observers!", source.hasSubscribers());
         assertFalse("Start has observers!", start.hasSubscribers());
@@ -372,7 +372,7 @@ public class FlowableWindowWithStartEndFlowableTest {
         PublishProcessor<Integer> start = PublishProcessor.create();
         final PublishProcessor<Integer> end = PublishProcessor.create();
 
-        TestSubscriber<Integer> to = source.window(start, new Function<Integer, Flowable<Integer>>() {
+        TestSubscriber<Integer> ts = source.window(start, new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer v) throws Exception {
                 return end;
@@ -384,7 +384,7 @@ public class FlowableWindowWithStartEndFlowableTest {
         start.onNext(1);
         end.onError(new TestException());
 
-        to.assertFailure(TestException.class);
+        ts.assertFailure(TestException.class);
 
         assertFalse("Source has observers!", source.hasSubscribers());
         assertFalse("Start has observers!", start.hasSubscribers());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -561,7 +561,7 @@ public class FlowableWindowWithTimeTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -579,11 +579,11 @@ public class FlowableWindowWithTimeTest {
                 return v;
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
         ps.onNext(1);
 
-        to
+        ts
         .awaitDone(1, TimeUnit.SECONDS)
         .assertResult(1, 2);
     }
@@ -594,7 +594,7 @@ public class FlowableWindowWithTimeTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -612,11 +612,11 @@ public class FlowableWindowWithTimeTest {
                 return v;
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
         ps.onNext(1);
 
-        to
+        ts
         .awaitDone(1, TimeUnit.SECONDS)
         .assertResult(1, 2);
     }
@@ -627,7 +627,7 @@ public class FlowableWindowWithTimeTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -645,11 +645,11 @@ public class FlowableWindowWithTimeTest {
                 return v;
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
         ps.onNext(1);
 
-        to
+        ts
         .awaitDone(1, TimeUnit.SECONDS)
         .assertResult(1, 2);
     }
@@ -660,7 +660,7 @@ public class FlowableWindowWithTimeTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -678,11 +678,11 @@ public class FlowableWindowWithTimeTest {
                 return v;
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
         ps.onNext(1);
 
-        to
+        ts
         .awaitDone(1, TimeUnit.SECONDS)
         .assertResult(1, 2);
     }
@@ -690,9 +690,9 @@ public class FlowableWindowWithTimeTest {
     @Test
     public void sizeTimeTimeout() {
         TestScheduler scheduler = new TestScheduler();
-        PublishProcessor<Integer> ps = PublishProcessor.<Integer>create();
+        PublishProcessor<Integer> pp = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Flowable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 100)
+        TestSubscriber<Flowable<Integer>> ts = pp.window(5, TimeUnit.MILLISECONDS, scheduler, 100)
         .test()
         .assertValueCount(1);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -313,36 +313,36 @@ public class FlowableWithLatestFromTest {
 
     @Test
     public void manySources() {
-        PublishProcessor<String> ps1 = PublishProcessor.create();
-        PublishProcessor<String> ps2 = PublishProcessor.create();
-        PublishProcessor<String> ps3 = PublishProcessor.create();
+        PublishProcessor<String> pp1 = PublishProcessor.create();
+        PublishProcessor<String> pp2 = PublishProcessor.create();
+        PublishProcessor<String> pp3 = PublishProcessor.create();
         PublishProcessor<String> main = PublishProcessor.create();
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
 
-        main.withLatestFrom(new Flowable[] { ps1, ps2, ps3 }, toArray)
+        main.withLatestFrom(new Flowable[] { pp1, pp2, pp3 }, toArray)
         .subscribe(ts);
 
         main.onNext("1");
         ts.assertNoValues();
-        ps1.onNext("a");
+        pp1.onNext("a");
         ts.assertNoValues();
-        ps2.onNext("A");
+        pp2.onNext("A");
         ts.assertNoValues();
-        ps3.onNext("=");
+        pp3.onNext("=");
         ts.assertNoValues();
 
         main.onNext("2");
         ts.assertValues("[2, a, A, =]");
 
-        ps2.onNext("B");
+        pp2.onNext("B");
 
         ts.assertValues("[2, a, A, =]");
 
-        ps3.onComplete();
+        pp3.onComplete();
         ts.assertValues("[2, a, A, =]");
 
-        ps1.onNext("b");
+        pp1.onNext("b");
 
         main.onNext("3");
 
@@ -353,43 +353,43 @@ public class FlowableWithLatestFromTest {
         ts.assertNoErrors();
         ts.assertComplete();
 
-        assertFalse("ps1 has subscribers?", ps1.hasSubscribers());
-        assertFalse("ps2 has subscribers?", ps2.hasSubscribers());
-        assertFalse("ps3 has subscribers?", ps3.hasSubscribers());
+        assertFalse("ps1 has subscribers?", pp1.hasSubscribers());
+        assertFalse("ps2 has subscribers?", pp2.hasSubscribers());
+        assertFalse("ps3 has subscribers?", pp3.hasSubscribers());
     }
 
     @Test
     public void manySourcesIterable() {
-        PublishProcessor<String> ps1 = PublishProcessor.create();
-        PublishProcessor<String> ps2 = PublishProcessor.create();
-        PublishProcessor<String> ps3 = PublishProcessor.create();
+        PublishProcessor<String> pp1 = PublishProcessor.create();
+        PublishProcessor<String> pp2 = PublishProcessor.create();
+        PublishProcessor<String> pp3 = PublishProcessor.create();
         PublishProcessor<String> main = PublishProcessor.create();
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
 
-        main.withLatestFrom(Arrays.<Flowable<?>>asList(ps1, ps2, ps3), toArray)
+        main.withLatestFrom(Arrays.<Flowable<?>>asList(pp1, pp2, pp3), toArray)
         .subscribe(ts);
 
         main.onNext("1");
         ts.assertNoValues();
-        ps1.onNext("a");
+        pp1.onNext("a");
         ts.assertNoValues();
-        ps2.onNext("A");
+        pp2.onNext("A");
         ts.assertNoValues();
-        ps3.onNext("=");
+        pp3.onNext("=");
         ts.assertNoValues();
 
         main.onNext("2");
         ts.assertValues("[2, a, A, =]");
 
-        ps2.onNext("B");
+        pp2.onNext("B");
 
         ts.assertValues("[2, a, A, =]");
 
-        ps3.onComplete();
+        pp3.onComplete();
         ts.assertValues("[2, a, A, =]");
 
-        ps1.onNext("b");
+        pp1.onNext("b");
 
         main.onNext("3");
 
@@ -400,9 +400,9 @@ public class FlowableWithLatestFromTest {
         ts.assertNoErrors();
         ts.assertComplete();
 
-        assertFalse("ps1 has subscribers?", ps1.hasSubscribers());
-        assertFalse("ps2 has subscribers?", ps2.hasSubscribers());
-        assertFalse("ps3 has subscribers?", ps3.hasSubscribers());
+        assertFalse("ps1 has subscribers?", pp1.hasSubscribers());
+        assertFalse("ps2 has subscribers?", pp2.hasSubscribers());
+        assertFalse("ps3 has subscribers?", pp3.hasSubscribers());
     }
 
     @Test
@@ -439,12 +439,12 @@ public class FlowableWithLatestFromTest {
 
     @Test
     public void backpressureNoSignal() {
-        PublishProcessor<String> ps1 = PublishProcessor.create();
-        PublishProcessor<String> ps2 = PublishProcessor.create();
+        PublishProcessor<String> pp1 = PublishProcessor.create();
+        PublishProcessor<String> pp2 = PublishProcessor.create();
 
         TestSubscriber<String> ts = new TestSubscriber<String>(0);
 
-        Flowable.range(1, 10).withLatestFrom(new Flowable<?>[] { ps1, ps2 }, toArray)
+        Flowable.range(1, 10).withLatestFrom(new Flowable<?>[] { pp1, pp2 }, toArray)
         .subscribe(ts);
 
         ts.assertNoValues();
@@ -455,24 +455,24 @@ public class FlowableWithLatestFromTest {
         ts.assertNoErrors();
         ts.assertComplete();
 
-        assertFalse("ps1 has subscribers?", ps1.hasSubscribers());
-        assertFalse("ps2 has subscribers?", ps2.hasSubscribers());
+        assertFalse("ps1 has subscribers?", pp1.hasSubscribers());
+        assertFalse("ps2 has subscribers?", pp2.hasSubscribers());
     }
 
     @Test
     public void backpressureWithSignal() {
-        PublishProcessor<String> ps1 = PublishProcessor.create();
-        PublishProcessor<String> ps2 = PublishProcessor.create();
+        PublishProcessor<String> pp1 = PublishProcessor.create();
+        PublishProcessor<String> pp2 = PublishProcessor.create();
 
         TestSubscriber<String> ts = new TestSubscriber<String>(0);
 
-        Flowable.range(1, 3).withLatestFrom(new Flowable<?>[] { ps1, ps2 }, toArray)
+        Flowable.range(1, 3).withLatestFrom(new Flowable<?>[] { pp1, pp2 }, toArray)
         .subscribe(ts);
 
         ts.assertNoValues();
 
-        ps1.onNext("1");
-        ps2.onNext("1");
+        pp1.onNext("1");
+        pp2.onNext("1");
 
         ts.request(1);
 
@@ -488,8 +488,8 @@ public class FlowableWithLatestFromTest {
         ts.assertNoErrors();
         ts.assertComplete();
 
-        assertFalse("ps1 has subscribers?", ps1.hasSubscribers());
-        assertFalse("ps2 has subscribers?", ps2.hasSubscribers());
+        assertFalse("ps1 has subscribers?", pp1.hasSubscribers());
+        assertFalse("ps2 has subscribers?", pp2.hasSubscribers());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
@@ -73,7 +73,7 @@ public class MaybeCacheTest {
 
         assertNotNull(((MaybeCache<Integer>)source).source.get());
 
-        TestObserver<Integer> ts = source.test();
+        TestObserver<Integer> to = source.test();
 
         assertNull(((MaybeCache<Integer>)source).source.get());
 
@@ -81,12 +81,12 @@ public class MaybeCacheTest {
 
         source.test(true).assertEmpty();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         pp.onNext(1);
         pp.onComplete();
 
-        ts.assertResult(1);
+        to.assertResult(1);
 
         source.test().assertResult(1);
 
@@ -103,7 +103,7 @@ public class MaybeCacheTest {
 
         assertNotNull(((MaybeCache<Integer>)source).source.get());
 
-        TestObserver<Integer> ts = source.test();
+        TestObserver<Integer> to = source.test();
 
         assertNull(((MaybeCache<Integer>)source).source.get());
 
@@ -111,11 +111,11 @@ public class MaybeCacheTest {
 
         source.test(true).assertEmpty();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         pp.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
 
         source.test().assertFailure(TestException.class);
 
@@ -132,7 +132,7 @@ public class MaybeCacheTest {
 
         assertNotNull(((MaybeCache<Integer>)source).source.get());
 
-        TestObserver<Integer> ts = source.test();
+        TestObserver<Integer> to = source.test();
 
         assertNull(((MaybeCache<Integer>)source).source.get());
 
@@ -140,11 +140,11 @@ public class MaybeCacheTest {
 
         source.test(true).assertEmpty();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         pp.onComplete();
 
-        ts.assertResult();
+        to.assertResult();
 
         source.test().assertResult();
 
@@ -246,20 +246,20 @@ public class MaybeCacheTest {
 
             final Maybe<Integer> source = pp.singleElement().cache();
 
-            final TestObserver<Integer> ts1 = source.test();
-            final TestObserver<Integer> ts2 = source.test();
+            final TestObserver<Integer> to1 = source.test();
+            final TestObserver<Integer> to2 = source.test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ts1.cancel();
+                    to1.cancel();
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts2.cancel();
+                    to2.cancel();
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatIterableTest.java
@@ -64,7 +64,7 @@ public class MaybeConcatIterableTest {
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestSubscriber<Integer> to = Maybe.concat(Arrays.asList(pp.singleElement()))
+            final TestSubscriber<Integer> ts = Maybe.concat(Arrays.asList(pp.singleElement()))
             .test();
 
             pp.onNext(1);
@@ -72,7 +72,7 @@ public class MaybeConcatIterableTest {
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    to.cancel();
+                    ts.cancel();
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
@@ -50,11 +50,11 @@ public class MaybeContainsTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Boolean> ts = pp.singleElement().contains(1).test();
+        TestObserver<Boolean> to = pp.singleElement().contains(1).test();
 
         assertTrue(pp.hasSubscribers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(pp.hasSubscribers());
     }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCountTest.java
@@ -45,11 +45,11 @@ public class MaybeCountTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Long> ts = pp.singleElement().count().test();
+        TestObserver<Long> to = pp.singleElement().count().test();
 
         assertTrue(pp.hasSubscribers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(pp.hasSubscribers());
     }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherTest.java
@@ -33,10 +33,10 @@ public class MaybeDelayOtherTest {
     public void justWithOnNext() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.just(1)
+        TestObserver<Integer> to = Maybe.just(1)
         .delay(pp).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp.hasSubscribers());
 
@@ -44,17 +44,17 @@ public class MaybeDelayOtherTest {
 
         assertFalse(pp.hasSubscribers());
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @Test
     public void justWithOnComplete() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.just(1)
+        TestObserver<Integer> to = Maybe.just(1)
         .delay(pp).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp.hasSubscribers());
 
@@ -62,7 +62,7 @@ public class MaybeDelayOtherTest {
 
         assertFalse(pp.hasSubscribers());
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
 
@@ -70,10 +70,10 @@ public class MaybeDelayOtherTest {
     public void justWithOnError() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.just(1)
+        TestObserver<Integer> to = Maybe.just(1)
         .delay(pp).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp.hasSubscribers());
 
@@ -81,17 +81,17 @@ public class MaybeDelayOtherTest {
 
         assertFalse(pp.hasSubscribers());
 
-        ts.assertFailureAndMessage(TestException.class, "Other");
+        to.assertFailureAndMessage(TestException.class, "Other");
     }
 
     @Test
     public void emptyWithOnNext() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.<Integer>empty()
+        TestObserver<Integer> to = Maybe.<Integer>empty()
         .delay(pp).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp.hasSubscribers());
 
@@ -99,7 +99,7 @@ public class MaybeDelayOtherTest {
 
         assertFalse(pp.hasSubscribers());
 
-        ts.assertResult();
+        to.assertResult();
     }
 
 
@@ -107,10 +107,10 @@ public class MaybeDelayOtherTest {
     public void emptyWithOnComplete() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.<Integer>empty()
+        TestObserver<Integer> to = Maybe.<Integer>empty()
         .delay(pp).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp.hasSubscribers());
 
@@ -118,17 +118,17 @@ public class MaybeDelayOtherTest {
 
         assertFalse(pp.hasSubscribers());
 
-        ts.assertResult();
+        to.assertResult();
     }
 
     @Test
     public void emptyWithOnError() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.<Integer>empty()
+        TestObserver<Integer> to = Maybe.<Integer>empty()
         .delay(pp).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp.hasSubscribers());
 
@@ -136,17 +136,17 @@ public class MaybeDelayOtherTest {
 
         assertFalse(pp.hasSubscribers());
 
-        ts.assertFailureAndMessage(TestException.class, "Other");
+        to.assertFailureAndMessage(TestException.class, "Other");
     }
 
     @Test
     public void errorWithOnNext() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
+        TestObserver<Integer> to = Maybe.<Integer>error(new TestException("Main"))
         .delay(pp).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp.hasSubscribers());
 
@@ -154,17 +154,17 @@ public class MaybeDelayOtherTest {
 
         assertFalse(pp.hasSubscribers());
 
-        ts.assertFailureAndMessage(TestException.class, "Main");
+        to.assertFailureAndMessage(TestException.class, "Main");
     }
 
     @Test
     public void errorWithOnComplete() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
+        TestObserver<Integer> to = Maybe.<Integer>error(new TestException("Main"))
         .delay(pp).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp.hasSubscribers());
 
@@ -172,17 +172,17 @@ public class MaybeDelayOtherTest {
 
         assertFalse(pp.hasSubscribers());
 
-        ts.assertFailureAndMessage(TestException.class, "Main");
+        to.assertFailureAndMessage(TestException.class, "Main");
     }
 
     @Test
     public void errorWithOnError() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.<Integer>error(new TestException("Main"))
+        TestObserver<Integer> to = Maybe.<Integer>error(new TestException("Main"))
         .delay(pp).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp.hasSubscribers());
 
@@ -190,9 +190,9 @@ public class MaybeDelayOtherTest {
 
         assertFalse(pp.hasSubscribers());
 
-        ts.assertFailure(CompositeException.class);
+        to.assertFailure(CompositeException.class);
 
-        List<Throwable> list = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
         assertEquals(2, list.size());
 
         TestHelper.assertError(list, 0, TestException.class, "Main");

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
@@ -36,18 +36,18 @@ public class MaybeDelaySubscriptionTest {
     public void normal() {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.just(1).delaySubscription(pp)
+        TestObserver<Integer> to = Maybe.just(1).delaySubscription(pp)
         .test();
 
         assertTrue(pp.hasSubscribers());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         pp.onNext("one");
 
         assertFalse(pp.hasSubscribers());
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @Test
@@ -70,19 +70,19 @@ public class MaybeDelaySubscriptionTest {
     public void timedTestScheduler() {
         TestScheduler scheduler = new TestScheduler();
 
-        TestObserver<Integer> ts = Maybe.just(1)
+        TestObserver<Integer> to = Maybe.just(1)
         .delaySubscription(100, TimeUnit.MILLISECONDS, scheduler)
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         scheduler.advanceTimeBy(99, TimeUnit.MILLISECONDS);
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayTest.java
@@ -66,25 +66,25 @@ public class MaybeDelayTest {
     public void disposeDuringDelay() {
         TestScheduler scheduler = new TestScheduler();
 
-        TestObserver<Integer> ts = Maybe.just(1).delay(100, TimeUnit.MILLISECONDS, scheduler)
+        TestObserver<Integer> to = Maybe.just(1).delay(100, TimeUnit.MILLISECONDS, scheduler)
         .test();
 
-        ts.cancel();
+        to.cancel();
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        ts.assertEmpty();
+        to.assertEmpty();
     }
 
     @Test
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp.singleElement().delay(100, TimeUnit.MILLISECONDS).test();
+        TestObserver<Integer> to = pp.singleElement().delay(100, TimeUnit.MILLISECONDS).test();
 
         assertTrue(pp.hasSubscribers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(pp.hasSubscribers());
     }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccessTest.java
@@ -38,7 +38,7 @@ public class MaybeDoAfterSuccessTest {
         }
     };
 
-    final TestObserver<Integer> ts = new TestObserver<Integer>() {
+    final TestObserver<Integer> to = new TestObserver<Integer>() {
         @Override
         public void onNext(Integer t) {
             super.onNext(t);
@@ -50,7 +50,7 @@ public class MaybeDoAfterSuccessTest {
     public void just() {
         Maybe.just(1)
         .doAfterSuccess(afterSuccess)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult(1);
 
         assertEquals(Arrays.asList(1, -1), values);
@@ -60,7 +60,7 @@ public class MaybeDoAfterSuccessTest {
     public void error() {
         Maybe.<Integer>error(new TestException())
         .doAfterSuccess(afterSuccess)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertFailure(TestException.class);
 
         assertTrue(values.isEmpty());
@@ -70,7 +70,7 @@ public class MaybeDoAfterSuccessTest {
     public void empty() {
         Maybe.<Integer>empty()
         .doAfterSuccess(afterSuccess)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult();
 
         assertTrue(values.isEmpty());
@@ -86,7 +86,7 @@ public class MaybeDoAfterSuccessTest {
         Maybe.just(1)
         .doAfterSuccess(afterSuccess)
         .filter(Functions.alwaysTrue())
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult(1);
 
         assertEquals(Arrays.asList(1, -1), values);
@@ -97,7 +97,7 @@ public class MaybeDoAfterSuccessTest {
         Maybe.<Integer>error(new TestException())
         .doAfterSuccess(afterSuccess)
         .filter(Functions.alwaysTrue())
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertFailure(TestException.class);
 
         assertTrue(values.isEmpty());
@@ -108,7 +108,7 @@ public class MaybeDoAfterSuccessTest {
         Maybe.<Integer>empty()
         .doAfterSuccess(afterSuccess)
         .filter(Functions.alwaysTrue())
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult();
 
         assertTrue(values.isEmpty());

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
@@ -19,7 +19,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
@@ -121,7 +121,7 @@ public class MaybeFlatMapIterableFlowableTest {
 
     @Test
     public void fused() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
             @Override
@@ -129,17 +129,17 @@ public class MaybeFlatMapIterableFlowableTest {
                 return Arrays.asList(v, v + 1);
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
-        to.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC))
+        ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2);
         ;
     }
 
     @Test
     public void fusedNoSync() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.SYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
             @Override
@@ -147,10 +147,10 @@ public class MaybeFlatMapIterableFlowableTest {
                 return Arrays.asList(v, v + 1);
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
-        to.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueDisposable.NONE))
+        ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertResult(1, 2);
         ;
     }
@@ -305,7 +305,7 @@ public class MaybeFlatMapIterableFlowableTest {
             public void onSubscribe(Subscription d) {
                 qd = (QueueSubscription<Integer>)d;
 
-                assertEquals(QueueSubscription.ASYNC, qd.requestFusion(QueueSubscription.ANY));
+                assertEquals(QueueFuseable.ASYNC, qd.requestFusion(QueueFuseable.ANY));
             }
 
             @Override

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
@@ -13,10 +13,11 @@
 
 package io.reactivex.internal.operators.maybe;
 
+import static org.junit.Assert.*;
+
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.*;
@@ -24,7 +25,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.util.CrashingIterable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
@@ -98,7 +99,7 @@ public class MaybeFlatMapIterableObservableTest {
 
     @Test
     public void fused() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
             @Override
@@ -109,14 +110,14 @@ public class MaybeFlatMapIterableObservableTest {
         .subscribe(to);
 
         to.assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2);
         ;
     }
 
     @Test
     public void fusedNoSync() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.SYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.SYNC);
 
         Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
             @Override
@@ -127,7 +128,7 @@ public class MaybeFlatMapIterableObservableTest {
         .subscribe(to);
 
         to.assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.NONE))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertResult(1, 2);
         ;
     }
@@ -307,7 +308,7 @@ public class MaybeFlatMapIterableObservableTest {
             public void onSubscribe(Disposable d) {
                 qd = (QueueDisposable<Integer>)d;
 
-                assertEquals(QueueDisposable.ASYNC, qd.requestFusion(QueueDisposable.ANY));
+                assertEquals(QueueFuseable.ASYNC, qd.requestFusion(QueueFuseable.ANY));
             }
 
             @Override

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeArrayTest.java
@@ -23,7 +23,7 @@ import org.reactivestreams.Subscription;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.operators.maybe.MaybeMergeArray.MergeMaybeObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
@@ -34,26 +34,26 @@ public class MaybeMergeArrayTest {
     @SuppressWarnings("unchecked")
     @Test
     public void normal() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.SYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Maybe.mergeArray(Maybe.just(1), Maybe.just(2))
         .subscribe(ts);
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertResult(1, 2);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void fusedPollMixed() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Maybe.mergeArray(Maybe.just(1), Maybe.<Integer>empty(), Maybe.just(2))
         .subscribe(ts);
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2);
     }
 
@@ -67,7 +67,7 @@ public class MaybeMergeArrayTest {
             public void onSubscribe(Subscription d) {
                 qd = (QueueSubscription<Integer>)d;
 
-                assertEquals(QueueSubscription.ASYNC, qd.requestFusion(QueueSubscription.ANY));
+                assertEquals(QueueFuseable.ASYNC, qd.requestFusion(QueueFuseable.ANY));
             }
 
             @Override
@@ -119,13 +119,13 @@ public class MaybeMergeArrayTest {
     @SuppressWarnings("unchecked")
     @Test
     public void errorFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Maybe.mergeArray(Maybe.<Integer>error(new TestException()), Maybe.just(2))
         .subscribe(ts);
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertFailure(TestException.class);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeOfTypeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeOfTypeTest.java
@@ -32,38 +32,38 @@ public class MaybeOfTypeTest {
 
     @Test
     public void normalDowncast() {
-        TestObserver<Number> ts = Maybe.just(1)
+        TestObserver<Number> to = Maybe.just(1)
         .ofType(Number.class)
         .test();
         // don't make this fluent, target type required!
-        ts.assertResult((Number)1);
+        to.assertResult((Number)1);
     }
 
     @Test
     public void notInstance() {
-        TestObserver<String> ts = Maybe.just(1)
+        TestObserver<String> to = Maybe.just(1)
         .ofType(String.class)
         .test();
         // don't make this fluent, target type required!
-        ts.assertResult();
+        to.assertResult();
     }
 
     @Test
     public void error() {
-        TestObserver<Number> ts = Maybe.<Integer>error(new TestException())
+        TestObserver<Number> to = Maybe.<Integer>error(new TestException())
         .ofType(Number.class)
         .test();
         // don't make this fluent, target type required!
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
     public void errorNotInstance() {
-        TestObserver<String> ts = Maybe.<Integer>error(new TestException())
+        TestObserver<String> to = Maybe.<Integer>error(new TestException())
         .ofType(String.class)
         .test();
         // don't make this fluent, target type required!
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
@@ -52,11 +52,11 @@ public class MaybeSwitchIfEmptySingleTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp.singleElement().switchIfEmpty(Single.just(2)).test();
+        TestObserver<Integer> to = pp.singleElement().switchIfEmpty(Single.just(2)).test();
 
         assertTrue(pp.hasSubscribers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(pp.hasSubscribers());
     }
@@ -84,7 +84,7 @@ public class MaybeSwitchIfEmptySingleTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestObserver<Integer> ts = pp.singleElement().switchIfEmpty(Single.just(2)).test();
+            final TestObserver<Integer> to = pp.singleElement().switchIfEmpty(Single.just(2)).test();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -96,7 +96,7 @@ public class MaybeSwitchIfEmptySingleTest {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
@@ -67,11 +67,11 @@ public class MaybeSwitchIfEmptyTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp.singleElement().switchIfEmpty(Maybe.just(2)).test();
+        TestObserver<Integer> to = pp.singleElement().switchIfEmpty(Maybe.just(2)).test();
 
         assertTrue(pp.hasSubscribers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(pp.hasSubscribers());
     }
@@ -99,7 +99,7 @@ public class MaybeSwitchIfEmptyTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestObserver<Integer> ts = pp.singleElement().switchIfEmpty(Maybe.just(2)).test();
+            final TestObserver<Integer> to = pp.singleElement().switchIfEmpty(Maybe.just(2)).test();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -111,7 +111,7 @@ public class MaybeSwitchIfEmptyTest {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimerTest.java
@@ -38,7 +38,7 @@ public class MaybeTimerTest {
         try {
             for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
-                TestObserver<Long> ts = Maybe.timer(1, TimeUnit.MILLISECONDS, s)
+                TestObserver<Long> to = Maybe.timer(1, TimeUnit.MILLISECONDS, s)
                 .map(new Function<Long, Long>() {
                     @Override
                     public Long apply(Long v) throws Exception {
@@ -54,7 +54,7 @@ public class MaybeTimerTest {
 
                 Thread.sleep(500);
 
-                ts.cancel();
+                to.cancel();
 
                 Thread.sleep(500);
 

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -114,9 +114,9 @@ public class ObservableConcatMapMaybeTest {
         .assertComplete()
         .assertOf(new Consumer<TestObserver<Integer>>() {
             @Override
-            public void accept(TestObserver<Integer> ts) throws Exception {
+            public void accept(TestObserver<Integer> to) throws Exception {
                 for (int i = 0; i < 512; i ++) {
-                    ts.assertValueAt(i, (i + 1) * 2);
+                    to.assertValueAt(i, (i + 1) * 2);
                 }
             }
         });
@@ -143,9 +143,9 @@ public class ObservableConcatMapMaybeTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestObserver<Integer> ts = ps.concatMapMaybeDelayError(Functions.justFunction(ms), false).test();
+        TestObserver<Integer> to = ps.concatMapMaybeDelayError(Functions.justFunction(ms), false).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
@@ -155,11 +155,11 @@ public class ObservableConcatMapMaybeTest {
 
         assertTrue(ms.hasObservers());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ms.onSuccess(1);
 
-        ts.assertFailure(TestException.class, 1);
+        to.assertFailure(TestException.class, 1);
     }
 
     @Test
@@ -167,9 +167,9 @@ public class ObservableConcatMapMaybeTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestObserver<Integer> ts = ps.concatMapMaybeDelayError(Functions.justFunction(ms), false).test();
+        TestObserver<Integer> to = ps.concatMapMaybeDelayError(Functions.justFunction(ms), false).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
@@ -179,11 +179,11 @@ public class ObservableConcatMapMaybeTest {
 
         assertTrue(ms.hasObservers());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ms.onComplete();
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -264,7 +264,7 @@ public class ObservableConcatMapMaybeTest {
 
             final AtomicReference<MaybeObserver<? super Integer>> obs = new AtomicReference<MaybeObserver<? super Integer>>();
 
-            TestObserver<Integer> ts = ps.concatMapMaybe(
+            TestObserver<Integer> to = ps.concatMapMaybe(
                     new Function<Integer, MaybeSource<Integer>>() {
                         @Override
                         public MaybeSource<Integer> apply(Integer v)
@@ -286,7 +286,7 @@ public class ObservableConcatMapMaybeTest {
             ps.onError(new TestException("outer"));
             obs.get().onError(new TestException("inner"));
 
-            ts.assertFailureAndMessage(TestException.class, "outer");
+            to.assertFailureAndMessage(TestException.class, "outer");
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class, "inner");
         } finally {
@@ -308,8 +308,8 @@ public class ObservableConcatMapMaybeTest {
         .assertFailure(CompositeException.class)
         .assertOf(new Consumer<TestObserver<Object>>() {
             @Override
-            public void accept(TestObserver<Object> ts) throws Exception {
-                CompositeException ce = (CompositeException)ts.errors().get(0);
+            public void accept(TestObserver<Object> to) throws Exception {
+                CompositeException ce = (CompositeException)to.errors().get(0);
                 assertEquals(5, ce.getExceptions().size());
             }
         });
@@ -319,7 +319,7 @@ public class ObservableConcatMapMaybeTest {
     public void mapperCrash() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Object> ts = ps
+        TestObserver<Object> to = ps
         .concatMapMaybe(new Function<Integer, MaybeSource<? extends Object>>() {
             @Override
             public MaybeSource<? extends Object> apply(Integer v)
@@ -329,13 +329,13 @@ public class ObservableConcatMapMaybeTest {
         })
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ps.hasObservers());
 
         ps.onNext(1);
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
 
         assertFalse(ps.hasObservers());
     }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -82,9 +82,9 @@ public class ObservableConcatMapSingleTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         SingleSubject<Integer> ms = SingleSubject.create();
 
-        TestObserver<Integer> ts = ps.concatMapSingleDelayError(Functions.justFunction(ms), false).test();
+        TestObserver<Integer> to = ps.concatMapSingleDelayError(Functions.justFunction(ms), false).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
@@ -94,11 +94,11 @@ public class ObservableConcatMapSingleTest {
 
         assertTrue(ms.hasObservers());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ms.onSuccess(1);
 
-        ts.assertFailure(TestException.class, 1);
+        to.assertFailure(TestException.class, 1);
     }
 
     @Test
@@ -179,7 +179,7 @@ public class ObservableConcatMapSingleTest {
 
             final AtomicReference<SingleObserver<? super Integer>> obs = new AtomicReference<SingleObserver<? super Integer>>();
 
-            TestObserver<Integer> ts = ps.concatMapSingle(
+            TestObserver<Integer> to = ps.concatMapSingle(
                     new Function<Integer, SingleSource<Integer>>() {
                         @Override
                         public SingleSource<Integer> apply(Integer v)
@@ -201,7 +201,7 @@ public class ObservableConcatMapSingleTest {
             ps.onError(new TestException("outer"));
             obs.get().onError(new TestException("inner"));
 
-            ts.assertFailureAndMessage(TestException.class, "outer");
+            to.assertFailureAndMessage(TestException.class, "outer");
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class, "inner");
         } finally {
@@ -223,8 +223,8 @@ public class ObservableConcatMapSingleTest {
         .assertFailure(CompositeException.class)
         .assertOf(new Consumer<TestObserver<Object>>() {
             @Override
-            public void accept(TestObserver<Object> ts) throws Exception {
-                CompositeException ce = (CompositeException)ts.errors().get(0);
+            public void accept(TestObserver<Object> to) throws Exception {
+                CompositeException ce = (CompositeException)to.errors().get(0);
                 assertEquals(5, ce.getExceptions().size());
             }
         });
@@ -234,7 +234,7 @@ public class ObservableConcatMapSingleTest {
     public void mapperCrash() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Object> ts = ps
+        TestObserver<Object> to = ps
         .concatMapSingle(new Function<Integer, SingleSource<? extends Object>>() {
             @Override
             public SingleSource<? extends Object> apply(Integer v)
@@ -244,13 +244,13 @@ public class ObservableConcatMapSingleTest {
         })
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ps.hasObservers());
 
         ps.onNext(1);
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
 
         assertFalse(ps.hasObservers());
     }
@@ -267,9 +267,9 @@ public class ObservableConcatMapSingleTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         SingleSubject<Integer> ms = SingleSubject.create();
 
-        TestObserver<Integer> ts = ps.concatMapSingleDelayError(Functions.justFunction(ms), false).test();
+        TestObserver<Integer> to = ps.concatMapSingleDelayError(Functions.justFunction(ms), false).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
         ps.onNext(2);
@@ -277,10 +277,10 @@ public class ObservableConcatMapSingleTest {
 
         assertTrue(ms.hasObservers());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ms.onSuccess(1);
 
-        ts.assertResult(1, 1);
+        to.assertResult(1, 1);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
@@ -127,7 +127,7 @@ public class ObservableSwitchMapMaybeTest {
         final MaybeSubject<Integer> ms1 = MaybeSubject.create();
         final MaybeSubject<Integer> ms2 = MaybeSubject.create();
 
-        TestObserver<Integer> ts = ps.switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
+        TestObserver<Integer> to = ps.switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v)
                     throws Exception {
@@ -138,11 +138,11 @@ public class ObservableSwitchMapMaybeTest {
                     }
         }).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ms1.hasObservers());
 
@@ -155,7 +155,7 @@ public class ObservableSwitchMapMaybeTest {
 
         assertFalse(ps.hasObservers());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -165,7 +165,7 @@ public class ObservableSwitchMapMaybeTest {
         final MaybeSubject<Integer> ms1 = MaybeSubject.create();
         final MaybeSubject<Integer> ms2 = MaybeSubject.create();
 
-        TestObserver<Integer> ts = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
+        TestObserver<Integer> to = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v)
                     throws Exception {
@@ -176,11 +176,11 @@ public class ObservableSwitchMapMaybeTest {
                     }
         }).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ms1.hasObservers());
 
@@ -191,13 +191,13 @@ public class ObservableSwitchMapMaybeTest {
 
         ms2.onError(new TestException());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ps.hasObservers());
 
         ps.onComplete();
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -206,7 +206,7 @@ public class ObservableSwitchMapMaybeTest {
 
         final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestObserver<Integer> ts = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
+        TestObserver<Integer> to = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v)
                     throws Exception {
@@ -214,11 +214,11 @@ public class ObservableSwitchMapMaybeTest {
                     }
         }).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ms.hasObservers());
 
@@ -226,11 +226,11 @@ public class ObservableSwitchMapMaybeTest {
 
         assertTrue(ms.hasObservers());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ms.onComplete();
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -239,7 +239,7 @@ public class ObservableSwitchMapMaybeTest {
 
         final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestObserver<Integer> ts = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
+        TestObserver<Integer> to = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v)
                     throws Exception {
@@ -247,11 +247,11 @@ public class ObservableSwitchMapMaybeTest {
                     }
         }).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ms.hasObservers());
 
@@ -259,11 +259,11 @@ public class ObservableSwitchMapMaybeTest {
 
         assertTrue(ms.hasObservers());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ms.onSuccess(1);
 
-        ts.assertFailure(TestException.class, 1);
+        to.assertFailure(TestException.class, 1);
     }
 
     @Test
@@ -282,24 +282,24 @@ public class ObservableSwitchMapMaybeTest {
 
     @Test
     public void disposeBeforeSwitchInOnNext() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.just(1)
         .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v)
                     throws Exception {
-                        ts.cancel();
+                        to.cancel();
                         return Maybe.just(1);
                     }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertEmpty();
+        to.assertEmpty();
     }
 
     @Test
     public void disposeOnNextAfterFirst() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.just(1, 2)
         .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
@@ -307,13 +307,13 @@ public class ObservableSwitchMapMaybeTest {
             public MaybeSource<Integer> apply(Integer v)
                     throws Exception {
                 if (v == 2) {
-                    ts.cancel();
+                    to.cancel();
                 }
                 return Maybe.just(1);
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertValue(1)
+        to.assertValue(1)
         .assertNoErrors()
         .assertNotComplete();
     }
@@ -324,7 +324,7 @@ public class ObservableSwitchMapMaybeTest {
 
         final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestObserver<Integer> ts = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
+        TestObserver<Integer> to = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v)
                     throws Exception {
@@ -332,16 +332,16 @@ public class ObservableSwitchMapMaybeTest {
                     }
         }).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ps.hasObservers());
         assertTrue(ms.hasObservers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(ps.hasObservers());
         assertFalse(ms.hasObservers());
@@ -382,7 +382,7 @@ public class ObservableSwitchMapMaybeTest {
         try {
             final AtomicReference<MaybeObserver<? super Integer>> moRef = new AtomicReference<MaybeObserver<? super Integer>>();
 
-            TestObserver<Integer> ts = new Observable<Integer>() {
+            TestObserver<Integer> to = new Observable<Integer>() {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> s) {
                     s.onSubscribe(Disposables.empty());
@@ -406,7 +406,7 @@ public class ObservableSwitchMapMaybeTest {
             })
             .test();
 
-            ts.assertFailureAndMessage(TestException.class, "outer");
+            to.assertFailureAndMessage(TestException.class, "outer");
 
             moRef.get().onError(new TestException("inner"));
             moRef.get().onComplete();
@@ -425,7 +425,7 @@ public class ObservableSwitchMapMaybeTest {
 
             final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-            final TestObserver<Integer> ts = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
+            final TestObserver<Integer> to = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
                 @Override
                 public MaybeSource<Integer> apply(Integer v)
                         throws Exception {
@@ -443,13 +443,13 @@ public class ObservableSwitchMapMaybeTest {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            ts.assertNoErrors()
+            to.assertNoErrors()
             .assertNotComplete();
         }
     }
@@ -466,7 +466,7 @@ public class ObservableSwitchMapMaybeTest {
 
                 final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-                final TestObserver<Integer> ts = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
+                final TestObserver<Integer> to = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
                     @Override
                     public MaybeSource<Integer> apply(Integer v)
                             throws Exception {
@@ -495,9 +495,9 @@ public class ObservableSwitchMapMaybeTest {
 
                 TestHelper.race(r1, r2);
 
-                if (ts.errorCount() != 0) {
+                if (to.errorCount() != 0) {
                     assertTrue(errors.isEmpty());
-                    ts.assertFailure(TestException.class);
+                    to.assertFailure(TestException.class);
                 } else if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
@@ -520,7 +520,7 @@ public class ObservableSwitchMapMaybeTest {
 
                 final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-                final TestObserver<Integer> ts = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
+                final TestObserver<Integer> to = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
                     @Override
                     public MaybeSource<Integer> apply(Integer v)
                             throws Exception {
@@ -549,7 +549,7 @@ public class ObservableSwitchMapMaybeTest {
 
                 TestHelper.race(r1, r2);
 
-                ts.assertError(new Predicate<Throwable>() {
+                to.assertError(new Predicate<Throwable>() {
                     @Override
                     public boolean test(Throwable e) throws Exception {
                         return e instanceof TestException || e instanceof CompositeException;
@@ -573,7 +573,7 @@ public class ObservableSwitchMapMaybeTest {
 
             final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-            final TestObserver<Integer> ts = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
+            final TestObserver<Integer> to = ps.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
                 @Override
                 public MaybeSource<Integer> apply(Integer v)
                         throws Exception {
@@ -602,7 +602,7 @@ public class ObservableSwitchMapMaybeTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertNoErrors()
+            to.assertNoErrors()
             .assertNotComplete();
         }
     }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
@@ -96,7 +96,7 @@ public class ObservableSwitchMapSingleTest {
         final SingleSubject<Integer> ms1 = SingleSubject.create();
         final SingleSubject<Integer> ms2 = SingleSubject.create();
 
-        TestObserver<Integer> ts = ps.switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
+        TestObserver<Integer> to = ps.switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
             @Override
             public SingleSource<Integer> apply(Integer v)
                     throws Exception {
@@ -107,11 +107,11 @@ public class ObservableSwitchMapSingleTest {
                     }
         }).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ms1.hasObservers());
 
@@ -124,7 +124,7 @@ public class ObservableSwitchMapSingleTest {
 
         assertFalse(ps.hasObservers());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class ObservableSwitchMapSingleTest {
         final SingleSubject<Integer> ms1 = SingleSubject.create();
         final SingleSubject<Integer> ms2 = SingleSubject.create();
 
-        TestObserver<Integer> ts = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
+        TestObserver<Integer> to = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
             @Override
             public SingleSource<Integer> apply(Integer v)
                     throws Exception {
@@ -145,11 +145,11 @@ public class ObservableSwitchMapSingleTest {
                     }
         }).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ms1.hasObservers());
 
@@ -160,13 +160,13 @@ public class ObservableSwitchMapSingleTest {
 
         ms2.onError(new TestException());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ps.hasObservers());
 
         ps.onComplete();
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -175,7 +175,7 @@ public class ObservableSwitchMapSingleTest {
 
         final SingleSubject<Integer> ms = SingleSubject.create();
 
-        TestObserver<Integer> ts = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
+        TestObserver<Integer> to = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
             @Override
             public SingleSource<Integer> apply(Integer v)
                     throws Exception {
@@ -183,11 +183,11 @@ public class ObservableSwitchMapSingleTest {
                     }
         }).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ms.hasObservers());
 
@@ -195,11 +195,11 @@ public class ObservableSwitchMapSingleTest {
 
         assertTrue(ms.hasObservers());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ms.onSuccess(1);
 
-        ts.assertFailure(TestException.class, 1);
+        to.assertFailure(TestException.class, 1);
     }
 
     @Test
@@ -208,7 +208,7 @@ public class ObservableSwitchMapSingleTest {
 
         final SingleSubject<Integer> ms = SingleSubject.create();
 
-        TestObserver<Integer> ts = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
+        TestObserver<Integer> to = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
             @Override
             public SingleSource<Integer> apply(Integer v)
                     throws Exception {
@@ -216,11 +216,11 @@ public class ObservableSwitchMapSingleTest {
                     }
         }).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ms.hasObservers());
 
@@ -228,11 +228,11 @@ public class ObservableSwitchMapSingleTest {
 
         assertTrue(ms.hasObservers());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ms.onSuccess(1);
 
-        ts.assertFailure(TestException.class, 1);
+        to.assertFailure(TestException.class, 1);
     }
 
     @Test
@@ -251,24 +251,24 @@ public class ObservableSwitchMapSingleTest {
 
     @Test
     public void disposeBeforeSwitchInOnNext() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.just(1)
         .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
             @Override
             public SingleSource<Integer> apply(Integer v)
                     throws Exception {
-                        ts.cancel();
+                        to.cancel();
                         return Single.just(1);
                     }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertEmpty();
+        to.assertEmpty();
     }
 
     @Test
     public void disposeOnNextAfterFirst() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.just(1, 2)
         .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
@@ -276,13 +276,13 @@ public class ObservableSwitchMapSingleTest {
             public SingleSource<Integer> apply(Integer v)
                     throws Exception {
                 if (v == 2) {
-                    ts.cancel();
+                    to.cancel();
                 }
                 return Single.just(1);
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertValue(1)
+        to.assertValue(1)
         .assertNoErrors()
         .assertNotComplete();
     }
@@ -293,7 +293,7 @@ public class ObservableSwitchMapSingleTest {
 
         final SingleSubject<Integer> ms = SingleSubject.create();
 
-        TestObserver<Integer> ts = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
+        TestObserver<Integer> to = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
             @Override
             public SingleSource<Integer> apply(Integer v)
                     throws Exception {
@@ -301,16 +301,16 @@ public class ObservableSwitchMapSingleTest {
                     }
         }).test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         ps.onNext(1);
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(ps.hasObservers());
         assertTrue(ms.hasObservers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(ps.hasObservers());
         assertFalse(ms.hasObservers());
@@ -351,7 +351,7 @@ public class ObservableSwitchMapSingleTest {
         try {
             final AtomicReference<SingleObserver<? super Integer>> moRef = new AtomicReference<SingleObserver<? super Integer>>();
 
-            TestObserver<Integer> ts = new Observable<Integer>() {
+            TestObserver<Integer> to = new Observable<Integer>() {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> s) {
                     s.onSubscribe(Disposables.empty());
@@ -375,7 +375,7 @@ public class ObservableSwitchMapSingleTest {
             })
             .test();
 
-            ts.assertFailureAndMessage(TestException.class, "outer");
+            to.assertFailureAndMessage(TestException.class, "outer");
 
             moRef.get().onError(new TestException("inner"));
 
@@ -393,7 +393,7 @@ public class ObservableSwitchMapSingleTest {
 
             final SingleSubject<Integer> ms = SingleSubject.create();
 
-            final TestObserver<Integer> ts = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
+            final TestObserver<Integer> to = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Integer v)
                         throws Exception {
@@ -411,13 +411,13 @@ public class ObservableSwitchMapSingleTest {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            ts.assertNoErrors()
+            to.assertNoErrors()
             .assertNotComplete();
         }
     }
@@ -434,7 +434,7 @@ public class ObservableSwitchMapSingleTest {
 
                 final SingleSubject<Integer> ms = SingleSubject.create();
 
-                final TestObserver<Integer> ts = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
+                final TestObserver<Integer> to = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
                     @Override
                     public SingleSource<Integer> apply(Integer v)
                             throws Exception {
@@ -463,9 +463,9 @@ public class ObservableSwitchMapSingleTest {
 
                 TestHelper.race(r1, r2);
 
-                if (ts.errorCount() != 0) {
+                if (to.errorCount() != 0) {
                     assertTrue(errors.isEmpty());
-                    ts.assertFailure(TestException.class);
+                    to.assertFailure(TestException.class);
                 } else if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);
                 }
@@ -488,7 +488,7 @@ public class ObservableSwitchMapSingleTest {
 
                 final SingleSubject<Integer> ms = SingleSubject.create();
 
-                final TestObserver<Integer> ts = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
+                final TestObserver<Integer> to = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
                     @Override
                     public SingleSource<Integer> apply(Integer v)
                             throws Exception {
@@ -517,7 +517,7 @@ public class ObservableSwitchMapSingleTest {
 
                 TestHelper.race(r1, r2);
 
-                ts.assertError(new Predicate<Throwable>() {
+                to.assertError(new Predicate<Throwable>() {
                     @Override
                     public boolean test(Throwable e) throws Exception {
                         return e instanceof TestException || e instanceof CompositeException;
@@ -541,7 +541,7 @@ public class ObservableSwitchMapSingleTest {
 
             final SingleSubject<Integer> ms = SingleSubject.create();
 
-            final TestObserver<Integer> ts = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
+            final TestObserver<Integer> to = ps.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Integer v)
                         throws Exception {
@@ -570,7 +570,7 @@ public class ObservableSwitchMapSingleTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertNoErrors()
+            to.assertNoErrors()
             .assertNotComplete();
         }
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAllTest.java
@@ -146,7 +146,7 @@ public class ObservableAllTest {
 
     @Test
     public void testPredicateThrowsExceptionAndValueInCauseMessageObservable() {
-        TestObserver<Boolean> ts = new TestObserver<Boolean>();
+        TestObserver<Boolean> to = new TestObserver<Boolean>();
 
         final IllegalArgumentException ex = new IllegalArgumentException();
 
@@ -156,12 +156,12 @@ public class ObservableAllTest {
                 throw ex;
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertTerminated();
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(ex);
+        to.assertTerminated();
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(ex);
         // FIXME need to decide about adding the value that probably caused the crash in some way
 //        assertTrue(ex.getCause().getMessage().contains("Boo!"));
     }
@@ -278,7 +278,7 @@ public class ObservableAllTest {
 
     @Test
     public void testPredicateThrowsExceptionAndValueInCauseMessage() {
-        TestObserver<Boolean> ts = new TestObserver<Boolean>();
+        TestObserver<Boolean> to = new TestObserver<Boolean>();
 
         final IllegalArgumentException ex = new IllegalArgumentException();
 
@@ -288,12 +288,12 @@ public class ObservableAllTest {
                 throw ex;
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertTerminated();
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(ex);
+        to.assertTerminated();
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(ex);
         // FIXME need to decide about adding the value that probably caused the crash in some way
 //        assertTrue(ex.getCause().getMessage().contains("Boo!"));
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAmbTest.java
@@ -176,10 +176,10 @@ public class ObservableAmbTest {
         //this stream emits second
         Observable<Integer> o2 = Observable.just(1).doOnSubscribe(incrementer)
                 .delay(100, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.computation());
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        Observable.ambArray(o1, o2).subscribe(ts);
-        ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
-        ts.assertNoErrors();
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Observable.ambArray(o1, o2).subscribe(to);
+        to.awaitTerminalEvent(5, TimeUnit.SECONDS);
+        to.assertNoErrors();
         assertEquals(2, count.get());
     }
 
@@ -210,9 +210,9 @@ public class ObservableAmbTest {
         PublishSubject<Integer> source2 = PublishSubject.create();
         PublishSubject<Integer> source3 = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        Observable.ambArray(source1, source2, source3).subscribe(ts);
+        Observable.ambArray(source1, source2, source3).subscribe(to);
 
         assertTrue("Source 1 doesn't have subscribers!", source1.hasObservers());
         assertTrue("Source 2 doesn't have subscribers!", source2.hasObservers());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAnyTest.java
@@ -246,7 +246,7 @@ public class ObservableAnyTest {
 
     @Test
     public void testPredicateThrowsExceptionAndValueInCauseMessageObservable() {
-        TestObserver<Boolean> ts = new TestObserver<Boolean>();
+        TestObserver<Boolean> to = new TestObserver<Boolean>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
         Observable.just("Boo!").any(new Predicate<String>() {
@@ -254,12 +254,12 @@ public class ObservableAnyTest {
             public boolean test(String v) {
                 throw ex;
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertTerminated();
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(ex);
+        to.assertTerminated();
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(ex);
         // FIXME value as last cause?
 //        assertTrue(ex.getCause().getMessage().contains("Boo!"));
     }
@@ -467,7 +467,7 @@ public class ObservableAnyTest {
 
     @Test
     public void testPredicateThrowsExceptionAndValueInCauseMessage() {
-        TestObserver<Boolean> ts = new TestObserver<Boolean>();
+        TestObserver<Boolean> to = new TestObserver<Boolean>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
         Observable.just("Boo!").any(new Predicate<String>() {
@@ -475,12 +475,12 @@ public class ObservableAnyTest {
             public boolean test(String v) {
                 throw ex;
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertTerminated();
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(ex);
+        to.assertTerminated();
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(ex);
         // FIXME value as last cause?
 //        assertTrue(ex.getCause().getMessage().contains("Boo!"));
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -344,7 +344,7 @@ public class ObservableBufferTest {
         Observable<Integer> source = Observable.never();
 
         Observer<List<Integer>> o = TestHelper.mockObserver();
-        TestObserver<List<Integer>> ts = new TestObserver<List<Integer>>(o);
+        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>(o);
 
         source.buffer(100, 200, TimeUnit.MILLISECONDS, scheduler)
         .doOnNext(new Consumer<List<Integer>>() {
@@ -353,7 +353,7 @@ public class ObservableBufferTest {
                 System.out.println(pv);
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
         InOrder inOrder = Mockito.inOrder(o);
 
@@ -361,7 +361,7 @@ public class ObservableBufferTest {
 
         inOrder.verify(o, times(5)).onNext(Arrays.<Integer> asList());
 
-        ts.dispose();
+        to.dispose();
 
         scheduler.advanceTimeBy(999, TimeUnit.MILLISECONDS);
 
@@ -1104,9 +1104,9 @@ public class ObservableBufferTest {
 
     @Test
     public void boundaryCancel() {
-        PublishSubject<Object> pp = PublishSubject.create();
+        PublishSubject<Object> ps = PublishSubject.create();
 
-        TestObserver<Collection<Object>> ts = pp
+        TestObserver<Collection<Object>> to = ps
         .buffer(Functions.justCallable(Observable.never()), new Callable<Collection<Object>>() {
             @Override
             public Collection<Object> call() throws Exception {
@@ -1115,11 +1115,11 @@ public class ObservableBufferTest {
         })
         .test();
 
-        assertTrue(pp.hasObservers());
+        assertTrue(ps.hasObservers());
 
-        ts.dispose();
+        to.dispose();
 
-        assertFalse(pp.hasObservers());
+        assertFalse(ps.hasObservers());
     }
 
     @Test
@@ -1173,9 +1173,9 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     @Test
     public void boundaryMainError() {
-        PublishSubject<Object> pp = PublishSubject.create();
+        PublishSubject<Object> ps = PublishSubject.create();
 
-        TestObserver<Collection<Object>> ts = pp
+        TestObserver<Collection<Object>> to = ps
         .buffer(Functions.justCallable(Observable.never()), new Callable<Collection<Object>>() {
             @Override
             public Collection<Object> call() throws Exception {
@@ -1184,17 +1184,17 @@ public class ObservableBufferTest {
         })
         .test();
 
-        pp.onError(new TestException());
+        ps.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void boundaryBoundaryError() {
-        PublishSubject<Object> pp = PublishSubject.create();
+        PublishSubject<Object> ps = PublishSubject.create();
 
-        TestObserver<Collection<Object>> ts = pp
+        TestObserver<Collection<Object>> to = ps
         .buffer(Functions.justCallable(Observable.error(new TestException())), new Callable<Collection<Object>>() {
             @Override
             public Collection<Object> call() throws Exception {
@@ -1203,9 +1203,9 @@ public class ObservableBufferTest {
         })
         .test();
 
-        pp.onError(new TestException());
+        ps.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -1409,7 +1409,7 @@ public class ObservableBufferTest {
 
             final PublishSubject<Object> ps = PublishSubject.create();
 
-            TestObserver<List<Object>> ts = ps.buffer(1, TimeUnit.SECONDS, scheduler, 5).test();
+            TestObserver<List<Object>> to = ps.buffer(1, TimeUnit.SECONDS, scheduler, 5).test();
 
             ps.onNext(1);
             ps.onNext(2);
@@ -1435,7 +1435,7 @@ public class ObservableBufferTest {
             ps.onComplete();
 
             int items = 0;
-            for (List<Object> o : ts.values()) {
+            for (List<Object> o : to.values()) {
                 items += o.size();
             }
 
@@ -1512,7 +1512,7 @@ public class ObservableBufferTest {
 
         PublishSubject<Integer> closeIndicator = PublishSubject.create();
 
-        TestObserver<List<Integer>> ts = source
+        TestObserver<List<Integer>> to = source
         .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .test();
 
@@ -1527,7 +1527,7 @@ public class ObservableBufferTest {
 
         source.onComplete();
 
-        ts.assertResult(Collections.<Integer>emptyList());
+        to.assertResult(Collections.<Integer>emptyList());
 
         assertFalse(openIndicator.hasObservers());
         assertFalse(closeIndicator.hasObservers());
@@ -1635,7 +1635,7 @@ public class ObservableBufferTest {
 
         PublishSubject<Integer> closeIndicator = PublishSubject.create();
 
-        TestObserver<List<Integer>> ts = source
+        TestObserver<List<Integer>> to = source
         .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .test();
 
@@ -1652,7 +1652,7 @@ public class ObservableBufferTest {
 
         assertFalse(source.hasObservers());
 
-        ts.assertResult(Collections.<Integer>emptyList());
+        to.assertResult(Collections.<Integer>emptyList());
     }
 
     @Test
@@ -1664,7 +1664,7 @@ public class ObservableBufferTest {
 
         PublishSubject<Integer> closeIndicator = PublishSubject.create();
 
-        TestObserver<List<Integer>> ts = source
+        TestObserver<List<Integer>> to = source
         .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .test();
 
@@ -1681,7 +1681,7 @@ public class ObservableBufferTest {
 
         assertFalse(source.hasObservers());
 
-        ts.assertResult(Collections.<Integer>emptyList());
+        to.assertResult(Collections.<Integer>emptyList());
     }
 
     @Test
@@ -1693,7 +1693,7 @@ public class ObservableBufferTest {
 
         PublishSubject<Integer> closeIndicator = PublishSubject.create();
 
-        TestObserver<List<Integer>> ts = source
+        TestObserver<List<Integer>> to = source
         .buffer(openIndicator, Functions.justFunction(closeIndicator))
         .take(1)
         .test();
@@ -1705,7 +1705,7 @@ public class ObservableBufferTest {
         assertFalse(openIndicator.hasObservers());
         assertFalse(closeIndicator.hasObservers());
 
-        ts.assertResult(Collections.<Integer>emptyList());
+        to.assertResult(Collections.<Integer>emptyList());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
@@ -39,16 +39,16 @@ public class ObservableCacheTest {
 
         assertFalse("Source is connected!", source.isConnected());
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        source.subscribe(ts);
+        source.subscribe(to);
 
         assertTrue("Source is not connected!", source.isConnected());
         assertFalse("Subscribers retained!", source.hasObservers());
 
-        ts.assertNoErrors();
-        ts.assertTerminated();
-        List<Integer> onNextEvents = ts.values();
+        to.assertNoErrors();
+        to.assertTerminated();
+        List<Integer> onNextEvents = to.values();
         assertEquals(1000, onNextEvents.size());
 
         for (int i = 0; i < 1000; i++) {
@@ -118,14 +118,14 @@ public class ObservableCacheTest {
 
     @Test
     public void testTake() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         ObservableCache<Integer> cached = (ObservableCache<Integer>)ObservableCache.from(Observable.range(1, 100));
-        cached.take(10).subscribe(ts);
+        cached.take(10).subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertComplete();
-        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        to.assertNoErrors();
+        to.assertComplete();
+        to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 //        ts.assertUnsubscribed(); // FIXME no longer valid
         assertFalse(cached.hasObservers());
     }
@@ -134,24 +134,24 @@ public class ObservableCacheTest {
     public void testAsync() {
         Observable<Integer> source = Observable.range(1, 10000);
         for (int i = 0; i < 100; i++) {
-            TestObserver<Integer> ts1 = new TestObserver<Integer>();
+            TestObserver<Integer> to1 = new TestObserver<Integer>();
 
             ObservableCache<Integer> cached = (ObservableCache<Integer>)ObservableCache.from(source);
 
-            cached.observeOn(Schedulers.computation()).subscribe(ts1);
+            cached.observeOn(Schedulers.computation()).subscribe(to1);
 
-            ts1.awaitTerminalEvent(2, TimeUnit.SECONDS);
-            ts1.assertNoErrors();
-            ts1.assertComplete();
-            assertEquals(10000, ts1.values().size());
+            to1.awaitTerminalEvent(2, TimeUnit.SECONDS);
+            to1.assertNoErrors();
+            to1.assertComplete();
+            assertEquals(10000, to1.values().size());
 
-            TestObserver<Integer> ts2 = new TestObserver<Integer>();
-            cached.observeOn(Schedulers.computation()).subscribe(ts2);
+            TestObserver<Integer> to2 = new TestObserver<Integer>();
+            cached.observeOn(Schedulers.computation()).subscribe(to2);
 
-            ts2.awaitTerminalEvent(2, TimeUnit.SECONDS);
-            ts2.assertNoErrors();
-            ts2.assertComplete();
-            assertEquals(10000, ts2.values().size());
+            to2.awaitTerminalEvent(2, TimeUnit.SECONDS);
+            to2.assertNoErrors();
+            to2.assertComplete();
+            assertEquals(10000, to2.values().size());
         }
     }
     @Test
@@ -165,9 +165,9 @@ public class ObservableCacheTest {
 
         List<TestObserver<Long>> list = new ArrayList<TestObserver<Long>>(100);
         for (int i = 0; i < 100; i++) {
-            TestObserver<Long> ts = new TestObserver<Long>();
-            list.add(ts);
-            output.skip(i * 10).take(10).subscribe(ts);
+            TestObserver<Long> to = new TestObserver<Long>();
+            list.add(to);
+            output.skip(i * 10).take(10).subscribe(to);
         }
 
         List<Long> expected = new ArrayList<Long>();
@@ -175,16 +175,16 @@ public class ObservableCacheTest {
             expected.add((long)(i - 10));
         }
         int j = 0;
-        for (TestObserver<Long> ts : list) {
-            ts.awaitTerminalEvent(3, TimeUnit.SECONDS);
-            ts.assertNoErrors();
-            ts.assertComplete();
+        for (TestObserver<Long> to : list) {
+            to.awaitTerminalEvent(3, TimeUnit.SECONDS);
+            to.assertNoErrors();
+            to.assertComplete();
 
             for (int i = j * 10; i < j * 10 + 10; i++) {
                 expected.set(i - j * 10, (long)i);
             }
 
-            ts.assertValueSequence(expected);
+            to.assertValueSequence(expected);
 
             j++;
         }
@@ -204,14 +204,14 @@ public class ObservableCacheTest {
             }
         });
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        firehose.cache().observeOn(Schedulers.computation()).takeLast(100).subscribe(ts);
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        firehose.cache().observeOn(Schedulers.computation()).takeLast(100).subscribe(to);
 
-        ts.awaitTerminalEvent(3, TimeUnit.SECONDS);
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.awaitTerminalEvent(3, TimeUnit.SECONDS);
+        to.assertNoErrors();
+        to.assertComplete();
 
-        assertEquals(100, ts.values().size());
+        assertEquals(100, to.values().size());
     }
 
     @Test
@@ -221,19 +221,19 @@ public class ObservableCacheTest {
                 .cache();
 
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        source.subscribe(ts);
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        source.subscribe(to);
 
-        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        ts.assertNotComplete();
-        ts.assertError(TestException.class);
+        to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        to.assertNotComplete();
+        to.assertError(TestException.class);
 
-        TestObserver<Integer> ts2 = new TestObserver<Integer>();
-        source.subscribe(ts2);
+        TestObserver<Integer> to2 = new TestObserver<Integer>();
+        source.subscribe(to2);
 
-        ts2.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        ts2.assertNotComplete();
-        ts2.assertError(TestException.class);
+        to2.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        to2.assertNotComplete();
+        to2.assertError(TestException.class);
     }
 
     @Test
@@ -250,20 +250,20 @@ public class ObservableCacheTest {
         })
         .cache();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();
             }
         };
 
-        source.subscribe(ts);
+        source.subscribe(to);
 
         Assert.assertEquals(100, count.get());
 
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(TestException.class);
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(TestException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
@@ -756,14 +756,14 @@ public class ObservableCombineLatestTest {
                     }
                 }).take(SIZE);
 
-        TestObserver<Long> ts = new TestObserver<Long>();
+        TestObserver<Long> to = new TestObserver<Long>();
 
         Observable.combineLatest(timer, Observable.<Integer> never(), new BiFunction<Long, Integer, Long>() {
             @Override
             public Long apply(Long t1, Integer t2) {
                 return t1;
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
         if (!latch.await(SIZE + 1000, TimeUnit.MILLISECONDS)) {
             fail("timed out");
@@ -1170,7 +1170,7 @@ public class ObservableCombineLatestTest {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1192,11 +1192,11 @@ public class ObservableCombineLatestTest {
                 return t1 + t2;
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
         ps1.onNext(1);
         ps2.onNext(2);
-        ts.assertResult(3);
+        to.assertResult(3);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -50,7 +50,7 @@ public class ObservableConcatMapEagerTest {
     @Test
     @Ignore("Observable doesn't do backpressure")
     public void normalBackpressured() {
-//        TestObserver<Integer> ts = Observable.range(1, 5)
+//        TestObserver<Integer> to = Observable.range(1, 5)
 //        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
 //            @Override
 //            public ObservableSource<Integer> apply(Integer t) {
@@ -59,19 +59,19 @@ public class ObservableConcatMapEagerTest {
 //        })
 //        .test(3);
 //
-//        ts.assertValues(1, 2, 2);
+//        to.assertValues(1, 2, 2);
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertValues(1, 2, 2, 3);
+//        to.assertValues(1, 2, 2, 3);
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertValues(1, 2, 2, 3, 3);
+//        to.assertValues(1, 2, 2, 3, 3);
 //
-//        ts.request(5);
+//        to.request(5);
 //
-//        ts.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+//        to.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class ObservableConcatMapEagerTest {
     @Test
     @Ignore("Observable doesn't do backpressure")
     public void normalDelayBoundaryBackpressured() {
-//        TestObserver<Integer> ts = Observable.range(1, 5)
+//        TestObserver<Integer> to = Observable.range(1, 5)
 //        .concatMapEagerDelayError(new Function<Integer, ObservableSource<Integer>>() {
 //            @Override
 //            public ObservableSource<Integer> apply(Integer t) {
@@ -99,19 +99,19 @@ public class ObservableConcatMapEagerTest {
 //        }, false)
 //        .test(3);
 //
-//        ts.assertValues(1, 2, 2);
+//        to.assertValues(1, 2, 2);
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertValues(1, 2, 2, 3);
+//        to.assertValues(1, 2, 2, 3);
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertValues(1, 2, 2, 3, 3);
+//        to.assertValues(1, 2, 2, 3, 3);
 //
-//        ts.request(5);
+//        to.request(5);
 //
-//        ts.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+//        to.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
     }
 
     @Test
@@ -130,7 +130,7 @@ public class ObservableConcatMapEagerTest {
     @Test
     @Ignore("Observable doesn't do backpressure")
     public void normalDelayEndBackpressured() {
-//        TestObserver<Integer> ts = Observable.range(1, 5)
+//        TestObserver<Integer> to = Observable.range(1, 5)
 //        .concatMapEagerDelayError(new Function<Integer, ObservableSource<Integer>>() {
 //            @Override
 //            public ObservableSource<Integer> apply(Integer t) {
@@ -139,19 +139,19 @@ public class ObservableConcatMapEagerTest {
 //        }, true)
 //        .test(3);
 //
-//        ts.assertValues(1, 2, 2);
+//        to.assertValues(1, 2, 2);
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertValues(1, 2, 2, 3);
+//        to.assertValues(1, 2, 2, 3);
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertValues(1, 2, 2, 3, 3);
+//        to.assertValues(1, 2, 2, 3, 3);
 //
-//        ts.request(5);
+//        to.request(5);
 //
-//        ts.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
+//        to.assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
     }
 
     @Test
@@ -159,7 +159,7 @@ public class ObservableConcatMapEagerTest {
         PublishSubject<Integer> main = PublishSubject.create();
         final PublishSubject<Integer> inner = PublishSubject.create();
 
-        TestObserver<Integer> ts = main.concatMapEagerDelayError(
+        TestObserver<Integer> to = main.concatMapEagerDelayError(
                 new Function<Integer, ObservableSource<Integer>>() {
                     @Override
                     public ObservableSource<Integer> apply(Integer t) {
@@ -171,16 +171,16 @@ public class ObservableConcatMapEagerTest {
 
         inner.onNext(2);
 
-        ts.assertValue(2);
+        to.assertValue(2);
 
         main.onError(new TestException("Forced failure"));
 
-        ts.assertNoErrors();
+        to.assertNoErrors();
 
         inner.onNext(3);
         inner.onComplete();
 
-        ts.assertFailureAndMessage(TestException.class, "Forced failure", 2, 3);
+        to.assertFailureAndMessage(TestException.class, "Forced failure", 2, 3);
     }
 
     @Test
@@ -188,7 +188,7 @@ public class ObservableConcatMapEagerTest {
         PublishSubject<Integer> main = PublishSubject.create();
         final PublishSubject<Integer> inner = PublishSubject.create();
 
-        TestObserver<Integer> ts = main.concatMapEagerDelayError(
+        TestObserver<Integer> to = main.concatMapEagerDelayError(
                 new Function<Integer, ObservableSource<Integer>>() {
                     @Override
                     public ObservableSource<Integer> apply(Integer t) {
@@ -201,16 +201,16 @@ public class ObservableConcatMapEagerTest {
 
         inner.onNext(2);
 
-        ts.assertValue(2);
+        to.assertValue(2);
 
         main.onError(new TestException("Forced failure"));
 
-        ts.assertNoErrors();
+        to.assertNoErrors();
 
         inner.onNext(3);
         inner.onComplete();
 
-        ts.assertFailureAndMessage(TestException.class, "Forced failure", 2, 3, 2, 3);
+        to.assertFailureAndMessage(TestException.class, "Forced failure", 2, 3, 2, 3);
     }
 
     @Test
@@ -218,7 +218,7 @@ public class ObservableConcatMapEagerTest {
         PublishSubject<Integer> main = PublishSubject.create();
         final PublishSubject<Integer> inner = PublishSubject.create();
 
-        TestObserver<Integer> ts = main.concatMapEager(
+        TestObserver<Integer> to = main.concatMapEager(
                 new Function<Integer, ObservableSource<Integer>>() {
                     @Override
                     public ObservableSource<Integer> apply(Integer t) {
@@ -231,7 +231,7 @@ public class ObservableConcatMapEagerTest {
 
         inner.onNext(2);
 
-        ts.assertValue(2);
+        to.assertValue(2);
 
         main.onError(new TestException("Forced failure"));
 
@@ -240,7 +240,7 @@ public class ObservableConcatMapEagerTest {
         inner.onNext(3);
         inner.onComplete();
 
-        ts.assertFailureAndMessage(TestException.class, "Forced failure", 2);
+        to.assertFailureAndMessage(TestException.class, "Forced failure", 2);
     }
 
     @Test
@@ -259,7 +259,7 @@ public class ObservableConcatMapEagerTest {
         .assertComplete();
     }
 
-    TestObserver<Object> ts;
+    TestObserver<Object> to;
 
     Function<Integer, Observable<Integer>> toJust = new Function<Integer, Observable<Integer>>() {
         @Override
@@ -277,25 +277,25 @@ public class ObservableConcatMapEagerTest {
 
     @Before
     public void before() {
-        ts = new TestObserver<Object>();
+        to = new TestObserver<Object>();
     }
 
     @Test
     public void testSimple() {
-        Observable.range(1, 100).concatMapEager(toJust).subscribe(ts);
+        Observable.range(1, 100).concatMapEager(toJust).subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertValueCount(100);
-        ts.assertComplete();
+        to.assertNoErrors();
+        to.assertValueCount(100);
+        to.assertComplete();
     }
 
     @Test
     public void testSimple2() {
-        Observable.range(1, 100).concatMapEager(toRange).subscribe(ts);
+        Observable.range(1, 100).concatMapEager(toRange).subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertValueCount(200);
-        ts.assertComplete();
+        to.assertNoErrors();
+        to.assertValueCount(200);
+        to.assertComplete();
     }
 
     @SuppressWarnings("unchecked")
@@ -309,13 +309,13 @@ public class ObservableConcatMapEagerTest {
             }
         }).hide();
 
-        Observable.concatArrayEager(source, source).subscribe(ts);
+        Observable.concatArrayEager(source, source).subscribe(to);
 
         Assert.assertEquals(2, count.get());
 
-        ts.assertValueCount(count.get());
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValueCount(count.get());
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @SuppressWarnings("unchecked")
@@ -329,13 +329,13 @@ public class ObservableConcatMapEagerTest {
             }
         }).hide();
 
-        Observable.concatArrayEager(source, source, source).subscribe(ts);
+        Observable.concatArrayEager(source, source, source).subscribe(to);
 
         Assert.assertEquals(3, count.get());
 
-        ts.assertValueCount(count.get());
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValueCount(count.get());
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @SuppressWarnings("unchecked")
@@ -349,13 +349,13 @@ public class ObservableConcatMapEagerTest {
             }
         }).hide();
 
-        Observable.concatArrayEager(source, source, source, source).subscribe(ts);
+        Observable.concatArrayEager(source, source, source, source).subscribe(to);
 
         Assert.assertEquals(4, count.get());
 
-        ts.assertValueCount(count.get());
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValueCount(count.get());
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @SuppressWarnings("unchecked")
@@ -369,13 +369,13 @@ public class ObservableConcatMapEagerTest {
             }
         }).hide();
 
-        Observable.concatArrayEager(source, source, source, source, source).subscribe(ts);
+        Observable.concatArrayEager(source, source, source, source, source).subscribe(to);
 
         Assert.assertEquals(5, count.get());
 
-        ts.assertValueCount(count.get());
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValueCount(count.get());
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @SuppressWarnings("unchecked")
@@ -389,13 +389,13 @@ public class ObservableConcatMapEagerTest {
             }
         }).hide();
 
-        Observable.concatArrayEager(source, source, source, source, source, source).subscribe(ts);
+        Observable.concatArrayEager(source, source, source, source, source, source).subscribe(to);
 
         Assert.assertEquals(6, count.get());
 
-        ts.assertValueCount(count.get());
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValueCount(count.get());
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @SuppressWarnings("unchecked")
@@ -409,13 +409,13 @@ public class ObservableConcatMapEagerTest {
             }
         }).hide();
 
-        Observable.concatArrayEager(source, source, source, source, source, source, source).subscribe(ts);
+        Observable.concatArrayEager(source, source, source, source, source, source, source).subscribe(to);
 
         Assert.assertEquals(7, count.get());
 
-        ts.assertValueCount(count.get());
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValueCount(count.get());
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @SuppressWarnings("unchecked")
@@ -429,13 +429,13 @@ public class ObservableConcatMapEagerTest {
             }
         }).hide();
 
-        Observable.concatArrayEager(source, source, source, source, source, source, source, source).subscribe(ts);
+        Observable.concatArrayEager(source, source, source, source, source, source, source, source).subscribe(to);
 
         Assert.assertEquals(8, count.get());
 
-        ts.assertValueCount(count.get());
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValueCount(count.get());
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @SuppressWarnings("unchecked")
@@ -449,22 +449,22 @@ public class ObservableConcatMapEagerTest {
             }
         }).hide();
 
-        Observable.concatArrayEager(source, source, source, source, source, source, source, source, source).subscribe(ts);
+        Observable.concatArrayEager(source, source, source, source, source, source, source, source, source).subscribe(to);
 
         Assert.assertEquals(9, count.get());
 
-        ts.assertValueCount(count.get());
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValueCount(count.get());
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
     public void testMainError() {
-        Observable.<Integer>error(new TestException()).concatMapEager(toJust).subscribe(ts);
+        Observable.<Integer>error(new TestException()).concatMapEager(toJust).subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertError(TestException.class);
+        to.assertNotComplete();
     }
 
     @SuppressWarnings("unchecked")
@@ -475,23 +475,23 @@ public class ObservableConcatMapEagerTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         Observable.concatArrayEager(Observable.just(1), ps)
-        .subscribe(ts);
+        .subscribe(to);
 
         ps.onError(new TestException());
 
-        ts.assertValue(1);
-        ts.assertError(TestException.class);
-        ts.assertNotComplete();
+        to.assertValue(1);
+        to.assertError(TestException.class);
+        to.assertNotComplete();
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testInnerEmpty() {
-        Observable.concatArrayEager(Observable.empty(), Observable.empty()).subscribe(ts);
+        Observable.concatArrayEager(Observable.empty(), Observable.empty()).subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
@@ -501,11 +501,11 @@ public class ObservableConcatMapEagerTest {
             public Observable<Integer> apply(Integer t) {
                 throw new TestException();
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(TestException.class);
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(TestException.class);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -546,11 +546,11 @@ public class ObservableConcatMapEagerTest {
             public Observable<Integer> apply(Integer t) {
                 return Observable.range(1, 1000).subscribeOn(Schedulers.computation());
             }
-        }).observeOn(Schedulers.newThread()).subscribe(ts);
+        }).observeOn(Schedulers.newThread()).subscribe(to);
 
-        ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
-        ts.assertNoErrors();
-        ts.assertValueCount(2000);
+        to.awaitTerminalEvent(5, TimeUnit.SECONDS);
+        to.assertNoErrors();
+        to.assertValueCount(2000);
     }
 
     @Test
@@ -573,13 +573,13 @@ public class ObservableConcatMapEagerTest {
                 }
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
         subject.onNext(1);
 
-        ts.assertNoErrors();
-        ts.assertNotComplete();
-        ts.assertValues(1, 2);
+        to.assertNoErrors();
+        to.assertNotComplete();
+        to.assertValues(1, 2);
     }
 
     @Test
@@ -587,7 +587,7 @@ public class ObservableConcatMapEagerTest {
     public void testPrefetchIsBounded() {
         final AtomicInteger count = new AtomicInteger();
 
-        TestObserver<Object> ts = TestObserver.create();
+        TestObserver<Object> to = TestObserver.create();
 
         Observable.just(1).concatMapEager(new Function<Integer, Observable<Integer>>() {
             @Override
@@ -600,11 +600,11 @@ public class ObservableConcatMapEagerTest {
                             }
                         }).hide();
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertNoValues();
-        ts.assertNotComplete();
+        to.assertNoErrors();
+        to.assertNoValues();
+        to.assertNotComplete();
         Assert.assertEquals(Observable.bufferSize(), count.get());
     }
 
@@ -616,11 +616,11 @@ public class ObservableConcatMapEagerTest {
             public Observable<Integer> apply(Integer t) {
                 return Observable.just(null);
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertComplete();
-        ts.assertValue(null);
+        to.assertNoErrors();
+        to.assertComplete();
+        to.assertValue(null);
     }
 
 
@@ -663,13 +663,13 @@ public class ObservableConcatMapEagerTest {
 
             Method m = Observable.class.getMethod("concatEager", clazz);
 
-            TestObserver<Integer> ts = TestObserver.create();
+            TestObserver<Integer> to = TestObserver.create();
 
-            ((Observable<Integer>)m.invoke(null, (Object[])obs)).subscribe(ts);
+            ((Observable<Integer>)m.invoke(null, (Object[])obs)).subscribe(to);
 
-            ts.assertValues(expected);
-            ts.assertNoErrors();
-            ts.assertComplete();
+            to.assertValues(expected);
+            to.assertNoErrors();
+            to.assertComplete();
         }
     }
 
@@ -677,37 +677,37 @@ public class ObservableConcatMapEagerTest {
     @Test
     public void capacityHint() {
         Observable<Integer> source = Observable.just(1);
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        Observable.concatEager(Arrays.asList(source, source, source), 1, 1).subscribe(ts);
+        Observable.concatEager(Arrays.asList(source, source, source), 1, 1).subscribe(to);
 
-        ts.assertValues(1, 1, 1);
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValues(1, 1, 1);
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
     public void Observable() {
         Observable<Integer> source = Observable.just(1);
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        Observable.concatEager(Observable.just(source, source, source)).subscribe(ts);
+        Observable.concatEager(Observable.just(source, source, source)).subscribe(to);
 
-        ts.assertValues(1, 1, 1);
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValues(1, 1, 1);
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
     public void ObservableCapacityHint() {
         Observable<Integer> source = Observable.just(1);
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        Observable.concatEager(Observable.just(source, source, source), 1, 1).subscribe(ts);
+        Observable.concatEager(Observable.just(source, source, source), 1, 1).subscribe(to);
 
-        ts.assertValues(1, 1, 1);
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValues(1, 1, 1);
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
@@ -393,17 +393,17 @@ public class ObservableConcatTest {
         final TestObservable<String> w2 = new TestObservable<String>(callOnce, okToContinue, "four", "five", "six");
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<String>(observer);
 
         final Observable<String> concat = Observable.concat(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
 
         try {
             // Subscribe
-            concat.subscribe(ts);
+            concat.subscribe(to);
             //Block main thread to allow Observable "w1" to complete and Observable "w2" to call onNext once.
             callOnce.await();
             // Unsubcribe
-            ts.dispose();
+            to.dispose();
             //Unblock the Observable to continue.
             okToContinue.countDown();
             w1.t.join();
@@ -435,19 +435,19 @@ public class ObservableConcatTest {
         final TestObservable<String> w2 = new TestObservable<String>(callOnce, okToContinue, "four", "five", "six");
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<String>(observer);
 
         @SuppressWarnings("unchecked")
         TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
         Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
 
-        concatF.subscribe(ts);
+        concatF.subscribe(to);
 
         try {
             //Block main thread to allow Observable "w1" to complete and Observable "w2" to call onNext exactly once.
             callOnce.await();
             //"four" from w2 has been processed by onNext()
-            ts.dispose();
+            to.dispose();
             //"five" and "six" will NOT be processed by onNext()
             //Unblock the Observable to continue.
             okToContinue.countDown();
@@ -672,12 +672,12 @@ public class ObservableConcatTest {
 
         });
 
-        TestObserver<String> ts = new TestObserver<String>();
-        Observable.concat(o, o).subscribe(ts);
-        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertTerminated();
-        ts.assertNoErrors();
-        ts.assertValues("hello", "hello");
+        TestObserver<String> to = new TestObserver<String>();
+        Observable.concat(o, o).subscribe(to);
+        to.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        to.assertTerminated();
+        to.assertNoErrors();
+        to.assertValues("hello", "hello");
     }
 
     @Test(timeout = 30000)
@@ -743,7 +743,7 @@ public class ObservableConcatTest {
             if (i % 1000 == 0) {
                 System.out.println("concatMapRangeAsyncLoop > " + i);
             }
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
             Observable.range(0, 1000)
             .concatMap(new Function<Integer, Observable<Integer>>() {
                 @Override
@@ -751,13 +751,13 @@ public class ObservableConcatTest {
                     return Observable.fromIterable(Arrays.asList(t));
                 }
             })
-            .observeOn(Schedulers.computation()).subscribe(ts);
+            .observeOn(Schedulers.computation()).subscribe(to);
 
-            ts.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
-            ts.assertTerminated();
-            ts.assertNoErrors();
-            assertEquals(1000, ts.valueCount());
-            assertEquals((Integer)999, ts.values().get(999));
+            to.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
+            to.assertTerminated();
+            to.assertNoErrors();
+            assertEquals(1000, to.valueCount());
+            assertEquals((Integer)999, to.values().get(999));
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletableTest.java
@@ -28,75 +28,75 @@ public class ObservableConcatWithCompletableTest {
 
     @Test
     public void normal() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5)
         .concatWith(Completable.fromAction(new Action() {
             @Override
             public void run() throws Exception {
-                ts.onNext(100);
+                to.onNext(100);
             }
         }))
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertResult(1, 2, 3, 4, 5, 100);
+        to.assertResult(1, 2, 3, 4, 5, 100);
     }
 
     @Test
     public void mainError() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.<Integer>error(new TestException())
         .concatWith(Completable.fromAction(new Action() {
             @Override
             public void run() throws Exception {
-                ts.onNext(100);
+                to.onNext(100);
             }
         }))
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
     public void otherError() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5)
         .concatWith(Completable.error(new TestException()))
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertFailure(TestException.class, 1, 2, 3, 4, 5);
+        to.assertFailure(TestException.class, 1, 2, 3, 4, 5);
     }
 
     @Test
     public void takeMain() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5)
         .concatWith(Completable.fromAction(new Action() {
             @Override
             public void run() throws Exception {
-                ts.onNext(100);
+                to.onNext(100);
             }
         }))
         .take(3)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertResult(1, 2, 3);
+        to.assertResult(1, 2, 3);
     }
 
     @Test
     public void cancelOther() {
         CompletableSubject other = CompletableSubject.create();
 
-        TestObserver<Object> ts = Observable.empty()
+        TestObserver<Object> to = Observable.empty()
                 .concatWith(other)
                 .test();
 
         assertTrue(other.hasObservers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(other.hasObservers());
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybeTest.java
@@ -28,87 +28,87 @@ public class ObservableConcatWithMaybeTest {
 
     @Test
     public void normalEmpty() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5)
         .concatWith(Maybe.<Integer>fromAction(new Action() {
             @Override
             public void run() throws Exception {
-                ts.onNext(100);
+                to.onNext(100);
             }
         }))
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertResult(1, 2, 3, 4, 5, 100);
+        to.assertResult(1, 2, 3, 4, 5, 100);
     }
 
 
     @Test
     public void normalNonEmpty() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5)
         .concatWith(Maybe.just(100))
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertResult(1, 2, 3, 4, 5, 100);
+        to.assertResult(1, 2, 3, 4, 5, 100);
     }
 
     @Test
     public void mainError() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.<Integer>error(new TestException())
         .concatWith(Maybe.<Integer>fromAction(new Action() {
             @Override
             public void run() throws Exception {
-                ts.onNext(100);
+                to.onNext(100);
             }
         }))
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
     public void otherError() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5)
         .concatWith(Maybe.<Integer>error(new TestException()))
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertFailure(TestException.class, 1, 2, 3, 4, 5);
+        to.assertFailure(TestException.class, 1, 2, 3, 4, 5);
     }
 
     @Test
     public void takeMain() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5)
         .concatWith(Maybe.<Integer>fromAction(new Action() {
             @Override
             public void run() throws Exception {
-                ts.onNext(100);
+                to.onNext(100);
             }
         }))
         .take(3)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertResult(1, 2, 3);
+        to.assertResult(1, 2, 3);
     }
 
     @Test
     public void cancelOther() {
         MaybeSubject<Object> other = MaybeSubject.create();
 
-        TestObserver<Object> ts = Observable.empty()
+        TestObserver<Object> to = Observable.empty()
                 .concatWith(other)
                 .test();
 
         assertTrue(other.hasObservers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(other.hasObservers());
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingleTest.java
@@ -27,60 +27,60 @@ public class ObservableConcatWithSingleTest {
 
     @Test
     public void normal() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5)
         .concatWith(Single.just(100))
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertResult(1, 2, 3, 4, 5, 100);
+        to.assertResult(1, 2, 3, 4, 5, 100);
     }
 
     @Test
     public void mainError() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.<Integer>error(new TestException())
         .concatWith(Single.just(100))
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
     public void otherError() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5)
         .concatWith(Single.<Integer>error(new TestException()))
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertFailure(TestException.class, 1, 2, 3, 4, 5);
+        to.assertFailure(TestException.class, 1, 2, 3, 4, 5);
     }
 
     @Test
     public void takeMain() {
-        final TestObserver<Integer> ts = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable.range(1, 5)
         .concatWith(Single.just(100))
         .take(3)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertResult(1, 2, 3);
+        to.assertResult(1, 2, 3);
     }
 
     @Test
     public void cancelOther() {
         SingleSubject<Object> other = SingleSubject.create();
 
-        TestObserver<Object> ts = Observable.empty()
+        TestObserver<Object> to = Observable.empty()
                 .concatWith(other)
                 .test();
 
         assertTrue(other.hasObservers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(other.hasObservers());
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
@@ -31,7 +31,7 @@ public class ObservableDelaySubscriptionOtherTest {
     public void testNoPrematureSubscription() {
         PublishSubject<Object> other = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -43,11 +43,11 @@ public class ObservableDelaySubscriptionOtherTest {
             }
         })
         .delaySubscription(other)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertNotComplete();
-        ts.assertNoErrors();
-        ts.assertNoValues();
+        to.assertNotComplete();
+        to.assertNoErrors();
+        to.assertNoValues();
 
         Assert.assertEquals("Premature subscription", 0, subscribed.get());
 
@@ -55,16 +55,16 @@ public class ObservableDelaySubscriptionOtherTest {
 
         Assert.assertEquals("No subscription", 1, subscribed.get());
 
-        ts.assertValue(1);
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValue(1);
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
     public void testNoMultipleSubscriptions() {
         PublishSubject<Object> other = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -76,11 +76,11 @@ public class ObservableDelaySubscriptionOtherTest {
             }
         })
         .delaySubscription(other)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertNotComplete();
-        ts.assertNoErrors();
-        ts.assertNoValues();
+        to.assertNotComplete();
+        to.assertNoErrors();
+        to.assertNoValues();
 
         Assert.assertEquals("Premature subscription", 0, subscribed.get());
 
@@ -89,16 +89,16 @@ public class ObservableDelaySubscriptionOtherTest {
 
         Assert.assertEquals("No subscription", 1, subscribed.get());
 
-        ts.assertValue(1);
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValue(1);
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
     public void testCompleteTriggersSubscription() {
         PublishSubject<Object> other = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -110,11 +110,11 @@ public class ObservableDelaySubscriptionOtherTest {
             }
         })
         .delaySubscription(other)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertNotComplete();
-        ts.assertNoErrors();
-        ts.assertNoValues();
+        to.assertNotComplete();
+        to.assertNoErrors();
+        to.assertNoValues();
 
         Assert.assertEquals("Premature subscription", 0, subscribed.get());
 
@@ -122,16 +122,16 @@ public class ObservableDelaySubscriptionOtherTest {
 
         Assert.assertEquals("No subscription", 1, subscribed.get());
 
-        ts.assertValue(1);
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValue(1);
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
     public void testNoPrematureSubscriptionToError() {
         PublishSubject<Object> other = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -143,11 +143,11 @@ public class ObservableDelaySubscriptionOtherTest {
             }
         })
         .delaySubscription(other)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertNotComplete();
-        ts.assertNoErrors();
-        ts.assertNoValues();
+        to.assertNotComplete();
+        to.assertNoErrors();
+        to.assertNoValues();
 
         Assert.assertEquals("Premature subscription", 0, subscribed.get());
 
@@ -155,16 +155,16 @@ public class ObservableDelaySubscriptionOtherTest {
 
         Assert.assertEquals("No subscription", 1, subscribed.get());
 
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(TestException.class);
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(TestException.class);
     }
 
     @Test
     public void testNoSubscriptionIfOtherErrors() {
         PublishSubject<Object> other = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -176,11 +176,11 @@ public class ObservableDelaySubscriptionOtherTest {
             }
         })
         .delaySubscription(other)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertNotComplete();
-        ts.assertNoErrors();
-        ts.assertNoValues();
+        to.assertNotComplete();
+        to.assertNoErrors();
+        to.assertNoValues();
 
         Assert.assertEquals("Premature subscription", 0, subscribed.get());
 
@@ -188,9 +188,9 @@ public class ObservableDelaySubscriptionOtherTest {
 
         Assert.assertEquals("Premature subscription", 0, subscribed.get());
 
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(TestException.class);
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(TestException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
@@ -218,10 +218,10 @@ public class ObservableDelayTest {
         Observable<Integer> result = Observable.just(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
 
         Observer<Object> o = TestHelper.mockObserver();
-        TestObserver<Object> ts = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<Object>(o);
 
-        result.subscribe(ts);
-        ts.dispose();
+        result.subscribe(to);
+        to.dispose();
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
         verify(o, never()).onNext(any());
@@ -640,7 +640,7 @@ public class ObservableDelayTest {
 
     @Test
     public void testBackpressureWithTimedDelay() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(1, Flowable.bufferSize() * 2)
                 .delay(100, TimeUnit.MILLISECONDS)
                 .observeOn(Schedulers.computation())
@@ -659,16 +659,16 @@ public class ObservableDelayTest {
                         return t;
                     }
 
-                }).subscribe(ts);
+                }).subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(Flowable.bufferSize() * 2, ts.valueCount());
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(Flowable.bufferSize() * 2, to.valueCount());
     }
 
     @Test
     public void testBackpressureWithSubscriptionTimedDelay() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(1, Flowable.bufferSize() * 2)
                 .delaySubscription(100, TimeUnit.MILLISECONDS)
                 .delay(100, TimeUnit.MILLISECONDS)
@@ -688,16 +688,16 @@ public class ObservableDelayTest {
                         return t;
                     }
 
-                }).subscribe(ts);
+                }).subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(Flowable.bufferSize() * 2, ts.valueCount());
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(Flowable.bufferSize() * 2, to.valueCount());
     }
 
     @Test
     public void testBackpressureWithSelectorDelay() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(1, Flowable.bufferSize() * 2)
                 .delay(new Function<Integer, Observable<Long>>() {
 
@@ -723,16 +723,16 @@ public class ObservableDelayTest {
                         return t;
                     }
 
-                }).subscribe(ts);
+                }).subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(Flowable.bufferSize() * 2, ts.valueCount());
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(Flowable.bufferSize() * 2, to.valueCount());
     }
 
     @Test
     public void testBackpressureWithSelectorDelayAndSubscriptionDelay() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(1, Flowable.bufferSize() * 2)
                 .delay(Observable.timer(500, TimeUnit.MILLISECONDS)
                 , new Function<Integer, Observable<Long>>() {
@@ -759,11 +759,11 @@ public class ObservableDelayTest {
                         return t;
                     }
 
-                }).subscribe(ts);
+                }).subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(Flowable.bufferSize() * 2, ts.valueCount());
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(Flowable.bufferSize() * 2, to.valueCount());
     }
 
     @Test
@@ -772,9 +772,9 @@ public class ObservableDelayTest {
 
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        ps.delay(1, TimeUnit.SECONDS, test).subscribe(ts);
+        ps.delay(1, TimeUnit.SECONDS, test).subscribe(to);
 
         ps.onNext(1);
 
@@ -784,9 +784,9 @@ public class ObservableDelayTest {
 
         test.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertError(TestException.class);
+        to.assertNotComplete();
     }
 
     @Test
@@ -795,19 +795,19 @@ public class ObservableDelayTest {
 
         Observable<Integer> source = Observable.range(1, 5);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        source.delaySubscription(ps).subscribe(ts);
+        source.delaySubscription(ps).subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertNotComplete();
 
         ps.onNext(1);
 
-        ts.assertValues(1, 2, 3, 4, 5);
-        ts.assertComplete();
-        ts.assertNoErrors();
+        to.assertValues(1, 2, 3, 4, 5);
+        to.assertComplete();
+        to.assertNoErrors();
     }
 
     @Test
@@ -816,20 +816,20 @@ public class ObservableDelayTest {
 
         Observable<Integer> source = Observable.range(1, 5);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        source.delaySubscription(ps).subscribe(ts);
+        source.delaySubscription(ps).subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertNotComplete();
 
         // FIXME should this complete the source instead of consuming it?
         ps.onComplete();
 
-        ts.assertValues(1, 2, 3, 4, 5);
-        ts.assertComplete();
-        ts.assertNoErrors();
+        to.assertValues(1, 2, 3, 4, 5);
+        to.assertComplete();
+        to.assertNoErrors();
     }
 
     @Test
@@ -838,19 +838,19 @@ public class ObservableDelayTest {
 
         Observable<Integer> source = Observable.range(1, 5);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        source.delaySubscription(ps).subscribe(ts);
+        source.delaySubscription(ps).subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertNotComplete();
 
         ps.onError(new TestException());
 
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(TestException.class);
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(TestException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDematerializeTest.java
@@ -96,10 +96,10 @@ public class ObservableDematerializeTest {
 
         Observer<Integer> observer = TestHelper.mockObserver();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>(observer);
-        dematerialize.subscribe(ts);
+        TestObserver<Integer> to = new TestObserver<Integer>(observer);
+        dematerialize.subscribe(to);
 
-        System.out.println(ts.errors());
+        System.out.println(to.errors());
 
         verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onComplete();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDetachTest.java
@@ -35,13 +35,13 @@ public class ObservableDetachTest {
 
         WeakReference<Object> wr = new WeakReference<Object>(o);
 
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
-        Observable.just(o).count().toObservable().onTerminateDetach().subscribe(ts);
+        Observable.just(o).count().toObservable().onTerminateDetach().subscribe(to);
 
-        ts.assertValue(1L);
-        ts.assertComplete();
-        ts.assertNoErrors();
+        to.assertValue(1L);
+        to.assertComplete();
+        to.assertNoErrors();
 
         o = null;
 
@@ -54,35 +54,35 @@ public class ObservableDetachTest {
 
     @Test
     public void error() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
-        Observable.error(new TestException()).onTerminateDetach().subscribe(ts);
+        Observable.error(new TestException()).onTerminateDetach().subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertError(TestException.class);
+        to.assertNotComplete();
     }
 
     @Test
     public void empty() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
-        Observable.empty().onTerminateDetach().subscribe(ts);
+        Observable.empty().onTerminateDetach().subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
     public void range() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
-        Observable.range(1, 1000).onTerminateDetach().subscribe(ts);
+        Observable.range(1, 1000).onTerminateDetach().subscribe(to);
 
-        ts.assertValueCount(1000);
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValueCount(1000);
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
 
@@ -93,17 +93,17 @@ public class ObservableDetachTest {
 //
 //        WeakReference<Object> wr = new WeakReference<Object>(o);
 //
-//        TestObserver<Object> ts = new TestObserver<Object>(0L);
+//        TestObserver<Object> to = new TestObserver<Object>(0L);
 //
 //        Observable.just(o).count().onTerminateDetach().subscribe(ts);
 //
-//        ts.assertNoValues();
+//        to.assertNoValues();
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertValue(1L);
-//        ts.assertComplete();
-//        ts.assertNoErrors();
+//        to.assertValue(1L);
+//        to.assertComplete();
+//        to.assertNoErrors();
 //
 //        o = null;
 //
@@ -119,10 +119,10 @@ public class ObservableDetachTest {
 
         WeakReference<Object> wr = new WeakReference<Object>(o);
 
-        TestObserver<Long> ts = Observable.just(o).count().toObservable().onTerminateDetach().test();
+        TestObserver<Long> to = Observable.just(o).count().toObservable().onTerminateDetach().test();
 
         o = null;
-        ts.cancel();
+        to.cancel();
 
         System.gc();
         Thread.sleep(200);
@@ -136,26 +136,26 @@ public class ObservableDetachTest {
     public void deferredUpstreamProducer() {
 //        final AtomicReference<Subscriber<? super Object>> subscriber = new AtomicReference<Subscriber<? super Object>>();
 //
-//        TestObserver<Object> ts = new TestObserver<Object>(0);
+//        TestObserver<Object> to = new TestObserver<Object>(0);
 //
 //        Observable.unsafeCreate(new ObservableSource<Object>() {
 //            @Override
 //            public void subscribe(Subscriber<? super Object> t) {
 //                subscriber.set(t);
 //            }
-//        }).onTerminateDetach().subscribe(ts);
+//        }).onTerminateDetach().subscribe(to);
 //
-//        ts.request(2);
+//        to.request(2);
 //
 //        new ObservableRange(1, 3).subscribe(subscriber.get());
 //
-//        ts.assertValues(1, 2);
+//        to.assertValues(1, 2);
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertValues(1, 2, 3);
-//        ts.assertComplete();
-//        ts.assertNoErrors();
+//        to.assertValues(1, 2, 3);
+//        to.assertComplete();
+//        to.assertNoErrors();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctTest.java
@@ -30,7 +30,7 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
@@ -144,19 +144,19 @@ public class ObservableDistinctTest {
 
     @Test
     public void fusedSync() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         Observable.just(1, 1, 2, 1, 3, 2, 4, 5, 4)
         .distinct()
         .subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.SYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void fusedAsync() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         UnicastSubject<Integer> us = UnicastSubject.create();
 
@@ -166,7 +166,7 @@ public class ObservableDistinctTest {
 
         TestHelper.emit(us, 1, 1, 2, 1, 3, 2, 4, 5, 4);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.ASYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoAfterNextTest.java
@@ -24,7 +24,7 @@ import io.reactivex.TestHelper;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.observers.*;
 import io.reactivex.subjects.UnicastSubject;
 
@@ -39,7 +39,7 @@ public class ObservableDoAfterNextTest {
         }
     };
 
-    final TestObserver<Integer> ts = new TestObserver<Integer>() {
+    final TestObserver<Integer> to = new TestObserver<Integer>() {
         @Override
         public void onNext(Integer t) {
             super.onNext(t);
@@ -51,7 +51,7 @@ public class ObservableDoAfterNextTest {
     public void just() {
         Observable.just(1)
         .doAfterNext(afterNext)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult(1);
 
         assertEquals(Arrays.asList(1, -1), values);
@@ -62,7 +62,7 @@ public class ObservableDoAfterNextTest {
         Observable.just(1)
         .hide()
         .doAfterNext(afterNext)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult(1);
 
         assertEquals(Arrays.asList(1, -1), values);
@@ -72,7 +72,7 @@ public class ObservableDoAfterNextTest {
     public void range() {
         Observable.range(1, 5)
         .doAfterNext(afterNext)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(1, -1, 2, -2, 3, -3, 4, -4, 5, -5), values);
@@ -82,7 +82,7 @@ public class ObservableDoAfterNextTest {
     public void error() {
         Observable.<Integer>error(new TestException())
         .doAfterNext(afterNext)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertFailure(TestException.class);
 
         assertTrue(values.isEmpty());
@@ -92,7 +92,7 @@ public class ObservableDoAfterNextTest {
     public void empty() {
         Observable.<Integer>empty()
         .doAfterNext(afterNext)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult();
 
         assertTrue(values.isEmpty());
@@ -100,13 +100,13 @@ public class ObservableDoAfterNextTest {
 
     @Test
     public void syncFused() {
-        TestObserver<Integer> ts0 = ObserverFusion.newTest(QueueSubscription.SYNC);
+        TestObserver<Integer> to0 = ObserverFusion.newTest(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
         .doAfterNext(afterNext)
-        .subscribe(ts0);
+        .subscribe(to0);
 
-        ObserverFusion.assertFusion(ts0, QueueSubscription.SYNC)
+        ObserverFusion.assertFusion(to0, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
@@ -114,13 +114,13 @@ public class ObservableDoAfterNextTest {
 
     @Test
     public void asyncFusedRejected() {
-        TestObserver<Integer> ts0 = ObserverFusion.newTest(QueueSubscription.ASYNC);
+        TestObserver<Integer> to0 = ObserverFusion.newTest(QueueFuseable.ASYNC);
 
         Observable.range(1, 5)
         .doAfterNext(afterNext)
-        .subscribe(ts0);
+        .subscribe(to0);
 
-        ObserverFusion.assertFusion(ts0, QueueSubscription.NONE)
+        ObserverFusion.assertFusion(to0, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
@@ -128,7 +128,7 @@ public class ObservableDoAfterNextTest {
 
     @Test
     public void asyncFused() {
-        TestObserver<Integer> ts0 = ObserverFusion.newTest(QueueSubscription.ASYNC);
+        TestObserver<Integer> to0 = ObserverFusion.newTest(QueueFuseable.ASYNC);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
 
@@ -136,9 +136,9 @@ public class ObservableDoAfterNextTest {
 
         up
         .doAfterNext(afterNext)
-        .subscribe(ts0);
+        .subscribe(to0);
 
-        ObserverFusion.assertFusion(ts0, QueueSubscription.ASYNC)
+        ObserverFusion.assertFusion(to0, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
@@ -154,7 +154,7 @@ public class ObservableDoAfterNextTest {
         Observable.just(1)
         .doAfterNext(afterNext)
         .filter(Functions.alwaysTrue())
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult(1);
 
         assertEquals(Arrays.asList(1, -1), values);
@@ -165,7 +165,7 @@ public class ObservableDoAfterNextTest {
         Observable.range(1, 5)
         .doAfterNext(afterNext)
         .filter(Functions.alwaysTrue())
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(1, -1, 2, -2, 3, -3, 4, -4, 5, -5), values);
@@ -176,7 +176,7 @@ public class ObservableDoAfterNextTest {
         Observable.<Integer>error(new TestException())
         .doAfterNext(afterNext)
         .filter(Functions.alwaysTrue())
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertFailure(TestException.class);
 
         assertTrue(values.isEmpty());
@@ -187,7 +187,7 @@ public class ObservableDoAfterNextTest {
         Observable.<Integer>empty()
         .doAfterNext(afterNext)
         .filter(Functions.alwaysTrue())
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult();
 
         assertTrue(values.isEmpty());
@@ -195,14 +195,14 @@ public class ObservableDoAfterNextTest {
 
     @Test
     public void syncFusedConditional() {
-        TestObserver<Integer> ts0 = ObserverFusion.newTest(QueueSubscription.SYNC);
+        TestObserver<Integer> to0 = ObserverFusion.newTest(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
         .doAfterNext(afterNext)
         .filter(Functions.alwaysTrue())
-        .subscribe(ts0);
+        .subscribe(to0);
 
-        ObserverFusion.assertFusion(ts0, QueueSubscription.SYNC)
+        ObserverFusion.assertFusion(to0, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
@@ -210,14 +210,14 @@ public class ObservableDoAfterNextTest {
 
     @Test
     public void asyncFusedRejectedConditional() {
-        TestObserver<Integer> ts0 = ObserverFusion.newTest(QueueSubscription.ASYNC);
+        TestObserver<Integer> to0 = ObserverFusion.newTest(QueueFuseable.ASYNC);
 
         Observable.range(1, 5)
         .doAfterNext(afterNext)
         .filter(Functions.alwaysTrue())
-        .subscribe(ts0);
+        .subscribe(to0);
 
-        ObserverFusion.assertFusion(ts0, QueueSubscription.NONE)
+        ObserverFusion.assertFusion(to0, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);
@@ -225,7 +225,7 @@ public class ObservableDoAfterNextTest {
 
     @Test
     public void asyncFusedConditional() {
-        TestObserver<Integer> ts0 = ObserverFusion.newTest(QueueSubscription.ASYNC);
+        TestObserver<Integer> to0 = ObserverFusion.newTest(QueueFuseable.ASYNC);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
 
@@ -234,9 +234,9 @@ public class ObservableDoAfterNextTest {
         up
         .doAfterNext(afterNext)
         .filter(Functions.alwaysTrue())
-        .subscribe(ts0);
+        .subscribe(to0);
 
-        ObserverFusion.assertFusion(ts0, QueueSubscription.ASYNC)
+        ObserverFusion.assertFusion(to0, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(Arrays.asList(-1, -2, -3, -4, -5), values);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoFinallyTest.java
@@ -26,7 +26,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
@@ -99,13 +99,13 @@ public class ObservableDoFinallyTest implements Action {
 
     @Test
     public void syncFused() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
         .doFinally(this)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ObserverFusion.assertFusion(ts, QueueDisposable.SYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -113,13 +113,13 @@ public class ObservableDoFinallyTest implements Action {
 
     @Test
     public void syncFusedBoundary() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC | QueueDisposable.BOUNDARY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.SYNC | QueueFuseable.BOUNDARY);
 
         Observable.range(1, 5)
         .doFinally(this)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -127,16 +127,16 @@ public class ObservableDoFinallyTest implements Action {
 
     @Test
     public void asyncFused() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ASYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ASYNC);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
 
         up
         .doFinally(this)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ObserverFusion.assertFusion(ts, QueueDisposable.ASYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -144,16 +144,16 @@ public class ObservableDoFinallyTest implements Action {
 
     @Test
     public void asyncFusedBoundary() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ASYNC | QueueDisposable.BOUNDARY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ASYNC | QueueFuseable.BOUNDARY);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
 
         up
         .doFinally(this)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -207,14 +207,14 @@ public class ObservableDoFinallyTest implements Action {
 
     @Test
     public void syncFusedConditional() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
         .doFinally(this)
         .filter(Functions.alwaysTrue())
-        .subscribe(ts);
+        .subscribe(to);
 
-        ObserverFusion.assertFusion(ts, QueueDisposable.SYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -222,13 +222,13 @@ public class ObservableDoFinallyTest implements Action {
 
     @Test
     public void nonFused() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.SYNC);
 
         Observable.range(1, 5).hide()
         .doFinally(this)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -236,14 +236,14 @@ public class ObservableDoFinallyTest implements Action {
 
     @Test
     public void nonFusedConditional() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.SYNC);
 
         Observable.range(1, 5).hide()
         .doFinally(this)
         .filter(Functions.alwaysTrue())
-        .subscribe(ts);
+        .subscribe(to);
 
-        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -251,14 +251,14 @@ public class ObservableDoFinallyTest implements Action {
 
     @Test
     public void syncFusedBoundaryConditional() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.SYNC | QueueDisposable.BOUNDARY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.SYNC | QueueFuseable.BOUNDARY);
 
         Observable.range(1, 5)
         .doFinally(this)
         .filter(Functions.alwaysTrue())
-        .subscribe(ts);
+        .subscribe(to);
 
-        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -266,7 +266,7 @@ public class ObservableDoFinallyTest implements Action {
 
     @Test
     public void asyncFusedConditional() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ASYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ASYNC);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -274,9 +274,9 @@ public class ObservableDoFinallyTest implements Action {
         up
         .doFinally(this)
         .filter(Functions.alwaysTrue())
-        .subscribe(ts);
+        .subscribe(to);
 
-        ObserverFusion.assertFusion(ts, QueueDisposable.ASYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -284,7 +284,7 @@ public class ObservableDoFinallyTest implements Action {
 
     @Test
     public void asyncFusedBoundaryConditional() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ASYNC | QueueDisposable.BOUNDARY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ASYNC | QueueFuseable.BOUNDARY);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -292,9 +292,9 @@ public class ObservableDoFinallyTest implements Action {
         up
         .doFinally(this)
         .filter(Functions.alwaysTrue())
-        .subscribe(ts);
+        .subscribe(to);
 
-        ObserverFusion.assertFusion(ts, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(1, calls);
@@ -359,7 +359,7 @@ public class ObservableDoFinallyTest implements Action {
                 @SuppressWarnings("unchecked")
                 QueueDisposable<Integer> qs = (QueueDisposable<Integer>)s;
 
-                qs.requestFusion(QueueDisposable.ANY);
+                qs.requestFusion(QueueFuseable.ANY);
 
                 assertFalse(qs.isEmpty());
 
@@ -406,7 +406,7 @@ public class ObservableDoFinallyTest implements Action {
                 @SuppressWarnings("unchecked")
                 QueueDisposable<Integer> qs = (QueueDisposable<Integer>)s;
 
-                qs.requestFusion(QueueDisposable.ANY);
+                qs.requestFusion(QueueFuseable.ANY);
 
                 assertFalse(qs.isEmpty());
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
@@ -28,7 +28,7 @@ import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
@@ -201,7 +201,7 @@ public class ObservableDoOnEachTest {
 
     @Test
     public void onErrorThrows() {
-        TestObserver<Object> ts = TestObserver.create();
+        TestObserver<Object> to = TestObserver.create();
 
         Observable.error(new TestException())
         .doOnError(new Consumer<Throwable>() {
@@ -209,13 +209,13 @@ public class ObservableDoOnEachTest {
             public void accept(Throwable e) {
                 throw new TestException();
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(CompositeException.class);
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(CompositeException.class);
 
-        CompositeException ex = (CompositeException)ts.errors().get(0);
+        CompositeException ex = (CompositeException)to.errors().get(0);
 
         List<Throwable> exceptions = ex.getExceptions();
         assertEquals(2, exceptions.size());
@@ -451,7 +451,7 @@ public class ObservableDoOnEachTest {
 
     @Test
     public void onErrorOnErrorCrashConditional() {
-        TestObserver<Object> ts = Observable.error(new TestException("Outer"))
+        TestObserver<Object> to = Observable.error(new TestException("Outer"))
         .doOnError(new Consumer<Throwable>() {
             @Override
             public void accept(Throwable e) throws Exception {
@@ -462,7 +462,7 @@ public class ObservableDoOnEachTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");
@@ -471,7 +471,7 @@ public class ObservableDoOnEachTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fused() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueSubscription.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -488,10 +488,10 @@ public class ObservableDoOnEachTest {
                 call[1]++;
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        to.assertOf(ObserverFusion.<Integer>assertFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(5, call[0]);
@@ -501,7 +501,7 @@ public class ObservableDoOnEachTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedOnErrorCrash() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueSubscription.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0 };
 
@@ -518,10 +518,10 @@ public class ObservableDoOnEachTest {
                 call[0]++;
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        to.assertOf(ObserverFusion.<Integer>assertFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertFailure(TestException.class);
 
         assertEquals(0, call[0]);
@@ -530,7 +530,7 @@ public class ObservableDoOnEachTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedConditional() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueSubscription.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -548,10 +548,10 @@ public class ObservableDoOnEachTest {
             }
         })
         .filter(Functions.alwaysTrue())
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        to.assertOf(ObserverFusion.<Integer>assertFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(5, call[0]);
@@ -561,7 +561,7 @@ public class ObservableDoOnEachTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedOnErrorCrashConditional() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueSubscription.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0 };
 
@@ -579,10 +579,10 @@ public class ObservableDoOnEachTest {
             }
         })
         .filter(Functions.alwaysTrue())
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        to.assertOf(ObserverFusion.<Integer>assertFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertFailure(TestException.class);
 
         assertEquals(0, call[0]);
@@ -591,7 +591,7 @@ public class ObservableDoOnEachTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedAsync() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueSubscription.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -610,12 +610,12 @@ public class ObservableDoOnEachTest {
                 call[1]++;
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
         TestHelper.emit(up, 1, 2, 3, 4, 5);
 
-        ts.assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        to.assertOf(ObserverFusion.<Integer>assertFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(5, call[0]);
@@ -625,7 +625,7 @@ public class ObservableDoOnEachTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedAsyncConditional() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueSubscription.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -645,12 +645,12 @@ public class ObservableDoOnEachTest {
             }
         })
         .filter(Functions.alwaysTrue())
-        .subscribe(ts);
+        .subscribe(to);
 
         TestHelper.emit(up, 1, 2, 3, 4, 5);
 
-        ts.assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        to.assertOf(ObserverFusion.<Integer>assertFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(5, call[0]);
@@ -660,7 +660,7 @@ public class ObservableDoOnEachTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedAsyncConditional2() {
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueSubscription.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -680,12 +680,12 @@ public class ObservableDoOnEachTest {
             }
         })
         .filter(Functions.alwaysTrue())
-        .subscribe(ts);
+        .subscribe(to);
 
         TestHelper.emit(up, 1, 2, 3, 4, 5);
 
-        ts.assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        to.assertOf(ObserverFusion.<Integer>assertFuseable())
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertResult(1, 2, 3, 4, 5);
 
         assertEquals(5, call[0]);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFilterTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFilterTest.java
@@ -23,7 +23,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.observers.*;
 import io.reactivex.subjects.UnicastSubject;
 
@@ -94,7 +94,7 @@ public class ObservableFilterTest {
 
     @Test
     public void fusedSync() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         Observable.range(1, 5)
         .filter(new Predicate<Integer>() {
@@ -105,13 +105,13 @@ public class ObservableFilterTest {
         })
         .subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.SYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.SYNC)
         .assertResult(2, 4);
     }
 
     @Test
     public void fusedAsync() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         UnicastSubject<Integer> us = UnicastSubject.create();
 
@@ -126,13 +126,13 @@ public class ObservableFilterTest {
 
         TestHelper.emit(us, 1, 2, 3, 4, 5);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.ASYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.ASYNC)
         .assertResult(2, 4);
     }
 
     @Test
     public void fusedReject() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY | QueueDisposable.BOUNDARY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
 
         Observable.range(1, 5)
         .filter(new Predicate<Integer>() {
@@ -143,7 +143,7 @@ public class ObservableFilterTest {
         })
         .subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(2, 4);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableTest.java
@@ -24,7 +24,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
@@ -169,7 +169,7 @@ public class ObservableFlatMapCompletableTest {
 
     @Test
     public void fusedObservable() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         Observable.range(1, 10)
         .flatMapCompletable(new Function<Integer, CompletableSource>() {
@@ -182,7 +182,7 @@ public class ObservableFlatMapCompletableTest {
 
         to
         .assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult();
     }
 
@@ -335,7 +335,7 @@ public class ObservableFlatMapCompletableTest {
 
     @Test
     public void fused() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         Observable.range(1, 10)
         .flatMapCompletable(new Function<Integer, CompletableSource>() {
@@ -349,7 +349,7 @@ public class ObservableFlatMapCompletableTest {
 
         to
         .assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
@@ -338,17 +338,17 @@ public class ObservableFlatMapTest {
             }
         }, m);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        source.subscribe(ts);
+        source.subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
         Set<Integer> expected = new HashSet<Integer>(Arrays.asList(
                 10, 11, 20, 21, 30, 31, 40, 41, 50, 51, 60, 61, 70, 71, 80, 81, 90, 91, 100, 101
         ));
-        Assert.assertEquals(expected.size(), ts.valueCount());
-        Assert.assertTrue(expected.containsAll(ts.values()));
+        Assert.assertEquals(expected.size(), to.valueCount());
+        Assert.assertTrue(expected.containsAll(to.values()));
     }
     @Test
     public void testFlatMapSelectorMaxConcurrent() {
@@ -368,19 +368,19 @@ public class ObservableFlatMapTest {
             }
         }, m);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        source.subscribe(ts);
+        source.subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
         Set<Integer> expected = new HashSet<Integer>(Arrays.asList(
                 1010, 1011, 2020, 2021, 3030, 3031, 4040, 4041, 5050, 5051,
                 6060, 6061, 7070, 7071, 8080, 8081, 9090, 9091, 10100, 10101
         ));
-        Assert.assertEquals(expected.size(), ts.valueCount());
-        System.out.println("--> testFlatMapSelectorMaxConcurrent: " + ts.values());
-        Assert.assertTrue(expected.containsAll(ts.values()));
+        Assert.assertEquals(expected.size(), to.valueCount());
+        System.out.println("--> testFlatMapSelectorMaxConcurrent: " + to.values());
+        Assert.assertTrue(expected.containsAll(to.values()));
     }
 
     @Test
@@ -414,14 +414,14 @@ public class ObservableFlatMapTest {
         Observable<Integer> source = Observable.fromIterable(Arrays.asList(10, 20, 30));
 
         Observer<Object> o = TestHelper.mockObserver();
-        TestObserver<Object> ts = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<Object>(o);
 
         Function<Throwable, Observable<Integer>> just = just(onError);
-        source.flatMap(just(onNext), just, just0(onComplete), m).subscribe(ts);
+        source.flatMap(just(onNext), just, just0(onComplete), m).subscribe(to);
 
-        ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
-        ts.assertNoErrors();
-        ts.assertTerminated();
+        to.awaitTerminalEvent(1, TimeUnit.SECONDS);
+        to.assertNoErrors();
+        to.assertTerminated();
 
         verify(o, times(3)).onNext(1);
         verify(o, times(3)).onNext(2);
@@ -440,7 +440,7 @@ public class ObservableFlatMapTest {
             if (i % 10 == 0) {
                 System.out.println("flatMapRangeAsyncLoop > " + i);
             }
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
             Observable.range(0, 1000)
             .flatMap(new Function<Integer, Observable<Integer>>() {
                 @Override
@@ -449,15 +449,15 @@ public class ObservableFlatMapTest {
                 }
             })
             .observeOn(Schedulers.computation())
-            .subscribe(ts);
+            .subscribe(to);
 
-            ts.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
-            if (ts.completions() == 0) {
-                System.out.println(ts.valueCount());
+            to.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
+            if (to.completions() == 0) {
+                System.out.println(to.valueCount());
             }
-            ts.assertTerminated();
-            ts.assertNoErrors();
-            List<Integer> list = ts.values();
+            to.assertTerminated();
+            to.assertNoErrors();
+            List<Integer> list = to.values();
             assertEquals(1000, list.size());
             boolean f = false;
             for (int j = 0; j < list.size(); j++) {
@@ -477,7 +477,7 @@ public class ObservableFlatMapTest {
             if (i % 10 == 0) {
                 System.out.println("flatMapRangeAsyncLoop > " + i);
             }
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
             Observable.range(0, 1000)
             .flatMap(new Function<Integer, Observable<Integer>>() {
                 final Random rnd = new Random();
@@ -491,15 +491,15 @@ public class ObservableFlatMapTest {
                 }
             })
             .observeOn(Schedulers.computation())
-            .subscribe(ts);
+            .subscribe(to);
 
-            ts.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
-            if (ts.completions() == 0) {
-                System.out.println(ts.valueCount());
+            to.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
+            if (to.completions() == 0) {
+                System.out.println(to.valueCount());
             }
-            ts.assertTerminated();
-            ts.assertNoErrors();
-            List<Integer> list = ts.values();
+            to.assertTerminated();
+            to.assertNoErrors();
+            List<Integer> list = to.values();
             if (list.size() < 1000) {
                 Set<Integer> set = new HashSet<Integer>(list);
                 for (int j = 0; j < 1000; j++) {
@@ -515,37 +515,37 @@ public class ObservableFlatMapTest {
     @Test
     public void flatMapIntPassthruAsync() {
         for (int i = 0;i < 1000; i++) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
 
             Observable.range(1, 1000).flatMap(new Function<Integer, Observable<Integer>>() {
                 @Override
                 public Observable<Integer> apply(Integer t) {
                     return Observable.just(1).subscribeOn(Schedulers.computation());
                 }
-            }).subscribe(ts);
+            }).subscribe(to);
 
-            ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
-            ts.assertNoErrors();
-            ts.assertComplete();
-            ts.assertValueCount(1000);
+            to.awaitTerminalEvent(5, TimeUnit.SECONDS);
+            to.assertNoErrors();
+            to.assertComplete();
+            to.assertValueCount(1000);
         }
     }
     @Test
     public void flatMapTwoNestedSync() {
         for (final int n : new int[] { 1, 1000, 1000000 }) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
 
             Observable.just(1, 2).flatMap(new Function<Integer, Observable<Integer>>() {
                 @Override
                 public Observable<Integer> apply(Integer t) {
                     return Observable.range(1, n);
                 }
-            }).subscribe(ts);
+            }).subscribe(to);
 
             System.out.println("flatMapTwoNestedSync >> @ " + n);
-            ts.assertNoErrors();
-            ts.assertComplete();
-            ts.assertValueCount(n * 2);
+            to.assertNoErrors();
+            to.assertComplete();
+            to.assertValueCount(n * 2);
         }
     }
 
@@ -762,7 +762,7 @@ public class ObservableFlatMapTest {
     @Test
     public void noCrossBoundaryFusion() {
         for (int i = 0; i < 500; i++) {
-            TestObserver<Object> ts = Observable.merge(
+            TestObserver<Object> to = Observable.merge(
                     Observable.just(1).observeOn(Schedulers.single()).map(new Function<Integer, Object>() {
                         @Override
                         public Object apply(Integer v) throws Exception {
@@ -780,7 +780,7 @@ public class ObservableFlatMapTest {
             .awaitDone(5, TimeUnit.SECONDS)
             .assertValueCount(2);
 
-            List<Object> list = ts.values();
+            List<Object> list = to.values();
 
             assertTrue(list.toString(), list.contains("RxSi"));
             assertTrue(list.toString(), list.contains("RxCo"));
@@ -793,20 +793,20 @@ public class ObservableFlatMapTest {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
-                final PublishSubject<Observable<Integer>> pp = PublishSubject.create();
+                final PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-                final TestObserver<Integer> ts = pp.flatMap(Functions.<Observable<Integer>>identity()).test();
+                final TestObserver<Integer> to = ps.flatMap(Functions.<Observable<Integer>>identity()).test();
 
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {
-                        ts.cancel();
+                        to.cancel();
                     }
                 };
                 Runnable r2 = new Runnable() {
                     @Override
                     public void run() {
-                        pp.onComplete();
+                        ps.onComplete();
                     }
                 };
 
@@ -826,20 +826,20 @@ public class ObservableFlatMapTest {
                 List<Throwable> errors = TestHelper.trackPluginErrors();
                 try {
 
-                    final PublishSubject<Observable<Integer>> pp = PublishSubject.create();
+                    final PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-                    final TestObserver<Integer> ts = pp.flatMap(Functions.<Observable<Integer>>identity()).test();
+                    final TestObserver<Integer> to = ps.flatMap(Functions.<Observable<Integer>>identity()).test();
 
                     final PublishSubject<Integer> just = PublishSubject.create();
                     final PublishSubject<Integer> just2 = PublishSubject.create();
-                    pp.onNext(just);
-                    pp.onNext(just2);
+                    ps.onNext(just);
+                    ps.onNext(just2);
 
                     Runnable r1 = new Runnable() {
                         @Override
                         public void run() {
                             just2.onNext(1);
-                            ts.cancel();
+                            to.cancel();
                         }
                     };
                     Runnable r2 = new Runnable() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromIterableTest.java
@@ -29,7 +29,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.util.CrashingIterable;
 import io.reactivex.observers.*;
 
@@ -118,12 +118,12 @@ public class ObservableFromIterableTest {
     public void testNoBackpressure() {
         Observable<Integer> o = Observable.fromIterable(Arrays.asList(1, 2, 3, 4, 5));
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        o.subscribe(ts);
+        o.subscribe(to);
 
-        ts.assertValues(1, 2, 3, 4, 5);
-        ts.assertTerminated();
+        to.assertValues(1, 2, 3, 4, 5);
+        to.assertTerminated();
     }
 
     @Test
@@ -131,13 +131,13 @@ public class ObservableFromIterableTest {
         Observable<Integer> o = Observable.fromIterable(Arrays.asList(1, 2, 3));
 
         for (int i = 0; i < 10; i++) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
 
-            o.subscribe(ts);
+            o.subscribe(to);
 
-            ts.assertValues(1, 2, 3);
-            ts.assertNoErrors();
-            ts.assertComplete();
+            to.assertValues(1, 2, 3);
+            to.assertNoErrors();
+            to.assertComplete();
         }
     }
 
@@ -302,12 +302,12 @@ public class ObservableFromIterableTest {
 
     @Test
     public void fusionRejected() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ASYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ASYNC);
 
         Observable.fromIterable(Arrays.asList(1, 2, 3))
         .subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(1, 2, 3);
     }
 
@@ -320,7 +320,7 @@ public class ObservableFromIterableTest {
                 @SuppressWarnings("unchecked")
                 QueueDisposable<Integer> qd = (QueueDisposable<Integer>)d;
 
-                qd.requestFusion(QueueDisposable.ANY);
+                qd.requestFusion(QueueFuseable.ANY);
 
                 try {
                     assertEquals(1, qd.poll().intValue());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
@@ -77,12 +77,12 @@ public class ObservableFromTest {
 
     @Test
     public void fusionRejected() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ASYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ASYNC);
 
         Observable.fromArray(1, 2, 3)
         .subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(1, 2, 3);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
@@ -1026,7 +1026,7 @@ public class ObservableGroupByTest {
     @Test
     public void testGroupByBackpressure() throws InterruptedException {
 
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
 
         Observable.range(1, 4000)
                 .groupBy(IS_EVEN2)
@@ -1052,9 +1052,9 @@ public class ObservableGroupByTest {
                         });
                     }
 
-                }).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+                }).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
     }
 
     <T, R> Function<T, R> just(final R value) {
@@ -1153,12 +1153,12 @@ public class ObservableGroupByTest {
             }
         });
 
-        TestObserver<String> ts = new TestObserver<String>();
-        m.subscribe(ts);
-        ts.awaitTerminalEvent();
-        System.out.println("ts .get " + ts.values());
-        ts.assertNoErrors();
-        assertEquals(ts.values(),
+        TestObserver<String> to = new TestObserver<String>();
+        m.subscribe(to);
+        to.awaitTerminalEvent();
+        System.out.println("ts .get " + to.values());
+        to.assertNoErrors();
+        assertEquals(to.values(),
                 Arrays.asList("foo-0", "foo-1", "bar-0", "foo-0", "baz-0", "qux-0", "bar-1", "bar-0", "foo-1", "baz-1", "baz-0", "foo-0"));
 
     }
@@ -1169,11 +1169,11 @@ public class ObservableGroupByTest {
 
         Observable<Integer> m = source.groupBy(fail(0), dbl).flatMap(FLATTEN_INTEGER);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        m.subscribe(ts);
-        ts.awaitTerminalEvent();
-        assertEquals(1, ts.errorCount());
-        ts.assertNoValues();
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        m.subscribe(to);
+        to.awaitTerminalEvent();
+        assertEquals(1, to.errorCount());
+        to.assertNoValues();
     }
 
     @Test
@@ -1181,11 +1181,11 @@ public class ObservableGroupByTest {
         Observable<Integer> source = Observable.just(0, 1, 2, 3, 4, 5, 6);
 
         Observable<Integer> m = source.groupBy(identity, fail(0)).flatMap(FLATTEN_INTEGER);
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        m.subscribe(ts);
-        ts.awaitTerminalEvent();
-        assertEquals(1, ts.errorCount());
-        ts.assertNoValues();
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        m.subscribe(to);
+        to.awaitTerminalEvent();
+        assertEquals(1, to.errorCount());
+        to.assertNoValues();
 
     }
 
@@ -1195,11 +1195,11 @@ public class ObservableGroupByTest {
 
         Observable<Integer> m = source.groupBy(identity, dbl).flatMap(FLATTEN_INTEGER);
 
-        TestObserver<Object> ts = new TestObserver<Object>();
-        m.subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        System.out.println(ts.values());
+        TestObserver<Object> to = new TestObserver<Object>();
+        m.subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        System.out.println(to.values());
     }
 
     /**
@@ -1239,16 +1239,16 @@ public class ObservableGroupByTest {
 
         Observable<Integer> m = source.groupBy(identity, dbl).flatMap(FLATTEN_INTEGER);
 
-        TestObserver<Object> ts = new TestObserver<Object>();
-        m.subscribe(ts);
-        ts.awaitTerminalEvent();
-        assertEquals(1, ts.errorCount());
-        ts.assertValueCount(1);
+        TestObserver<Object> to = new TestObserver<Object>();
+        m.subscribe(to);
+        to.awaitTerminalEvent();
+        assertEquals(1, to.errorCount());
+        to.assertValueCount(1);
     }
 
     @Test
     public void testgroupByBackpressure() throws InterruptedException {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
 
         Observable.range(1, 4000).groupBy(IS_EVEN2).flatMap(new Function<GroupedObservable<Boolean, Integer>, Observable<String>>() {
 
@@ -1297,15 +1297,15 @@ public class ObservableGroupByTest {
                 System.out.println("NEXT: " + t1);
             }
 
-        }).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+        }).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
     }
 
     @Test
     public void testgroupByBackpressure2() throws InterruptedException {
 
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
 
         Observable.range(1, 4000).groupBy(IS_EVEN2).flatMap(new Function<GroupedObservable<Boolean, Integer>, Observable<String>>() {
 
@@ -1329,9 +1329,9 @@ public class ObservableGroupByTest {
                 });
             }
 
-        }).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+        }).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
     }
 
     static Function<GroupedObservable<Integer, Integer>, Observable<Integer>> FLATTEN_INTEGER = new Function<GroupedObservable<Integer, Integer>, Observable<Integer>>() {
@@ -1382,7 +1382,7 @@ public class ObservableGroupByTest {
                     }
                 }
         );
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
         o.groupBy(new Function<Integer, Integer>() {
 
@@ -1390,9 +1390,9 @@ public class ObservableGroupByTest {
             public Integer apply(Integer integer) {
                 return null;
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.dispose();
+        to.dispose();
 
         verify(s).dispose();
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableIgnoreElementsTest.java
@@ -57,26 +57,26 @@ public class ObservableIgnoreElementsTest {
 
     @Test
     public void testCompletedOkObservable() {
-        TestObserver<Object> ts = new TestObserver<Object>();
-        Observable.range(1, 10).ignoreElements().toObservable().subscribe(ts);
-        ts.assertNoErrors();
-        ts.assertNoValues();
-        ts.assertTerminated();
+        TestObserver<Object> to = new TestObserver<Object>();
+        Observable.range(1, 10).ignoreElements().toObservable().subscribe(to);
+        to.assertNoErrors();
+        to.assertNoValues();
+        to.assertTerminated();
         // FIXME no longer testable
 //        ts.assertUnsubscribed();
     }
 
     @Test
     public void testErrorReceivedObservable() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
         TestException ex = new TestException("boo");
-        Observable.error(ex).ignoreElements().toObservable().subscribe(ts);
-        ts.assertNoValues();
-        ts.assertTerminated();
+        Observable.error(ex).ignoreElements().toObservable().subscribe(to);
+        to.assertNoValues();
+        to.assertTerminated();
         // FIXME no longer testable
 //        ts.assertUnsubscribed();
-        ts.assertError(TestException.class);
-        ts.assertErrorMessage("boo");
+        to.assertError(TestException.class);
+        to.assertErrorMessage("boo");
     }
 
     @Test
@@ -124,26 +124,26 @@ public class ObservableIgnoreElementsTest {
 
     @Test
     public void testCompletedOk() {
-        TestObserver<Object> ts = new TestObserver<Object>();
-        Observable.range(1, 10).ignoreElements().subscribe(ts);
-        ts.assertNoErrors();
-        ts.assertNoValues();
-        ts.assertTerminated();
+        TestObserver<Object> to = new TestObserver<Object>();
+        Observable.range(1, 10).ignoreElements().subscribe(to);
+        to.assertNoErrors();
+        to.assertNoValues();
+        to.assertTerminated();
         // FIXME no longer testable
 //        ts.assertUnsubscribed();
     }
 
     @Test
     public void testErrorReceived() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
         TestException ex = new TestException("boo");
-        Observable.error(ex).ignoreElements().subscribe(ts);
-        ts.assertNoValues();
-        ts.assertTerminated();
+        Observable.error(ex).ignoreElements().subscribe(to);
+        to.assertNoValues();
+        to.assertTerminated();
         // FIXME no longer testable
 //        ts.assertUnsubscribed();
-        ts.assertError(TestException.class);
-        ts.assertErrorMessage("boo");
+        to.assertError(TestException.class);
+        to.assertErrorMessage("boo");
     }
 
     @Test
@@ -164,17 +164,17 @@ public class ObservableIgnoreElementsTest {
     @Test
     public void cancel() {
 
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = pp.ignoreElements().<Integer>toObservable().test();
+        TestObserver<Integer> to = ps.ignoreElements().<Integer>toObservable().test();
 
-        assertTrue(pp.hasObservers());
+        assertTrue(ps.hasObservers());
 
-        ts.cancel();
+        to.cancel();
 
-        assertFalse(pp.hasObservers());
+        assertFalse(ps.hasObservers());
 
-        TestHelper.checkDisposed(pp.ignoreElements().<Integer>toObservable());
+        TestHelper.checkDisposed(ps.ignoreElements().<Integer>toObservable());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableIntervalTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableIntervalTest.java
@@ -39,14 +39,14 @@ public class ObservableIntervalTest {
 
     @Test
     public void cancelledOnRun() {
-        TestObserver<Long> ts = new TestObserver<Long>();
-        IntervalObserver is = new IntervalObserver(ts);
-        ts.onSubscribe(is);
+        TestObserver<Long> to = new TestObserver<Long>();
+        IntervalObserver is = new IntervalObserver(to);
+        to.onSubscribe(is);
 
         is.dispose();
 
         is.run();
 
-        ts.assertEmpty();
+        to.assertEmpty();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMapNotificationTest.java
@@ -28,7 +28,7 @@ import io.reactivex.observers.TestObserver;
 public class ObservableMapNotificationTest {
     @Test
     public void testJust() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
         Observable.just(1)
         .flatMap(
                 new Function<Integer, Observable<Object>>() {
@@ -49,11 +49,11 @@ public class ObservableMapNotificationTest {
                         return Observable.never();
                     }
                 }
-        ).subscribe(ts);
+        ).subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertNotComplete();
-        ts.assertValue(2);
+        to.assertNoErrors();
+        to.assertNotComplete();
+        to.assertValue(2);
     }
 
     @Test
@@ -89,7 +89,7 @@ public class ObservableMapNotificationTest {
 
     @Test
     public void onErrorCrash() {
-        TestObserver<Integer> ts = Observable.<Integer>error(new TestException("Outer"))
+        TestObserver<Integer> to = Observable.<Integer>error(new TestException("Outer"))
         .flatMap(Functions.justFunction(Observable.just(1)),
                 new Function<Throwable, Observable<Integer>>() {
                     @Override
@@ -101,7 +101,7 @@ public class ObservableMapNotificationTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        TestHelper.assertError(ts, 0, TestException.class, "Outer");
-        TestHelper.assertError(ts, 1, TestException.class, "Inner");
+        TestHelper.assertError(to, 0, TestException.class, "Outer");
+        TestHelper.assertError(to, 1, TestException.class, "Inner");
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMapTest.java
@@ -13,7 +13,8 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -25,7 +26,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.UnicastSubject;
@@ -349,19 +350,19 @@ public class ObservableMapTest {
 
     @Test
     public void fusedSync() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         Observable.range(1, 5)
         .map(Functions.<Integer>identity())
         .subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.SYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void fusedAsync() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         UnicastSubject<Integer> us = UnicastSubject.create();
 
@@ -371,19 +372,19 @@ public class ObservableMapTest {
 
         TestHelper.emit(us, 1, 2, 3, 4, 5);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.ASYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void fusedReject() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY | QueueDisposable.BOUNDARY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
 
         Observable.range(1, 5)
         .map(Functions.<Integer>identity())
         .subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMaterializeTest.java
@@ -101,17 +101,17 @@ public class ObservableMaterializeTest {
 
     @Test
     public void testWithCompletionCausingError() {
-        TestObserver<Notification<Integer>> ts = new TestObserver<Notification<Integer>>();
+        TestObserver<Notification<Integer>> to = new TestObserver<Notification<Integer>>();
         final RuntimeException ex = new RuntimeException("boo");
         Observable.<Integer>empty().materialize().doOnNext(new Consumer<Object>() {
             @Override
             public void accept(Object t) {
                 throw ex;
             }
-        }).subscribe(ts);
-        ts.assertError(ex);
-        ts.assertNoValues();
-        ts.assertTerminated();
+        }).subscribe(to);
+        to.assertError(ex);
+        to.assertNoValues();
+        to.assertTerminated();
     }
 
     private static class TestLocalObserver extends DefaultObserver<Notification<String>> {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -487,15 +487,15 @@ public class ObservableMergeDelayErrorTest {
 
     @Test
     public void testErrorInParentObservable() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.mergeDelayError(
                 Observable.just(Observable.just(1), Observable.just(2))
                         .startWith(Observable.<Integer> error(new RuntimeException()))
-                ).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertTerminated();
-        ts.assertValues(1, 2);
-        assertEquals(1, ts.errorCount());
+                ).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertTerminated();
+        to.assertValues(1, 2);
+        assertEquals(1, to.errorCount());
 
     }
 
@@ -516,12 +516,12 @@ public class ObservableMergeDelayErrorTest {
 
             Observer<String> stringObserver = TestHelper.mockObserver();
 
-            TestObserver<String> ts = new TestObserver<String>(stringObserver);
+            TestObserver<String> to = new TestObserver<String>(stringObserver);
             Observable<String> m = Observable.mergeDelayError(parentObservable);
-            m.subscribe(ts);
+            m.subscribe(to);
             System.out.println("testErrorInParentObservableDelayed | " + i);
-            ts.awaitTerminalEvent(2000, TimeUnit.MILLISECONDS);
-            ts.assertTerminated();
+            to.awaitTerminalEvent(2000, TimeUnit.MILLISECONDS);
+            to.assertTerminated();
 
             verify(stringObserver, times(2)).onNext("hello");
             verify(stringObserver, times(1)).onError(any(NullPointerException.class));

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
@@ -156,7 +156,7 @@ public class ObservableMergeMaxConcurrentTest {
     @Test
     public void testSimple() {
         for (int i = 1; i < 100; i++) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
             List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(i);
             List<Integer> result = new ArrayList<Integer>(i);
             for (int j = 1; j <= i; j++) {
@@ -164,17 +164,17 @@ public class ObservableMergeMaxConcurrentTest {
                 result.add(j);
             }
 
-            Observable.merge(sourceList, i).subscribe(ts);
+            Observable.merge(sourceList, i).subscribe(to);
 
-            ts.assertNoErrors();
-            ts.assertTerminated();
-            ts.assertValueSequence(result);
+            to.assertNoErrors();
+            to.assertTerminated();
+            to.assertValueSequence(result);
         }
     }
     @Test
     public void testSimpleOneLess() {
         for (int i = 2; i < 100; i++) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
             List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(i);
             List<Integer> result = new ArrayList<Integer>(i);
             for (int j = 1; j <= i; j++) {
@@ -182,11 +182,11 @@ public class ObservableMergeMaxConcurrentTest {
                 result.add(j);
             }
 
-            Observable.merge(sourceList, i - 1).subscribe(ts);
+            Observable.merge(sourceList, i - 1).subscribe(to);
 
-            ts.assertNoErrors();
-            ts.assertTerminated();
-            ts.assertValueSequence(result);
+            to.assertNoErrors();
+            to.assertTerminated();
+            to.assertValueSequence(result);
         }
     }
     @Test//(timeout = 20000)
@@ -204,7 +204,7 @@ public class ObservableMergeMaxConcurrentTest {
     @Test(timeout = 30000)
     public void testSimpleAsync() {
         for (int i = 1; i < 50; i++) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
             List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(i);
             Set<Integer> expected = new HashSet<Integer>(i);
             for (int j = 1; j <= i; j++) {
@@ -212,11 +212,11 @@ public class ObservableMergeMaxConcurrentTest {
                 expected.add(j);
             }
 
-            Observable.merge(sourceList, i).subscribe(ts);
+            Observable.merge(sourceList, i).subscribe(to);
 
-            ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
-            ts.assertNoErrors();
-            Set<Integer> actual = new HashSet<Integer>(ts.values());
+            to.awaitTerminalEvent(1, TimeUnit.SECONDS);
+            to.assertNoErrors();
+            Set<Integer> actual = new HashSet<Integer>(to.values());
 
             assertEquals(expected, actual);
         }
@@ -234,7 +234,7 @@ public class ObservableMergeMaxConcurrentTest {
             if (System.currentTimeMillis() - t > TimeUnit.SECONDS.toMillis(9)) {
                 break;
             }
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
             List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(i);
             Set<Integer> expected = new HashSet<Integer>(i);
             for (int j = 1; j <= i; j++) {
@@ -242,11 +242,11 @@ public class ObservableMergeMaxConcurrentTest {
                 expected.add(j);
             }
 
-            Observable.merge(sourceList, i - 1).subscribe(ts);
+            Observable.merge(sourceList, i - 1).subscribe(to);
 
-            ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
-            ts.assertNoErrors();
-            Set<Integer> actual = new HashSet<Integer>(ts.values());
+            to.awaitTerminalEvent(1, TimeUnit.SECONDS);
+            to.assertNoErrors();
+            Set<Integer> actual = new HashSet<Integer>(to.values());
 
             assertEquals(expected, actual);
         }
@@ -260,12 +260,12 @@ public class ObservableMergeMaxConcurrentTest {
         sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
         sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        Observable.merge(sourceList, 2).take(5).subscribe(ts);
+        Observable.merge(sourceList, 2).take(5).subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        ts.assertValueCount(5);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        to.assertValueCount(5);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
@@ -189,11 +189,11 @@ public class ObservableMergeTest {
         final TestASynchronousObservable o2 = new TestASynchronousObservable();
 
         Observable<String> m = Observable.merge(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
-        TestObserver<String> ts = new TestObserver<String>(stringObserver);
-        m.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>(stringObserver);
+        m.subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
 
         verify(stringObserver, never()).onError(any(Throwable.class));
         verify(stringObserver, times(2)).onNext("hello");
@@ -339,7 +339,7 @@ public class ObservableMergeTest {
     @Test
     @Ignore("Subscribe should not throw")
     public void testThrownErrorHandling() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
         Observable<String> o1 = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
@@ -349,10 +349,10 @@ public class ObservableMergeTest {
 
         });
 
-        Observable.merge(o1, o1).subscribe(ts);
-        ts.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
-        ts.assertTerminated();
-        System.out.println("Error: " + ts.errors());
+        Observable.merge(o1, o1).subscribe(to);
+        to.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
+        to.assertTerminated();
+        System.out.println("Error: " + to.errors());
     }
 
     private static class TestSynchronousObservable implements ObservableSource<String> {
@@ -425,16 +425,16 @@ public class ObservableMergeTest {
         AtomicBoolean os2 = new AtomicBoolean(false);
         Observable<Long> o2 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
-        TestObserver<Long> ts = new TestObserver<Long>();
-        Observable.merge(o1, o2).subscribe(ts);
+        TestObserver<Long> to = new TestObserver<Long>();
+        Observable.merge(o1, o2).subscribe(to);
 
         // we haven't incremented time so nothing should be received yet
-        ts.assertNoValues();
+        to.assertNoValues();
 
         scheduler1.advanceTimeBy(3, TimeUnit.SECONDS);
         scheduler2.advanceTimeBy(2, TimeUnit.SECONDS);
 
-        ts.assertValues(0L, 1L, 2L, 0L, 1L);
+        to.assertValues(0L, 1L, 2L, 0L, 1L);
         // not unsubscribed yet
         assertFalse(os1.get());
         assertFalse(os2.get());
@@ -442,18 +442,18 @@ public class ObservableMergeTest {
         // advance to the end at which point it should complete
         scheduler1.advanceTimeBy(3, TimeUnit.SECONDS);
 
-        ts.assertValues(0L, 1L, 2L, 0L, 1L, 3L, 4L);
+        to.assertValues(0L, 1L, 2L, 0L, 1L, 3L, 4L);
         assertTrue(os1.get());
         assertFalse(os2.get());
 
         // both should be completed now
         scheduler2.advanceTimeBy(3, TimeUnit.SECONDS);
 
-        ts.assertValues(0L, 1L, 2L, 0L, 1L, 3L, 4L, 2L, 3L, 4L);
+        to.assertValues(0L, 1L, 2L, 0L, 1L, 3L, 4L, 2L, 3L, 4L);
         assertTrue(os1.get());
         assertTrue(os2.get());
 
-        ts.assertTerminated();
+        to.assertTerminated();
     }
 
     @Test
@@ -467,27 +467,27 @@ public class ObservableMergeTest {
             AtomicBoolean os2 = new AtomicBoolean(false);
             Observable<Long> o2 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
-            TestObserver<Long> ts = new TestObserver<Long>();
-            Observable.merge(o1, o2).subscribe(ts);
+            TestObserver<Long> to = new TestObserver<Long>();
+            Observable.merge(o1, o2).subscribe(to);
 
             // we haven't incremented time so nothing should be received yet
-            ts.assertNoValues();
+            to.assertNoValues();
 
             scheduler1.advanceTimeBy(3, TimeUnit.SECONDS);
             scheduler2.advanceTimeBy(2, TimeUnit.SECONDS);
 
-            ts.assertValues(0L, 1L, 2L, 0L, 1L);
+            to.assertValues(0L, 1L, 2L, 0L, 1L);
             // not unsubscribed yet
             assertFalse(os1.get());
             assertFalse(os2.get());
 
             // early unsubscribe
-            ts.dispose();
+            to.dispose();
 
             assertTrue(os1.get());
             assertTrue(os2.get());
 
-            ts.assertValues(0L, 1L, 2L, 0L, 1L);
+            to.assertValues(0L, 1L, 2L, 0L, 1L);
             // FIXME not happening anymore
 //            ts.assertUnsubscribed();
         }
@@ -540,14 +540,14 @@ public class ObservableMergeTest {
 
         for (int i = 0; i < 10; i++) {
             Observable<Integer> merge = Observable.merge(o, o, o);
-            TestObserver<Integer> ts = new TestObserver<Integer>();
-            merge.subscribe(ts);
+            TestObserver<Integer> to = new TestObserver<Integer>();
+            merge.subscribe(to);
 
-            ts.awaitTerminalEvent(3, TimeUnit.SECONDS);
-            ts.assertTerminated();
-            ts.assertNoErrors();
-            ts.assertComplete();
-            List<Integer> onNextEvents = ts.values();
+            to.awaitTerminalEvent(3, TimeUnit.SECONDS);
+            to.assertTerminated();
+            to.assertNoErrors();
+            to.assertComplete();
+            List<Integer> onNextEvents = to.values();
             assertEquals(30000, onNextEvents.size());
             //            System.out.println("onNext: " + onNextEvents.size() + " onComplete: " + ts.getOnCompletedEvents().size());
         }
@@ -593,12 +593,12 @@ public class ObservableMergeTest {
 
         for (int i = 0; i < 10; i++) {
             Observable<Integer> merge = Observable.merge(o, o, o);
-            TestObserver<Integer> ts = new TestObserver<Integer>();
-            merge.subscribe(ts);
+            TestObserver<Integer> to = new TestObserver<Integer>();
+            merge.subscribe(to);
 
-            ts.awaitTerminalEvent();
-            ts.assertComplete();
-            List<Integer> onNextEvents = ts.values();
+            to.awaitTerminalEvent();
+            to.assertComplete();
+            List<Integer> onNextEvents = to.values();
             assertEquals(300, onNextEvents.size());
             //            System.out.println("onNext: " + onNextEvents.size() + " onComplete: " + ts.getOnCompletedEvents().size());
         }
@@ -640,13 +640,13 @@ public class ObservableMergeTest {
 
         for (int i = 0; i < 10; i++) {
             Observable<Integer> merge = Observable.merge(o, o, o);
-            TestObserver<Integer> ts = new TestObserver<Integer>();
-            merge.subscribe(ts);
+            TestObserver<Integer> to = new TestObserver<Integer>();
+            merge.subscribe(to);
 
-            ts.awaitTerminalEvent();
-            ts.assertNoErrors();
-            ts.assertComplete();
-            List<Integer> onNextEvents = ts.values();
+            to.awaitTerminalEvent();
+            to.assertNoErrors();
+            to.assertComplete();
+            List<Integer> onNextEvents = to.values();
             assertEquals(30000, onNextEvents.size());
             //                System.out.println("onNext: " + onNextEvents.size() + " onComplete: " + ts.getOnCompletedEvents().size());
         }
@@ -825,18 +825,18 @@ public class ObservableMergeTest {
     @Ignore("Null values not permitted")
     public void mergeWithNullValues() {
         System.out.println("mergeWithNullValues");
-        TestObserver<String> ts = new TestObserver<String>();
-        Observable.merge(Observable.just(null, "one"), Observable.just("two", null)).subscribe(ts);
-        ts.assertTerminated();
-        ts.assertNoErrors();
-        ts.assertValues(null, "one", "two", null);
+        TestObserver<String> to = new TestObserver<String>();
+        Observable.merge(Observable.just(null, "one"), Observable.just("two", null)).subscribe(to);
+        to.assertTerminated();
+        to.assertNoErrors();
+        to.assertValues(null, "one", "two", null);
     }
 
     @Test
     @Ignore("Null values are no longer permitted")
     public void mergeWithTerminalEventAfterUnsubscribe() {
         System.out.println("mergeWithTerminalEventAfterUnsubscribe");
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
         Observable<String> bad = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
@@ -848,72 +848,72 @@ public class ObservableMergeTest {
             }
 
         });
-        Observable.merge(Observable.just(null, "one"), bad).subscribe(ts);
-        ts.assertNoErrors();
-        ts.assertValues(null, "one", "two");
+        Observable.merge(Observable.just(null, "one"), bad).subscribe(to);
+        to.assertNoErrors();
+        to.assertValues(null, "one", "two");
     }
 
     @Test
     @Ignore("Null values are not permitted")
     public void mergingNullObservable() {
-        TestObserver<String> ts = new TestObserver<String>();
-        Observable.merge(Observable.just("one"), null).subscribe(ts);
-        ts.assertNoErrors();
-        ts.assertValue("one");
+        TestObserver<String> to = new TestObserver<String>();
+        Observable.merge(Observable.just("one"), null).subscribe(to);
+        to.assertNoErrors();
+        to.assertValue("one");
     }
 
     @Test
     public void merge1AsyncStreamOf1() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        mergeNAsyncStreamsOfN(1, 1).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(1, ts.values().size());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        mergeNAsyncStreamsOfN(1, 1).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(1, to.values().size());
     }
 
     @Test
     public void merge1AsyncStreamOf1000() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        mergeNAsyncStreamsOfN(1, 1000).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(1000, ts.values().size());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        mergeNAsyncStreamsOfN(1, 1000).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(1000, to.values().size());
     }
 
     @Test
     public void merge10AsyncStreamOf1000() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        mergeNAsyncStreamsOfN(10, 1000).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(10000, ts.values().size());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        mergeNAsyncStreamsOfN(10, 1000).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(10000, to.values().size());
     }
 
     @Test
     public void merge1000AsyncStreamOf1000() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        mergeNAsyncStreamsOfN(1000, 1000).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(1000000, ts.values().size());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        mergeNAsyncStreamsOfN(1000, 1000).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(1000000, to.values().size());
     }
 
     @Test
     public void merge2000AsyncStreamOf100() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        mergeNAsyncStreamsOfN(2000, 100).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(200000, ts.values().size());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        mergeNAsyncStreamsOfN(2000, 100).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(200000, to.values().size());
     }
 
     @Test
     public void merge100AsyncStreamOf1() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        mergeNAsyncStreamsOfN(100, 1).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(100, ts.values().size());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        mergeNAsyncStreamsOfN(100, 1).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(100, to.values().size());
     }
 
     private Observable<Integer> mergeNAsyncStreamsOfN(final int outerSize, final int innerSize) {
@@ -931,47 +931,47 @@ public class ObservableMergeTest {
 
     @Test
     public void merge1SyncStreamOf1() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        mergeNSyncStreamsOfN(1, 1).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(1, ts.values().size());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        mergeNSyncStreamsOfN(1, 1).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(1, to.values().size());
     }
 
     @Test
     public void merge1SyncStreamOf1000000() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        mergeNSyncStreamsOfN(1, 1000000).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(1000000, ts.values().size());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        mergeNSyncStreamsOfN(1, 1000000).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(1000000, to.values().size());
     }
 
     @Test
     public void merge1000SyncStreamOf1000() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        mergeNSyncStreamsOfN(1000, 1000).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(1000000, ts.values().size());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        mergeNSyncStreamsOfN(1000, 1000).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(1000000, to.values().size());
     }
 
     @Test
     public void merge10000SyncStreamOf10() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        mergeNSyncStreamsOfN(10000, 10).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(100000, ts.values().size());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        mergeNSyncStreamsOfN(10000, 10).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(100000, to.values().size());
     }
 
     @Test
     public void merge1000000SyncStreamOf1() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        mergeNSyncStreamsOfN(1000000, 1).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(1000000, ts.values().size());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        mergeNSyncStreamsOfN(1000000, 1).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(1000000, to.values().size());
     }
 
     private Observable<Integer> mergeNSyncStreamsOfN(final int outerSize, final int innerSize) {
@@ -1014,7 +1014,7 @@ public class ObservableMergeTest {
 
     @Test
     public void mergeManyAsyncSingle() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable<Observable<Integer>> os = Observable.range(1, 10000)
         .map(new Function<Integer, Observable<Integer>>() {
 
@@ -1040,10 +1040,10 @@ public class ObservableMergeTest {
             }
 
         });
-        Observable.merge(os).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(10000, ts.values().size());
+        Observable.merge(os).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(10000, to.values().size());
     }
 
     Function<Integer, Observable<Integer>> toScalar = new Function<Integer, Observable<Integer>>() {
@@ -1061,21 +1061,21 @@ public class ObservableMergeTest {
     };
     ;
 
-    void runMerge(Function<Integer, Observable<Integer>> func, TestObserver<Integer> ts) {
+    void runMerge(Function<Integer, Observable<Integer>> func, TestObserver<Integer> to) {
         List<Integer> list = new ArrayList<Integer>();
         for (int i = 0; i < 1000; i++) {
             list.add(i);
         }
         Observable<Integer> source = Observable.fromIterable(list);
-        source.flatMap(func).subscribe(ts);
+        source.flatMap(func).subscribe(to);
 
-        if (ts.values().size() != 1000) {
-            System.out.println(ts.values());
+        if (to.values().size() != 1000) {
+            System.out.println(to.values());
         }
 
-        ts.assertTerminated();
-        ts.assertNoErrors();
-        ts.assertValueSequence(list);
+        to.assertTerminated();
+        to.assertNoErrors();
+        to.assertValueSequence(list);
     }
 
     @Test
@@ -1089,7 +1089,7 @@ public class ObservableMergeTest {
     @Test
     public void testSlowMergeFullScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
-            TestObserver<Integer> ts = new TestObserver<Integer>() {
+            TestObserver<Integer> to = new TestObserver<Integer>() {
                 int remaining = req;
 
                 @Override
@@ -1100,13 +1100,13 @@ public class ObservableMergeTest {
                     }
                 }
             };
-            runMerge(toScalar, ts);
+            runMerge(toScalar, to);
         }
     }
     @Test
     public void testSlowMergeHiddenScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
-            TestObserver<Integer> ts = new TestObserver<Integer>() {
+            TestObserver<Integer> to = new TestObserver<Integer>() {
                 int remaining = req;
                 @Override
                 public void onNext(Integer t) {
@@ -1116,7 +1116,7 @@ public class ObservableMergeTest {
                     }
                 }
             };
-            runMerge(toHiddenScalar, ts);
+            runMerge(toHiddenScalar, to);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
@@ -64,13 +64,13 @@ public class ObservableObserveOnTest {
         Observer<String> observer = TestHelper.mockObserver();
 
         InOrder inOrder = inOrder(observer);
-        TestObserver<String> ts = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<String>(observer);
 
-        obs.observeOn(Schedulers.computation()).subscribe(ts);
+        obs.observeOn(Schedulers.computation()).subscribe(to);
 
-        ts.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
-        if (ts.errors().size() > 0) {
-            for (Throwable t : ts.errors()) {
+        to.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
+        if (to.errors().size() > 0) {
+            for (Throwable t : to.errors()) {
                 t.printStackTrace();
             }
             fail("failed with exception");
@@ -388,13 +388,13 @@ public class ObservableObserveOnTest {
         final TestScheduler testScheduler = new TestScheduler();
 
         final Observer<Integer> observer = TestHelper.mockObserver();
-        TestObserver<Integer> ts = new TestObserver<Integer>(observer);
+        TestObserver<Integer> to = new TestObserver<Integer>(observer);
 
         Observable.just(1, 2, 3)
                 .observeOn(testScheduler)
-                .subscribe(ts);
+                .subscribe(to);
 
-        ts.dispose();
+        to.dispose();
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
         final InOrder inOrder = inOrder(observer);
@@ -429,23 +429,23 @@ public class ObservableObserveOnTest {
             }
         });
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         o
                 .take(7)
                 .observeOn(Schedulers.newThread())
-                .subscribe(ts);
+                .subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertValues(0, 1, 2, 3, 4, 5, 6);
+        to.awaitTerminalEvent();
+        to.assertValues(0, 1, 2, 3, 4, 5, 6);
         assertEquals(7, generated.get());
     }
 
     @Test
     public void testAsyncChild() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        Observable.range(0, 100000).observeOn(Schedulers.newThread()).observeOn(Schedulers.newThread()).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Observable.range(0, 100000).observeOn(Schedulers.newThread()).observeOn(Schedulers.newThread()).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
     }
 
     @Test
@@ -566,33 +566,33 @@ public class ObservableObserveOnTest {
 
     @Test
     public void outputFused() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         Observable.range(1, 5).hide()
         .observeOn(Schedulers.single())
         .subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.ASYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.ASYNC)
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void outputFusedReject() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.SYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.SYNC);
 
         Observable.range(1, 5).hide()
         .observeOn(Schedulers.single())
         .subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void inputOutputAsyncFusedError() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         UnicastSubject<Integer> us = UnicastSubject.create();
 
@@ -605,14 +605,14 @@ public class ObservableObserveOnTest {
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.ASYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.ASYNC)
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
     }
 
     @Test
     public void inputOutputAsyncFusedErrorDelayed() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         UnicastSubject<Integer> us = UnicastSubject.create();
 
@@ -625,7 +625,7 @@ public class ObservableObserveOnTest {
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.ASYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.ASYNC)
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
     }
@@ -643,7 +643,7 @@ public class ObservableObserveOnTest {
             @Override
             public void onSubscribe(Disposable d) {
                 this.d = d;
-                ((QueueDisposable<?>)d).requestFusion(QueueDisposable.ANY);
+                ((QueueDisposable<?>)d).requestFusion(QueueFuseable.ANY);
             }
 
             @Override

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaFunctionTest.java
@@ -151,7 +151,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
     @Test
     @Ignore("Failed operator may leave the child Observer in an inconsistent state which prevents further error delivery.")
     public void testOnErrorResumeReceivesErrorFromPreviousNonProtectedOperator() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
         Observable.just(1).lift(new ObservableOperator<String, Integer>() {
 
             @Override
@@ -170,11 +170,11 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
                 }
             }
 
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertTerminated();
-        System.out.println(ts.values());
-        ts.assertValue("success");
+        to.assertTerminated();
+        System.out.println(to.values());
+        to.assertValue("success");
     }
 
     /**
@@ -184,7 +184,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
     @Test
     @Ignore("A crashing operator may leave the downstream in an inconsistent state and not suitable for event delivery")
     public void testOnErrorResumeReceivesErrorFromPreviousNonProtectedOperatorOnNext() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
         Observable.just(1).lift(new ObservableOperator<String, Integer>() {
 
             @Override
@@ -225,11 +225,11 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
                 }
             }
 
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertTerminated();
-        System.out.println(ts.values());
-        ts.assertValue("success");
+        to.assertTerminated();
+        System.out.println(to.values());
+        to.assertValue("success");
     }
 
     @Test
@@ -262,9 +262,9 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
         @SuppressWarnings("unchecked")
         DefaultObserver<String> observer = mock(DefaultObserver.class);
 
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        o.subscribe(ts);
-        ts.awaitTerminalEvent();
+        TestObserver<String> to = new TestObserver<String>(observer);
+        o.subscribe(to);
+        to.awaitTerminalEvent();
 
         verify(observer, Mockito.never()).onError(any(Throwable.class));
         verify(observer, times(1)).onComplete();
@@ -314,7 +314,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
 
     @Test
     public void testBackpressure() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(0, 100000)
                 .onErrorResumeNext(new Function<Throwable, Observable<Integer>>() {
 
@@ -342,9 +342,9 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
                     }
 
                 })
-                .subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+                .subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaObservableTest.java
@@ -135,10 +135,10 @@ public class ObservableOnErrorResumeNextViaObservableTest {
 
         @SuppressWarnings("unchecked")
         DefaultObserver<String> observer = mock(DefaultObserver.class);
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        observable.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>(observer);
+        observable.subscribe(to);
 
-        ts.awaitTerminalEvent();
+        to.awaitTerminalEvent();
 
         verify(observer, Mockito.never()).onError(any(Throwable.class));
         verify(observer, times(1)).onComplete();
@@ -190,7 +190,7 @@ public class ObservableOnErrorResumeNextViaObservableTest {
 
     @Test
     public void testBackpressure() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(0, 100000)
                 .onErrorResumeNext(Observable.just(1))
                 .observeOn(Schedulers.computation())
@@ -211,8 +211,8 @@ public class ObservableOnErrorResumeNextViaObservableTest {
                     }
 
                 })
-                .subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+                .subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
@@ -130,9 +130,9 @@ public class ObservableOnErrorReturnTest {
 
         @SuppressWarnings("unchecked")
         DefaultObserver<String> observer = mock(DefaultObserver.class);
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        observable.subscribe(ts);
-        ts.awaitTerminalEvent();
+        TestObserver<String> to = new TestObserver<String>(observer);
+        observable.subscribe(to);
+        to.awaitTerminalEvent();
 
         verify(observer, Mockito.never()).onError(any(Throwable.class));
         verify(observer, times(1)).onComplete();
@@ -144,7 +144,7 @@ public class ObservableOnErrorReturnTest {
 
     @Test
     public void testBackpressure() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(0, 100000)
                 .onErrorReturn(new Function<Throwable, Integer>() {
 
@@ -172,9 +172,9 @@ public class ObservableOnErrorReturnTest {
                     }
 
                 })
-                .subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+                .subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
     }
 
     private static class TestObservable implements ObservableSource<String> {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnExceptionResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnExceptionResumeNextViaObservableTest.java
@@ -186,7 +186,7 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
 
     @Test
     public void testBackpressure() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(0, 100000)
                 .onExceptionResumeNext(Observable.just(1))
                 .observeOn(Schedulers.computation())
@@ -207,9 +207,9 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
                     }
 
                 })
-                .subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+                .subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
     }
 
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -125,12 +125,12 @@ public class ObservablePublishTest {
 
         });
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        Observable.merge(fast, slow).subscribe(ts);
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Observable.merge(fast, slow).subscribe(to);
         is.connect();
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(Flowable.bufferSize() * 4, ts.valueCount());
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(Flowable.bufferSize() * 4, to.valueCount());
     }
 
     // use case from https://github.com/ReactiveX/RxJava/issues/1732
@@ -145,7 +145,7 @@ public class ObservablePublishTest {
             }
 
         });
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         xs.publish(new Function<Observable<Integer>, Observable<Integer>>() {
 
             @Override
@@ -160,19 +160,19 @@ public class ObservablePublishTest {
                 }));
             }
 
-        }).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        ts.assertValues(0, 1, 2, 3);
+        }).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        to.assertValues(0, 1, 2, 3);
         assertEquals(5, emitted.get());
-        System.out.println(ts.values());
+        System.out.println(to.values());
     }
 
     // use case from https://github.com/ReactiveX/RxJava/issues/1732
     @Test
     public void testTakeUntilWithPublishedStream() {
         Observable<Integer> xs = Observable.range(0, Flowable.bufferSize() * 2);
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         ConnectableObservable<Integer> xsp = xs.publish();
         xsp.takeUntil(xsp.skipWhile(new Predicate<Integer>() {
 
@@ -181,9 +181,9 @@ public class ObservablePublishTest {
                 return i <= 3;
             }
 
-        })).subscribe(ts);
+        })).subscribe(to);
         xsp.connect();
-        System.out.println(ts.values());
+        System.out.println(to.values());
     }
 
     @Test(timeout = 10000)
@@ -208,9 +208,9 @@ public class ObservablePublishTest {
         final AtomicBoolean child1Unsubscribed = new AtomicBoolean();
         final AtomicBoolean child2Unsubscribed = new AtomicBoolean();
 
-        final TestObserver<Integer> ts2 = new TestObserver<Integer>();
+        final TestObserver<Integer> to2 = new TestObserver<Integer>();
 
-        final TestObserver<Integer> ts1 = new TestObserver<Integer>() {
+        final TestObserver<Integer> to1 = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
                 if (valueCount() == 2) {
@@ -219,7 +219,7 @@ public class ObservablePublishTest {
                         public void run() {
                             child2Unsubscribed.set(true);
                         }
-                    }).take(5).subscribe(ts2);
+                    }).take(5).subscribe(to2);
                 }
                 super.onNext(t);
             }
@@ -231,20 +231,20 @@ public class ObservablePublishTest {
                 child1Unsubscribed.set(true);
             }
         }).take(5)
-        .subscribe(ts1);
+        .subscribe(to1);
 
-        ts1.awaitTerminalEvent();
-        ts2.awaitTerminalEvent();
+        to1.awaitTerminalEvent();
+        to2.awaitTerminalEvent();
 
-        ts1.assertNoErrors();
-        ts2.assertNoErrors();
+        to1.assertNoErrors();
+        to2.assertNoErrors();
 
         assertTrue(sourceUnsubscribed.get());
         assertTrue(child1Unsubscribed.get());
         assertTrue(child2Unsubscribed.get());
 
-        ts1.assertValues(1, 2, 3, 4, 5);
-        ts2.assertValues(4, 5, 6, 7, 8);
+        to1.assertValues(1, 2, 3, 4, 5);
+        to2.assertValues(4, 5, 6, 7, 8);
 
         assertEquals(8, sourceEmission.get());
     }
@@ -269,25 +269,25 @@ public class ObservablePublishTest {
     public void testSubscribeAfterDisconnectThenConnect() {
         ConnectableObservable<Integer> source = Observable.just(1).publish();
 
-        TestObserver<Integer> ts1 = new TestObserver<Integer>();
+        TestObserver<Integer> to1 = new TestObserver<Integer>();
 
-        source.subscribe(ts1);
+        source.subscribe(to1);
 
         Disposable s = source.connect();
 
-        ts1.assertValue(1);
-        ts1.assertNoErrors();
-        ts1.assertTerminated();
+        to1.assertValue(1);
+        to1.assertNoErrors();
+        to1.assertTerminated();
 
-        TestObserver<Integer> ts2 = new TestObserver<Integer>();
+        TestObserver<Integer> to2 = new TestObserver<Integer>();
 
-        source.subscribe(ts2);
+        source.subscribe(to2);
 
         Disposable s2 = source.connect();
 
-        ts2.assertValue(1);
-        ts2.assertNoErrors();
-        ts2.assertTerminated();
+        to2.assertValue(1);
+        to2.assertNoErrors();
+        to2.assertTerminated();
 
         System.out.println(s);
         System.out.println(s2);
@@ -297,19 +297,19 @@ public class ObservablePublishTest {
     public void testNoSubscriberRetentionOnCompleted() {
         ObservablePublish<Integer> source = (ObservablePublish<Integer>)Observable.just(1).publish();
 
-        TestObserver<Integer> ts1 = new TestObserver<Integer>();
+        TestObserver<Integer> to1 = new TestObserver<Integer>();
 
-        source.subscribe(ts1);
+        source.subscribe(to1);
 
-        ts1.assertNoValues();
-        ts1.assertNoErrors();
-        ts1.assertNotComplete();
+        to1.assertNoValues();
+        to1.assertNoErrors();
+        to1.assertNotComplete();
 
         source.connect();
 
-        ts1.assertValue(1);
-        ts1.assertNoErrors();
-        ts1.assertTerminated();
+        to1.assertValue(1);
+        to1.assertNoErrors();
+        to1.assertTerminated();
 
         assertNull(source.current.get());
     }
@@ -378,20 +378,20 @@ public class ObservablePublishTest {
         Observable<Integer> obs = co.observeOn(Schedulers.computation());
         for (int i = 0; i < 1000; i++) {
             for (int j = 1; j < 6; j++) {
-                List<TestObserver<Integer>> tss = new ArrayList<TestObserver<Integer>>();
+                List<TestObserver<Integer>> tos = new ArrayList<TestObserver<Integer>>();
                 for (int k = 1; k < j; k++) {
-                    TestObserver<Integer> ts = new TestObserver<Integer>();
-                    tss.add(ts);
-                    obs.subscribe(ts);
+                    TestObserver<Integer> to = new TestObserver<Integer>();
+                    tos.add(to);
+                    obs.subscribe(to);
                 }
 
                 Disposable s = co.connect();
 
-                for (TestObserver<Integer> ts : tss) {
-                    ts.awaitTerminalEvent(2, TimeUnit.SECONDS);
-                    ts.assertTerminated();
-                    ts.assertNoErrors();
-                    assertEquals(1000, ts.valueCount());
+                for (TestObserver<Integer> to : tos) {
+                    to.awaitTerminalEvent(2, TimeUnit.SECONDS);
+                    to.assertTerminated();
+                    to.assertNoErrors();
+                    assertEquals(1000, to.valueCount());
                 }
                 s.dispose();
             }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRangeLongTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRangeLongTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.observers.*;
 
 public class ObservableRangeLongTest {
@@ -99,12 +99,12 @@ public class ObservableRangeLongTest {
 
         Observable<Long> o = Observable.rangeLong(1, list.size());
 
-        TestObserver<Long> ts = new TestObserver<Long>();
+        TestObserver<Long> to = new TestObserver<Long>();
 
-        o.subscribe(ts);
+        o.subscribe(to);
 
-        ts.assertValueSequence(list);
-        ts.assertTerminated();
+        to.assertValueSequence(list);
+        to.assertTerminated();
     }
 
     @Test
@@ -136,12 +136,12 @@ public class ObservableRangeLongTest {
 
     @Test(timeout = 1000)
     public void testNearMaxValueWithoutBackpressure() {
-        TestObserver<Long> ts = new TestObserver<Long>();
-        Observable.rangeLong(Long.MAX_VALUE - 1L, 2L).subscribe(ts);
+        TestObserver<Long> to = new TestObserver<Long>();
+        Observable.rangeLong(Long.MAX_VALUE - 1L, 2L).subscribe(to);
 
-        ts.assertComplete();
-        ts.assertNoErrors();
-        ts.assertValues(Long.MAX_VALUE - 1, Long.MAX_VALUE);
+        to.assertComplete();
+        to.assertNoErrors();
+        to.assertValues(Long.MAX_VALUE - 1, Long.MAX_VALUE);
     }
 
     @Test
@@ -170,21 +170,21 @@ public class ObservableRangeLongTest {
 
     @Test
     public void fused() {
-        TestObserver<Long> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Long> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         Observable.rangeLong(1, 2).subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.SYNC)
+        ObserverFusion.assertFusion(to, QueueFuseable.SYNC)
         .assertResult(1L, 2L);
     }
 
     @Test
     public void fusedReject() {
-        TestObserver<Long> to = ObserverFusion.newTest(QueueDisposable.ASYNC);
+        TestObserver<Long> to = ObserverFusion.newTest(QueueFuseable.ASYNC);
 
         Observable.rangeLong(1, 2).subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(1L, 2L);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRangeTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
@@ -23,7 +24,7 @@ import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.observers.*;
 
 public class ObservableRangeTest {
@@ -99,12 +100,12 @@ public class ObservableRangeTest {
 
         Observable<Integer> o = Observable.range(1, list.size());
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        o.subscribe(ts);
+        o.subscribe(to);
 
-        ts.assertValueSequence(list);
-        ts.assertTerminated();
+        to.assertValueSequence(list);
+        to.assertTerminated();
     }
 
     @Test
@@ -136,12 +137,12 @@ public class ObservableRangeTest {
 
     @Test(timeout = 1000)
     public void testNearMaxValueWithoutBackpressure() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        Observable.range(Integer.MAX_VALUE - 1, 2).subscribe(ts);
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Observable.range(Integer.MAX_VALUE - 1, 2).subscribe(to);
 
-        ts.assertComplete();
-        ts.assertNoErrors();
-        ts.assertValues(Integer.MAX_VALUE - 1, Integer.MAX_VALUE);
+        to.assertComplete();
+        to.assertNoErrors();
+        to.assertValues(Integer.MAX_VALUE - 1, Integer.MAX_VALUE);
     }
 
     @Test
@@ -156,12 +157,12 @@ public class ObservableRangeTest {
 
     @Test
     public void requestWrongFusion() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ASYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ASYNC);
 
         Observable.range(1, 5)
         .subscribe(to);
 
-        ObserverFusion.assertFusion(to, QueueDisposable.NONE)
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -186,20 +186,20 @@ public class ObservableRefCountTest {
                 .publish().refCount();
 
         for (int i = 0; i < 10; i++) {
-            TestObserver<Long> ts1 = new TestObserver<Long>();
-            TestObserver<Long> ts2 = new TestObserver<Long>();
-            r.subscribe(ts1);
-            r.subscribe(ts2);
+            TestObserver<Long> to1 = new TestObserver<Long>();
+            TestObserver<Long> to2 = new TestObserver<Long>();
+            r.subscribe(to1);
+            r.subscribe(to2);
             try {
                 Thread.sleep(50);
             } catch (InterruptedException e) {
             }
-            ts1.dispose();
-            ts2.dispose();
-            ts1.assertNoErrors();
-            ts2.assertNoErrors();
-            assertTrue(ts1.valueCount() > 0);
-            assertTrue(ts2.valueCount() > 0);
+            to1.dispose();
+            to2.dispose();
+            to1.assertNoErrors();
+            to2.assertNoErrors();
+            assertTrue(to1.valueCount() > 0);
+            assertTrue(to2.valueCount() > 0);
         }
 
         assertEquals(10, subscribeCount.get());
@@ -494,19 +494,19 @@ public class ObservableRefCountTest {
         })
         .publish().refCount();
 
-        TestObserver<Integer> ts1 = new TestObserver<Integer>();
-        TestObserver<Integer> ts2 = new TestObserver<Integer>();
+        TestObserver<Integer> to1 = new TestObserver<Integer>();
+        TestObserver<Integer> to2 = new TestObserver<Integer>();
 
-        combined.subscribe(ts1);
-        combined.subscribe(ts2);
+        combined.subscribe(to1);
+        combined.subscribe(to2);
 
-        ts1.assertTerminated();
-        ts1.assertNoErrors();
-        ts1.assertValue(30);
+        to1.assertTerminated();
+        to1.assertNoErrors();
+        to1.assertValue(30);
 
-        ts2.assertTerminated();
-        ts2.assertNoErrors();
-        ts2.assertValue(30);
+        to2.assertTerminated();
+        to2.assertNoErrors();
+        to2.assertValue(30);
     }
 
     @Test(timeout = 10000)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRepeatTest.java
@@ -162,20 +162,20 @@ public class ObservableRepeatTest {
                 .repeat(3)
                 .distinct();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        src.subscribe(ts);
+        src.subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertTerminated();
-        ts.assertValues(1, 2, 3);
+        to.assertNoErrors();
+        to.assertTerminated();
+        to.assertValues(1, 2, 3);
     }
 
     /** Issue #2844: wrong target of request. */
     @Test(timeout = 3000)
     public void testRepeatRetarget() {
         final List<Integer> concatBase = new ArrayList<Integer>();
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.just(1, 2)
         .repeat(5)
         .concatMap(new Function<Integer, Observable<Integer>>() {
@@ -187,11 +187,11 @@ public class ObservableRepeatTest {
                         .delay(200, TimeUnit.MILLISECONDS);
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        ts.assertNoValues();
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        to.assertNoValues();
 
         assertEquals(Arrays.asList(1, 2, 1, 2, 1, 2, 1, 2, 1, 2), concatBase);
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -872,13 +872,13 @@ public class ObservableReplayTest {
     public void testColdReplayNoBackpressure() {
         Observable<Integer> source = Observable.range(0, 1000).replay().autoConnect();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        source.subscribe(ts);
+        source.subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertTerminated();
-        List<Integer> onNextEvents = ts.values();
+        to.assertNoErrors();
+        to.assertTerminated();
+        List<Integer> onNextEvents = to.values();
         assertEquals(1000, onNextEvents.size());
 
         for (int i = 0; i < 1000; i++) {
@@ -950,14 +950,14 @@ public class ObservableReplayTest {
 
     @Test
     public void testTake() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         Observable<Integer> cached = Observable.range(1, 100).replay().autoConnect();
-        cached.take(10).subscribe(ts);
+        cached.take(10).subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertTerminated();
-        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        to.assertNoErrors();
+        to.assertTerminated();
+        to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         // FIXME no longer assertable
 //        ts.assertUnsubscribed();
     }
@@ -966,24 +966,24 @@ public class ObservableReplayTest {
     public void testAsync() {
         Observable<Integer> source = Observable.range(1, 10000);
         for (int i = 0; i < 100; i++) {
-            TestObserver<Integer> ts1 = new TestObserver<Integer>();
+            TestObserver<Integer> to1 = new TestObserver<Integer>();
 
             Observable<Integer> cached = source.replay().autoConnect();
 
-            cached.observeOn(Schedulers.computation()).subscribe(ts1);
+            cached.observeOn(Schedulers.computation()).subscribe(to1);
 
-            ts1.awaitTerminalEvent(2, TimeUnit.SECONDS);
-            ts1.assertNoErrors();
-            ts1.assertTerminated();
-            assertEquals(10000, ts1.values().size());
+            to1.awaitTerminalEvent(2, TimeUnit.SECONDS);
+            to1.assertNoErrors();
+            to1.assertTerminated();
+            assertEquals(10000, to1.values().size());
 
-            TestObserver<Integer> ts2 = new TestObserver<Integer>();
-            cached.observeOn(Schedulers.computation()).subscribe(ts2);
+            TestObserver<Integer> to2 = new TestObserver<Integer>();
+            cached.observeOn(Schedulers.computation()).subscribe(to2);
 
-            ts2.awaitTerminalEvent(2, TimeUnit.SECONDS);
-            ts2.assertNoErrors();
-            ts2.assertTerminated();
-            assertEquals(10000, ts2.values().size());
+            to2.awaitTerminalEvent(2, TimeUnit.SECONDS);
+            to2.assertNoErrors();
+            to2.assertTerminated();
+            assertEquals(10000, to2.values().size());
         }
     }
     @Test
@@ -997,9 +997,9 @@ public class ObservableReplayTest {
 
         List<TestObserver<Long>> list = new ArrayList<TestObserver<Long>>(100);
         for (int i = 0; i < 100; i++) {
-            TestObserver<Long> ts = new TestObserver<Long>();
-            list.add(ts);
-            output.skip(i * 10).take(10).subscribe(ts);
+            TestObserver<Long> to = new TestObserver<Long>();
+            list.add(to);
+            output.skip(i * 10).take(10).subscribe(to);
         }
 
         List<Long> expected = new ArrayList<Long>();
@@ -1007,16 +1007,16 @@ public class ObservableReplayTest {
             expected.add((long)(i - 10));
         }
         int j = 0;
-        for (TestObserver<Long> ts : list) {
-            ts.awaitTerminalEvent(3, TimeUnit.SECONDS);
-            ts.assertNoErrors();
-            ts.assertTerminated();
+        for (TestObserver<Long> to : list) {
+            to.awaitTerminalEvent(3, TimeUnit.SECONDS);
+            to.assertNoErrors();
+            to.assertTerminated();
 
             for (int i = j * 10; i < j * 10 + 10; i++) {
                 expected.set(i - j * 10, (long)i);
             }
 
-            ts.assertValueSequence(expected);
+            to.assertValueSequence(expected);
 
             j++;
         }
@@ -1036,14 +1036,14 @@ public class ObservableReplayTest {
             }
         });
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        firehose.replay().autoConnect().observeOn(Schedulers.computation()).takeLast(100).subscribe(ts);
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        firehose.replay().autoConnect().observeOn(Schedulers.computation()).takeLast(100).subscribe(to);
 
-        ts.awaitTerminalEvent(3, TimeUnit.SECONDS);
-        ts.assertNoErrors();
-        ts.assertTerminated();
+        to.awaitTerminalEvent(3, TimeUnit.SECONDS);
+        to.assertNoErrors();
+        to.assertTerminated();
 
-        assertEquals(100, ts.values().size());
+        assertEquals(100, to.values().size());
     }
 
     @Test
@@ -1053,19 +1053,19 @@ public class ObservableReplayTest {
                 .replay().autoConnect();
 
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        source.subscribe(ts);
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        source.subscribe(to);
 
-        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        ts.assertNotComplete();
-        Assert.assertEquals(1, ts.errors().size());
+        to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        to.assertNotComplete();
+        Assert.assertEquals(1, to.errors().size());
 
-        TestObserver<Integer> ts2 = new TestObserver<Integer>();
-        source.subscribe(ts2);
+        TestObserver<Integer> to2 = new TestObserver<Integer>();
+        source.subscribe(to2);
 
-        ts2.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        ts2.assertNotComplete();
-        Assert.assertEquals(1, ts2.errors().size());
+        to2.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        to2.assertNotComplete();
+        Assert.assertEquals(1, to2.errors().size());
     }
 
     @Test
@@ -1082,20 +1082,20 @@ public class ObservableReplayTest {
         })
         .replay().autoConnect();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();
             }
         };
 
-        source.subscribe(ts);
+        source.subscribe(to);
 
         Assert.assertEquals(100, count.get());
 
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(TestException.class);
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(TestException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
@@ -60,7 +60,7 @@ public class ObservableRetryTest {
             }
 
         });
-        TestObserver<String> ts = new TestObserver<String>(consumer);
+        TestObserver<String> to = new TestObserver<String>(consumer);
         producer.retryWhen(new Function<Observable<? extends Throwable>, Observable<Object>>() {
 
             @Override
@@ -86,9 +86,9 @@ public class ObservableRetryTest {
                                 Observable.timer(t.count * 1L, TimeUnit.MILLISECONDS);
                     }}).cast(Object.class);
             }
-        }).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+        }).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
 
         InOrder inOrder = inOrder(consumer);
         inOrder.verify(consumer, never()).onError(any(Throwable.class));
@@ -451,7 +451,7 @@ public class ObservableRetryTest {
     public void testSourceObservableCallsUnsubscribe() throws InterruptedException {
         final AtomicInteger subsCount = new AtomicInteger(0);
 
-        final TestObserver<String> ts = new TestObserver<String>();
+        final TestObserver<String> to = new TestObserver<String>();
 
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
@@ -474,7 +474,7 @@ public class ObservableRetryTest {
             }
         };
 
-        Observable.unsafeCreate(onSubscribe).retry(3).subscribe(ts);
+        Observable.unsafeCreate(onSubscribe).retry(3).subscribe(to);
         assertEquals(4, subsCount.get()); // 1 + 3 retries
     }
 
@@ -482,7 +482,7 @@ public class ObservableRetryTest {
     public void testSourceObservableRetry1() throws InterruptedException {
         final AtomicInteger subsCount = new AtomicInteger(0);
 
-        final TestObserver<String> ts = new TestObserver<String>();
+        final TestObserver<String> to = new TestObserver<String>();
 
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
@@ -493,7 +493,7 @@ public class ObservableRetryTest {
             }
         };
 
-        Observable.unsafeCreate(onSubscribe).retry(1).subscribe(ts);
+        Observable.unsafeCreate(onSubscribe).retry(1).subscribe(to);
         assertEquals(2, subsCount.get());
     }
 
@@ -501,7 +501,7 @@ public class ObservableRetryTest {
     public void testSourceObservableRetry0() throws InterruptedException {
         final AtomicInteger subsCount = new AtomicInteger(0);
 
-        final TestObserver<String> ts = new TestObserver<String>();
+        final TestObserver<String> to = new TestObserver<String>();
 
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
@@ -512,7 +512,7 @@ public class ObservableRetryTest {
             }
         };
 
-        Observable.unsafeCreate(onSubscribe).retry(0).subscribe(ts);
+        Observable.unsafeCreate(onSubscribe).retry(0).subscribe(to);
         assertEquals(1, subsCount.get());
     }
 
@@ -663,9 +663,9 @@ public class ObservableRetryTest {
             for (int i = 0; i < 400; i++) {
                 Observer<String> observer = TestHelper.mockObserver();
                 Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
-                TestObserver<String> ts = new TestObserver<String>(observer);
-                origin.retry().observeOn(Schedulers.computation()).subscribe(ts);
-                ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
+                TestObserver<String> to = new TestObserver<String>(observer);
+                origin.retry().observeOn(Schedulers.computation()).subscribe(to);
+                to.awaitTerminalEvent(5, TimeUnit.SECONDS);
 
                 InOrder inOrder = inOrder(observer);
                 // should have no errors
@@ -706,16 +706,16 @@ public class ObservableRetryTest {
                             final AtomicInteger nexts = new AtomicInteger();
                             try {
                                 Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
-                                TestObserver<String> ts = new TestObserver<String>();
+                                TestObserver<String> to = new TestObserver<String>();
                                 origin.retry()
-                                .observeOn(Schedulers.computation()).subscribe(ts);
-                                ts.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
-                                List<String> onNextEvents = new ArrayList<String>(ts.values());
+                                .observeOn(Schedulers.computation()).subscribe(to);
+                                to.awaitTerminalEvent(2500, TimeUnit.MILLISECONDS);
+                                List<String> onNextEvents = new ArrayList<String>(to.values());
                                 if (onNextEvents.size() != NUM_RETRIES + 2) {
-                                    for (Throwable t : ts.errors()) {
+                                    for (Throwable t : to.errors()) {
                                         onNextEvents.add(t.toString());
                                     }
-                                    for (long err = ts.completions(); err != 0; err--) {
+                                    for (long err = to.completions(); err != 0; err--) {
                                         onNextEvents.add("onComplete");
                                     }
                                     data.put(j, onNextEvents);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -277,7 +277,7 @@ public class ObservableRetryWithPredicateTest {
 
     @Test
     public void testIssue2826() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         final RuntimeException e = new RuntimeException("You shall not pass");
         final AtomicInteger c = new AtomicInteger();
         Observable.just(1).map(new Function<Integer, Integer>() {
@@ -286,11 +286,11 @@ public class ObservableRetryWithPredicateTest {
                 c.incrementAndGet();
                 throw e;
             }
-        }).retry(retry5).subscribe(ts);
+        }).retry(retry5).subscribe(to);
 
-        ts.assertTerminated();
+        to.assertTerminated();
         assertEquals(6, c.get());
-        assertEquals(Collections.singletonList(e), ts.errors());
+        assertEquals(Collections.singletonList(e), to.errors());
     }
     @Test
     public void testJustAndRetry() throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSampleTest.java
@@ -323,17 +323,17 @@ public class ObservableSampleTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestScheduler scheduler = new TestScheduler();
 
-            final PublishSubject<Integer> pp = PublishSubject.create();
+            final PublishSubject<Integer> ps = PublishSubject.create();
 
-            TestObserver<Integer> ts = pp.sample(1, TimeUnit.SECONDS, scheduler, true)
+            TestObserver<Integer> to = ps.sample(1, TimeUnit.SECONDS, scheduler, true)
             .test();
 
-            pp.onNext(1);
+            ps.onNext(1);
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.onComplete();
+                    ps.onComplete();
                 }
             };
 
@@ -346,7 +346,7 @@ public class ObservableSampleTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertResult(1);
+            to.assertResult(1);
         }
     }
 
@@ -369,18 +369,18 @@ public class ObservableSampleTest {
     @Test
     public void emitLastOtherRunCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishSubject<Integer> pp = PublishSubject.create();
+            final PublishSubject<Integer> ps = PublishSubject.create();
             final PublishSubject<Integer> sampler = PublishSubject.create();
 
-            TestObserver<Integer> ts = pp.sample(sampler, true)
+            TestObserver<Integer> to = ps.sample(sampler, true)
             .test();
 
-            pp.onNext(1);
+            ps.onNext(1);
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.onComplete();
+                    ps.onComplete();
                 }
             };
 
@@ -393,24 +393,24 @@ public class ObservableSampleTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertResult(1);
+            to.assertResult(1);
         }
     }
 
     @Test
     public void emitLastOtherCompleteCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishSubject<Integer> pp = PublishSubject.create();
+            final PublishSubject<Integer> ps = PublishSubject.create();
             final PublishSubject<Integer> sampler = PublishSubject.create();
 
-            TestObserver<Integer> ts = pp.sample(sampler, true).test();
+            TestObserver<Integer> to = ps.sample(sampler, true).test();
 
-            pp.onNext(1);
+            ps.onNext(1);
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.onComplete();
+                    ps.onComplete();
                 }
             };
 
@@ -423,7 +423,7 @@ public class ObservableSampleTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertResult(1);
+            to.assertResult(1);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableScalarXMapTest.java
@@ -73,85 +73,85 @@ public class ObservableScalarXMapTest {
 
     @Test
     public void tryScalarXMap() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new CallablePublisher(), ts, new Function<Integer, ObservableSource<Integer>>() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new CallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
             public ObservableSource<Integer> apply(Integer f) throws Exception {
                 return Observable.just(1);
             }
         }));
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
     public void emptyXMap() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new EmptyCallablePublisher(), ts, new Function<Integer, ObservableSource<Integer>>() {
+        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new EmptyCallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
             public ObservableSource<Integer> apply(Integer f) throws Exception {
                 return Observable.just(1);
             }
         }));
 
-        ts.assertResult();
+        to.assertResult();
     }
 
     @Test
     public void mapperCrashes() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, ObservableSource<Integer>>() {
+        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
             public ObservableSource<Integer> apply(Integer f) throws Exception {
                 throw new TestException();
             }
         }));
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
     public void mapperToJust() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, ObservableSource<Integer>>() {
+        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
             public ObservableSource<Integer> apply(Integer f) throws Exception {
                 return Observable.just(1);
             }
         }));
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @Test
     public void mapperToEmpty() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, ObservableSource<Integer>>() {
+        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
             public ObservableSource<Integer> apply(Integer f) throws Exception {
                 return Observable.empty();
             }
         }));
 
-        ts.assertResult();
+        to.assertResult();
     }
 
     @Test
     public void mapperToCrashingCallable() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, ObservableSource<Integer>>() {
+        assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
             public ObservableSource<Integer> apply(Integer f) throws Exception {
                 return new CallablePublisher();
             }
         }));
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableScanTest.java
@@ -115,7 +115,7 @@ public class ObservableScanTest {
 
     @Test
     public void shouldNotEmitUntilAfterSubscription() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(1, 100).scan(0, new BiFunction<Integer, Integer, Integer>() {
 
             @Override
@@ -131,9 +131,9 @@ public class ObservableScanTest {
                 return t1 > 0;
             }
 
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        assertEquals(100, ts.values().size());
+        assertEquals(100, to.values().size());
     }
 
     @Test
@@ -219,18 +219,18 @@ public class ObservableScanTest {
     public void testInitialValueEmittedNoProducer() {
         PublishSubject<Integer> source = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         source.scan(0, new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2) {
                 return t1 + t2;
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertNotComplete();
-        ts.assertValue(0);
+        to.assertNoErrors();
+        to.assertNotComplete();
+        to.assertValue(0);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipLastTest.java
@@ -96,11 +96,11 @@ public class ObservableSkipLastTest {
     @Test
     public void testSkipLastWithBackpressure() {
         Observable<Integer> o = Observable.range(0, Flowable.bufferSize() * 2).skipLast(Flowable.bufferSize() + 10);
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        o.observeOn(Schedulers.computation()).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals((Flowable.bufferSize()) - 10, ts.valueCount());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        o.observeOn(Schedulers.computation()).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals((Flowable.bufferSize()) - 10, to.valueCount());
 
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSkipTest.java
@@ -137,12 +137,12 @@ public class ObservableSkipTest {
 
     @Test
     public void testRequestOverflowDoesNotOccur() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        Observable.range(1, 10).skip(5).subscribe(ts);
-        ts.assertTerminated();
-        ts.assertComplete();
-        ts.assertNoErrors();
-        assertEquals(Arrays.asList(6,7,8,9,10), ts.values());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Observable.range(1, 10).skip(5).subscribe(to);
+        to.assertTerminated();
+        to.assertComplete();
+        to.assertNoErrors();
+        assertEquals(Arrays.asList(6,7,8,9,10), to.values());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
@@ -74,7 +74,7 @@ public class ObservableSubscribeOnTest {
     @Test
     @Ignore("ObservableSource.subscribe can't throw")
     public void testThrownErrorHandling() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
         Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
@@ -82,14 +82,14 @@ public class ObservableSubscribeOnTest {
                 throw new RuntimeException("fail");
             }
 
-        }).subscribeOn(Schedulers.computation()).subscribe(ts);
-        ts.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
-        ts.assertTerminated();
+        }).subscribeOn(Schedulers.computation()).subscribe(to);
+        to.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
+        to.assertTerminated();
     }
 
     @Test
     public void testOnError() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
         Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
@@ -98,9 +98,9 @@ public class ObservableSubscribeOnTest {
                 s.onError(new RuntimeException("fail"));
             }
 
-        }).subscribeOn(Schedulers.computation()).subscribe(ts);
-        ts.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
-        ts.assertTerminated();
+        }).subscribeOn(Schedulers.computation()).subscribe(to);
+        to.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
+        to.assertTerminated();
     }
 
     public static class SlowScheduler extends Scheduler {
@@ -162,7 +162,7 @@ public class ObservableSubscribeOnTest {
 
     @Test(timeout = 5000)
     public void testUnsubscribeInfiniteStream() throws InterruptedException {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         final AtomicInteger count = new AtomicInteger();
         Observable.unsafeCreate(new ObservableSource<Integer>() {
 
@@ -176,12 +176,12 @@ public class ObservableSubscribeOnTest {
                 }
             }
 
-        }).subscribeOn(Schedulers.newThread()).take(10).subscribe(ts);
+        }).subscribeOn(Schedulers.newThread()).take(10).subscribe(to);
 
-        ts.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
-        ts.dispose();
+        to.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
+        to.dispose();
         Thread.sleep(200); // give time for the loop to continue
-        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         assertEquals(10, count.get());
     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
@@ -461,7 +461,7 @@ public class ObservableSwitchTest {
         .share()
         ;
 
-        TestObserver<String> ts = new TestObserver<String>() {
+        TestObserver<String> to = new TestObserver<String>() {
             @Override
             public void onNext(String t) {
                 super.onNext(t);
@@ -471,16 +471,16 @@ public class ObservableSwitchTest {
                 }
             }
         };
-        src.subscribe(ts);
+        src.subscribe(to);
 
-        ts.awaitTerminalEvent(10, TimeUnit.SECONDS);
+        to.awaitTerminalEvent(10, TimeUnit.SECONDS);
 
-        System.out.println("> testIssue2654: " + ts.valueCount());
+        System.out.println("> testIssue2654: " + to.valueCount());
 
-        ts.assertTerminated();
-        ts.assertNoErrors();
+        to.assertTerminated();
+        to.assertNoErrors();
 
-        Assert.assertEquals(250, ts.valueCount());
+        Assert.assertEquals(250, to.valueCount());
     }
 
 
@@ -488,10 +488,10 @@ public class ObservableSwitchTest {
     public void delayErrors() {
         PublishSubject<ObservableSource<Integer>> source = PublishSubject.create();
 
-        TestObserver<Integer> ts = source.switchMapDelayError(Functions.<ObservableSource<Integer>>identity())
+        TestObserver<Integer> to = source.switchMapDelayError(Functions.<ObservableSource<Integer>>identity())
         .test();
 
-        ts.assertNoValues()
+        to.assertNoValues()
         .assertNoErrors()
         .assertNotComplete();
 
@@ -507,11 +507,11 @@ public class ObservableSwitchTest {
 
         source.onError(new TestException("Forced failure 3"));
 
-        ts.assertValues(1, 2, 3, 4, 5)
+        to.assertValues(1, 2, 3, 4, 5)
         .assertNotComplete()
         .assertError(CompositeException.class);
 
-        List<Throwable> errors = ExceptionHelper.flatten(ts.errors().get(0));
+        List<Throwable> errors = ExceptionHelper.flatten(to.errors().get(0));
 
         TestHelper.assertError(errors, 0, TestException.class, "Forced failure 1");
         TestHelper.assertError(errors, 1, TestException.class, "Forced failure 2");
@@ -522,40 +522,40 @@ public class ObservableSwitchTest {
     public void switchOnNextDelayError() {
         PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = Observable.switchOnNextDelayError(ps).test();
+        TestObserver<Integer> to = Observable.switchOnNextDelayError(ps).test();
 
         ps.onNext(Observable.just(1));
         ps.onNext(Observable.range(2, 4));
         ps.onComplete();
 
-        ts.assertResult(1, 2, 3, 4, 5);
+        to.assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void switchOnNextDelayErrorWithError() {
         PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = Observable.switchOnNextDelayError(ps).test();
+        TestObserver<Integer> to = Observable.switchOnNextDelayError(ps).test();
 
         ps.onNext(Observable.just(1));
         ps.onNext(Observable.<Integer>error(new TestException()));
         ps.onNext(Observable.range(2, 4));
         ps.onComplete();
 
-        ts.assertFailure(TestException.class, 1, 2, 3, 4, 5);
+        to.assertFailure(TestException.class, 1, 2, 3, 4, 5);
     }
 
     @Test
     public void switchOnNextDelayErrorBufferSize() {
         PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = Observable.switchOnNextDelayError(ps, 2).test();
+        TestObserver<Integer> to = Observable.switchOnNextDelayError(ps, 2).test();
 
         ps.onNext(Observable.just(1));
         ps.onNext(Observable.range(2, 4));
         ps.onComplete();
 
-        ts.assertResult(1, 2, 3, 4, 5);
+        to.assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
@@ -610,17 +610,17 @@ public class ObservableSwitchTest {
 
     @Test
     public void switchMapInnerCancelled() {
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = Observable.just(1)
-                .switchMap(Functions.justFunction(pp))
+        TestObserver<Integer> to = Observable.just(1)
+                .switchMap(Functions.justFunction(ps))
                 .test();
 
-        assertTrue(pp.hasObservers());
+        assertTrue(ps.hasObservers());
 
-        ts.cancel();
+        to.cancel();
 
-        assertFalse(pp.hasObservers());
+        assertFalse(ps.hasObservers());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTest.java
@@ -103,23 +103,23 @@ public class ObservableTakeLastTest {
 
     @Test
     public void testBackpressure1() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(1, 100000).takeLast(1)
         .observeOn(Schedulers.newThread())
-        .map(newSlowProcessor()).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        ts.assertValue(100000);
+        .map(newSlowProcessor()).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        to.assertValue(100000);
     }
 
     @Test
     public void testBackpressure2() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(1, 100000).takeLast(Flowable.bufferSize() * 4)
-        .observeOn(Schedulers.newThread()).map(newSlowProcessor()).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(Flowable.bufferSize() * 4, ts.valueCount());
+        .observeOn(Schedulers.newThread()).map(newSlowProcessor()).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(Flowable.bufferSize() * 4, to.valueCount());
     }
 
     private Function<Integer, Integer> newSlowProcessor() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
@@ -281,12 +281,12 @@ public class ObservableTakeTest {
     @Test(timeout = 2000)
     public void testTakeObserveOn() {
         Observer<Object> o = TestHelper.mockObserver();
-        TestObserver<Object> ts = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<Object>(o);
 
         INFINITE_OBSERVABLE
-        .observeOn(Schedulers.newThread()).take(1).subscribe(ts);
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+        .observeOn(Schedulers.newThread()).take(1).subscribe(to);
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
 
         verify(o).onNext(1L);
         verify(o, never()).onNext(2L);
@@ -323,38 +323,38 @@ public class ObservableTakeTest {
     public void takeFinalValueThrows() {
         Observable<Integer> source = Observable.just(1).take(1);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();
             }
         };
 
-        source.safeSubscribe(ts);
+        source.safeSubscribe(to);
 
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertError(TestException.class);
+        to.assertNotComplete();
     }
 
     @Test
     public void testReentrantTake() {
         final PublishSubject<Integer> source = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         source.take(1).doOnNext(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) {
                 source.onNext(2);
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
         source.onNext(1);
 
-        ts.assertValue(1);
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValue(1);
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicateTest.java
@@ -136,7 +136,7 @@ public class ObservableTakeUntilPredicateTest {
 
     @Test
     public void testErrorIncludesLastValueAsCause() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
         final TestException e = new TestException("Forced failure");
         Predicate<String> predicate = (new Predicate<String>() {
             @Override
@@ -144,11 +144,11 @@ public class ObservableTakeUntilPredicateTest {
                     throw e;
             }
         });
-        Observable.just("abc").takeUntil(predicate).subscribe(ts);
+        Observable.just("abc").takeUntil(predicate).subscribe(to);
 
-        ts.assertTerminated();
-        ts.assertNotComplete();
-        ts.assertError(TestException.class);
+        to.assertTerminated();
+        to.assertNotComplete();
+        to.assertError(TestException.class);
         // FIXME last cause value is not saved
 //        assertTrue(ts.errors().get(0).getCause().getMessage().contains("abc"));
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
@@ -188,21 +188,21 @@ public class ObservableTakeUntilTest {
         PublishSubject<Integer> source = PublishSubject.create();
         PublishSubject<Integer> until = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        source.takeUntil(until).subscribe(ts);
+        source.takeUntil(until).subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(until.hasObservers());
 
         source.onNext(1);
 
-        ts.assertValue(1);
+        to.assertValue(1);
         until.onNext(1);
 
-        ts.assertValue(1);
-        ts.assertNoErrors();
-        ts.assertTerminated();
+        to.assertValue(1);
+        to.assertNoErrors();
+        to.assertTerminated();
 
         assertFalse("Source still has observers", source.hasObservers());
         assertFalse("Until still has observers", until.hasObservers());
@@ -214,9 +214,9 @@ public class ObservableTakeUntilTest {
         PublishSubject<Integer> source = PublishSubject.create();
         PublishSubject<Integer> until = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        source.takeUntil(until).subscribe(ts);
+        source.takeUntil(until).subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(until.hasObservers());
@@ -224,9 +224,9 @@ public class ObservableTakeUntilTest {
         source.onNext(1);
         source.onComplete();
 
-        ts.assertValue(1);
-        ts.assertNoErrors();
-        ts.assertTerminated();
+        to.assertValue(1);
+        to.assertNoErrors();
+        to.assertTerminated();
 
         assertFalse("Source still has observers", source.hasObservers());
         assertFalse("Until still has observers", until.hasObservers());
@@ -238,18 +238,18 @@ public class ObservableTakeUntilTest {
         PublishSubject<Integer> source = PublishSubject.create();
         PublishSubject<Integer> until = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        source.takeUntil(until).take(1).subscribe(ts);
+        source.takeUntil(until).take(1).subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(until.hasObservers());
 
         source.onNext(1);
 
-        ts.assertValue(1);
-        ts.assertNoErrors();
-        ts.assertTerminated();
+        to.assertValue(1);
+        to.assertNoErrors();
+        to.assertTerminated();
 
         assertFalse("Source still has observers", source.hasObservers());
         assertFalse("Until still has observers", until.hasObservers());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
@@ -266,8 +266,8 @@ public class ObservableTakeUntilTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Integer>, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Observable<Integer> c) throws Exception {
-                return c.takeUntil(Observable.never());
+            public Observable<Integer> apply(Observable<Integer> o) throws Exception {
+                return o.takeUntil(Observable.never());
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeWhileTest.java
@@ -221,12 +221,12 @@ public class ObservableTakeWhileTest {
                 return t1 < 2;
             }
         });
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        source.subscribe(ts);
+        source.subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertValue(1);
+        to.assertNoErrors();
+        to.assertValue(1);
 
         // 2.0.2 - not anymore
 //        Assert.assertTrue("Not cancelled!", ts.isCancelled());
@@ -234,17 +234,17 @@ public class ObservableTakeWhileTest {
 
     @Test
     public void testErrorCauseIncludesLastValue() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
         Observable.just("abc").takeWhile(new Predicate<String>() {
             @Override
             public boolean test(String t1) {
                 throw new TestException();
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.assertTerminated();
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
+        to.assertTerminated();
+        to.assertNoValues();
+        to.assertError(TestException.class);
         // FIXME last cause value not recorded
 //        assertTrue(ts.getOnErrorEvents().get(0).getCause().getMessage().contains("abc"));
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
@@ -50,24 +50,24 @@ public class ObservableTimeoutTests {
     @Test
     public void shouldNotTimeoutIfOnNextWithinTimeout() {
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<String>(observer);
 
-        withTimeout.subscribe(ts);
+        withTimeout.subscribe(to);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
         verify(observer).onNext("One");
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         verify(observer, never()).onError(any(Throwable.class));
-        ts.dispose();
+        to.dispose();
     }
 
     @Test
     public void shouldNotTimeoutIfSecondOnNextWithinTimeout() {
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<String>(observer);
 
-        withTimeout.subscribe(ts);
+        withTimeout.subscribe(to);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
@@ -76,57 +76,57 @@ public class ObservableTimeoutTests {
         verify(observer).onNext("Two");
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         verify(observer, never()).onError(any(Throwable.class));
-        ts.dispose();
+        to.dispose();
     }
 
     @Test
     public void shouldTimeoutIfOnNextNotWithinTimeout() {
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<String>(observer);
 
-        withTimeout.subscribe(ts);
+        withTimeout.subscribe(to);
 
         testScheduler.advanceTimeBy(TIMEOUT + 1, TimeUnit.SECONDS);
         verify(observer).onError(any(TimeoutException.class));
-        ts.dispose();
+        to.dispose();
     }
 
     @Test
     public void shouldTimeoutIfSecondOnNextNotWithinTimeout() {
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<String>(observer);
         withTimeout.subscribe(observer);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
         verify(observer).onNext("One");
         testScheduler.advanceTimeBy(TIMEOUT + 1, TimeUnit.SECONDS);
         verify(observer).onError(any(TimeoutException.class));
-        ts.dispose();
+        to.dispose();
     }
 
     @Test
     public void shouldCompleteIfUnderlyingComletes() {
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<String>(observer);
         withTimeout.subscribe(observer);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onComplete();
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         verify(observer).onComplete();
         verify(observer, never()).onError(any(Throwable.class));
-        ts.dispose();
+        to.dispose();
     }
 
     @Test
     public void shouldErrorIfUnderlyingErrors() {
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<String>(observer);
         withTimeout.subscribe(observer);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onError(new UnsupportedOperationException());
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         verify(observer).onError(any(UnsupportedOperationException.class));
-        ts.dispose();
+        to.dispose();
     }
 
     @Test
@@ -135,8 +135,8 @@ public class ObservableTimeoutTests {
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        source.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>(observer);
+        source.subscribe(to);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
@@ -149,7 +149,7 @@ public class ObservableTimeoutTests {
         inOrder.verify(observer, times(1)).onNext("c");
         inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
-        ts.dispose();
+        to.dispose();
     }
 
     @Test
@@ -158,8 +158,8 @@ public class ObservableTimeoutTests {
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        source.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>(observer);
+        source.subscribe(to);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
@@ -172,7 +172,7 @@ public class ObservableTimeoutTests {
         inOrder.verify(observer, times(1)).onNext("c");
         inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
-        ts.dispose();
+        to.dispose();
     }
 
     @Test
@@ -181,8 +181,8 @@ public class ObservableTimeoutTests {
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        source.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>(observer);
+        source.subscribe(to);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
@@ -195,7 +195,7 @@ public class ObservableTimeoutTests {
         inOrder.verify(observer, times(1)).onNext("c");
         inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
-        ts.dispose();
+        to.dispose();
     }
 
     @Test
@@ -204,8 +204,8 @@ public class ObservableTimeoutTests {
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        source.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>(observer);
+        source.subscribe(to);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
@@ -214,7 +214,7 @@ public class ObservableTimeoutTests {
 
         other.onNext("a");
         other.onNext("b");
-        ts.dispose();
+        to.dispose();
 
         // The following messages should not be delivered.
         other.onNext("c");
@@ -235,7 +235,7 @@ public class ObservableTimeoutTests {
         final CountDownLatch timeoutSetuped = new CountDownLatch(1);
 
         final Observer<String> observer = TestHelper.mockObserver();
-        final TestObserver<String> ts = new TestObserver<String>(observer);
+        final TestObserver<String> to = new TestObserver<String>(observer);
 
         new Thread(new Runnable() {
 
@@ -257,7 +257,7 @@ public class ObservableTimeoutTests {
                     }
 
                 }).timeout(1, TimeUnit.SECONDS, testScheduler)
-                        .subscribe(ts);
+                        .subscribe(to);
             }
         }).start();
 
@@ -287,8 +287,8 @@ public class ObservableTimeoutTests {
         Observable<String> observableWithTimeout = never.timeout(1000, TimeUnit.MILLISECONDS, testScheduler);
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        observableWithTimeout.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>(observer);
+        observableWithTimeout.subscribe(to);
 
         testScheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
 
@@ -318,8 +318,8 @@ public class ObservableTimeoutTests {
                 testScheduler);
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        observableWithTimeout.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>(observer);
+        observableWithTimeout.subscribe(to);
 
         testScheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
 
@@ -349,8 +349,8 @@ public class ObservableTimeoutTests {
                 testScheduler);
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        observableWithTimeout.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>(observer);
+        observableWithTimeout.subscribe(to);
 
         testScheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
 
@@ -524,14 +524,14 @@ public class ObservableTimeoutTests {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestScheduler sch = new TestScheduler();
 
-            final PublishSubject<Integer> pp = PublishSubject.create();
+            final PublishSubject<Integer> ps = PublishSubject.create();
 
-            TestObserver<Integer> ts = pp.timeout(1, TimeUnit.SECONDS, sch).test();
+            TestObserver<Integer> to = ps.timeout(1, TimeUnit.SECONDS, sch).test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.onNext(1);
+                    ps.onNext(1);
                 }
             };
 
@@ -544,14 +544,14 @@ public class ObservableTimeoutTests {
 
             TestHelper.race(r1, r2);
 
-            if (ts.valueCount() != 0) {
-                if (ts.errorCount() != 0) {
-                    ts.assertFailure(TimeoutException.class, 1);
+            if (to.valueCount() != 0) {
+                if (to.errorCount() != 0) {
+                    to.assertFailure(TimeoutException.class, 1);
                 } else {
-                    ts.assertValuesOnly(1);
+                    to.assertValuesOnly(1);
                 }
             } else {
-                ts.assertFailure(TimeoutException.class);
+                to.assertFailure(TimeoutException.class);
             }
         }
     }
@@ -561,14 +561,14 @@ public class ObservableTimeoutTests {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestScheduler sch = new TestScheduler();
 
-            final PublishSubject<Integer> pp = PublishSubject.create();
+            final PublishSubject<Integer> ps = PublishSubject.create();
 
-            TestObserver<Integer> ts = pp.timeout(1, TimeUnit.SECONDS, sch, Observable.just(2)).test();
+            TestObserver<Integer> to = ps.timeout(1, TimeUnit.SECONDS, sch, Observable.just(2)).test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.onNext(1);
+                    ps.onNext(1);
                 }
             };
 
@@ -581,16 +581,16 @@ public class ObservableTimeoutTests {
 
             TestHelper.race(r1, r2);
 
-            if (ts.isTerminated()) {
-                int c = ts.valueCount();
+            if (to.isTerminated()) {
+                int c = to.valueCount();
                 if (c == 1) {
-                    int v = ts.values().get(0);
+                    int v = to.values().get(0);
                     assertTrue("" + v, v == 1 || v == 2);
                 } else {
-                    ts.assertResult(1, 2);
+                    to.assertResult(1, 2);
                 }
             } else {
-                ts.assertValuesOnly(1);
+                to.assertValuesOnly(1);
             }
         }
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -328,14 +328,14 @@ public class ObservableTimeoutWithSelectorTest {
 
         }).when(o).onComplete();
 
-        final TestObserver<Integer> ts = new TestObserver<Integer>(o);
+        final TestObserver<Integer> to = new TestObserver<Integer>(o);
 
         new Thread(new Runnable() {
 
             @Override
             public void run() {
                 PublishSubject<Integer> source = PublishSubject.create();
-                source.timeout(timeoutFunc, Observable.just(3)).subscribe(ts);
+                source.timeout(timeoutFunc, Observable.just(3)).subscribe(to);
                 source.onNext(1); // start timeout
                 try {
                     if (!enteredTimeoutOne.await(30, TimeUnit.SECONDS)) {
@@ -568,7 +568,7 @@ public class ObservableTimeoutWithSelectorTest {
                     }
                 };
 
-                TestObserver<Integer> ts = ps.timeout(Functions.justFunction(pp2)).test();
+                TestObserver<Integer> to = ps.timeout(Functions.justFunction(pp2)).test();
 
                 ps.onNext(0);
 
@@ -590,7 +590,7 @@ public class ObservableTimeoutWithSelectorTest {
 
                 TestHelper.race(r1, r2);
 
-                ts.assertValueAt(0, 0);
+                to.assertValueAt(0, 0);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);
@@ -623,7 +623,7 @@ public class ObservableTimeoutWithSelectorTest {
                     }
                 };
 
-                TestObserver<Integer> ts = ps.timeout(Functions.justFunction(pp2), Observable.<Integer>never()).test();
+                TestObserver<Integer> to = ps.timeout(Functions.justFunction(pp2), Observable.<Integer>never()).test();
 
                 ps.onNext(0);
 
@@ -645,7 +645,7 @@ public class ObservableTimeoutWithSelectorTest {
 
                 TestHelper.race(r1, r2);
 
-                ts.assertValueAt(0, 0);
+                to.assertValueAt(0, 0);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);
@@ -678,7 +678,7 @@ public class ObservableTimeoutWithSelectorTest {
                     }
                 };
 
-                TestObserver<Integer> ts = ps.timeout(Functions.justFunction(pp2)).test();
+                TestObserver<Integer> to = ps.timeout(Functions.justFunction(pp2)).test();
 
                 ps.onNext(0);
 
@@ -700,7 +700,7 @@ public class ObservableTimeoutWithSelectorTest {
 
                 TestHelper.race(r1, r2);
 
-                ts.assertValueAt(0, 0);
+                to.assertValueAt(0, 0);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);
@@ -733,7 +733,7 @@ public class ObservableTimeoutWithSelectorTest {
                     }
                 };
 
-                TestObserver<Integer> ts = ps.timeout(Functions.justFunction(pp2)).test();
+                TestObserver<Integer> to = ps.timeout(Functions.justFunction(pp2)).test();
 
                 ps.onNext(0);
 
@@ -753,7 +753,7 @@ public class ObservableTimeoutWithSelectorTest {
 
                 TestHelper.race(r1, r2);
 
-                ts.assertValueAt(0, 0);
+                to.assertValueAt(0, 0);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);
@@ -786,7 +786,7 @@ public class ObservableTimeoutWithSelectorTest {
                     }
                 };
 
-                TestObserver<Integer> ts = ps.timeout(Functions.justFunction(pp2), Observable.<Integer>never()).test();
+                TestObserver<Integer> to = ps.timeout(Functions.justFunction(pp2), Observable.<Integer>never()).test();
 
                 ps.onNext(0);
 
@@ -806,7 +806,7 @@ public class ObservableTimeoutWithSelectorTest {
 
                 TestHelper.race(r1, r2);
 
-                ts.assertValueAt(0, 0);
+                to.assertValueAt(0, 0);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimerTest.java
@@ -63,169 +63,169 @@ public class ObservableTimerTest {
 
     @Test
     public void testTimerPeriodically() {
-        TestObserver<Long> ts = new TestObserver<Long>();
+        TestObserver<Long> to = new TestObserver<Long>();
 
-        Observable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler).subscribe(ts);
-
-        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
-
-        ts.assertValue(0L);
+        Observable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler).subscribe(to);
 
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
-        ts.assertValues(0L, 1L);
+
+        to.assertValue(0L);
 
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
-        ts.assertValues(0L, 1L, 2L);
+        to.assertValues(0L, 1L);
 
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
-        ts.assertValues(0L, 1L, 2L, 3L);
+        to.assertValues(0L, 1L, 2L);
 
-        ts.dispose();
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
-        ts.assertValues(0L, 1L, 2L, 3L);
+        to.assertValues(0L, 1L, 2L, 3L);
 
-        ts.assertNotComplete();
-        ts.assertNoErrors();
+        to.dispose();
+        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+        to.assertValues(0L, 1L, 2L, 3L);
+
+        to.assertNotComplete();
+        to.assertNoErrors();
     }
     @Test
     public void testInterval() {
         Observable<Long> w = Observable.interval(1, TimeUnit.SECONDS, scheduler);
-        TestObserver<Long> ts = new TestObserver<Long>();
-        w.subscribe(ts);
+        TestObserver<Long> to = new TestObserver<Long>();
+        w.subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertNotComplete();
 
         scheduler.advanceTimeTo(2, TimeUnit.SECONDS);
 
-        ts.assertValues(0L, 1L);
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+        to.assertValues(0L, 1L);
+        to.assertNoErrors();
+        to.assertNotComplete();
 
-        ts.dispose();
+        to.dispose();
 
         scheduler.advanceTimeTo(4, TimeUnit.SECONDS);
-        ts.assertValues(0L, 1L);
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+        to.assertValues(0L, 1L);
+        to.assertNoErrors();
+        to.assertNotComplete();
     }
 
     @Test
     public void testWithMultipleSubscribersStartingAtSameTime() {
         Observable<Long> w = Observable.interval(1, TimeUnit.SECONDS, scheduler);
 
-        TestObserver<Long> ts1 = new TestObserver<Long>();
-        TestObserver<Long> ts2 = new TestObserver<Long>();
+        TestObserver<Long> to1 = new TestObserver<Long>();
+        TestObserver<Long> to2 = new TestObserver<Long>();
 
-        w.subscribe(ts1);
-        w.subscribe(ts2);
+        w.subscribe(to1);
+        w.subscribe(to2);
 
-        ts1.assertNoValues();
-        ts2.assertNoValues();
+        to1.assertNoValues();
+        to2.assertNoValues();
 
         scheduler.advanceTimeTo(2, TimeUnit.SECONDS);
 
-        ts1.assertValues(0L, 1L);
-        ts1.assertNoErrors();
-        ts1.assertNotComplete();
+        to1.assertValues(0L, 1L);
+        to1.assertNoErrors();
+        to1.assertNotComplete();
 
-        ts2.assertValues(0L, 1L);
-        ts2.assertNoErrors();
-        ts2.assertNotComplete();
+        to2.assertValues(0L, 1L);
+        to2.assertNoErrors();
+        to2.assertNotComplete();
 
-        ts1.dispose();
-        ts2.dispose();
+        to1.dispose();
+        to2.dispose();
 
         scheduler.advanceTimeTo(4, TimeUnit.SECONDS);
 
-        ts1.assertValues(0L, 1L);
-        ts1.assertNoErrors();
-        ts1.assertNotComplete();
+        to1.assertValues(0L, 1L);
+        to1.assertNoErrors();
+        to1.assertNotComplete();
 
-        ts2.assertValues(0L, 1L);
-        ts2.assertNoErrors();
-        ts2.assertNotComplete();
+        to2.assertValues(0L, 1L);
+        to2.assertNoErrors();
+        to2.assertNotComplete();
     }
 
     @Test
     public void testWithMultipleStaggeredSubscribers() {
         Observable<Long> w = Observable.interval(1, TimeUnit.SECONDS, scheduler);
 
-        TestObserver<Long> ts1 = new TestObserver<Long>();
+        TestObserver<Long> to1 = new TestObserver<Long>();
 
-        w.subscribe(ts1);
+        w.subscribe(to1);
 
-        ts1.assertNoErrors();
+        to1.assertNoErrors();
 
         scheduler.advanceTimeTo(2, TimeUnit.SECONDS);
 
-        TestObserver<Long> ts2 = new TestObserver<Long>();
+        TestObserver<Long> to2 = new TestObserver<Long>();
 
-        w.subscribe(ts2);
+        w.subscribe(to2);
 
-        ts1.assertValues(0L, 1L);
-        ts1.assertNoErrors();
-        ts1.assertNotComplete();
+        to1.assertValues(0L, 1L);
+        to1.assertNoErrors();
+        to1.assertNotComplete();
 
-        ts2.assertNoValues();
+        to2.assertNoValues();
 
         scheduler.advanceTimeTo(4, TimeUnit.SECONDS);
 
-        ts1.assertValues(0L, 1L, 2L, 3L);
+        to1.assertValues(0L, 1L, 2L, 3L);
 
-        ts2.assertValues(0L, 1L);
+        to2.assertValues(0L, 1L);
 
-        ts1.dispose();
-        ts2.dispose();
+        to1.dispose();
+        to2.dispose();
 
-        ts1.assertValues(0L, 1L, 2L, 3L);
-        ts1.assertNoErrors();
-        ts1.assertNotComplete();
+        to1.assertValues(0L, 1L, 2L, 3L);
+        to1.assertNoErrors();
+        to1.assertNotComplete();
 
-        ts2.assertValues(0L, 1L);
-        ts2.assertNoErrors();
-        ts2.assertNotComplete();
+        to2.assertValues(0L, 1L);
+        to2.assertNoErrors();
+        to2.assertNotComplete();
     }
 
     @Test
     public void testWithMultipleStaggeredSubscribersAndPublish() {
         ConnectableObservable<Long> w = Observable.interval(1, TimeUnit.SECONDS, scheduler).publish();
 
-        TestObserver<Long> ts1 = new TestObserver<Long>();
+        TestObserver<Long> to1 = new TestObserver<Long>();
 
-        w.subscribe(ts1);
+        w.subscribe(to1);
         w.connect();
 
-        ts1.assertNoValues();
+        to1.assertNoValues();
 
         scheduler.advanceTimeTo(2, TimeUnit.SECONDS);
 
-        TestObserver<Long> ts2 = new TestObserver<Long>();
-        w.subscribe(ts2);
+        TestObserver<Long> to2 = new TestObserver<Long>();
+        w.subscribe(to2);
 
-        ts1.assertValues(0L, 1L);
-        ts1.assertNoErrors();
-        ts1.assertNotComplete();
+        to1.assertValues(0L, 1L);
+        to1.assertNoErrors();
+        to1.assertNotComplete();
 
-        ts2.assertNoValues();
+        to2.assertNoValues();
 
         scheduler.advanceTimeTo(4, TimeUnit.SECONDS);
 
-        ts1.assertValues(0L, 1L, 2L, 3L);
+        to1.assertValues(0L, 1L, 2L, 3L);
 
-        ts2.assertValues(2L, 3L);
+        to2.assertValues(2L, 3L);
 
-        ts1.dispose();
-        ts2.dispose();
+        to1.dispose();
+        to2.dispose();
 
-        ts1.assertValues(0L, 1L, 2L, 3L);
-        ts1.assertNoErrors();
-        ts1.assertNotComplete();
+        to1.assertValues(0L, 1L, 2L, 3L);
+        to1.assertNoErrors();
+        to1.assertNotComplete();
 
-        ts2.assertValues(2L, 3L);
-        ts2.assertNoErrors();
-        ts2.assertNotComplete();
+        to2.assertValues(2L, 3L);
+        to2.assertNoErrors();
+        to2.assertNotComplete();
     }
     @Test
     public void testOnceObserverThrows() {
@@ -315,7 +315,7 @@ public class ObservableTimerTest {
         try {
             for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
-                TestObserver<Long> ts = Observable.timer(1, TimeUnit.MILLISECONDS, s)
+                TestObserver<Long> to = Observable.timer(1, TimeUnit.MILLISECONDS, s)
                 .map(new Function<Long, Long>() {
                     @Override
                     public Long apply(Long v) throws Exception {
@@ -331,7 +331,7 @@ public class ObservableTimerTest {
 
                 Thread.sleep(500);
 
-                ts.cancel();
+                to.cancel();
 
                 Thread.sleep(500);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToFutureTest.java
@@ -35,11 +35,11 @@ public class ObservableToFutureTest {
 
         Observer<Object> o = TestHelper.mockObserver();
 
-        TestObserver<Object> ts = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<Object>(o);
 
-        Observable.fromFuture(future).subscribe(ts);
+        Observable.fromFuture(future).subscribe(to);
 
-        ts.dispose();
+        to.dispose();
 
         verify(o, times(1)).onNext(value);
         verify(o, times(1)).onComplete();
@@ -57,9 +57,9 @@ public class ObservableToFutureTest {
         Observer<Object> o = TestHelper.mockObserver();
 
         TestScheduler scheduler = new TestScheduler();
-        TestObserver<Object> ts = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<Object>(o);
 
-        Observable.fromFuture(future, scheduler).subscribe(ts);
+        Observable.fromFuture(future, scheduler).subscribe(to);
 
         verify(o, never()).onNext(value);
 
@@ -77,11 +77,11 @@ public class ObservableToFutureTest {
 
         Observer<Object> o = TestHelper.mockObserver();
 
-        TestObserver<Object> ts = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<Object>(o);
 
-        Observable.fromFuture(future).subscribe(ts);
+        Observable.fromFuture(future).subscribe(to);
 
-        ts.dispose();
+        to.dispose();
 
         verify(o, never()).onNext(null);
         verify(o, never()).onComplete();
@@ -98,13 +98,13 @@ public class ObservableToFutureTest {
 
         Observer<Object> o = TestHelper.mockObserver();
 
-        TestObserver<Object> ts = new TestObserver<Object>(o);
-        ts.dispose();
+        TestObserver<Object> to = new TestObserver<Object>(o);
+        to.dispose();
 
-        Observable.fromFuture(future).subscribe(ts);
+        Observable.fromFuture(future).subscribe(to);
 
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+        to.assertNoErrors();
+        to.assertNotComplete();
     }
 
     @Test
@@ -144,17 +144,17 @@ public class ObservableToFutureTest {
 
         Observer<Object> o = TestHelper.mockObserver();
 
-        TestObserver<Object> ts = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<Object>(o);
         Observable<Object> futureObservable = Observable.fromFuture(future);
 
-        futureObservable.subscribeOn(Schedulers.computation()).subscribe(ts);
+        futureObservable.subscribeOn(Schedulers.computation()).subscribe(to);
 
         Thread.sleep(100);
 
-        ts.dispose();
+        to.dispose();
 
-        ts.assertNoErrors();
-        ts.assertNoValues();
-        ts.assertNotComplete();
+        to.assertNoErrors();
+        to.assertNoValues();
+        to.assertNotComplete();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithObservableTest.java
@@ -253,7 +253,7 @@ public class ObservableWindowWithObservableTest {
     @Test
     public void testWindowNoDuplication() {
         final PublishSubject<Integer> source = PublishSubject.create();
-        final TestObserver<Integer> tsw = new TestObserver<Integer>() {
+        final TestObserver<Integer> tow = new TestObserver<Integer>() {
             boolean once;
             @Override
             public void onNext(Integer t) {
@@ -264,10 +264,10 @@ public class ObservableWindowWithObservableTest {
                 super.onNext(t);
             }
         };
-        TestObserver<Observable<Integer>> ts = new TestObserver<Observable<Integer>>() {
+        TestObserver<Observable<Integer>> to = new TestObserver<Observable<Integer>>() {
             @Override
             public void onNext(Observable<Integer> t) {
-                t.subscribe(tsw);
+                t.subscribe(tow);
                 super.onNext(t);
             }
         };
@@ -276,13 +276,13 @@ public class ObservableWindowWithObservableTest {
             public Observable<Object> call() {
                 return Observable.never();
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
         source.onNext(1);
         source.onComplete();
 
-        ts.assertValueCount(1);
-        tsw.assertValues(1, 2);
+        to.assertValueCount(1);
+        tow.assertValues(1, 2);
     }
 
     @Test
@@ -295,12 +295,12 @@ public class ObservableWindowWithObservableTest {
             }
         };
 
-        TestObserver<Observable<Integer>> ts = new TestObserver<Observable<Integer>>();
-        source.window(boundary).subscribe(ts);
+        TestObserver<Observable<Integer>> to = new TestObserver<Observable<Integer>>();
+        source.window(boundary).subscribe(to);
 
         // 2.0.2 - not anymore
         // assertTrue("Not cancelled!", ts.isCancelled());
-        ts.assertComplete();
+        to.assertComplete();
     }
 
     @Test
@@ -314,8 +314,8 @@ public class ObservableWindowWithObservableTest {
             }
         };
 
-        TestObserver<Observable<Integer>> ts = new TestObserver<Observable<Integer>>();
-        source.window(boundaryFunc).subscribe(ts);
+        TestObserver<Observable<Integer>> to = new TestObserver<Observable<Integer>>();
+        source.window(boundaryFunc).subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(boundary.hasObservers());
@@ -325,9 +325,9 @@ public class ObservableWindowWithObservableTest {
         assertFalse(source.hasObservers());
         assertFalse(boundary.hasObservers());
 
-        ts.assertComplete();
-        ts.assertNoErrors();
-        ts.assertValueCount(1);
+        to.assertComplete();
+        to.assertNoErrors();
+        to.assertValueCount(1);
     }
     @Test
     public void testMainUnsubscribedOnBoundaryCompletion() {
@@ -340,8 +340,8 @@ public class ObservableWindowWithObservableTest {
             }
         };
 
-        TestObserver<Observable<Integer>> ts = new TestObserver<Observable<Integer>>();
-        source.window(boundaryFunc).subscribe(ts);
+        TestObserver<Observable<Integer>> to = new TestObserver<Observable<Integer>>();
+        source.window(boundaryFunc).subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(boundary.hasObservers());
@@ -352,9 +352,9 @@ public class ObservableWindowWithObservableTest {
         assertFalse(source.hasObservers());
         assertFalse(boundary.hasObservers());
 
-        ts.assertComplete();
-        ts.assertNoErrors();
-        ts.assertValueCount(1);
+        to.assertComplete();
+        to.assertNoErrors();
+        to.assertValueCount(1);
     }
 
     @Test
@@ -368,25 +368,25 @@ public class ObservableWindowWithObservableTest {
             }
         };
 
-        TestObserver<Observable<Integer>> ts = new TestObserver<Observable<Integer>>();
-        source.window(boundaryFunc).subscribe(ts);
+        TestObserver<Observable<Integer>> to = new TestObserver<Observable<Integer>>();
+        source.window(boundaryFunc).subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(boundary.hasObservers());
 
-        ts.dispose();
+        to.dispose();
 
         assertTrue(source.hasObservers());
 
         assertFalse(boundary.hasObservers());
 
-        ts.values().get(0).test(true);
+        to.values().get(0).test(true);
 
         assertFalse(source.hasObservers());
 
-        ts.assertNotComplete();
-        ts.assertNoErrors();
-        ts.assertValueCount(1);
+        to.assertNotComplete();
+        to.assertNoErrors();
+        to.assertValueCount(1);
     }
 
     @Test
@@ -402,8 +402,8 @@ public class ObservableWindowWithObservableTest {
             }
         };
 
-        TestObserver<Observable<Integer>> ts = new TestObserver<Observable<Integer>>();
-        source.window(boundaryFunc).subscribe(ts);
+        TestObserver<Observable<Integer>> to = new TestObserver<Observable<Integer>>();
+        source.window(boundaryFunc).subscribe(to);
 
         source.onNext(1);
         boundary.onNext(1);
@@ -420,9 +420,9 @@ public class ObservableWindowWithObservableTest {
         source.onNext(4);
         source.onComplete();
 
-        ts.assertNoErrors();
-        ts.assertValueCount(4);
-        ts.assertComplete();
+        to.assertNoErrors();
+        to.assertValueCount(4);
+        to.assertComplete();
 
         assertFalse(source.hasObservers());
         assertFalse(boundary.hasObservers());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -105,7 +105,7 @@ public class ObservableWindowWithSizeTest {
 
     @Test
     public void testWindowUnsubscribeNonOverlapping() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         final AtomicInteger count = new AtomicInteger();
         Observable.merge(Observable.range(1, 10000).doOnNext(new Consumer<Integer>() {
 
@@ -114,17 +114,17 @@ public class ObservableWindowWithSizeTest {
                 count.incrementAndGet();
             }
 
-        }).window(5).take(2)).subscribe(ts);
-        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertTerminated();
-        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        }).window(5).take(2)).subscribe(to);
+        to.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        to.assertTerminated();
+        to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         //        System.out.println(ts.getOnNextEvents());
         assertEquals(10, count.get());
     }
 
     @Test
     public void testWindowUnsubscribeNonOverlappingAsyncSource() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         final AtomicInteger count = new AtomicInteger();
         Observable.merge(Observable.range(1, 100000)
                 .doOnNext(new Consumer<Integer>() {
@@ -145,17 +145,17 @@ public class ObservableWindowWithSizeTest {
                 .observeOn(Schedulers.computation())
                 .window(5)
                 .take(2))
-                .subscribe(ts);
-        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertTerminated();
-        ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                .subscribe(to);
+        to.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        to.assertTerminated();
+        to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         // make sure we don't emit all values ... the unsubscribe should propagate
         assertTrue(count.get() < 100000);
     }
 
     @Test
     public void testWindowUnsubscribeOverlapping() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         final AtomicInteger count = new AtomicInteger();
         Observable.merge(Observable.range(1, 10000).doOnNext(new Consumer<Integer>() {
 
@@ -164,17 +164,17 @@ public class ObservableWindowWithSizeTest {
                 count.incrementAndGet();
             }
 
-        }).window(5, 4).take(2)).subscribe(ts);
-        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertTerminated();
+        }).window(5, 4).take(2)).subscribe(to);
+        to.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        to.assertTerminated();
         //        System.out.println(ts.getOnNextEvents());
-        ts.assertValues(1, 2, 3, 4, 5, 5, 6, 7, 8, 9);
+        to.assertValues(1, 2, 3, 4, 5, 5, 6, 7, 8, 9);
         assertEquals(9, count.get());
     }
 
     @Test
     public void testWindowUnsubscribeOverlappingAsyncSource() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
         final AtomicInteger count = new AtomicInteger();
         Observable.merge(Observable.range(1, 100000)
                 .doOnNext(new Consumer<Integer>() {
@@ -188,10 +188,10 @@ public class ObservableWindowWithSizeTest {
                 .observeOn(Schedulers.computation())
                 .window(5, 4)
                 .take(2), 128)
-                .subscribe(ts);
-        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertTerminated();
-        ts.assertValues(1, 2, 3, 4, 5, 5, 6, 7, 8, 9);
+                .subscribe(to);
+        to.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        to.assertTerminated();
+        to.assertValues(1, 2, 3, 4, 5, 5, 6, 7, 8, 9);
         // make sure we don't emit all values ... the unsubscribe should propagate
         // assertTrue(count.get() < 100000); // disabled: a small hiccup in the consumption may allow the source to run to completion
     }
@@ -231,7 +231,7 @@ public class ObservableWindowWithSizeTest {
 
     @Test
     public void testTakeFlatMapCompletes() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         final int indicator = 999999999;
 
@@ -243,11 +243,11 @@ public class ObservableWindowWithSizeTest {
             public Observable<Integer> apply(Observable<Integer> w) {
                 return w.startWith(indicator);
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
-        ts.awaitTerminalEvent(2, TimeUnit.SECONDS);
-        ts.assertComplete();
-        ts.assertValueCount(22);
+        to.awaitTerminalEvent(2, TimeUnit.SECONDS);
+        to.assertComplete();
+        to.assertValueCount(22);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -202,14 +202,14 @@ public class ObservableWindowWithStartEndObservableTest {
         PublishSubject<Integer> open = PublishSubject.create();
         final PublishSubject<Integer> close = PublishSubject.create();
 
-        TestObserver<Observable<Integer>> ts = new TestObserver<Observable<Integer>>();
+        TestObserver<Observable<Integer>> to = new TestObserver<Observable<Integer>>();
 
         source.window(open, new Function<Integer, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Integer t) {
                 return close;
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
         open.onNext(1);
         source.onNext(1);
@@ -223,9 +223,9 @@ public class ObservableWindowWithStartEndObservableTest {
 
         source.onComplete();
 
-        ts.assertComplete();
-        ts.assertNoErrors();
-        ts.assertValueCount(1);
+        to.assertComplete();
+        to.assertNoErrors();
+        to.assertValueCount(1);
 
         // 2.0.2 - not anymore
 //        assertTrue("Not cancelled!", ts.isCancelled());
@@ -240,21 +240,21 @@ public class ObservableWindowWithStartEndObservableTest {
         PublishSubject<Integer> open = PublishSubject.create();
         final PublishSubject<Integer> close = PublishSubject.create();
 
-        TestObserver<Observable<Integer>> ts = new TestObserver<Observable<Integer>>();
+        TestObserver<Observable<Integer>> to = new TestObserver<Observable<Integer>>();
 
         source.window(open, new Function<Integer, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Integer t) {
                 return close;
             }
-        }).subscribe(ts);
+        }).subscribe(to);
 
         open.onNext(1);
 
         assertTrue(open.hasObservers());
         assertTrue(close.hasObservers());
 
-        ts.dispose();
+        to.dispose();
 
         // FIXME subject has subscribers because of the open window
         assertTrue(open.hasObservers());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -181,7 +181,7 @@ public class ObservableWindowWithTimeTest {
 
     @Test
     public void testTakeFlatMapCompletes() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         final AtomicInteger wip = new AtomicInteger();
 
@@ -215,11 +215,11 @@ public class ObservableWindowWithTimeTest {
                 System.out.println(pv);
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
-        ts.assertComplete();
-        Assert.assertTrue(ts.valueCount() != 0);
+        to.awaitTerminalEvent(5, TimeUnit.SECONDS);
+        to.assertComplete();
+        Assert.assertTrue(to.valueCount() != 0);
     }
 
     @Test
@@ -306,107 +306,107 @@ public class ObservableWindowWithTimeTest {
     public void timeskipSkipping() {
         TestScheduler scheduler = new TestScheduler();
 
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = pp.window(1, 2, TimeUnit.SECONDS, scheduler)
+        TestObserver<Integer> to = ps.window(1, 2, TimeUnit.SECONDS, scheduler)
         .flatMap(Functions.<Observable<Integer>>identity())
         .test();
 
-        pp.onNext(1);
-        pp.onNext(2);
+        ps.onNext(1);
+        ps.onNext(2);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        pp.onNext(3);
-        pp.onNext(4);
+        ps.onNext(3);
+        ps.onNext(4);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        pp.onNext(5);
-        pp.onNext(6);
+        ps.onNext(5);
+        ps.onNext(6);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        pp.onNext(7);
-        pp.onComplete();
+        ps.onNext(7);
+        ps.onComplete();
 
-        ts.assertResult(1, 2, 5, 6);
+        to.assertResult(1, 2, 5, 6);
     }
 
     @Test
     public void timeskipOverlapping() {
         TestScheduler scheduler = new TestScheduler();
 
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = pp.window(2, 1, TimeUnit.SECONDS, scheduler)
+        TestObserver<Integer> to = ps.window(2, 1, TimeUnit.SECONDS, scheduler)
         .flatMap(Functions.<Observable<Integer>>identity())
         .test();
 
-        pp.onNext(1);
-        pp.onNext(2);
+        ps.onNext(1);
+        ps.onNext(2);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        pp.onNext(3);
-        pp.onNext(4);
+        ps.onNext(3);
+        ps.onNext(4);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        pp.onNext(5);
-        pp.onNext(6);
+        ps.onNext(5);
+        ps.onNext(6);
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        pp.onNext(7);
-        pp.onComplete();
+        ps.onNext(7);
+        ps.onComplete();
 
-        ts.assertResult(1, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7);
+        to.assertResult(1, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7);
     }
 
     @Test
     public void exactOnError() {
         TestScheduler scheduler = new TestScheduler();
 
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = pp.window(1, 1, TimeUnit.SECONDS, scheduler)
+        TestObserver<Integer> to = ps.window(1, 1, TimeUnit.SECONDS, scheduler)
         .flatMap(Functions.<Observable<Integer>>identity())
         .test();
 
-        pp.onError(new TestException());
+        ps.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
     public void overlappingOnError() {
         TestScheduler scheduler = new TestScheduler();
 
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = pp.window(2, 1, TimeUnit.SECONDS, scheduler)
+        TestObserver<Integer> to = ps.window(2, 1, TimeUnit.SECONDS, scheduler)
         .flatMap(Functions.<Observable<Integer>>identity())
         .test();
 
-        pp.onError(new TestException());
+        ps.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
     public void skipOnError() {
         TestScheduler scheduler = new TestScheduler();
 
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = pp.window(1, 2, TimeUnit.SECONDS, scheduler)
+        TestObserver<Integer> to = ps.window(1, 2, TimeUnit.SECONDS, scheduler)
         .flatMap(Functions.<Observable<Integer>>identity())
         .test();
 
-        pp.onError(new TestException());
+        ps.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -591,17 +591,17 @@ public class ObservableWindowWithTimeTest {
         TestScheduler scheduler = new TestScheduler();
         Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 100)
+        TestObserver<Observable<Integer>> to = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 100)
         .test()
         .assertValueCount(1);
 
         scheduler.advanceTimeBy(5, TimeUnit.MILLISECONDS);
 
-        ts.assertValueCount(2)
+        to.assertValueCount(2)
         .assertNoErrors()
         .assertNotComplete();
 
-        ts.values().get(0).test().assertResult();
+        to.values().get(0).test().assertResult();
     }
 
     @Test
@@ -609,12 +609,12 @@ public class ObservableWindowWithTimeTest {
         TestScheduler scheduler = new TestScheduler();
         Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, Long.MAX_VALUE, false)
+        TestObserver<Observable<Integer>> to = ps.window(5, TimeUnit.MILLISECONDS, scheduler, Long.MAX_VALUE, false)
         .test();
 
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
-        ts.assertValueCount(21)
+        to.assertValueCount(21)
         .assertNoErrors()
         .assertNotComplete();
     }
@@ -624,12 +624,12 @@ public class ObservableWindowWithTimeTest {
         TestScheduler scheduler = new TestScheduler();
         Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, Long.MAX_VALUE, true)
+        TestObserver<Observable<Integer>> to = ps.window(5, TimeUnit.MILLISECONDS, scheduler, Long.MAX_VALUE, true)
         .test();
 
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
-        ts.assertValueCount(21)
+        to.assertValueCount(21)
         .assertNoErrors()
         .assertNotComplete();
     }
@@ -639,12 +639,12 @@ public class ObservableWindowWithTimeTest {
         TestScheduler scheduler = new TestScheduler();
         Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, false)
+        TestObserver<Observable<Integer>> to = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, false)
         .test();
 
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
-        ts.assertValueCount(21)
+        to.assertValueCount(21)
         .assertNoErrors()
         .assertNotComplete();
     }
@@ -654,12 +654,12 @@ public class ObservableWindowWithTimeTest {
         TestScheduler scheduler = new TestScheduler();
         Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, true)
+        TestObserver<Observable<Integer>> to = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, true)
         .test();
 
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
-        ts.assertValueCount(21)
+        to.assertValueCount(21)
         .assertNoErrors()
         .assertNotComplete();
     }
@@ -669,7 +669,7 @@ public class ObservableWindowWithTimeTest {
         TestScheduler scheduler = new TestScheduler();
         Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 2, true)
+        TestObserver<Observable<Integer>> to = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 2, true)
         .test();
 
         ps.onNext(1);
@@ -677,7 +677,7 @@ public class ObservableWindowWithTimeTest {
 
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
-        ts.assertValueCount(22)
+        to.assertValueCount(22)
         .assertNoErrors()
         .assertNotComplete();
     }
@@ -687,7 +687,7 @@ public class ObservableWindowWithTimeTest {
         TestScheduler scheduler = new TestScheduler();
         Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Observable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, true)
+        TestObserver<Observable<Integer>> to = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, true)
         .test();
 
         // window #1
@@ -702,7 +702,7 @@ public class ObservableWindowWithTimeTest {
         ps.onNext(5);
         ps.onNext(6);
 
-        ts.assertValueCount(2)
+        to.assertValueCount(2)
         .assertNoErrors()
         .assertNotComplete();
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromTest.java
@@ -89,9 +89,9 @@ public class ObservableWithLatestFromTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        result.subscribe(ts);
+        result.subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(other.hasObservers());
@@ -100,9 +100,9 @@ public class ObservableWithLatestFromTest {
 
         source.onComplete();
 
-        ts.assertNoErrors();
-        ts.assertTerminated();
-        ts.assertNoValues();
+        to.assertNoErrors();
+        to.assertTerminated();
+        to.assertNoValues();
 
         assertFalse(source.hasObservers());
         assertFalse(other.hasObservers());
@@ -115,9 +115,9 @@ public class ObservableWithLatestFromTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        result.subscribe(ts);
+        result.subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(other.hasObservers());
@@ -126,9 +126,9 @@ public class ObservableWithLatestFromTest {
 
         source.onComplete();
 
-        ts.assertNoErrors();
-        ts.assertTerminated();
-        ts.assertNoValues();
+        to.assertNoErrors();
+        to.assertTerminated();
+        to.assertNoValues();
 
         assertFalse(source.hasObservers());
         assertFalse(other.hasObservers());
@@ -142,9 +142,9 @@ public class ObservableWithLatestFromTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        result.subscribe(ts);
+        result.subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(other.hasObservers());
@@ -152,11 +152,11 @@ public class ObservableWithLatestFromTest {
         other.onNext(1);
         source.onNext(1);
 
-        ts.dispose();
+        to.dispose();
 
-        ts.assertValue((1 << 8) + 1);
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+        to.assertValue((1 << 8) + 1);
+        to.assertNoErrors();
+        to.assertNotComplete();
 
         assertFalse(source.hasObservers());
         assertFalse(other.hasObservers());
@@ -169,9 +169,9 @@ public class ObservableWithLatestFromTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        result.subscribe(ts);
+        result.subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(other.hasObservers());
@@ -181,10 +181,10 @@ public class ObservableWithLatestFromTest {
 
         source.onError(new TestException());
 
-        ts.assertTerminated();
-        ts.assertValue((1 << 8) + 1);
-        ts.assertError(TestException.class);
-        ts.assertNotComplete();
+        to.assertTerminated();
+        to.assertValue((1 << 8) + 1);
+        to.assertError(TestException.class);
+        to.assertNotComplete();
 
         assertFalse(source.hasObservers());
         assertFalse(other.hasObservers());
@@ -196,9 +196,9 @@ public class ObservableWithLatestFromTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        result.subscribe(ts);
+        result.subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(other.hasObservers());
@@ -208,10 +208,10 @@ public class ObservableWithLatestFromTest {
 
         other.onError(new TestException());
 
-        ts.assertTerminated();
-        ts.assertValue((1 << 8) + 1);
-        ts.assertNotComplete();
-        ts.assertError(TestException.class);
+        to.assertTerminated();
+        to.assertValue((1 << 8) + 1);
+        to.assertNotComplete();
+        to.assertError(TestException.class);
 
         assertFalse(source.hasObservers());
         assertFalse(other.hasObservers());
@@ -224,9 +224,9 @@ public class ObservableWithLatestFromTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER_ERROR);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        result.subscribe(ts);
+        result.subscribe(to);
 
         assertTrue(source.hasObservers());
         assertTrue(other.hasObservers());
@@ -234,10 +234,10 @@ public class ObservableWithLatestFromTest {
         other.onNext(1);
         source.onNext(1);
 
-        ts.assertTerminated();
-        ts.assertNotComplete();
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
+        to.assertTerminated();
+        to.assertNotComplete();
+        to.assertNoValues();
+        to.assertError(TestException.class);
 
         assertFalse(source.hasObservers());
         assertFalse(other.hasObservers());
@@ -250,9 +250,9 @@ public class ObservableWithLatestFromTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        result.subscribe(ts);
+        result.subscribe(to);
 
         source.onComplete();
 
@@ -275,40 +275,40 @@ public class ObservableWithLatestFromTest {
         PublishSubject<String> ps3 = PublishSubject.create();
         PublishSubject<String> main = PublishSubject.create();
 
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
 
         main.withLatestFrom(new Observable[] { ps1, ps2, ps3 }, toArray)
-        .subscribe(ts);
+        .subscribe(to);
 
         main.onNext("1");
-        ts.assertNoValues();
+        to.assertNoValues();
         ps1.onNext("a");
-        ts.assertNoValues();
+        to.assertNoValues();
         ps2.onNext("A");
-        ts.assertNoValues();
+        to.assertNoValues();
         ps3.onNext("=");
-        ts.assertNoValues();
+        to.assertNoValues();
 
         main.onNext("2");
-        ts.assertValues("[2, a, A, =]");
+        to.assertValues("[2, a, A, =]");
 
         ps2.onNext("B");
 
-        ts.assertValues("[2, a, A, =]");
+        to.assertValues("[2, a, A, =]");
 
         ps3.onComplete();
-        ts.assertValues("[2, a, A, =]");
+        to.assertValues("[2, a, A, =]");
 
         ps1.onNext("b");
 
         main.onNext("3");
 
-        ts.assertValues("[2, a, A, =]", "[3, b, B, =]");
+        to.assertValues("[2, a, A, =]", "[3, b, B, =]");
 
         main.onComplete();
-        ts.assertValues("[2, a, A, =]", "[3, b, B, =]");
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValues("[2, a, A, =]", "[3, b, B, =]");
+        to.assertNoErrors();
+        to.assertComplete();
 
         assertFalse("ps1 has subscribers?", ps1.hasObservers());
         assertFalse("ps2 has subscribers?", ps2.hasObservers());
@@ -322,40 +322,40 @@ public class ObservableWithLatestFromTest {
         PublishSubject<String> ps3 = PublishSubject.create();
         PublishSubject<String> main = PublishSubject.create();
 
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
 
         main.withLatestFrom(Arrays.<Observable<?>>asList(ps1, ps2, ps3), toArray)
-        .subscribe(ts);
+        .subscribe(to);
 
         main.onNext("1");
-        ts.assertNoValues();
+        to.assertNoValues();
         ps1.onNext("a");
-        ts.assertNoValues();
+        to.assertNoValues();
         ps2.onNext("A");
-        ts.assertNoValues();
+        to.assertNoValues();
         ps3.onNext("=");
-        ts.assertNoValues();
+        to.assertNoValues();
 
         main.onNext("2");
-        ts.assertValues("[2, a, A, =]");
+        to.assertValues("[2, a, A, =]");
 
         ps2.onNext("B");
 
-        ts.assertValues("[2, a, A, =]");
+        to.assertValues("[2, a, A, =]");
 
         ps3.onComplete();
-        ts.assertValues("[2, a, A, =]");
+        to.assertValues("[2, a, A, =]");
 
         ps1.onNext("b");
 
         main.onNext("3");
 
-        ts.assertValues("[2, a, A, =]", "[3, b, B, =]");
+        to.assertValues("[2, a, A, =]", "[3, b, B, =]");
 
         main.onComplete();
-        ts.assertValues("[2, a, A, =]", "[3, b, B, =]");
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValues("[2, a, A, =]", "[3, b, B, =]");
+        to.assertNoErrors();
+        to.assertComplete();
 
         assertFalse("ps1 has subscribers?", ps1.hasObservers());
         assertFalse("ps2 has subscribers?", ps2.hasObservers());
@@ -376,20 +376,20 @@ public class ObservableWithLatestFromTest {
                     expected.add(String.valueOf(val));
                 }
 
-                TestObserver<String> ts = new TestObserver<String>();
+                TestObserver<String> to = new TestObserver<String>();
 
                 PublishSubject<String> main = PublishSubject.create();
 
-                main.withLatestFrom(sources, toArray).subscribe(ts);
+                main.withLatestFrom(sources, toArray).subscribe(to);
 
-                ts.assertNoValues();
+                to.assertNoValues();
 
                 main.onNext(val);
                 main.onComplete();
 
-                ts.assertValue(expected.toString());
-                ts.assertNoErrors();
-                ts.assertComplete();
+                to.assertValue(expected.toString());
+                to.assertNoErrors();
+                to.assertComplete();
             }
         }
     }
@@ -400,18 +400,18 @@ public class ObservableWithLatestFromTest {
 //        PublishSubject<String> ps1 = PublishSubject.create();
 //        PublishSubject<String> ps2 = PublishSubject.create();
 //
-//        TestObserver<String> ts = new TestObserver<String>();
+//        TestObserver<String> to = new TestObserver<String>();
 //
 //        Observable.range(1, 10).withLatestFrom(new Observable<?>[] { ps1, ps2 }, toArray)
-//        .subscribe(ts);
+//        .subscribe(to);
 //
-//        ts.assertNoValues();
+//        to.assertNoValues();
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertNoValues();
-//        ts.assertNoErrors();
-//        ts.assertComplete();
+//        to.assertNoValues();
+//        to.assertNoErrors();
+//        to.assertComplete();
 //
 //        assertFalse("ps1 has subscribers?", ps1.hasSubscribers());
 //        assertFalse("ps2 has subscribers?", ps2.hasSubscribers());
@@ -423,29 +423,29 @@ public class ObservableWithLatestFromTest {
 //        PublishSubject<String> ps1 = PublishSubject.create();
 //        PublishSubject<String> ps2 = PublishSubject.create();
 //
-//        TestObserver<String> ts = new TestObserver<String>();
+//        TestObserver<String> to = new TestObserver<String>();
 //
 //        Observable.range(1, 3).withLatestFrom(new Observable<?>[] { ps1, ps2 }, toArray)
 //        .subscribe(ts);
 //
-//        ts.assertNoValues();
+//        to.assertNoValues();
 //
 //        ps1.onNext("1");
 //        ps2.onNext("1");
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertValue("[1, 1, 1]");
+//        to.assertValue("[1, 1, 1]");
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertValues("[1, 1, 1]", "[2, 1, 1]");
+//        to.assertValues("[1, 1, 1]", "[2, 1, 1]");
 //
-//        ts.request(1);
+//        to.request(1);
 //
-//        ts.assertValues("[1, 1, 1]", "[2, 1, 1]", "[3, 1, 1]");
-//        ts.assertNoErrors();
-//        ts.assertComplete();
+//        to.assertValues("[1, 1, 1]", "[2, 1, 1]", "[3, 1, 1]");
+//        to.assertNoErrors();
+//        to.assertComplete();
 //
 //        assertFalse("ps1 has subscribers?", ps1.hasSubscribers());
 //        assertFalse("ps2 has subscribers?", ps2.hasSubscribers());
@@ -453,48 +453,48 @@ public class ObservableWithLatestFromTest {
 
     @Test
     public void withEmpty() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
 
         Observable.range(1, 3).withLatestFrom(
                 new Observable<?>[] { Observable.just(1), Observable.empty() }, toArray)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
     public void withError() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
 
         Observable.range(1, 3).withLatestFrom(
                 new Observable<?>[] { Observable.just(1), Observable.error(new TestException()) }, toArray)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertError(TestException.class);
+        to.assertNotComplete();
     }
 
     @Test
     public void withMainError() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
 
         Observable.error(new TestException()).withLatestFrom(
                 new Observable<?>[] { Observable.just(1), Observable.just(1) }, toArray)
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertNoValues();
-        ts.assertError(TestException.class);
-        ts.assertNotComplete();
+        to.assertNoValues();
+        to.assertError(TestException.class);
+        to.assertNotComplete();
     }
 
     @Test
     public void with2Others() {
         Observable<Integer> just = Observable.just(1);
 
-        TestObserver<List<Integer>> ts = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
 
         just.withLatestFrom(just, just, new Function3<Integer, Integer, Integer, List<Integer>>() {
             @Override
@@ -502,18 +502,18 @@ public class ObservableWithLatestFromTest {
                 return Arrays.asList(a, b, c);
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertValue(Arrays.asList(1, 1, 1));
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValue(Arrays.asList(1, 1, 1));
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
     public void with3Others() {
         Observable<Integer> just = Observable.just(1);
 
-        TestObserver<List<Integer>> ts = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
 
         just.withLatestFrom(just, just, just, new Function4<Integer, Integer, Integer, Integer, List<Integer>>() {
             @Override
@@ -521,18 +521,18 @@ public class ObservableWithLatestFromTest {
                 return Arrays.asList(a, b, c, d);
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertValue(Arrays.asList(1, 1, 1, 1));
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValue(Arrays.asList(1, 1, 1, 1));
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test
     public void with4Others() {
         Observable<Integer> just = Observable.just(1);
 
-        TestObserver<List<Integer>> ts = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
 
         just.withLatestFrom(just, just, just, just, new Function5<Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
             @Override
@@ -540,11 +540,11 @@ public class ObservableWithLatestFromTest {
                 return Arrays.asList(a, b, c, d, e);
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertValue(Arrays.asList(1, 1, 1, 1, 1));
-        ts.assertNoErrors();
-        ts.assertComplete();
+        to.assertValue(Arrays.asList(1, 1, 1, 1, 1));
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
@@ -349,9 +349,9 @@ public class ObservableZipTest {
         PublishSubject<String> r2 = PublishSubject.create();
         /* define an Observer to receive aggregated events */
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<String>(observer);
 
-        Observable.zip(r1, r2, zipr2).subscribe(ts);
+        Observable.zip(r1, r2, zipr2).subscribe(to);
 
         /* simulate the Observables pushing data into the aggregator */
         r1.onNext("hello");
@@ -361,7 +361,7 @@ public class ObservableZipTest {
         verify(observer, never()).onComplete();
         verify(observer, times(1)).onNext("helloworld");
 
-        ts.dispose();
+        to.dispose();
         r1.onNext("hello");
         r2.onNext("again");
 
@@ -794,16 +794,16 @@ public class ObservableZipTest {
                     }
                 }).take(5);
 
-        TestObserver<String> ts = new TestObserver<String>();
-        os.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>();
+        os.subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
 
-        assertEquals(5, ts.valueCount());
-        assertEquals("1-1", ts.values().get(0));
-        assertEquals("2-2", ts.values().get(1));
-        assertEquals("5-5", ts.values().get(4));
+        assertEquals(5, to.valueCount());
+        assertEquals("1-1", to.values().get(0));
+        assertEquals("2-2", to.values().get(1));
+        assertEquals("5-5", to.values().get(4));
     }
 
     @Test
@@ -969,10 +969,10 @@ public class ObservableZipTest {
             }
         });
 
-        TestObserver<Object> ts = new TestObserver<Object>();
-        o.subscribe(ts);
-        ts.awaitTerminalEvent(200, TimeUnit.MILLISECONDS);
-        ts.assertNoValues();
+        TestObserver<Object> to = new TestObserver<Object>();
+        o.subscribe(to);
+        to.awaitTerminalEvent(200, TimeUnit.MILLISECONDS);
+        to.assertNoValues();
     }
 
     /**
@@ -1003,7 +1003,7 @@ public class ObservableZipTest {
         Observable<Integer> o1 = createInfiniteObservable(generatedA).take(Observable.bufferSize() * 2);
         Observable<Integer> o2 = createInfiniteObservable(generatedB).take(Observable.bufferSize() * 2);
 
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
         Observable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
 
             @Override
@@ -1011,11 +1011,11 @@ public class ObservableZipTest {
                 return t1 + "-" + t2;
             }
 
-        }).observeOn(Schedulers.computation()).take(Observable.bufferSize() * 2).subscribe(ts);
+        }).observeOn(Schedulers.computation()).take(Observable.bufferSize() * 2).subscribe(to);
 
-        ts.awaitTerminalEvent();
-        ts.assertNoErrors();
-        assertEquals(Observable.bufferSize() * 2, ts.valueCount());
+        to.awaitTerminalEvent();
+        to.assertNoErrors();
+        assertEquals(Observable.bufferSize() * 2, to.valueCount());
         System.out.println("Generated => A: " + generatedA.get() + " B: " + generatedB.get());
         assertTrue(generatedA.get() < (Observable.bufferSize() * 3));
         assertTrue(generatedB.get() < (Observable.bufferSize() * 3));
@@ -1363,7 +1363,7 @@ public class ObservableZipTest {
     @Test
     public void noCrossBoundaryFusion() {
         for (int i = 0; i < 500; i++) {
-            TestObserver<List<Object>> ts = Observable.zip(
+            TestObserver<List<Object>> to = Observable.zip(
                     Observable.just(1).observeOn(Schedulers.single()).map(new Function<Integer, Object>() {
                         @Override
                         public Object apply(Integer v) throws Exception {
@@ -1387,7 +1387,7 @@ public class ObservableZipTest {
             .awaitDone(5, TimeUnit.SECONDS)
             .assertValueCount(1);
 
-            List<Object> list = ts.values().get(0);
+            List<Object> list = to.values().get(0);
 
             assertTrue(list.toString(), list.contains("RxSi"));
             assertTrue(list.toString(), list.contains("RxCo"));
@@ -1399,7 +1399,7 @@ public class ObservableZipTest {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1421,10 +1421,10 @@ public class ObservableZipTest {
                 return t1 + t2;
             }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
         ps1.onNext(1);
         ps2.onNext(2);
-        ts.assertResult(3);
+        to.assertResult(3);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
@@ -32,7 +32,7 @@ public class SingleAmbTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp1.single(-99).ambWith(pp2.single(-99)).test();
+        TestObserver<Integer> to = pp1.single(-99).ambWith(pp2.single(-99)).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -43,7 +43,7 @@ public class SingleAmbTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult(1);
+        to.assertResult(1);
 
     }
 
@@ -52,7 +52,7 @@ public class SingleAmbTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp1.single(-99).ambWith(pp2.single(-99)).test();
+        TestObserver<Integer> to = pp1.single(-99).ambWith(pp2.single(-99)).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -63,7 +63,7 @@ public class SingleAmbTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult(2);
+        to.assertResult(2);
     }
 
     @SuppressWarnings("unchecked")
@@ -73,7 +73,7 @@ public class SingleAmbTest {
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
         List<Single<Integer>> singles = Arrays.asList(pp1.single(-99), pp2.single(-99));
-        TestObserver<Integer> ts = Single.amb(singles).test();
+        TestObserver<Integer> to = Single.amb(singles).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -84,7 +84,7 @@ public class SingleAmbTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult(1);
+        to.assertResult(1);
 
     }
 
@@ -95,7 +95,7 @@ public class SingleAmbTest {
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
         List<Single<Integer>> singles = Arrays.asList(pp1.single(-99), pp2.single(-99));
-        TestObserver<Integer> ts = Single.amb(singles).test();
+        TestObserver<Integer> to = Single.amb(singles).test();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -106,7 +106,7 @@ public class SingleAmbTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult(2);
+        to.assertResult(2);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
@@ -28,12 +28,12 @@ public class SingleCacheTest {
 
         Single<Integer> cached = pp.single(-99).cache();
 
-        TestObserver<Integer> ts = cached.test(true);
+        TestObserver<Integer> to = cached.test(true);
 
         pp.onNext(1);
         pp.onComplete();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         cached.test().assertResult(1);
     }
@@ -45,12 +45,12 @@ public class SingleCacheTest {
 
             final Single<Integer> cached = pp.single(-99).cache();
 
-            final TestObserver<Integer> ts1 = cached.test();
+            final TestObserver<Integer> to1 = cached.test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ts1.cancel();
+                    to1.cancel();
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterSuccessTest.java
@@ -38,7 +38,7 @@ public class SingleDoAfterSuccessTest {
         }
     };
 
-    final TestObserver<Integer> ts = new TestObserver<Integer>() {
+    final TestObserver<Integer> to = new TestObserver<Integer>() {
         @Override
         public void onNext(Integer t) {
             super.onNext(t);
@@ -50,7 +50,7 @@ public class SingleDoAfterSuccessTest {
     public void just() {
         Single.just(1)
         .doAfterSuccess(afterSuccess)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult(1);
 
         assertEquals(Arrays.asList(1, -1), values);
@@ -60,7 +60,7 @@ public class SingleDoAfterSuccessTest {
     public void error() {
         Single.<Integer>error(new TestException())
         .doAfterSuccess(afterSuccess)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertFailure(TestException.class);
 
         assertTrue(values.isEmpty());
@@ -76,7 +76,7 @@ public class SingleDoAfterSuccessTest {
         Single.just(1)
         .doAfterSuccess(afterSuccess)
         .filter(Functions.alwaysTrue())
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult(1);
 
         assertEquals(Arrays.asList(1, -1), values);
@@ -87,7 +87,7 @@ public class SingleDoAfterSuccessTest {
         Single.<Integer>error(new TestException())
         .doAfterSuccess(afterSuccess)
         .filter(Functions.alwaysTrue())
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertFailure(TestException.class);
 
         assertTrue(values.isEmpty());

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterTerminateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterTerminateTest.java
@@ -40,13 +40,13 @@ public class SingleDoAfterTerminateTest {
         }
     };
 
-    private final TestObserver<Integer> ts = new TestObserver<Integer>();
+    private final TestObserver<Integer> to = new TestObserver<Integer>();
 
     @Test
     public void just() {
         Single.just(1)
         .doAfterTerminate(afterTerminate)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult(1);
 
         assertAfterTerminateCalledOnce();
@@ -56,7 +56,7 @@ public class SingleDoAfterTerminateTest {
     public void error() {
         Single.<Integer>error(new TestException())
         .doAfterTerminate(afterTerminate)
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertFailure(TestException.class);
 
         assertAfterTerminateCalledOnce();
@@ -72,7 +72,7 @@ public class SingleDoAfterTerminateTest {
         Single.just(1)
         .doAfterTerminate(afterTerminate)
         .filter(Functions.alwaysTrue())
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertResult(1);
 
         assertAfterTerminateCalledOnce();
@@ -83,7 +83,7 @@ public class SingleDoAfterTerminateTest {
         Single.<Integer>error(new TestException())
         .doAfterTerminate(afterTerminate)
         .filter(Functions.alwaysTrue())
-        .subscribeWith(ts)
+        .subscribeWith(to)
         .assertFailure(TestException.class);
 
         assertAfterTerminateCalledOnce();

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowableTest.java
@@ -19,7 +19,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
@@ -108,7 +108,7 @@ public class SingleFlatMapIterableFlowableTest {
 
     @Test
     public void fused() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
             @Override
@@ -116,17 +116,17 @@ public class SingleFlatMapIterableFlowableTest {
                 return Arrays.asList(v, v + 1);
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
-        to.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC))
+        ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2);
         ;
     }
 
     @Test
     public void fusedNoSync() {
-        TestSubscriber<Integer> to = SubscriberFusion.newTest(QueueDisposable.SYNC);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
             @Override
@@ -134,10 +134,10 @@ public class SingleFlatMapIterableFlowableTest {
                 return Arrays.asList(v, v + 1);
             }
         })
-        .subscribe(to);
+        .subscribe(ts);
 
-        to.assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueDisposable.NONE))
+        ts.assertOf(SubscriberFusion.<Integer>assertFuseable())
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertResult(1, 2);
         ;
     }
@@ -292,7 +292,7 @@ public class SingleFlatMapIterableFlowableTest {
             public void onSubscribe(Subscription d) {
                 qd = (QueueSubscription<Integer>)d;
 
-                assertEquals(QueueSubscription.ASYNC, qd.requestFusion(QueueSubscription.ANY));
+                assertEquals(QueueFuseable.ASYNC, qd.requestFusion(QueueFuseable.ANY));
             }
 
             @Override

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservableTest.java
@@ -25,7 +25,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.util.CrashingIterable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
@@ -86,7 +86,7 @@ public class SingleFlatMapIterableObservableTest {
 
     @Test
     public void fused() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
         Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
             @Override
@@ -97,14 +97,14 @@ public class SingleFlatMapIterableObservableTest {
         .subscribe(to);
 
         to.assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2);
         ;
     }
 
     @Test
     public void fusedNoSync() {
-        TestObserver<Integer> to = ObserverFusion.newTest(QueueDisposable.SYNC);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.SYNC);
 
         Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
             @Override
@@ -115,7 +115,7 @@ public class SingleFlatMapIterableObservableTest {
         .subscribe(to);
 
         to.assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.NONE))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertResult(1, 2);
         ;
     }
@@ -295,7 +295,7 @@ public class SingleFlatMapIterableObservableTest {
             public void onSubscribe(Disposable d) {
                 qd = (QueueDisposable<Integer>)d;
 
-                assertEquals(QueueDisposable.ASYNC, qd.requestFusion(QueueDisposable.ANY));
+                assertEquals(QueueFuseable.ASYNC, qd.requestFusion(QueueFuseable.ANY));
             }
 
             @Override

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFromPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFromPublisherTest.java
@@ -61,13 +61,13 @@ public class SingleFromPublisherTest {
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Single.fromPublisher(pp).test();
+        TestObserver<Integer> to = Single.fromPublisher(pp).test();
 
         assertTrue(pp.hasSubscribers());
 
         pp.onNext(1);
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(pp.hasSubscribers());
     }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleSubscribeOnTest.java
@@ -35,13 +35,13 @@ public class SingleSubscribeOnTest {
         try {
             TestScheduler scheduler = new TestScheduler();
 
-            TestObserver<Integer> ts = Single.just(1)
+            TestObserver<Integer> to = Single.just(1)
             .subscribeOn(scheduler)
             .test();
 
             scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-            ts.assertResult(1);
+            to.assertResult(1);
 
             assertTrue(list.toString(), list.isEmpty());
         } finally {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
@@ -33,13 +33,13 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp)
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp)
         .test();
 
         source.onNext(1);
         source.onComplete();
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @Test
@@ -47,13 +47,13 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.single(-99))
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp.single(-99))
         .test();
 
         source.onNext(1);
         source.onComplete();
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
 
@@ -62,13 +62,13 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.ignoreElements())
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp.ignoreElements())
         .test();
 
         source.onNext(1);
         source.onComplete();
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @Test
@@ -76,12 +76,12 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp)
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp)
         .test();
 
         source.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -89,12 +89,12 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.single(-99))
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp.single(-99))
         .test();
 
         source.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -102,12 +102,12 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.ignoreElements())
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp.ignoreElements())
         .test();
 
         source.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -115,12 +115,12 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp)
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp)
         .test();
 
         pp.onNext(1);
 
-        ts.assertFailure(CancellationException.class);
+        to.assertFailure(CancellationException.class);
     }
 
     @Test
@@ -128,13 +128,13 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.single(-99))
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp.single(-99))
         .test();
 
         pp.onNext(1);
         pp.onComplete();
 
-        ts.assertFailure(CancellationException.class);
+        to.assertFailure(CancellationException.class);
     }
 
     @Test
@@ -142,13 +142,13 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.ignoreElements())
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp.ignoreElements())
         .test();
 
         pp.onNext(1);
         pp.onComplete();
 
-        ts.assertFailure(CancellationException.class);
+        to.assertFailure(CancellationException.class);
     }
 
     @Test
@@ -156,12 +156,12 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp)
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp)
         .test();
 
         pp.onComplete();
 
-        ts.assertFailure(CancellationException.class);
+        to.assertFailure(CancellationException.class);
     }
 
     @Test
@@ -169,12 +169,12 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.ignoreElements())
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp.ignoreElements())
         .test();
 
         pp.onComplete();
 
-        ts.assertFailure(CancellationException.class);
+        to.assertFailure(CancellationException.class);
     }
 
     @Test
@@ -182,12 +182,12 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp)
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp)
         .test();
 
         pp.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -195,12 +195,12 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.single(-99))
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp.single(-99))
         .test();
 
         pp.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -208,12 +208,12 @@ public class SingleTakeUntilTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestObserver<Integer> ts = source.single(-99).takeUntil(pp.ignoreElements())
+        TestObserver<Integer> to = source.single(-99).takeUntil(pp.ignoreElements())
         .test();
 
         pp.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
@@ -227,24 +227,24 @@ public class SingleTakeUntilTest {
             List<Throwable> errors = TestHelper.trackPluginErrors();
 
             try {
-                final PublishProcessor<Integer> ps1 = PublishProcessor.create();
-                final PublishProcessor<Integer> ps2 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp1 = PublishProcessor.create();
+                final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-                TestObserver<Integer> to = ps1.singleOrError().takeUntil(ps2).test();
+                TestObserver<Integer> to = pp1.singleOrError().takeUntil(pp2).test();
 
                 final TestException ex = new TestException();
 
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {
-                        ps1.onError(ex);
+                        pp1.onError(ex);
                     }
                 };
 
                 Runnable r2 = new Runnable() {
                     @Override
                     public void run() {
-                        ps2.onError(ex);
+                        pp2.onError(ex);
                     }
                 };
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTimerTest.java
@@ -38,7 +38,7 @@ public class SingleTimerTest {
         try {
             for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
-                TestObserver<Long> ts = Single.timer(1, TimeUnit.MILLISECONDS, s)
+                TestObserver<Long> to = Single.timer(1, TimeUnit.MILLISECONDS, s)
                 .map(new Function<Long, Long>() {
                     @Override
                     public Long apply(Long v) throws Exception {
@@ -54,7 +54,7 @@ public class SingleTimerTest {
 
                 Thread.sleep(500);
 
-                ts.cancel();
+                to.cancel();
 
                 Thread.sleep(500);
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
@@ -101,11 +101,11 @@ public class SingleUsingTest {
 
     @Test
     public void eagerMapperThrowsDisposerThrows() {
-        TestObserver<Integer> ts = Single.using(Functions.justCallable(Disposables.empty()), mapperThrows, disposerThrows)
+        TestObserver<Integer> to = Single.using(Functions.justCallable(Disposables.empty()), mapperThrows, disposerThrows)
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> ce = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> ce = TestHelper.compositeList(to.errors().get(0));
         TestHelper.assertError(ce, 0, TestException.class, "Mapper");
         TestHelper.assertError(ce, 1, TestException.class, "Disposer");
     }
@@ -182,7 +182,7 @@ public class SingleUsingTest {
 
     @Test
     public void errorAndDisposerThrowsEager() {
-        TestObserver<Integer> ts = Single.using(Functions.justCallable(Disposables.empty()),
+        TestObserver<Integer> to = Single.using(Functions.justCallable(Disposables.empty()),
         new Function<Disposable, SingleSource<Integer>>() {
             @Override
             public SingleSource<Integer> apply(Disposable v) throws Exception {
@@ -192,7 +192,7 @@ public class SingleUsingTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> ce = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> ce = TestHelper.compositeList(to.errors().get(0));
         TestHelper.assertError(ce, 0, TestException.class, "Mapper-run");
         TestHelper.assertError(ce, 1, TestException.class, "Disposer");
     }
@@ -224,7 +224,7 @@ public class SingleUsingTest {
 
             Disposable d = Disposables.empty();
 
-            final TestObserver<Integer> ts = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
+            final TestObserver<Integer> to = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Disposable v) throws Exception {
                     return pp.single(-99);
@@ -243,7 +243,7 @@ public class SingleUsingTest {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 
@@ -299,7 +299,7 @@ public class SingleUsingTest {
 
             Disposable d = Disposables.empty();
 
-            final TestObserver<Integer> ts = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
+            final TestObserver<Integer> to = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Disposable v) throws Exception {
                     return pp.single(-99);
@@ -318,7 +318,7 @@ public class SingleUsingTest {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/subscribers/DeferredScalarSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/DeferredScalarSubscriberTest.java
@@ -106,13 +106,13 @@ public class DeferredScalarSubscriberTest {
 
     @Test
     public void unsubscribeComposes() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
         TestSubscriber<Integer> ts = TestSubscriber.create(0L);
         TestingDeferredScalarSubscriber ds = new TestingDeferredScalarSubscriber(ts);
 
-        ps.subscribe(ds);
+        pp.subscribe(ds);
 
-        assertTrue("No subscribers?", ps.hasSubscribers());
+        assertTrue("No subscribers?", pp.hasSubscribers());
 
         ts.cancel();
 
@@ -125,7 +125,7 @@ public class DeferredScalarSubscriberTest {
         ts.assertNoErrors();
         ts.assertNotComplete();
 
-        assertFalse("Subscribers?", ps.hasSubscribers());
+        assertFalse("Subscribers?", pp.hasSubscribers());
         assertTrue("Deferred not unsubscribed?", ds.isCancelled());
     }
 

--- a/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
@@ -290,11 +290,11 @@ public class LambdaSubscriberTest {
 
     @Test
     public void onNextThrowsCancelsUpstream() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
         final List<Throwable> errors = new ArrayList<Throwable>();
 
-        ps.subscribe(new Consumer<Integer>() {
+        pp.subscribe(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
                 throw new TestException();
@@ -306,12 +306,12 @@ public class LambdaSubscriberTest {
             }
         });
 
-        assertTrue("No observers?!", ps.hasSubscribers());
+        assertTrue("No observers?!", pp.hasSubscribers());
         assertTrue("Has errors already?!", errors.isEmpty());
 
-        ps.onNext(1);
+        pp.onNext(1);
 
-        assertFalse("Has observers?!", ps.hasSubscribers());
+        assertFalse("Has observers?!", pp.hasSubscribers());
         assertFalse("No errors?!", errors.isEmpty());
 
         assertTrue(errors.toString(), errors.get(0) instanceof TestException);
@@ -319,11 +319,11 @@ public class LambdaSubscriberTest {
 
     @Test
     public void onSubscribeThrowsCancelsUpstream() {
-        PublishProcessor<Integer> ps = PublishProcessor.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
 
         final List<Throwable> errors = new ArrayList<Throwable>();
 
-        ps.subscribe(new Consumer<Integer>() {
+        pp.subscribe(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
             }
@@ -343,7 +343,7 @@ public class LambdaSubscriberTest {
             }
         });
 
-        assertFalse("Has observers?!", ps.hasSubscribers());
+        assertFalse("Has observers?!", pp.hasSubscribers());
         assertFalse("No errors?!", errors.isEmpty());
 
         assertTrue(errors.toString(), errors.get(0) instanceof TestException);

--- a/src/test/java/io/reactivex/internal/subscriptions/DeferredScalarSubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/DeferredScalarSubscriptionTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.TestHelper;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class DeferredScalarSubscriptionTest {
@@ -27,7 +27,7 @@ public class DeferredScalarSubscriptionTest {
     public void queueSubscriptionSyncRejected() {
         DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(new TestSubscriber<Integer>());
 
-        assertEquals(QueueSubscription.NONE, ds.requestFusion(QueueSubscription.SYNC));
+        assertEquals(QueueFuseable.NONE, ds.requestFusion(QueueFuseable.SYNC));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/util/HalfSerializerObserverTest.java
+++ b/src/test/java/io/reactivex/internal/util/HalfSerializerObserverTest.java
@@ -207,28 +207,28 @@ public class HalfSerializerObserverTest {
             final AtomicInteger wip = new AtomicInteger();
             final AtomicThrowable error = new AtomicThrowable();
 
-            final TestObserver<Integer> ts = new TestObserver<Integer>();
-            ts.onSubscribe(Disposables.empty());
+            final TestObserver<Integer> to = new TestObserver<Integer>();
+            to.onSubscribe(Disposables.empty());
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    HalfSerializer.onNext(ts, 1, wip, error);
+                    HalfSerializer.onNext(to, 1, wip, error);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    HalfSerializer.onComplete(ts, wip, error);
+                    HalfSerializer.onComplete(to, wip, error);
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            ts.assertComplete().assertNoErrors();
+            to.assertComplete().assertNoErrors();
 
-            assertTrue(ts.valueCount() <= 1);
+            assertTrue(to.valueCount() <= 1);
         }
     }
 
@@ -239,32 +239,32 @@ public class HalfSerializerObserverTest {
             final AtomicInteger wip = new AtomicInteger();
             final AtomicThrowable error = new AtomicThrowable();
 
-            final TestObserver<Integer> ts = new TestObserver<Integer>();
+            final TestObserver<Integer> to = new TestObserver<Integer>();
 
-            ts.onSubscribe(Disposables.empty());
+            to.onSubscribe(Disposables.empty());
 
             final TestException ex = new TestException();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    HalfSerializer.onError(ts, ex, wip, error);
+                    HalfSerializer.onError(to, ex, wip, error);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    HalfSerializer.onComplete(ts, wip, error);
+                    HalfSerializer.onComplete(to, wip, error);
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            if (ts.completions() != 0) {
-                ts.assertResult();
+            if (to.completions() != 0) {
+                to.assertResult();
             } else {
-                ts.assertFailure(TestException.class);
+                to.assertFailure(TestException.class);
             }
         }
     }

--- a/src/test/java/io/reactivex/internal/util/QueueDrainHelperTest.java
+++ b/src/test/java/io/reactivex/internal/util/QueueDrainHelperTest.java
@@ -598,8 +598,8 @@ public class QueueDrainHelperTest {
 
     @Test
     public void observerCheckTerminatedDelayErrorEmpty() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        ts.onSubscribe(Disposables.empty());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onSubscribe(Disposables.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
             @Override
@@ -634,15 +634,15 @@ public class QueueDrainHelperTest {
 
         SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
 
-        QueueDrainHelper.checkTerminated(true, true, ts, true, q, null, qd);
+        QueueDrainHelper.checkTerminated(true, true, to, true, q, null, qd);
 
-        ts.assertResult();
+        to.assertResult();
     }
 
     @Test
     public void observerCheckTerminatedDelayErrorEmptyResource() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        ts.onSubscribe(Disposables.empty());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onSubscribe(Disposables.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
             @Override
@@ -679,17 +679,17 @@ public class QueueDrainHelperTest {
 
         Disposable d = Disposables.empty();
 
-        QueueDrainHelper.checkTerminated(true, true, ts, true, q, d, qd);
+        QueueDrainHelper.checkTerminated(true, true, to, true, q, d, qd);
 
-        ts.assertResult();
+        to.assertResult();
 
         assertTrue(d.isDisposed());
     }
 
     @Test
     public void observerCheckTerminatedDelayErrorNonEmpty() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        ts.onSubscribe(Disposables.empty());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onSubscribe(Disposables.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
             @Override
@@ -724,15 +724,15 @@ public class QueueDrainHelperTest {
 
         SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
 
-        QueueDrainHelper.checkTerminated(true, false, ts, true, q, null, qd);
+        QueueDrainHelper.checkTerminated(true, false, to, true, q, null, qd);
 
-        ts.assertEmpty();
+        to.assertEmpty();
     }
 
     @Test
     public void observerCheckTerminatedDelayErrorEmptyError() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        ts.onSubscribe(Disposables.empty());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onSubscribe(Disposables.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
             @Override
@@ -767,15 +767,15 @@ public class QueueDrainHelperTest {
 
         SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
 
-        QueueDrainHelper.checkTerminated(true, true, ts, true, q, null, qd);
+        QueueDrainHelper.checkTerminated(true, true, to, true, q, null, qd);
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @Test
     public void observerCheckTerminatedNonDelayErrorError() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        ts.onSubscribe(Disposables.empty());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onSubscribe(Disposables.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
             @Override
@@ -810,14 +810,14 @@ public class QueueDrainHelperTest {
 
         SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
 
-        QueueDrainHelper.checkTerminated(true, false, ts, false, q, null, qd);
+        QueueDrainHelper.checkTerminated(true, false, to, false, q, null, qd);
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
     @Test
     public void observerCheckTerminatedNonDelayErrorErrorResource() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        ts.onSubscribe(Disposables.empty());
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        to.onSubscribe(Disposables.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
             @Override
@@ -854,9 +854,9 @@ public class QueueDrainHelperTest {
 
         Disposable d = Disposables.empty();
 
-        QueueDrainHelper.checkTerminated(true, false, ts, false, q, d, qd);
+        QueueDrainHelper.checkTerminated(true, false, to, false, q, d, qd);
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
 
         assertTrue(d.isDisposed());
     }

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -30,7 +30,7 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.internal.operators.flowable.FlowableZipTest.ArgsToString;
 import io.reactivex.internal.operators.maybe.*;
 import io.reactivex.observers.TestObserver;
@@ -89,11 +89,11 @@ public class MaybeTest {
     public void fromFlowableDisposeComposesThrough() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp.singleElement().test();
+        TestObserver<Integer> to = pp.singleElement().test();
 
         assertTrue(pp.hasSubscribers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(pp.hasSubscribers());
     }
@@ -144,24 +144,24 @@ public class MaybeTest {
 
     @Test
     public void fromObservableDisposeComposesThrough() {
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = pp.singleElement().test(false);
+        TestObserver<Integer> to = ps.singleElement().test(false);
 
-        assertTrue(pp.hasObservers());
+        assertTrue(ps.hasObservers());
 
-        ts.cancel();
+        to.cancel();
 
-        assertFalse(pp.hasObservers());
+        assertFalse(ps.hasObservers());
     }
 
     @Test
     public void fromObservableDisposeComposesThroughImmediatelyCancelled() {
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        pp.singleElement().test(true);
+        ps.singleElement().test(true);
 
-        assertFalse(pp.hasObservers());
+        assertFalse(ps.hasObservers());
     }
 
     @Test
@@ -542,9 +542,9 @@ public class MaybeTest {
 
     @Test
     public void cast() {
-        TestObserver<Number> ts = Maybe.just(1).cast(Number.class).test();
+        TestObserver<Number> to = Maybe.just(1).cast(Number.class).test();
         // don'n inline this due to the generic type
-        ts.assertResult((Number)1);
+        to.assertResult((Number)1);
     }
 
     @Test(expected = NullPointerException.class)
@@ -870,7 +870,7 @@ public class MaybeTest {
         try {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            TestObserver<Integer> ts = pp.singleElement().doOnDispose(new Action() {
+            TestObserver<Integer> to = pp.singleElement().doOnDispose(new Action() {
                 @Override
                 public void run() throws Exception {
                     throw new TestException();
@@ -880,11 +880,11 @@ public class MaybeTest {
 
             assertTrue(pp.hasSubscribers());
 
-            ts.cancel();
+            to.cancel();
 
             assertFalse(pp.hasSubscribers());
 
-            ts.assertSubscribed()
+            to.assertSubscribed()
             .assertNoValues()
             .assertNoErrors()
             .assertNotComplete();
@@ -1623,10 +1623,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
+        TestObserver<Integer> to = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1637,7 +1637,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @SuppressWarnings("unchecked")
@@ -1646,10 +1646,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
+        TestObserver<Integer> to = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1660,7 +1660,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult(2);
+        to.assertResult(2);
     }
 
     @SuppressWarnings("unchecked")
@@ -1669,10 +1669,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
+        TestObserver<Integer> to = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1682,7 +1682,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @SuppressWarnings("unchecked")
@@ -1691,10 +1691,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
+        TestObserver<Integer> to = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1704,7 +1704,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @SuppressWarnings("unchecked")
@@ -1713,10 +1713,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
+        TestObserver<Integer> to = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1726,7 +1726,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult();
+        to.assertResult();
     }
 
     @SuppressWarnings("unchecked")
@@ -1735,10 +1735,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
+        TestObserver<Integer> to = Maybe.ambArray(pp1.singleElement(), pp2.singleElement())
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1748,7 +1748,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult();
+        to.assertResult();
     }
 
     @SuppressWarnings("unchecked")
@@ -1757,10 +1757,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
+        TestObserver<Integer> to = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1771,7 +1771,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @SuppressWarnings("unchecked")
@@ -1780,10 +1780,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
+        TestObserver<Integer> to = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1794,7 +1794,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult(2);
+        to.assertResult(2);
     }
 
     @SuppressWarnings("unchecked")
@@ -1803,10 +1803,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
+        TestObserver<Integer> to = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
                 .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1818,7 +1818,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult(2);
+        to.assertResult(2);
     }
 
     @SuppressWarnings("unchecked")
@@ -1827,10 +1827,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
+        TestObserver<Integer> to = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1840,7 +1840,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @SuppressWarnings("unchecked")
@@ -1849,10 +1849,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
+        TestObserver<Integer> to = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1862,7 +1862,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
     }
 
     @SuppressWarnings("unchecked")
@@ -1871,10 +1871,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
+        TestObserver<Integer> to = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
                 .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1885,7 +1885,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertFailureAndMessage(TestException.class, "2");
+        to.assertFailureAndMessage(TestException.class, "2");
     }
 
     @SuppressWarnings("unchecked")
@@ -1894,10 +1894,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
+        TestObserver<Integer> to = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1907,7 +1907,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult();
+        to.assertResult();
     }
 
     @SuppressWarnings("unchecked")
@@ -1916,10 +1916,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
+        TestObserver<Integer> to = Maybe.amb(Arrays.asList(pp1.singleElement(), pp2.singleElement()))
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -1929,7 +1929,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult();
+        to.assertResult();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2076,13 +2076,13 @@ public class MaybeTest {
     @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayFused() {
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Maybe.mergeArray(Maybe.just(1), Maybe.just(2), Maybe.just(3)).subscribe(ts);
 
         ts.assertSubscribed()
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1, 2, 3);
     }
 
@@ -2093,13 +2093,13 @@ public class MaybeTest {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-            TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+            TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
             Maybe.mergeArray(pp1.singleElement(), pp2.singleElement()).subscribe(ts);
 
             ts.assertSubscribed()
             .assertOf(SubscriberFusion.<Integer>assertFuseable())
-            .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+            .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
             ;
 
             TestHelper.race(new Runnable() {
@@ -2210,14 +2210,14 @@ public class MaybeTest {
         Maybe<Integer>[] sources = new Maybe[Flowable.bufferSize() * 2];
         Arrays.fill(sources, Maybe.just(1));
 
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         Maybe.mergeArray(sources).subscribe(ts);
 
         ts
         .assertSubscribed()
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertValueCount(sources.length)
         .assertNoErrors()
         .assertComplete();
@@ -2420,7 +2420,7 @@ public class MaybeTest {
 
     @Test
     public void doOnEventErrorThrows() {
-        TestObserver<Integer> ts = Maybe.<Integer>error(new TestException("Outer"))
+        TestObserver<Integer> to = Maybe.<Integer>error(new TestException("Outer"))
         .doOnEvent(new BiConsumer<Integer, Throwable>() {
             @Override
             public void accept(Integer v, Throwable e) throws Exception {
@@ -2430,7 +2430,7 @@ public class MaybeTest {
         .test()
         .assertFailure(CompositeException.class);
 
-        List<Throwable> list = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
         TestHelper.assertError(list, 0, TestException.class, "Outer");
         TestHelper.assertError(list, 1, TestException.class, "Inner");
         assertEquals(2, list.size());
@@ -2989,10 +2989,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp1.singleElement().ambWith(pp2.singleElement())
+        TestObserver<Integer> to = pp1.singleElement().ambWith(pp2.singleElement())
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -3003,7 +3003,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @Test
@@ -3011,10 +3011,10 @@ public class MaybeTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Integer> ts = pp1.singleElement().ambWith(pp2.singleElement())
+        TestObserver<Integer> to = pp1.singleElement().ambWith(pp2.singleElement())
         .test();
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
         assertTrue(pp1.hasSubscribers());
         assertTrue(pp2.hasSubscribers());
@@ -3025,7 +3025,7 @@ public class MaybeTest {
         assertFalse(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
 
-        ts.assertResult(2);
+        to.assertResult(2);
     }
 
     @Test

--- a/src/test/java/io/reactivex/observable/ObservableCovarianceTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableCovarianceTest.java
@@ -66,7 +66,7 @@ public class ObservableCovarianceTest {
     @Test
     public void testGroupByCompose() {
         Observable<Movie> movies = Observable.just(new HorrorMovie(), new ActionMovie(), new Movie());
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
         movies
         .groupBy(new Function<Movie, Object>() {
             @Override
@@ -105,11 +105,11 @@ public class ObservableCovarianceTest {
                 });
             }
         })
-        .subscribe(ts);
-        ts.assertTerminated();
-        ts.assertNoErrors();
+        .subscribe(to);
+        to.assertTerminated();
+        to.assertNoErrors();
         //        System.out.println(ts.getOnNextEvents());
-        assertEquals(6, ts.valueCount());
+        assertEquals(6, to.valueCount());
     }
 
     @SuppressWarnings("unused")

--- a/src/test/java/io/reactivex/observable/ObservableFuseableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableFuseableTest.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import io.reactivex.Observable;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.observers.ObserverFusion;
 
 public class ObservableFuseableTest {
@@ -26,8 +26,8 @@ public class ObservableFuseableTest {
     public void syncRange() {
 
         Observable.range(1, 10)
-        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .to(ObserverFusion.<Integer>test(QueueFuseable.ANY, false))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -37,8 +37,8 @@ public class ObservableFuseableTest {
     public void syncArray() {
 
         Observable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
-        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .to(ObserverFusion.<Integer>test(QueueFuseable.ANY, false))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -48,8 +48,8 @@ public class ObservableFuseableTest {
     public void syncIterable() {
 
         Observable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
-        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.SYNC))
+        .to(ObserverFusion.<Integer>test(QueueFuseable.ANY, false))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -59,9 +59,9 @@ public class ObservableFuseableTest {
     public void syncRangeHidden() {
 
         Observable.range(1, 10).hide()
-        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
+        .to(ObserverFusion.<Integer>test(QueueFuseable.ANY, false))
         .assertOf(ObserverFusion.<Integer>assertNotFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -71,9 +71,9 @@ public class ObservableFuseableTest {
     public void syncArrayHidden() {
         Observable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
         .hide()
-        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
+        .to(ObserverFusion.<Integer>test(QueueFuseable.ANY, false))
         .assertOf(ObserverFusion.<Integer>assertNotFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();
@@ -83,9 +83,9 @@ public class ObservableFuseableTest {
     public void syncIterableHidden() {
         Observable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
         .hide()
-        .to(ObserverFusion.<Integer>test(QueueSubscription.ANY, false))
+        .to(ObserverFusion.<Integer>test(QueueFuseable.ANY, false))
         .assertOf(ObserverFusion.<Integer>assertNotFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueSubscription.NONE))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.NONE))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .assertNoErrors()
         .assertComplete();

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -368,11 +368,11 @@ public class ObservableNullTests {
         FutureTask<Object> f = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
         f.run();
 
-        TestObserver<Object> ts = new TestObserver<Object>();
-        Observable.fromFuture(f).subscribe(ts);
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(NullPointerException.class);
+        TestObserver<Object> to = new TestObserver<Object>();
+        Observable.fromFuture(f).subscribe(to);
+        to.assertNoValues();
+        to.assertNotComplete();
+        to.assertError(NullPointerException.class);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/observable/ObservableSubscriberTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableSubscriberTest.java
@@ -174,10 +174,10 @@ public class ObservableSubscriberTest {
 
     @Test
     public void safeSubscriberAlreadySafe() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        Observable.just(1).safeSubscribe(new SafeObserver<Integer>(ts));
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Observable.just(1).safeSubscribe(new SafeObserver<Integer>(to));
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
 

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -1026,23 +1026,23 @@ public class ObservableTest {
 
     @Test
     public void testMergeWith() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        Observable.just(1).mergeWith(Observable.just(2)).subscribe(ts);
-        ts.assertValues(1, 2);
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Observable.just(1).mergeWith(Observable.just(2)).subscribe(to);
+        to.assertValues(1, 2);
     }
 
     @Test
     public void testConcatWith() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        Observable.just(1).concatWith(Observable.just(2)).subscribe(ts);
-        ts.assertValues(1, 2);
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Observable.just(1).concatWith(Observable.just(2)).subscribe(to);
+        to.assertValues(1, 2);
     }
 
     @Test
     public void testAmbWith() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
-        Observable.just(1).ambWith(Observable.just(2)).subscribe(ts);
-        ts.assertValue(1);
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Observable.just(1).ambWith(Observable.just(2)).subscribe(to);
+        to.assertValue(1);
     }
 
     @Test
@@ -1072,7 +1072,7 @@ public class ObservableTest {
 
     @Test
     public void testCompose() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
         Observable.just(1, 2, 3).compose(new ObservableTransformer<Integer, String>() {
             @Override
             public Observable<String> apply(Observable<Integer> t1) {
@@ -1084,10 +1084,10 @@ public class ObservableTest {
                 });
             }
         })
-        .subscribe(ts);
-        ts.assertTerminated();
-        ts.assertNoErrors();
-        ts.assertValues("1", "2", "3");
+        .subscribe(to);
+        to.assertTerminated();
+        to.assertNoErrors();
+        to.assertValues("1", "2", "3");
     }
 
     @Test

--- a/src/test/java/io/reactivex/observers/ObserverFusion.java
+++ b/src/test/java/io/reactivex/observers/ObserverFusion.java
@@ -32,7 +32,7 @@ public enum ObserverFusion {
      * Use this as follows:
      * <pre>
      * source
-     * .to(ObserverFusion.test(QueueDisposable.ANY, false))
+     * .to(ObserverFusion.test(QueueFuseable.ANY, false))
      * .assertResult(0);
      * </pre>
      * @param <T> the value type
@@ -52,7 +52,7 @@ public enum ObserverFusion {
      * Use this as follows:
      * <pre>
      * source
-     * .to(ObserverFusion.test(0, QueueDisposable.ANY, false))
+     * .to(ObserverFusion.test(0, QueueFuseable.ANY, false))
      * .assertOf(ObserverFusion.assertFuseable());
      * </pre>
      * @param <T> the value type
@@ -71,8 +71,8 @@ public enum ObserverFusion {
         }
 
         @Override
-        public void accept(TestObserver<T> ts) throws Exception {
-            ts.assertFusionMode(mode);
+        public void accept(TestObserver<T> to) throws Exception {
+            to.assertFusionMode(mode);
         }
     }
 
@@ -87,21 +87,21 @@ public enum ObserverFusion {
 
         @Override
         public TestObserver<T> apply(Observable<T> t) throws Exception {
-            TestObserver<T> ts = new TestObserver<T>();
-            ts.setInitialFusionMode(mode);
+            TestObserver<T> to = new TestObserver<T>();
+            to.setInitialFusionMode(mode);
             if (cancelled) {
-                ts.cancel();
+                to.cancel();
             }
-            t.subscribe(ts);
-            return ts;
+            t.subscribe(to);
+            return to;
         }
     }
 
     enum AssertFuseable implements Consumer<TestObserver<Object>> {
         INSTANCE;
         @Override
-        public void accept(TestObserver<Object> ts) throws Exception {
-            ts.assertFuseable();
+        public void accept(TestObserver<Object> to) throws Exception {
+            to.assertFuseable();
         }
     }
 
@@ -112,7 +112,7 @@ public enum ObserverFusion {
      * Use this as follows:
      * <pre>
      * source
-     * .to(ObserverFusion.test(0, QueueDisposable.ANY, false))
+     * .to(ObserverFusion.test(0, QueueFuseable.ANY, false))
      * .assertOf(ObserverFusion.assertNotFuseable());
      * </pre>
      * @param <T> the value type
@@ -126,8 +126,8 @@ public enum ObserverFusion {
     enum AssertNotFuseable implements Consumer<TestObserver<Object>> {
         INSTANCE;
         @Override
-        public void accept(TestObserver<Object> ts) throws Exception {
-            ts.assertNotFuseable();
+        public void accept(TestObserver<Object> to) throws Exception {
+            to.assertNotFuseable();
         }
     }
 
@@ -139,11 +139,11 @@ public enum ObserverFusion {
      * Use this as follows:
      * <pre>
      * source
-     * .to(ObserverFusion.test(0, QueueDisposable.ANY, false))
-     * .assertOf(ObserverFusion.assertFusionMode(QueueDisposable.SYNC));
+     * .to(ObserverFusion.test(0, QueueFuseable.ANY, false))
+     * .assertOf(ObserverFusion.assertFusionMode(QueueFuseable.SYNC));
      * </pre>
      * @param <T> the value type
-     * @param mode the expected established fusion mode, see {@link QueueDisposable} constants.
+     * @param mode the expected established fusion mode, see {@link QueueFuseable} constants.
      * @return the new Consumer instance
      */
     public static <T> Consumer<TestObserver<T>> assertFusionMode(final int mode) {
@@ -154,25 +154,25 @@ public enum ObserverFusion {
     /**
      * Constructs a TestObserver with the given required fusion mode.
      * @param <T> the value type
-     * @param mode the requested fusion mode, see {@link QueueSubscription} constants
+     * @param mode the requested fusion mode, see {@link QueueFuseable} constants
      * @return the new TestSubscriber
      */
     public static <T> TestObserver<T> newTest(int mode) {
-        TestObserver<T> ts = new TestObserver<T>();
-        ts.setInitialFusionMode(mode);
-        return ts;
+        TestObserver<T> to = new TestObserver<T>();
+        to.setInitialFusionMode(mode);
+        return to;
     }
 
     /**
-     * Assert that the TestSubscriber received a fuseabe QueueSubscription and
+     * Assert that the TestSubscriber received a fuseabe QueueFuseable.and
      * is in the given fusion mode.
      * @param <T> the value type
-     * @param ts the TestSubscriber instance
+     * @param to the TestSubscriber instance
      * @param mode the expected mode
      * @return the TestSubscriber
      */
-    public static <T> TestObserver<T> assertFusion(TestObserver<T> ts, int mode) {
-        return ts.assertOf(ObserverFusion.<T>assertFuseable())
+    public static <T> TestObserver<T> assertFusion(TestObserver<T> to, int mode) {
+        return to.assertOf(ObserverFusion.<T>assertFuseable())
                 .assertOf(ObserverFusion.<T>assertFusionMode(mode));
     }
 }

--- a/src/test/java/io/reactivex/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SafeObserverTest.java
@@ -490,15 +490,15 @@ public class SafeObserverTest {
 
     @Test
     public void dispose() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
 
         Disposable d = Disposables.empty();
 
         so.onSubscribe(d);
 
-        ts.dispose();
+        to.dispose();
 
         assertTrue(d.isDisposed());
 
@@ -507,9 +507,9 @@ public class SafeObserverTest {
 
     @Test
     public void onNextAfterComplete() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
 
         Disposable d = Disposables.empty();
 
@@ -523,14 +523,14 @@ public class SafeObserverTest {
 
         so.onComplete();
 
-        ts.assertResult();
+        to.assertResult();
     }
 
     @Test
     public void onNextNull() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
 
         Disposable d = Disposables.empty();
 
@@ -538,50 +538,50 @@ public class SafeObserverTest {
 
         so.onNext(null);
 
-        ts.assertFailure(NullPointerException.class);
+        to.assertFailure(NullPointerException.class);
     }
 
     @Test
     public void onNextWithoutOnSubscribe() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
 
         so.onNext(1);
 
-        ts.assertFailureAndMessage(NullPointerException.class, "Subscription not set!");
+        to.assertFailureAndMessage(NullPointerException.class, "Subscription not set!");
     }
 
     @Test
     public void onErrorWithoutOnSubscribe() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
 
         so.onError(new TestException());
 
-        ts.assertFailure(CompositeException.class);
+        to.assertFailure(CompositeException.class);
 
-        TestHelper.assertError(ts, 0, TestException.class);
-        TestHelper.assertError(ts, 1, NullPointerException.class, "Subscription not set!");
+        TestHelper.assertError(to, 0, TestException.class);
+        TestHelper.assertError(to, 1, NullPointerException.class, "Subscription not set!");
     }
 
     @Test
     public void onCompleteWithoutOnSubscribe() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
 
         so.onComplete();
 
-        ts.assertFailureAndMessage(NullPointerException.class, "Subscription not set!");
+        to.assertFailureAndMessage(NullPointerException.class, "Subscription not set!");
     }
 
     @Test
     public void onNextNormal() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(ts);
+        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
 
         Disposable d = Disposables.empty();
 
@@ -590,7 +590,7 @@ public class SafeObserverTest {
         so.onNext(1);
         so.onComplete();
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     static final class CrashDummy implements Observer<Object>, Disposable {

--- a/src/test/java/io/reactivex/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SerializedObserverTest.java
@@ -957,7 +957,7 @@ public class SerializedObserverTest {
     public void testErrorReentry() {
         final AtomicReference<Observer<Integer>> serial = new AtomicReference<Observer<Integer>>();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer v) {
                 serial.get().onError(new TestException());
@@ -965,20 +965,20 @@ public class SerializedObserverTest {
                 super.onNext(v);
             }
         };
-        SerializedObserver<Integer> sobs = new SerializedObserver<Integer>(ts);
+        SerializedObserver<Integer> sobs = new SerializedObserver<Integer>(to);
         sobs.onSubscribe(Disposables.empty());
         serial.set(sobs);
 
         sobs.onNext(1);
 
-        ts.assertValue(1);
-        ts.assertError(TestException.class);
+        to.assertValue(1);
+        to.assertError(TestException.class);
     }
     @Test
     public void testCompleteReentry() {
         final AtomicReference<Observer<Integer>> serial = new AtomicReference<Observer<Integer>>();
 
-        TestObserver<Integer> ts = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer v) {
                 serial.get().onComplete();
@@ -986,22 +986,22 @@ public class SerializedObserverTest {
                 super.onNext(v);
             }
         };
-        SerializedObserver<Integer> sobs = new SerializedObserver<Integer>(ts);
+        SerializedObserver<Integer> sobs = new SerializedObserver<Integer>(to);
         sobs.onSubscribe(Disposables.empty());
         serial.set(sobs);
 
         sobs.onNext(1);
 
-        ts.assertValue(1);
-        ts.assertComplete();
-        ts.assertNoErrors();
+        to.assertValue(1);
+        to.assertComplete();
+        to.assertNoErrors();
     }
 
     @Test
     public void dispose() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts);
+        SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
 
         Disposable d = Disposables.empty();
 
@@ -1009,7 +1009,7 @@ public class SerializedObserverTest {
 
         assertFalse(so.isDisposed());
 
-        ts.cancel();
+        to.cancel();
 
         assertTrue(so.isDisposed());
 
@@ -1019,9 +1019,9 @@ public class SerializedObserverTest {
     @Test
     public void onCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
 
-            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts);
+            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
 
             Disposable d = Disposables.empty();
 
@@ -1036,7 +1036,7 @@ public class SerializedObserverTest {
 
             TestHelper.race(r, r);
 
-            ts.awaitDone(5, TimeUnit.SECONDS)
+            to.awaitDone(5, TimeUnit.SECONDS)
             .assertResult();
         }
 
@@ -1045,9 +1045,9 @@ public class SerializedObserverTest {
     @Test
     public void onNextOnCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
 
-            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts);
+            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
 
             Disposable d = Disposables.empty();
 
@@ -1069,11 +1069,11 @@ public class SerializedObserverTest {
 
             TestHelper.race(r1, r2);
 
-            ts.awaitDone(5, TimeUnit.SECONDS)
+            to.awaitDone(5, TimeUnit.SECONDS)
             .assertNoErrors()
             .assertComplete();
 
-            assertTrue(ts.valueCount() <= 1);
+            assertTrue(to.valueCount() <= 1);
         }
 
     }
@@ -1081,9 +1081,9 @@ public class SerializedObserverTest {
     @Test
     public void onNextOnErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
 
-            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts);
+            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
 
             Disposable d = Disposables.empty();
 
@@ -1107,11 +1107,11 @@ public class SerializedObserverTest {
 
             TestHelper.race(r1, r2);
 
-            ts.awaitDone(5, TimeUnit.SECONDS)
+            to.awaitDone(5, TimeUnit.SECONDS)
             .assertError(ex)
             .assertNotComplete();
 
-            assertTrue(ts.valueCount() <= 1);
+            assertTrue(to.valueCount() <= 1);
         }
 
     }
@@ -1119,9 +1119,9 @@ public class SerializedObserverTest {
     @Test
     public void onNextOnErrorRaceDelayError() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
 
-            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts, true);
+            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to, true);
 
             Disposable d = Disposables.empty();
 
@@ -1145,11 +1145,11 @@ public class SerializedObserverTest {
 
             TestHelper.race(r1, r2);
 
-            ts.awaitDone(5, TimeUnit.SECONDS)
+            to.awaitDone(5, TimeUnit.SECONDS)
             .assertError(ex)
             .assertNotComplete();
 
-            assertTrue(ts.valueCount() <= 1);
+            assertTrue(to.valueCount() <= 1);
         }
 
     }
@@ -1160,9 +1160,9 @@ public class SerializedObserverTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<Integer>();
 
-            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts);
+            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
 
             so.onSubscribe(Disposables.empty());
 
@@ -1184,9 +1184,9 @@ public class SerializedObserverTest {
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                TestObserver<Integer> ts = new TestObserver<Integer>();
+                TestObserver<Integer> to = new TestObserver<Integer>();
 
-                final SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts);
+                final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
 
                 Disposable d = Disposables.empty();
 
@@ -1210,12 +1210,12 @@ public class SerializedObserverTest {
 
                 TestHelper.race(r1, r2);
 
-                ts.awaitDone(5, TimeUnit.SECONDS);
+                to.awaitDone(5, TimeUnit.SECONDS);
 
-                if (ts.completions() != 0) {
-                    ts.assertResult();
+                if (to.completions() != 0) {
+                    to.assertResult();
                 } else {
-                    ts.assertFailure(TestException.class).assertError(ex);
+                    to.assertFailure(TestException.class).assertError(ex);
                 }
 
                 for (Throwable e : errors) {
@@ -1231,9 +1231,9 @@ public class SerializedObserverTest {
     @Test
     public void nullOnNext() {
 
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        final SerializedObserver<Integer> so = new SerializedObserver<Integer>(ts);
+        final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
 
         Disposable d = Disposables.empty();
 
@@ -1241,6 +1241,6 @@ public class SerializedObserverTest {
 
         so.onNext(null);
 
-        ts.assertFailureAndMessage(NullPointerException.class, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        to.assertFailureAndMessage(NullPointerException.class, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
     }
 }

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -32,7 +32,7 @@ import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.operators.observable.ObservableScalarXMap.ScalarDisposable;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.processors.PublishProcessor;
@@ -197,46 +197,46 @@ public class TestObserverTest {
 
     @Test
     public void testGetEvents() {
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>();
-        to.onSubscribe(EmptySubscription.INSTANCE);
-        to.onNext(1);
-        to.onNext(2);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.onSubscribe(EmptySubscription.INSTANCE);
+        ts.onNext(1);
+        ts.onNext(2);
 
         assertEquals(Arrays.<Object>asList(Arrays.asList(1, 2),
                 Collections.emptyList(),
-                Collections.emptyList()), to.getEvents());
+                Collections.emptyList()), ts.getEvents());
 
-        to.onComplete();
+        ts.onComplete();
 
         assertEquals(Arrays.<Object>asList(Arrays.asList(1, 2), Collections.emptyList(),
-                Collections.singletonList(Notification.createOnComplete())), to.getEvents());
+                Collections.singletonList(Notification.createOnComplete())), ts.getEvents());
 
         TestException ex = new TestException();
-        TestSubscriber<Integer> to2 = new TestSubscriber<Integer>();
-        to2.onSubscribe(EmptySubscription.INSTANCE);
-        to2.onNext(1);
-        to2.onNext(2);
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+        ts2.onSubscribe(EmptySubscription.INSTANCE);
+        ts2.onNext(1);
+        ts2.onNext(2);
 
         assertEquals(Arrays.<Object>asList(Arrays.asList(1, 2),
                 Collections.emptyList(),
-                Collections.emptyList()), to2.getEvents());
+                Collections.emptyList()), ts2.getEvents());
 
-        to2.onError(ex);
+        ts2.onError(ex);
 
         assertEquals(Arrays.<Object>asList(
                 Arrays.asList(1, 2),
                 Collections.singletonList(ex),
                 Collections.emptyList()),
-                    to2.getEvents());
+                    ts2.getEvents());
     }
 
     @Test
     public void testNullExpected() {
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>();
-        to.onNext(1);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.onNext(1);
 
         try {
-            to.assertValue((Integer) null);
+            ts.assertValue((Integer) null);
         } catch (AssertionError ex) {
             // this is expected
             return;
@@ -246,11 +246,11 @@ public class TestObserverTest {
 
     @Test
     public void testNullActual() {
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>();
-        to.onNext(null);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.onNext(null);
 
         try {
-            to.assertValue(1);
+            ts.assertValue(1);
         } catch (AssertionError ex) {
             // this is expected
             return;
@@ -260,12 +260,12 @@ public class TestObserverTest {
 
     @Test
     public void testTerminalErrorOnce() {
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>();
-        to.onError(new TestException());
-        to.onError(new TestException());
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.onError(new TestException());
+        ts.onError(new TestException());
 
         try {
-            to.assertTerminated();
+            ts.assertTerminated();
         } catch (AssertionError ex) {
             // this is expected
             return;
@@ -274,12 +274,12 @@ public class TestObserverTest {
     }
     @Test
     public void testTerminalCompletedOnce() {
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>();
-        to.onComplete();
-        to.onComplete();
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.onComplete();
+        ts.onComplete();
 
         try {
-            to.assertTerminated();
+            ts.assertTerminated();
         } catch (AssertionError ex) {
             // this is expected
             return;
@@ -289,12 +289,12 @@ public class TestObserverTest {
 
     @Test
     public void testTerminalOneKind() {
-        TestSubscriber<Integer> to = new TestSubscriber<Integer>();
-        to.onError(new TestException());
-        to.onComplete();
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        ts.onError(new TestException());
+        ts.onComplete();
 
         try {
-            to.assertTerminated();
+            ts.assertTerminated();
         } catch (AssertionError ex) {
             // this is expected
             return;
@@ -304,68 +304,68 @@ public class TestObserverTest {
 
     @Test
     public void createDelegate() {
-        TestObserver<Integer> ts1 = TestObserver.create();
+        TestObserver<Integer> to1 = TestObserver.create();
 
-        TestObserver<Integer> ts = TestObserver.create(ts1);
+        TestObserver<Integer> to = TestObserver.create(to1);
 
-        ts.assertNotSubscribed();
+        to.assertNotSubscribed();
 
-        assertFalse(ts.hasSubscription());
+        assertFalse(to.hasSubscription());
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
         try {
-            ts.assertNotSubscribed();
+            to.assertNotSubscribed();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
-        assertTrue(ts.hasSubscription());
+        assertTrue(to.hasSubscription());
 
-        assertFalse(ts.isDisposed());
+        assertFalse(to.isDisposed());
 
-        ts.onNext(1);
-        ts.onError(new TestException());
-        ts.onComplete();
+        to.onNext(1);
+        to.onError(new TestException());
+        to.onComplete();
 
-        ts1.assertValue(1).assertError(TestException.class).assertComplete();
+        to1.assertValue(1).assertError(TestException.class).assertComplete();
 
-        ts.dispose();
+        to.dispose();
 
-        assertTrue(ts.isDisposed());
+        assertTrue(to.isDisposed());
 
-        assertTrue(ts.isTerminated());
+        assertTrue(to.isTerminated());
 
-        assertSame(Thread.currentThread(), ts.lastThread());
+        assertSame(Thread.currentThread(), to.lastThread());
 
         try {
-            ts.assertNoValues();
+            to.assertNoValues();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
         }
 
         try {
-            ts.assertValueCount(0);
+            to.assertValueCount(0);
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
         }
 
-        ts.assertValueSequence(Collections.singletonList(1));
+        to.assertValueSequence(Collections.singletonList(1));
 
         try {
-            ts.assertValueSequence(Collections.singletonList(2));
+            to.assertValueSequence(Collections.singletonList(2));
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
         }
 
-        ts.assertValueSet(Collections.singleton(1));
+        to.assertValueSet(Collections.singleton(1));
 
         try {
-            ts.assertValueSet(Collections.singleton(2));
+            to.assertValueSet(Collections.singleton(2));
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
@@ -375,115 +375,115 @@ public class TestObserverTest {
 
     @Test
     public void assertError() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
         try {
-            ts.assertError(TestException.class);
+            to.assertError(TestException.class);
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
         try {
-            ts.assertError(new TestException());
+            to.assertError(new TestException());
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
         try {
-            ts.assertError(Functions.<Throwable>alwaysTrue());
+            to.assertError(Functions.<Throwable>alwaysTrue());
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
         try {
-            ts.assertErrorMessage("");
+            to.assertErrorMessage("");
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
         }
 
         try {
-            ts.assertSubscribed();
+            to.assertSubscribed();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
         }
 
         try {
-            ts.assertTerminated();
+            to.assertTerminated();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
         }
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        ts.assertSubscribed();
+        to.assertSubscribed();
 
-        ts.assertNoErrors();
+        to.assertNoErrors();
 
         TestException ex = new TestException("Forced failure");
 
-        ts.onError(ex);
+        to.onError(ex);
 
-        ts.assertError(ex);
+        to.assertError(ex);
 
-        ts.assertError(TestException.class);
+        to.assertError(TestException.class);
 
-        ts.assertError(Functions.<Throwable>alwaysTrue());
+        to.assertError(Functions.<Throwable>alwaysTrue());
 
-        ts.assertError(new Predicate<Throwable>() {
+        to.assertError(new Predicate<Throwable>() {
             @Override
             public boolean test(Throwable t) throws Exception {
                 return t.getMessage() != null && t.getMessage().contains("Forced");
             }
         });
 
-        ts.assertErrorMessage("Forced failure");
+        to.assertErrorMessage("Forced failure");
 
         try {
-            ts.assertErrorMessage("");
+            to.assertErrorMessage("");
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
         }
 
         try {
-            ts.assertError(new RuntimeException());
+            to.assertError(new RuntimeException());
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
         }
 
         try {
-            ts.assertError(IOException.class);
+            to.assertError(IOException.class);
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
         }
 
         try {
-            ts.assertError(Functions.<Throwable>alwaysFalse());
+            to.assertError(Functions.<Throwable>alwaysFalse());
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
         }
 
         try {
-            ts.assertNoErrors();
+            to.assertNoErrors();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
         }
 
-        ts.assertTerminated();
+        to.assertTerminated();
 
-        ts.assertValueCount(0);
+        to.assertValueCount(0);
 
-        ts.assertNoValues();
+        to.assertNoValues();
 
 
     }
@@ -502,67 +502,67 @@ public class TestObserverTest {
 
     @Test
     public void assertFailure() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        ts.onError(new TestException("Forced failure"));
+        to.onError(new TestException("Forced failure"));
 
-        ts.assertFailure(TestException.class);
+        to.assertFailure(TestException.class);
 
-        ts.assertFailure(Functions.<Throwable>alwaysTrue());
+        to.assertFailure(Functions.<Throwable>alwaysTrue());
 
-        ts.assertFailureAndMessage(TestException.class, "Forced failure");
+        to.assertFailureAndMessage(TestException.class, "Forced failure");
 
-        ts.onNext(1);
+        to.onNext(1);
 
-        ts.assertFailure(TestException.class, 1);
+        to.assertFailure(TestException.class, 1);
 
-        ts.assertFailure(Functions.<Throwable>alwaysTrue(), 1);
+        to.assertFailure(Functions.<Throwable>alwaysTrue(), 1);
 
-        ts.assertFailureAndMessage(TestException.class, "Forced failure", 1);
+        to.assertFailureAndMessage(TestException.class, "Forced failure", 1);
     }
 
     @Test
     public void assertFuseable() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        ts.assertNotFuseable();
+        to.assertNotFuseable();
 
         try {
-            ts.assertFuseable();
+            to.assertFuseable();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
         try {
-            ts.assertFusionMode(QueueDisposable.SYNC);
+            to.assertFusionMode(QueueFuseable.SYNC);
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
-        ts = TestObserver.create();
-        ts.setInitialFusionMode(QueueDisposable.ANY);
+        to = TestObserver.create();
+        to.setInitialFusionMode(QueueFuseable.ANY);
 
-        ts.onSubscribe(new ScalarDisposable<Integer>(ts, 1));
+        to.onSubscribe(new ScalarDisposable<Integer>(to, 1));
 
-        ts.assertFuseable();
+        to.assertFuseable();
 
-        ts.assertFusionMode(QueueDisposable.SYNC);
+        to.assertFusionMode(QueueFuseable.SYNC);
 
         try {
-            ts.assertFusionMode(QueueDisposable.NONE);
+            to.assertFusionMode(QueueFuseable.NONE);
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
         try {
-            ts.assertNotFuseable();
+            to.assertNotFuseable();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
@@ -572,14 +572,14 @@ public class TestObserverTest {
 
     @Test
     public void assertTerminated() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.assertNotTerminated();
+        to.assertNotTerminated();
 
-        ts.onError(null);
+        to.onError(null);
 
         try {
-            ts.assertNotTerminated();
+            to.assertNotTerminated();
             throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             // expected
@@ -588,9 +588,9 @@ public class TestObserverTest {
 
     @Test
     public void assertOf() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.assertOf(new Consumer<TestObserver<Integer>>() {
+        to.assertOf(new Consumer<TestObserver<Integer>>() {
             @Override
             public void accept(TestObserver<Integer> f) throws Exception {
                 f.assertNotSubscribed();
@@ -598,7 +598,7 @@ public class TestObserverTest {
         });
 
         try {
-            ts.assertOf(new Consumer<TestObserver<Integer>>() {
+            to.assertOf(new Consumer<TestObserver<Integer>>() {
                 @Override
                 public void accept(TestObserver<Integer> f) throws Exception {
                     f.assertSubscribed();
@@ -610,7 +610,7 @@ public class TestObserverTest {
         }
 
         try {
-            ts.assertOf(new Consumer<TestObserver<Integer>>() {
+            to.assertOf(new Consumer<TestObserver<Integer>>() {
                 @Override
                 public void accept(TestObserver<Integer> f) throws Exception {
                     throw new IllegalArgumentException();
@@ -624,34 +624,34 @@ public class TestObserverTest {
 
     @Test
     public void assertResult() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        ts.onComplete();
+        to.onComplete();
 
-        ts.assertResult();
+        to.assertResult();
 
         try {
-            ts.assertResult(1);
+            to.assertResult(1);
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
-        ts.onNext(1);
+        to.onNext(1);
 
-        ts.assertResult(1);
+        to.assertResult(1);
 
         try {
-            ts.assertResult(2);
+            to.assertResult(2);
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
         try {
-            ts.assertResult();
+            to.assertResult();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
@@ -661,139 +661,139 @@ public class TestObserverTest {
 
     @Test(timeout = 5000)
     public void await() throws Exception {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        assertFalse(ts.await(100, TimeUnit.MILLISECONDS));
+        assertFalse(to.await(100, TimeUnit.MILLISECONDS));
 
-        ts.awaitDone(100, TimeUnit.MILLISECONDS);
+        to.awaitDone(100, TimeUnit.MILLISECONDS);
 
-        assertTrue(ts.isDisposed());
+        assertTrue(to.isDisposed());
 
-        assertFalse(ts.awaitTerminalEvent(100, TimeUnit.MILLISECONDS));
+        assertFalse(to.awaitTerminalEvent(100, TimeUnit.MILLISECONDS));
 
-        assertEquals(0, ts.completions());
-        assertEquals(0, ts.errorCount());
+        assertEquals(0, to.completions());
+        assertEquals(0, to.errorCount());
 
-        ts.onComplete();
+        to.onComplete();
 
-        assertTrue(ts.await(100, TimeUnit.MILLISECONDS));
+        assertTrue(to.await(100, TimeUnit.MILLISECONDS));
 
-        ts.await();
+        to.await();
 
-        ts.awaitDone(5, TimeUnit.SECONDS);
+        to.awaitDone(5, TimeUnit.SECONDS);
 
-        assertEquals(1, ts.completions());
-        assertEquals(0, ts.errorCount());
+        assertEquals(1, to.completions());
+        assertEquals(0, to.errorCount());
 
-        assertTrue(ts.awaitTerminalEvent());
+        assertTrue(to.awaitTerminalEvent());
 
-        final TestObserver<Integer> ts1 = TestObserver.create();
+        final TestObserver<Integer> to1 = TestObserver.create();
 
-        ts1.onSubscribe(Disposables.empty());
+        to1.onSubscribe(Disposables.empty());
 
         Schedulers.single().scheduleDirect(new Runnable() {
             @Override
             public void run() {
-                ts1.onComplete();
+                to1.onComplete();
             }
         }, 200, TimeUnit.MILLISECONDS);
 
-        ts1.await();
+        to1.await();
 
-        ts1.assertValueSet(Collections.<Integer>emptySet());
+        to1.assertValueSet(Collections.<Integer>emptySet());
     }
 
     @Test
     public void errors() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        assertEquals(0, ts.errors().size());
+        assertEquals(0, to.errors().size());
 
-        ts.onError(new TestException());
+        to.onError(new TestException());
 
-        assertEquals(1, ts.errors().size());
+        assertEquals(1, to.errors().size());
 
-        TestHelper.assertError(ts.errors(), 0, TestException.class);
+        TestHelper.assertError(to.errors(), 0, TestException.class);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void onNext() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        assertEquals(0, ts.valueCount());
+        assertEquals(0, to.valueCount());
 
-        assertEquals(Collections.emptyList(), ts.values());
+        assertEquals(Collections.emptyList(), to.values());
 
-        ts.onNext(1);
+        to.onNext(1);
 
-        assertEquals(Collections.singletonList(1), ts.values());
+        assertEquals(Collections.singletonList(1), to.values());
 
-        ts.cancel();
+        to.cancel();
 
-        assertTrue(ts.isCancelled());
-        assertTrue(ts.isDisposed());
+        assertTrue(to.isCancelled());
+        assertTrue(to.isDisposed());
 
-        ts.assertValue(1);
+        to.assertValue(1);
 
-        assertEquals(Arrays.asList(Collections.singletonList(1), Collections.emptyList(), Collections.emptyList()), ts.getEvents());
+        assertEquals(Arrays.asList(Collections.singletonList(1), Collections.emptyList(), Collections.emptyList()), to.getEvents());
 
-        ts.onComplete();
+        to.onComplete();
 
-        assertEquals(Arrays.asList(Collections.singletonList(1), Collections.emptyList(), Collections.singletonList(Notification.createOnComplete())), ts.getEvents());
+        assertEquals(Arrays.asList(Collections.singletonList(1), Collections.emptyList(), Collections.singletonList(Notification.createOnComplete())), to.getEvents());
     }
 
     @Test
     public void fusionModeToString() {
-        assertEquals("NONE", TestObserver.fusionModeToString(QueueDisposable.NONE));
-        assertEquals("SYNC", TestObserver.fusionModeToString(QueueDisposable.SYNC));
-        assertEquals("ASYNC", TestObserver.fusionModeToString(QueueDisposable.ASYNC));
+        assertEquals("NONE", TestObserver.fusionModeToString(QueueFuseable.NONE));
+        assertEquals("SYNC", TestObserver.fusionModeToString(QueueFuseable.SYNC));
+        assertEquals("ASYNC", TestObserver.fusionModeToString(QueueFuseable.ASYNC));
         assertEquals("Unknown(100)", TestObserver.fusionModeToString(100));
     }
 
     @Test
     public void multipleTerminals() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        ts.assertNotComplete();
+        to.assertNotComplete();
 
-        ts.onComplete();
+        to.onComplete();
 
         try {
-            ts.assertNotComplete();
+            to.assertNotComplete();
             throw new RuntimeException("Should have thrown");
         } catch (Throwable ex) {
             // expected
         }
 
-        ts.assertTerminated();
+        to.assertTerminated();
 
-        ts.onComplete();
-
-        try {
-            ts.assertComplete();
-            throw new RuntimeException("Should have thrown");
-        } catch (Throwable ex) {
-            // expected
-        }
+        to.onComplete();
 
         try {
-            ts.assertTerminated();
+            to.assertComplete();
             throw new RuntimeException("Should have thrown");
         } catch (Throwable ex) {
             // expected
         }
 
         try {
-            ts.assertNotComplete();
+            to.assertTerminated();
+            throw new RuntimeException("Should have thrown");
+        } catch (Throwable ex) {
+            // expected
+        }
+
+        try {
+            to.assertNotComplete();
             throw new RuntimeException("Should have thrown");
         } catch (Throwable ex) {
             // expected
@@ -802,32 +802,32 @@ public class TestObserverTest {
 
     @Test
     public void assertValue() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
         try {
-            ts.assertValue(1);
+            to.assertValue(1);
             throw new RuntimeException("Should have thrown");
         } catch (Throwable ex) {
             // expected
         }
 
-        ts.onNext(1);
+        to.onNext(1);
 
-        ts.assertValue(1);
+        to.assertValue(1);
 
         try {
-            ts.assertValue(2);
+            to.assertValue(2);
             throw new RuntimeException("Should have thrown");
         } catch (Throwable ex) {
             // expected
         }
 
-        ts.onNext(2);
+        to.onNext(2);
 
         try {
-            ts.assertValue(1);
+            to.assertValue(1);
             throw new RuntimeException("Should have thrown");
         } catch (Throwable ex) {
             // expected
@@ -836,77 +836,77 @@ public class TestObserverTest {
 
     @Test
     public void onNextMisbehave() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onNext(1);
+        to.onNext(1);
 
-        ts.assertError(IllegalStateException.class);
+        to.assertError(IllegalStateException.class);
 
-        ts = TestObserver.create();
+        to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        ts.onNext(null);
+        to.onNext(null);
 
-        ts.assertFailure(NullPointerException.class, (Integer)null);
+        to.assertFailure(NullPointerException.class, (Integer)null);
     }
 
     @Test
     public void awaitTerminalEventInterrupt() {
-        final TestObserver<Integer> ts = TestObserver.create();
+        final TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
         Thread.currentThread().interrupt();
 
-        ts.awaitTerminalEvent();
+        to.awaitTerminalEvent();
 
         assertTrue(Thread.interrupted());
 
         Thread.currentThread().interrupt();
 
-        ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
+        to.awaitTerminalEvent(5, TimeUnit.SECONDS);
 
         assertTrue(Thread.interrupted());
     }
 
     @Test
     public void assertTerminated2() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        assertFalse(ts.isTerminated());
+        assertFalse(to.isTerminated());
 
-        ts.onError(new TestException());
-        ts.onError(new IOException());
+        to.onError(new TestException());
+        to.onError(new IOException());
 
-        assertTrue(ts.isTerminated());
+        assertTrue(to.isTerminated());
 
         try {
-            ts.assertTerminated();
+            to.assertTerminated();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
         try {
-            ts.assertError(TestException.class);
+            to.assertError(TestException.class);
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
         }
 
 
-        ts = TestObserver.create();
+        to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        ts.onError(new TestException());
-        ts.onComplete();
+        to.onError(new TestException());
+        to.onComplete();
 
         try {
-            ts.assertTerminated();
+            to.assertTerminated();
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
@@ -915,30 +915,30 @@ public class TestObserverTest {
 
     @Test
     public void onSubscribe() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(null);
+        to.onSubscribe(null);
 
-        ts.assertError(NullPointerException.class);
+        to.assertError(NullPointerException.class);
 
-        ts = TestObserver.create();
+        to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
         Disposable d1 = Disposables.empty();
 
-        ts.onSubscribe(d1);
+        to.onSubscribe(d1);
 
         assertTrue(d1.isDisposed());
 
-        ts.assertError(IllegalStateException.class);
+        to.assertError(IllegalStateException.class);
 
-        ts = TestObserver.create();
-        ts.dispose();
+        to = TestObserver.create();
+        to.dispose();
 
         d1 = Disposables.empty();
 
-        ts.onSubscribe(d1);
+        to.onSubscribe(d1);
 
         assertTrue(d1.isDisposed());
 
@@ -946,31 +946,31 @@ public class TestObserverTest {
 
     @Test
     public void assertValueSequence() {
-        TestObserver<Integer> ts = TestObserver.create();
+        TestObserver<Integer> to = TestObserver.create();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        ts.onNext(1);
-        ts.onNext(2);
+        to.onNext(1);
+        to.onNext(2);
 
         try {
-            ts.assertValueSequence(Collections.<Integer>emptyList());
+            to.assertValueSequence(Collections.<Integer>emptyList());
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError expected) {
             assertTrue(expected.getMessage(), expected.getMessage().startsWith("More values received than expected (0)"));
         }
 
         try {
-            ts.assertValueSequence(Collections.singletonList(1));
+            to.assertValueSequence(Collections.singletonList(1));
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError expected) {
             assertTrue(expected.getMessage(), expected.getMessage().startsWith("More values received than expected (1)"));
         }
 
-        ts.assertValueSequence(Arrays.asList(1, 2));
+        to.assertValueSequence(Arrays.asList(1, 2));
 
         try {
-            ts.assertValueSequence(Arrays.asList(1, 2, 3));
+            to.assertValueSequence(Arrays.asList(1, 2, 3));
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError expected) {
             assertTrue(expected.getMessage(), expected.getMessage().startsWith("Fewer values received than expected (2)"));
@@ -979,23 +979,23 @@ public class TestObserverTest {
 
     @Test
     public void assertEmpty() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         try {
-            ts.assertEmpty();
+            to.assertEmpty();
             throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             // expected
         }
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
-        ts.assertEmpty();
+        to.assertEmpty();
 
-        ts.onNext(1);
+        to.onNext(1);
 
         try {
-            ts.assertEmpty();
+            to.assertEmpty();
             throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             // expected
@@ -1004,12 +1004,12 @@ public class TestObserverTest {
 
     @Test
     public void awaitDoneTimed() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         Thread.currentThread().interrupt();
 
         try {
-            ts.awaitDone(5, TimeUnit.SECONDS);
+            to.awaitDone(5, TimeUnit.SECONDS);
         } catch (RuntimeException ex) {
             assertTrue(ex.toString(), ex.getCause() instanceof InterruptedException);
         }
@@ -1017,14 +1017,14 @@ public class TestObserverTest {
 
     @Test
     public void assertNotSubscribed() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        ts.assertNotSubscribed();
+        to.assertNotSubscribed();
 
-        ts.errors().add(new TestException());
+        to.errors().add(new TestException());
 
         try {
-            ts.assertNotSubscribed();
+            to.assertNotSubscribed();
             throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             // expected
@@ -1033,32 +1033,32 @@ public class TestObserverTest {
 
     @Test
     public void assertErrorMultiple() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
         TestException e = new TestException();
-        ts.errors().add(e);
-        ts.errors().add(new TestException());
+        to.errors().add(e);
+        to.errors().add(new TestException());
 
         try {
-            ts.assertError(TestException.class);
+            to.assertError(TestException.class);
             throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             // expected
         }
         try {
-            ts.assertError(e);
+            to.assertError(e);
             throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             // expected
         }
         try {
-            ts.assertError(Functions.<Throwable>alwaysTrue());
+            to.assertError(Functions.<Throwable>alwaysTrue());
             throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             // expected
         }
         try {
-            ts.assertErrorMessage("");
+            to.assertErrorMessage("");
             throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             // expected
@@ -1067,10 +1067,10 @@ public class TestObserverTest {
 
     @Test
     public void testErrorInPredicate() {
-        TestObserver<Object> ts = new TestObserver<Object>();
-        ts.onError(new RuntimeException());
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onError(new RuntimeException());
         try {
-            ts.assertError(new Predicate<Throwable>() {
+            to.assertError(new Predicate<Throwable>() {
                 @Override
                 public boolean test(Throwable throwable) throws Exception {
                     throw new TestException();
@@ -1085,25 +1085,25 @@ public class TestObserverTest {
 
     @Test
     public void assertComplete() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
         try {
-            ts.assertComplete();
+            to.assertComplete();
             throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             // expected
         }
 
-        ts.onComplete();
+        to.onComplete();
 
-        ts.assertComplete();
+        to.assertComplete();
 
-        ts.onComplete();
+        to.onComplete();
 
         try {
-            ts.assertComplete();
+            to.assertComplete();
             throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             // expected
@@ -1112,16 +1112,16 @@ public class TestObserverTest {
 
     @Test
     public void completeWithoutOnSubscribe() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        ts.onComplete();
+        to.onComplete();
 
-        ts.assertError(IllegalStateException.class);
+        to.assertError(IllegalStateException.class);
     }
 
     @Test
     public void completeDelegateThrows() {
-        TestObserver<Integer> ts = new TestObserver<Integer>(new Observer<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>(new Observer<Integer>() {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -1145,19 +1145,19 @@ public class TestObserverTest {
 
         });
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
         try {
-            ts.onComplete();
+            to.onComplete();
             throw new RuntimeException("Should have thrown!");
         } catch (TestException ex) {
-            assertTrue(ts.isTerminated());
+            assertTrue(to.isTerminated());
         }
     }
 
     @Test
     public void errorDelegateThrows() {
-        TestObserver<Integer> ts = new TestObserver<Integer>(new Observer<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>(new Observer<Integer>() {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -1181,38 +1181,38 @@ public class TestObserverTest {
 
         });
 
-        ts.onSubscribe(Disposables.empty());
+        to.onSubscribe(Disposables.empty());
 
         try {
-            ts.onError(new IOException());
+            to.onError(new IOException());
             throw new RuntimeException("Should have thrown!");
         } catch (TestException ex) {
-            assertTrue(ts.isTerminated());
+            assertTrue(to.isTerminated());
         }
     }
 
     @Test
     public void syncQueueThrows() {
-        TestObserver<Object> ts = new TestObserver<Object>();
-        ts.setInitialFusionMode(QueueDisposable.SYNC);
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.setInitialFusionMode(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
         .map(new Function<Integer, Object>() {
             @Override
             public Object apply(Integer v) throws Exception { throw new TestException(); }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
-        ts.assertSubscribed()
+        to.assertSubscribed()
         .assertFuseable()
-        .assertFusionMode(QueueDisposable.SYNC)
+        .assertFusionMode(QueueFuseable.SYNC)
         .assertFailure(TestException.class);
     }
 
     @Test
     public void asyncQueueThrows() {
-        TestObserver<Object> ts = new TestObserver<Object>();
-        ts.setInitialFusionMode(QueueDisposable.ANY);
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.setInitialFusionMode(QueueFuseable.ANY);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
 
@@ -1221,13 +1221,13 @@ public class TestObserverTest {
             @Override
             public Object apply(Integer v) throws Exception { throw new TestException(); }
         })
-        .subscribe(ts);
+        .subscribe(to);
 
         up.onNext(1);
 
-        ts.assertSubscribed()
+        to.assertSubscribed()
         .assertFuseable()
-        .assertFusionMode(QueueDisposable.ASYNC)
+        .assertFusionMode(QueueFuseable.ASYNC)
         .assertFailure(TestException.class);
     }
 
@@ -1249,32 +1249,32 @@ public class TestObserverTest {
 
     @Test
     public void asyncFusion() {
-        TestObserver<Object> ts = new TestObserver<Object>();
-        ts.setInitialFusionMode(QueueDisposable.ANY);
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.setInitialFusionMode(QueueFuseable.ANY);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
 
         up
-        .subscribe(ts);
+        .subscribe(to);
 
         up.onNext(1);
         up.onComplete();
 
-        ts.assertSubscribed()
+        to.assertSubscribed()
         .assertFuseable()
-        .assertFusionMode(QueueDisposable.ASYNC)
+        .assertFusionMode(QueueFuseable.ASYNC)
         .assertResult(1);
     }
 
     @Test
     public void assertValuePredicateEmpty() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
-        Observable.empty().subscribe(ts);
+        Observable.empty().subscribe(to);
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("No values");
-        ts.assertValue(new Predicate<Object>() {
+        to.assertValue(new Predicate<Object>() {
             @Override public boolean test(final Object o) throws Exception {
                 return false;
             }
@@ -1283,11 +1283,11 @@ public class TestObserverTest {
 
     @Test
     public void assertValuePredicateMatch() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        Observable.just(1).subscribe(ts);
+        Observable.just(1).subscribe(to);
 
-        ts.assertValue(new Predicate<Integer>() {
+        to.assertValue(new Predicate<Integer>() {
             @Override public boolean test(final Integer o) throws Exception {
                 return o == 1;
             }
@@ -1296,13 +1296,13 @@ public class TestObserverTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        Observable.just(1).subscribe(ts);
+        Observable.just(1).subscribe(to);
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("Value not present");
-        ts.assertValue(new Predicate<Integer>() {
+        to.assertValue(new Predicate<Integer>() {
             @Override public boolean test(final Integer o) throws Exception {
                 return o != 1;
             }
@@ -1311,13 +1311,13 @@ public class TestObserverTest {
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        Observable.just(1, 2).subscribe(ts);
+        Observable.just(1, 2).subscribe(to);
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("Value present but other values as well");
-        ts.assertValue(new Predicate<Integer>() {
+        to.assertValue(new Predicate<Integer>() {
             @Override public boolean test(final Integer o) throws Exception {
                 return o == 1;
             }
@@ -1326,13 +1326,13 @@ public class TestObserverTest {
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
-        Observable.empty().subscribe(ts);
+        Observable.empty().subscribe(to);
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("No values");
-        ts.assertValueAt(0, new Predicate<Object>() {
+        to.assertValueAt(0, new Predicate<Object>() {
             @Override public boolean test(final Object o) throws Exception {
                 return false;
             }
@@ -1341,11 +1341,11 @@ public class TestObserverTest {
 
     @Test
     public void assertValueAtPredicateMatch() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        Observable.just(1, 2).subscribe(ts);
+        Observable.just(1, 2).subscribe(to);
 
-        ts.assertValueAt(1, new Predicate<Integer>() {
+        to.assertValueAt(1, new Predicate<Integer>() {
             @Override public boolean test(final Integer o) throws Exception {
                 return o == 2;
             }
@@ -1354,13 +1354,13 @@ public class TestObserverTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        Observable.just(1, 2, 3).subscribe(ts);
+        Observable.just(1, 2, 3).subscribe(to);
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("Value not present");
-        ts.assertValueAt(2, new Predicate<Integer>() {
+        to.assertValueAt(2, new Predicate<Integer>() {
             @Override public boolean test(final Integer o) throws Exception {
                 return o != 3;
             }
@@ -1369,13 +1369,13 @@ public class TestObserverTest {
 
     @Test
     public void assertValueAtInvalidIndex() {
-        TestObserver<Integer> ts = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<Integer>();
 
-        Observable.just(1, 2).subscribe(ts);
+        Observable.just(1, 2).subscribe(to);
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)");
-        ts.assertValueAt(2, new Predicate<Integer>() {
+        to.assertValueAt(2, new Predicate<Integer>() {
             @Override public boolean test(final Integer o) throws Exception {
                 return o == 1;
             }
@@ -1384,44 +1384,44 @@ public class TestObserverTest {
 
     @Test
     public void assertValueAtIndexEmpty() {
-        TestObserver<Object> ts = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<Object>();
 
-        Observable.empty().subscribe(ts);
+        Observable.empty().subscribe(to);
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("No values");
-        ts.assertValueAt(0, "a");
+        to.assertValueAt(0, "a");
     }
 
     @Test
     public void assertValueAtIndexMatch() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
 
-        Observable.just("a", "b").subscribe(ts);
+        Observable.just("a", "b").subscribe(to);
 
-        ts.assertValueAt(1, "b");
+        to.assertValueAt(1, "b");
     }
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
 
-        Observable.just("a", "b", "c").subscribe(ts);
+        Observable.just("a", "b", "c").subscribe(to);
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("Expected: b (class: String), Actual: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)");
-        ts.assertValueAt(2, "b");
+        to.assertValueAt(2, "b");
     }
 
     @Test
     public void assertValueAtIndexInvalidIndex() {
-        TestObserver<String> ts = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<String>();
 
-        Observable.just("a", "b").subscribe(ts);
+        Observable.just("a", "b").subscribe(to);
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)");
-        ts.assertValueAt(2, "c");
+        to.assertValueAt(2, "c");
     }
 
     @Test

--- a/src/test/java/io/reactivex/parallel/ParallelFromPublisherTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFromPublisherTest.java
@@ -25,7 +25,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscribers.BasicFuseableSubscriber;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.processors.UnicastProcessor;
@@ -93,11 +93,11 @@ public class ParallelFromPublisherTest {
             public int requestFusion(int mode) {
                 QueueSubscription<T> fs = qs;
                 if (fs != null) {
-                    int m = fs.requestFusion(mode & ~QueueSubscription.BOUNDARY);
+                    int m = fs.requestFusion(mode & ~QueueFuseable.BOUNDARY);
                     this.sourceMode = m;
                     return m;
                 }
-                return QueueSubscription.NONE;
+                return QueueFuseable.NONE;
             }
 
             @Override

--- a/src/test/java/io/reactivex/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/AsyncProcessorTest.java
@@ -27,7 +27,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.TestHelper;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.subscribers.*;
 
@@ -391,13 +391,13 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     public void fusionLive() {
         AsyncProcessor<Integer> ap = new AsyncProcessor<Integer>();
 
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         ap.subscribe(ts);
 
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC));
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC));
 
         ts.assertNoValues().assertNoErrors().assertNotComplete();
 
@@ -416,13 +416,13 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
         ap.onNext(1);
         ap.onComplete();
 
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         ap.subscribe(ts);
 
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1);
     }
 

--- a/src/test/java/io/reactivex/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/PublishProcessorTest.java
@@ -260,14 +260,14 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
      */
     @Test
     public void testReSubscribe() {
-        final PublishProcessor<Integer> ps = PublishProcessor.create();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
 
         Subscriber<Integer> o1 = TestHelper.mockSubscriber();
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(o1);
-        ps.subscribe(ts);
+        pp.subscribe(ts);
 
         // emit
-        ps.onNext(1);
+        pp.onNext(1);
 
         // validate we got it
         InOrder inOrder1 = inOrder(o1);
@@ -278,14 +278,14 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         ts.dispose();
 
         // emit again but nothing will be there to receive it
-        ps.onNext(2);
+        pp.onNext(2);
 
         Subscriber<Integer> o2 = TestHelper.mockSubscriber();
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(o2);
-        ps.subscribe(ts2);
+        pp.subscribe(ts2);
 
         // emit
-        ps.onNext(3);
+        pp.onNext(3);
 
         // validate we got it
         InOrder inOrder2 = inOrder(o2);

--- a/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
@@ -39,13 +39,13 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     public void fusionLive() {
         UnicastProcessor<Integer> ap = UnicastProcessor.create();
 
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         ap.subscribe(ts);
 
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC));
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC));
 
         ts.assertNoValues().assertNoErrors().assertNotComplete();
 
@@ -64,13 +64,13 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
         ap.onNext(1);
         ap.onComplete();
 
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         ap.subscribe(ts);
 
         ts
         .assertOf(SubscriberFusion.<Integer>assertFuseable())
-        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueSubscription.ASYNC))
+        .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1);
     }
 
@@ -95,7 +95,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
         ap.onNext(1);
         ap.onError(new RuntimeException());
 
-        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+        TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
         ap.subscribe(ts);
         ts
@@ -263,11 +263,11 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     public void rejectSyncFusion() {
         UnicastProcessor<Object> p = UnicastProcessor.create();
 
-        TestSubscriber<Object> ts = SubscriberFusion.newTest(QueueSubscription.SYNC);
+        TestSubscriber<Object> ts = SubscriberFusion.newTest(QueueFuseable.SYNC);
 
         p.subscribe(ts);
 
-        SubscriberFusion.assertFusion(ts, QueueSubscription.NONE);
+        SubscriberFusion.assertFusion(ts, QueueFuseable.NONE);
     }
 
     @Test
@@ -297,7 +297,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final UnicastProcessor<Object> p = UnicastProcessor.create();
 
-            final TestSubscriber<Object> ts = SubscriberFusion.newTest(QueueSubscription.ANY);
+            final TestSubscriber<Object> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
 
             p.subscribe(ts);
 
@@ -360,11 +360,11 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
 
         assertFalse(us.hasSubscribers());
 
-        TestSubscriber<Integer> to = us.test();
+        TestSubscriber<Integer> ts = us.test();
 
         assertTrue(us.hasSubscribers());
 
-        to.cancel();
+        ts.cancel();
 
         assertFalse(us.hasSubscribers());
     }
@@ -374,12 +374,12 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
         UnicastProcessor<Integer> us = UnicastProcessor.create(false);
 
 
-        TestSubscriber<Integer> to = us.to(SubscriberFusion.<Integer>test(1, QueueDisposable.ANY, false));
+        TestSubscriber<Integer> ts = us.to(SubscriberFusion.<Integer>test(1, QueueFuseable.ANY, false));
 
         us.done = true;
-        us.drainFused(to);
+        us.drainFused(ts);
 
-        to.assertResult();
+        ts.assertResult();
     }
 
     @Test
@@ -387,22 +387,22 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
         UnicastProcessor<Integer> us = UnicastProcessor.create(false);
 
 
-        TestSubscriber<Integer> to = us.to(SubscriberFusion.<Integer>test(1, QueueDisposable.ANY, false));
+        TestSubscriber<Integer> ts = us.to(SubscriberFusion.<Integer>test(1, QueueFuseable.ANY, false));
 
-        us.drainFused(to);
+        us.drainFused(ts);
 
-        to.assertEmpty();
+        ts.assertEmpty();
     }
 
     @Test
     public void checkTerminatedFailFastEmpty() {
         UnicastProcessor<Integer> us = UnicastProcessor.create(false);
 
-        TestSubscriber<Integer> to = us.to(SubscriberFusion.<Integer>test(1, QueueDisposable.ANY, false));
+        TestSubscriber<Integer> ts = us.to(SubscriberFusion.<Integer>test(1, QueueFuseable.ANY, false));
 
-        us.checkTerminated(true, true, false, to, us.queue);
+        us.checkTerminated(true, true, false, ts, us.queue);
 
-        to.assertEmpty();
+        ts.assertEmpty();
     }
 
     @Test

--- a/src/test/java/io/reactivex/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/single/SingleCacheTest.java
@@ -55,15 +55,15 @@ public class SingleCacheTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         Single<Integer> cache = ps.single(-99).cache();
 
-        TestObserver<Integer> ts1 = cache.test();
+        TestObserver<Integer> to1 = cache.test();
 
-        TestObserver<Integer> ts2 = cache.test();
+        TestObserver<Integer> to2 = cache.test();
 
         ps.onNext(1);
         ps.onComplete();
 
-        ts1.assertResult(1);
-        ts2.assertResult(1);
+        to1.assertResult(1);
+        to2.assertResult(1);
     }
 
     @Test
@@ -71,17 +71,17 @@ public class SingleCacheTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         Single<Integer> cache = ps.single(-99).cache();
 
-        TestObserver<Integer> ts1 = cache.test();
+        TestObserver<Integer> to1 = cache.test();
 
-        TestObserver<Integer> ts2 = cache.test();
+        TestObserver<Integer> to2 = cache.test();
 
-        ts1.cancel();
+        to1.cancel();
 
         ps.onNext(1);
         ps.onComplete();
 
-        ts1.assertNoValues().assertNoErrors().assertNotComplete();
-        ts2.assertResult(1);
+        to1.assertNoValues().assertNoErrors().assertNotComplete();
+        to2.assertResult(1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
@@ -135,9 +135,9 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         Observer<Object> observerB = TestHelper.mockObserver();
         Observer<Object> observerC = TestHelper.mockObserver();
 
-        TestObserver<Object> ts = new TestObserver<Object>(observerA);
+        TestObserver<Object> to = new TestObserver<Object>(observerA);
 
-        channel.subscribe(ts);
+        channel.subscribe(to);
         channel.subscribe(observerB);
 
         InOrder inOrderA = inOrder(observerA);
@@ -152,7 +152,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         inOrderA.verify(observerA).onNext(42);
         inOrderB.verify(observerB).onNext(42);
 
-        ts.dispose();
+        to.dispose();
         inOrderA.verifyNoMoreInteractions();
 
         channel.onNext(4711);
@@ -367,8 +367,8 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 //        BehaviorSubject<String> ps = BehaviorSubject.create();
 //
 //        ps.subscribe();
-//        TestObserver<String> ts = new TestObserver<T>();
-//        ps.subscribe(ts);
+//        TestObserver<String> to = new TestObserver<T>();
+//        ps.subscribe(to);
 //
 //        try {
 //            ps.onError(new RuntimeException("an exception"));
@@ -377,7 +377,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 //            // ignore
 //        }
 //        // even though the onError above throws we should still receive it on the other subscriber
-//        assertEquals(1, ts.getOnErrorEvents().size());
+//        assertEquals(1, to.getOnErrorEvents().size());
 //    }
 
     // FIXME RS subscribers are not allowed to throw
@@ -390,8 +390,8 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 //
 //        ps.subscribe();
 //        ps.subscribe();
-//        TestObserver<String> ts = new TestObserver<String>();
-//        ps.subscribe(ts);
+//        TestObserver<String> to = new TestObserver<String>();
+//        ps.subscribe(to);
 //        ps.subscribe();
 //        ps.subscribe();
 //        ps.subscribe();
@@ -404,7 +404,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 //            assertEquals(5, e.getExceptions().size());
 //        }
 //        // even though the onError above throws we should still receive it on the other subscriber
-//        assertEquals(1, ts.getOnErrorEvents().size());
+//        assertEquals(1, to.getOnErrorEvents().size());
 //    }
     @Test
     public void testEmissionSubscriptionRace() throws Exception {
@@ -619,14 +619,14 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
     public void cancelOnArrival2() {
         BehaviorSubject<Object> p = BehaviorSubject.create();
 
-        TestObserver<Object> ts = p.test();
+        TestObserver<Object> to = p.test();
 
         p.test(true).assertEmpty();
 
         p.onNext(1);
         p.onComplete();
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @Test
@@ -634,7 +634,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorSubject<Object> p = BehaviorSubject.create();
 
-            final TestObserver<Object> ts = p.test();
+            final TestObserver<Object> to = p.test();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -646,7 +646,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 
@@ -660,12 +660,12 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorSubject<Object> p = BehaviorSubject.createDefault((Object)1);
 
-            final TestObserver[] ts = { null };
+            final TestObserver[] to = { null };
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ts[0] = p.test();
+                    to[0] = p.test();
                 }
             };
 
@@ -678,10 +678,10 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
             TestHelper.race(r1, r2);
 
-            if (ts[0].valueCount() == 1) {
-                ts[0].assertValue(2).assertNoErrors().assertNotComplete();
+            if (to[0].valueCount() == 1) {
+                to[0].assertValue(2).assertNoErrors().assertNotComplete();
             } else {
-                ts[0].assertValues(1, 2).assertNoErrors().assertNotComplete();
+                to[0].assertValues(1, 2).assertNoErrors().assertNotComplete();
             }
         }
     }
@@ -722,12 +722,12 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorSubject<Object> p = BehaviorSubject.create();
 
-            final TestObserver<Object> ts = new TestObserver<Object>();
+            final TestObserver<Object> to = new TestObserver<Object>();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    p.subscribe(ts);
+                    p.subscribe(to);
                 }
             };
 
@@ -740,7 +740,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
             TestHelper.race(r1, r2);
 
-            ts.assertResult();
+            to.assertResult();
         }
     }
 
@@ -749,14 +749,14 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorSubject<Object> p = BehaviorSubject.create();
 
-            final TestObserver<Object> ts = new TestObserver<Object>();
+            final TestObserver<Object> to = new TestObserver<Object>();
 
             final TestException ex = new TestException();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    p.subscribe(ts);
+                    p.subscribe(to);
                 }
             };
 
@@ -769,7 +769,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
             TestHelper.race(r1, r2);
 
-            ts.assertFailure(TestException.class);
+            to.assertFailure(TestException.class);
         }
     }
 

--- a/src/test/java/io/reactivex/subjects/PublishSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/PublishSubjectTest.java
@@ -67,9 +67,9 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         Observer<Object> observerB = TestHelper.mockObserver();
         Observer<Object> observerC = TestHelper.mockObserver();
 
-        TestObserver<Object> ts = new TestObserver<Object>(observerA);
+        TestObserver<Object> to = new TestObserver<Object>(observerA);
 
-        channel.subscribe(ts);
+        channel.subscribe(to);
         channel.subscribe(observerB);
 
         InOrder inOrderA = inOrder(observerA);
@@ -81,7 +81,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         inOrderA.verify(observerA).onNext(42);
         inOrderB.verify(observerB).onNext(42);
 
-        ts.dispose();
+        to.dispose();
         inOrderA.verifyNoMoreInteractions();
 
         channel.onNext(4711);
@@ -176,13 +176,13 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         PublishSubject<String> subject = PublishSubject.create();
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        subject.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>(observer);
+        subject.subscribe(to);
 
         subject.onNext("one");
         subject.onNext("two");
 
-        ts.dispose();
+        to.dispose();
         assertObservedUntilTwo(observer);
 
         Observer<String> anotherSubscriber = TestHelper.mockObserver();
@@ -262,8 +262,8 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
         Observer<Integer> o1 = TestHelper.mockObserver();
-        TestObserver<Integer> ts = new TestObserver<Integer>(o1);
-        ps.subscribe(ts);
+        TestObserver<Integer> to = new TestObserver<Integer>(o1);
+        ps.subscribe(to);
 
         // emit
         ps.onNext(1);
@@ -274,14 +274,14 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         inOrder1.verifyNoMoreInteractions();
 
         // unsubscribe
-        ts.dispose();
+        to.dispose();
 
         // emit again but nothing will be there to receive it
         ps.onNext(2);
 
         Observer<Integer> o2 = TestHelper.mockObserver();
-        TestObserver<Integer> ts2 = new TestObserver<Integer>(o2);
-        ps.subscribe(ts2);
+        TestObserver<Integer> to2 = new TestObserver<Integer>(o2);
+        ps.subscribe(to2);
 
         // emit
         ps.onNext(3);
@@ -291,7 +291,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         inOrder2.verify(o2, times(1)).onNext(3);
         inOrder2.verifyNoMoreInteractions();
 
-        ts2.dispose();
+        to2.dispose();
     }
 
     private final Throwable testException = new Throwable();
@@ -345,8 +345,8 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 //        PublishSubject<String> ps = PublishSubject.create();
 //
 //        ps.subscribe();
-//        TestObserver<String> ts = new TestObserver<String>();
-//        ps.subscribe(ts);
+//        TestObserver<String> to = new TestObserver<String>();
+//        ps.subscribe(to);
 //
 //        try {
 //            ps.onError(new RuntimeException("an exception"));
@@ -355,7 +355,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 //            // ignore
 //        }
 //        // even though the onError above throws we should still receive it on the other subscriber
-//        assertEquals(1, ts.getOnErrorEvents().size());
+//        assertEquals(1, to.getOnErrorEvents().size());
 //    }
 
     // FIXME RS subscribers are not allowed to throw
@@ -368,8 +368,8 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 //
 //        ps.subscribe();
 //        ps.subscribe();
-//        TestObserver<String> ts = new TestObserver<String>();
-//        ps.subscribe(ts);
+//        TestObserver<String> to = new TestObserver<String>();
+//        ps.subscribe(to);
 //        ps.subscribe();
 //        ps.subscribe();
 //        ps.subscribe();
@@ -382,7 +382,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 //            assertEquals(5, e.getExceptions().size());
 //        }
 //        // even though the onError above throws we should still receive it on the other subscriber
-//        assertEquals(1, ts.getOnErrorEvents().size());
+//        assertEquals(1, to.getOnErrorEvents().size());
 //    }
     @Test
     public void testCurrentStateMethodsNormal() {
@@ -442,83 +442,83 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void crossCancel() {
-        final TestObserver<Integer> ts1 = new TestObserver<Integer>();
-        TestObserver<Integer> ts2 = new TestObserver<Integer>() {
+        final TestObserver<Integer> to1 = new TestObserver<Integer>();
+        TestObserver<Integer> to2 = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
-                ts1.cancel();
+                to1.cancel();
             }
         };
 
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        pp.subscribe(ts2);
-        pp.subscribe(ts1);
+        ps.subscribe(to2);
+        ps.subscribe(to1);
 
-        pp.onNext(1);
+        ps.onNext(1);
 
-        ts2.assertValue(1);
+        to2.assertValue(1);
 
-        ts1.assertNoValues();
+        to1.assertNoValues();
     }
 
     @Test
     public void crossCancelOnError() {
-        final TestObserver<Integer> ts1 = new TestObserver<Integer>();
-        TestObserver<Integer> ts2 = new TestObserver<Integer>() {
+        final TestObserver<Integer> to1 = new TestObserver<Integer>();
+        TestObserver<Integer> to2 = new TestObserver<Integer>() {
             @Override
             public void onError(Throwable t) {
                 super.onError(t);
-                ts1.cancel();
+                to1.cancel();
             }
         };
 
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        pp.subscribe(ts2);
-        pp.subscribe(ts1);
+        ps.subscribe(to2);
+        ps.subscribe(to1);
 
-        pp.onError(new TestException());
+        ps.onError(new TestException());
 
-        ts2.assertError(TestException.class);
+        to2.assertError(TestException.class);
 
-        ts1.assertNoErrors();
+        to1.assertNoErrors();
     }
 
     @Test
     public void crossCancelOnComplete() {
-        final TestObserver<Integer> ts1 = new TestObserver<Integer>();
-        TestObserver<Integer> ts2 = new TestObserver<Integer>() {
+        final TestObserver<Integer> to1 = new TestObserver<Integer>();
+        TestObserver<Integer> to2 = new TestObserver<Integer>() {
             @Override
             public void onComplete() {
                 super.onComplete();
-                ts1.cancel();
+                to1.cancel();
             }
         };
 
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        pp.subscribe(ts2);
-        pp.subscribe(ts1);
+        ps.subscribe(to2);
+        ps.subscribe(to1);
 
-        pp.onComplete();
+        ps.onComplete();
 
-        ts2.assertComplete();
+        to2.assertComplete();
 
-        ts1.assertNotComplete();
+        to1.assertNotComplete();
     }
 
     @Test
     @Ignore("Observable doesn't do backpressure")
     public void backpressureOverflow() {
-//        PublishSubject<Integer> pp = PublishSubject.create();
+//        PublishSubject<Integer> ps = PublishSubject.create();
 //
-//        TestObserver<Integer> ts = pp.test(0L);
+//        TestObserver<Integer> to = ps.test(0L);
 //
-//        pp.onNext(1);
+//        ps.onNext(1);
 //
-//        ts.assertNoValues()
+//        to.assertNoValues()
 //        .assertNotComplete()
 //        .assertError(MissingBackpressureException.class)
 //        ;
@@ -526,11 +526,11 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void onSubscribeCancelsImmediately() {
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> ts = pp.test();
+        TestObserver<Integer> to = ps.test();
 
-        pp.subscribe(new Observer<Integer>() {
+        ps.subscribe(new Observer<Integer>() {
 
             @Override
             public void onSubscribe(Disposable s) {
@@ -555,29 +555,29 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 
         });
 
-        ts.cancel();
+        to.cancel();
 
-        assertFalse(pp.hasObservers());
+        assertFalse(ps.hasObservers());
     }
 
     @Test
     public void terminateRace() throws Exception {
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishSubject<Integer> pp = PublishSubject.create();
+            final PublishSubject<Integer> ps = PublishSubject.create();
 
-            TestObserver<Integer> ts = pp.test();
+            TestObserver<Integer> to = ps.test();
 
             Runnable task = new Runnable() {
                 @Override
                 public void run() {
-                    pp.onComplete();
+                    ps.onComplete();
                 }
             };
 
             TestHelper.race(task, task);
 
-            ts
+            to
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult();
         }
@@ -587,20 +587,20 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     public void addRemoveRance() throws Exception {
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishSubject<Integer> pp = PublishSubject.create();
+            final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Integer> ts = pp.test();
+            final TestObserver<Integer> to = ps.test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.subscribe();
+                    ps.subscribe();
                 }
             };
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 
@@ -612,18 +612,18 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     public void addTerminateRance() throws Exception {
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishSubject<Integer> pp = PublishSubject.create();
+            final PublishSubject<Integer> ps = PublishSubject.create();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.subscribe();
+                    ps.subscribe();
                 }
             };
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.onComplete();
+                    ps.onComplete();
                 }
             };
 
@@ -635,56 +635,56 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     public void addCompleteRance() throws Exception {
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishSubject<Integer> pp = PublishSubject.create();
+            final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Integer> ts = new TestObserver<Integer>();
+            final TestObserver<Integer> to = new TestObserver<Integer>();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.subscribe(ts);
+                    ps.subscribe(to);
                 }
             };
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    pp.onComplete();
+                    ps.onComplete();
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            ts.awaitDone(5, TimeUnit.SECONDS)
+            to.awaitDone(5, TimeUnit.SECONDS)
             .assertResult();
         }
     }
 
     @Test
     public void subscribeToAfterComplete() {
-        PublishSubject<Integer> pp = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
 
-        pp.onComplete();
+        ps.onComplete();
 
-        PublishSubject<Integer> pp2 = PublishSubject.create();
+        PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        pp2.subscribe(pp);
+        ps2.subscribe(ps);
 
-        assertFalse(pp2.hasObservers());
+        assertFalse(ps2.hasObservers());
     }
 
     @Test
     public void subscribedTo() {
-        PublishSubject<Integer> pp = PublishSubject.create();
-        PublishSubject<Integer> pp2 = PublishSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
+        PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        pp.subscribe(pp2);
+        ps.subscribe(ps2);
 
-        TestObserver<Integer> ts = pp2.test();
+        TestObserver<Integer> to = ps2.test();
 
-        pp.onNext(1);
-        pp.onNext(2);
-        pp.onComplete();
+        ps.onNext(1);
+        ps.onNext(2);
+        ps.onComplete();
 
-        ts.assertResult(1, 2);
+        to.assertResult(1, 2);
     }
 }

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -294,11 +294,11 @@ public class ReplaySubjectBoundedConcurrencyTest {
     public void testRaceForTerminalState() {
         final List<Integer> expected = Arrays.asList(1);
         for (int i = 0; i < 100000; i++) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
-            Observable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(ts);
-            ts.awaitTerminalEvent();
-            ts.assertValueSequence(expected);
-            ts.assertTerminated();
+            TestObserver<Integer> to = new TestObserver<Integer>();
+            Observable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(to);
+            to.awaitTerminalEvent();
+            to.assertValueSequence(expected);
+            to.assertTerminated();
         }
     }
 

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
@@ -294,11 +294,11 @@ public class ReplaySubjectConcurrencyTest {
     public void testRaceForTerminalState() {
         final List<Integer> expected = Arrays.asList(1);
         for (int i = 0; i < 100000; i++) {
-            TestObserver<Integer> ts = new TestObserver<Integer>();
-            Observable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(ts);
-            ts.awaitTerminalEvent();
-            ts.assertValueSequence(expected);
-            ts.assertTerminated();
+            TestObserver<Integer> to = new TestObserver<Integer>();
+            Observable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(to);
+            to.awaitTerminalEvent();
+            to.assertValueSequence(expected);
+            to.assertTerminated();
         }
     }
 

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
@@ -72,9 +72,9 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         Observer<Object> observerB = TestHelper.mockObserver();
         Observer<Object> observerC = TestHelper.mockObserver();
         Observer<Object> observerD = TestHelper.mockObserver();
-        TestObserver<Object> ts = new TestObserver<Object>(observerA);
+        TestObserver<Object> to = new TestObserver<Object>(observerA);
 
-        channel.subscribe(ts);
+        channel.subscribe(to);
         channel.subscribe(observerB);
 
         InOrder inOrderA = inOrder(observerA);
@@ -88,7 +88,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         inOrderA.verify(observerA).onNext(42);
         inOrderB.verify(observerB).onNext(42);
 
-        ts.dispose();
+        to.dispose();
 
         // a should receive no more
         inOrderA.verifyNoMoreInteractions();
@@ -223,13 +223,13 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         ReplaySubject<String> subject = ReplaySubject.create();
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> ts = new TestObserver<String>(observer);
-        subject.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>(observer);
+        subject.subscribe(to);
 
         subject.onNext("one");
         subject.onNext("two");
 
-        ts.dispose();
+        to.dispose();
         assertObservedUntilTwo(observer);
 
         Observer<String> anotherSubscriber = TestHelper.mockObserver();
@@ -541,8 +541,8 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 //        ReplaySubject<String> ps = ReplaySubject.create();
 //
 //        ps.subscribe();
-//        TestObserver<String> ts = new TestObserver<String>();
-//        ps.subscribe(ts);
+//        TestObserver<String> to = new TestObserver<String>();
+//        ps.subscribe(to);
 //
 //        try {
 //            ps.onError(new RuntimeException("an exception"));
@@ -551,7 +551,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 //            // ignore
 //        }
 //        // even though the onError above throws we should still receive it on the other subscriber
-//        assertEquals(1, ts.errors().size());
+//        assertEquals(1, to.errors().size());
 //    }
 
     // FIXME RS subscribers can't throw
@@ -564,8 +564,8 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 //
 //        ps.subscribe();
 //        ps.subscribe();
-//        TestObserver<String> ts = new TestObserver<String>();
-//        ps.subscribe(ts);
+//        TestObserver<String> to = new TestObserver<String>();
+//        ps.subscribe(to);
 //        ps.subscribe();
 //        ps.subscribe();
 //        ps.subscribe();
@@ -578,7 +578,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 //            assertEquals(5, e.getExceptions().size());
 //        }
 //        // even though the onError above throws we should still receive it on the other subscriber
-//        assertEquals(1, ts.getOnErrorEvents().size());
+//        assertEquals(1, to.getOnErrorEvents().size());
 //    }
 
     @Test
@@ -780,8 +780,8 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void testSizeAndHasAnyValueTimeBounded() {
-        TestScheduler ts = new TestScheduler();
-        ReplaySubject<Object> rs = ReplaySubject.createWithTime(1, TimeUnit.SECONDS, ts);
+        TestScheduler to = new TestScheduler();
+        ReplaySubject<Object> rs = ReplaySubject.createWithTime(1, TimeUnit.SECONDS, to);
 
         assertEquals(0, rs.size());
         assertFalse(rs.hasValue());
@@ -790,7 +790,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
             rs.onNext(i);
             assertEquals(1, rs.size());
             assertTrue(rs.hasValue());
-            ts.advanceTimeBy(2, TimeUnit.SECONDS);
+            to.advanceTimeBy(2, TimeUnit.SECONDS);
             assertEquals(0, rs.size());
             assertFalse(rs.hasValue());
         }
@@ -864,11 +864,11 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
         assertFalse(rp.hasObservers());
 
-        TestObserver<Integer> ts = rp.test();
+        TestObserver<Integer> to = rp.test();
 
         assertTrue(rp.hasObservers());
 
-        ts.cancel();
+        to.cancel();
 
         assertFalse(rp.hasObservers());
     }
@@ -972,21 +972,21 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
     @Test
     public void subscribeCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestObserver<Integer> ts = new TestObserver<Integer>();
+            final TestObserver<Integer> to = new TestObserver<Integer>();
 
             final ReplaySubject<Integer> rp = ReplaySubject.create();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    rp.subscribe(ts);
+                    rp.subscribe(to);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 
@@ -1028,11 +1028,11 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         rp.test();
         rp.test();
 
-        TestObserver<Integer> ts = rp.test(true);
+        TestObserver<Integer> to = rp.test(true);
 
         assertEquals(2, rp.observerCount());
 
-        ts.assertEmpty();
+        to.assertEmpty();
     }
 
     @Test
@@ -1040,20 +1040,20 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             final ReplaySubject<Integer> rp = ReplaySubject.create();
-            final TestObserver<Integer> ts1 = rp.test();
-            final TestObserver<Integer> ts2 = rp.test();
+            final TestObserver<Integer> to1 = rp.test();
+            final TestObserver<Integer> to2 = rp.test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ts1.cancel();
+                    to1.cancel();
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts2.cancel();
+                    to2.cancel();
                 }
             };
 
@@ -1140,7 +1140,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
         final ReplaySubject<Integer> rp = ReplaySubject.createWithTimeAndSize(1, TimeUnit.SECONDS, scheduler, 2);
 
-        TestObserver<Integer> ts = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1150,12 +1150,12 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
             }
         };
 
-        rp.subscribe(ts);
+        rp.subscribe(to);
 
         rp.onNext(1);
         rp.onComplete();
 
-        ts.assertResult(1, 2);
+        to.assertResult(1, 2);
     }
 
     @Test

--- a/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
@@ -23,22 +23,20 @@ import io.reactivex.Observable;
 import io.reactivex.TestHelper;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.internal.subscriptions.BooleanSubscription;
-import io.reactivex.observers.TestObserver;
+import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.subscribers.*;
 
 public class SerializedSubjectTest {
 
     @Test
     public void testBasic() {
         SerializedSubject<String> subject = new SerializedSubject<String>(PublishSubject.<String> create());
-        TestObserver<String> ts = new TestObserver<String>();
-        subject.subscribe(ts);
+        TestObserver<String> to = new TestObserver<String>();
+        subject.subscribe(to);
         subject.onNext("hello");
         subject.onComplete();
-        ts.awaitTerminalEvent();
-        ts.assertValue("hello");
+        to.awaitTerminalEvent();
+        to.assertValue("hello");
     }
 
     @Test
@@ -407,11 +405,11 @@ public class SerializedSubjectTest {
     public void normal() {
         Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
-        TestObserver<Integer> ts = s.test();
+        TestObserver<Integer> to = s.test();
 
         Observable.range(1, 10).subscribe(s);
 
-        ts.assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        to.assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
         assertFalse(s.hasObservers());
 
@@ -437,7 +435,7 @@ public class SerializedSubjectTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
-            TestObserver<Integer> ts = s.test();
+            TestObserver<Integer> to = s.test();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -455,7 +453,7 @@ public class SerializedSubjectTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertSubscribed().assertNoErrors().assertNotComplete()
+            to.assertSubscribed().assertNoErrors().assertNotComplete()
             .assertValueSet(Arrays.asList(1, 2));
         }
     }
@@ -465,7 +463,7 @@ public class SerializedSubjectTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
-            TestObserver<Integer> ts = s.test();
+            TestObserver<Integer> to = s.test();
 
             final TestException ex = new TestException();
 
@@ -485,10 +483,10 @@ public class SerializedSubjectTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertError(ex).assertNotComplete();
+            to.assertError(ex).assertNotComplete();
 
-            if (ts.valueCount() != 0) {
-                ts.assertValue(1);
+            if (to.valueCount() != 0) {
+                to.assertValue(1);
             }
         }
     }
@@ -498,7 +496,7 @@ public class SerializedSubjectTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
-            TestObserver<Integer> ts = s.test();
+            TestObserver<Integer> to = s.test();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -516,10 +514,10 @@ public class SerializedSubjectTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertComplete().assertNoErrors();
+            to.assertComplete().assertNoErrors();
 
-            if (ts.valueCount() != 0) {
-                ts.assertValue(1);
+            if (to.valueCount() != 0) {
+                to.assertValue(1);
             }
         }
     }
@@ -529,7 +527,7 @@ public class SerializedSubjectTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
-            TestObserver<Integer> ts = s.test();
+            TestObserver<Integer> to = s.test();
 
             final Disposable bs = Disposables.empty();
 
@@ -549,7 +547,7 @@ public class SerializedSubjectTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertValue(1).assertNotComplete().assertNoErrors();
+            to.assertValue(1).assertNotComplete().assertNoErrors();
         }
     }
 
@@ -558,7 +556,7 @@ public class SerializedSubjectTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
-            TestObserver<Integer> ts = s.test();
+            TestObserver<Integer> to = s.test();
 
             final Disposable bs = Disposables.empty();
 
@@ -578,7 +576,7 @@ public class SerializedSubjectTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertResult();
+            to.assertResult();
         }
     }
 
@@ -587,7 +585,7 @@ public class SerializedSubjectTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
-            TestObserver<Integer> ts = s.test();
+            TestObserver<Integer> to = s.test();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -605,7 +603,7 @@ public class SerializedSubjectTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertResult();
+            to.assertResult();
         }
     }
 
@@ -614,7 +612,7 @@ public class SerializedSubjectTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
-            TestObserver<Integer> ts = s.test();
+            TestObserver<Integer> to = s.test();
 
             final TestException ex = new TestException();
 
@@ -636,7 +634,7 @@ public class SerializedSubjectTest {
 
                 TestHelper.race(r1, r2);
 
-                ts.assertFailure(TestException.class);
+                to.assertFailure(TestException.class);
 
                 TestHelper.assertUndeliverable(errors, 0, TestException.class);
             } finally {
@@ -650,7 +648,7 @@ public class SerializedSubjectTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
 
-            TestObserver<Integer> ts = s.test();
+            TestObserver<Integer> to = s.test();
 
             final Disposable bs1 = Disposables.empty();
             final Disposable bs2 = Disposables.empty();
@@ -671,21 +669,7 @@ public class SerializedSubjectTest {
 
             TestHelper.race(r1, r2);
 
-            ts.assertEmpty();
+            to.assertEmpty();
         }
-    }
-
-    @Test
-    public void nullOnNext() {
-
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-
-        final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
-
-        so.onSubscribe(new BooleanSubscription());
-
-        so.onNext(null);
-
-        ts.assertFailureAndMessage(NullPointerException.class, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
     }
 }

--- a/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
@@ -39,23 +39,23 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void fusionLive() {
         UnicastSubject<Integer> ap = UnicastSubject.create();
 
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
-        ap.subscribe(ts);
+        ap.subscribe(to);
 
-        ts
+        to
         .assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC));
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC));
 
-        ts.assertNoValues().assertNoErrors().assertNotComplete();
+        to.assertNoValues().assertNoErrors().assertNotComplete();
 
         ap.onNext(1);
 
-        ts.assertValue(1).assertNoErrors().assertNotComplete();
+        to.assertValue(1).assertNoErrors().assertNotComplete();
 
         ap.onComplete();
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @Test
@@ -64,13 +64,13 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         ap.onNext(1);
         ap.onComplete();
 
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ANY);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
-        ap.subscribe(ts);
+        ap.subscribe(to);
 
-        ts
+        to
         .assertOf(ObserverFusion.<Integer>assertFuseable())
-        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueDisposable.ASYNC))
+        .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.ASYNC))
         .assertResult(1);
     }
 
@@ -79,10 +79,10 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         UnicastSubject<Integer> ap = UnicastSubject.create(false);
         ap.onNext(1);
         ap.onError(new RuntimeException());
-        TestObserver<Integer> ts = TestObserver.create();
-        ap.subscribe(ts);
+        TestObserver<Integer> to = TestObserver.create();
+        ap.subscribe(to);
 
-        ts
+        to
                 .assertValueCount(0)
                 .assertError(RuntimeException.class);
     }
@@ -93,10 +93,10 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         UnicastSubject<Integer> ap = UnicastSubject.create(16, noop, false);
         ap.onNext(1);
         ap.onError(new RuntimeException());
-        TestObserver<Integer> ts = TestObserver.create();
-        ap.subscribe(ts);
+        TestObserver<Integer> to = TestObserver.create();
+        ap.subscribe(to);
 
-        ts
+        to
                 .assertValueCount(0)
                 .assertError(RuntimeException.class);
     }
@@ -107,10 +107,10 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         UnicastSubject<Integer> ap = UnicastSubject.create(16, noop, true);
         ap.onNext(1);
         ap.onError(new RuntimeException());
-        TestObserver<Integer> ts = TestObserver.create();
-        ap.subscribe(ts);
+        TestObserver<Integer> to = TestObserver.create();
+        ap.subscribe(to);
 
-        ts
+        to
                 .assertValueCount(1)
                 .assertError(RuntimeException.class);
     }
@@ -120,10 +120,10 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         UnicastSubject<Integer> ap = UnicastSubject.create(false);
         ap.onNext(1);
         ap.onError(new RuntimeException());
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ANY);
-        ap.subscribe(ts);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
+        ap.subscribe(to);
 
-        ts
+        to
                 .assertValueCount(0)
                 .assertError(RuntimeException.class);
     }
@@ -135,10 +135,10 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         ap.onNext(2);
         ap.onNext(3);
         ap.onComplete();
-        TestObserver<Integer> ts = ObserverFusion.newTest(QueueDisposable.ANY);
-        ap.subscribe(ts);
+        TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
+        ap.subscribe(to);
 
-        ts
+        to
                 .assertValueCount(3)
                 .assertComplete();
     }
@@ -150,10 +150,10 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         ap.onNext(2);
         ap.onNext(3);
         ap.onComplete();
-        TestObserver<Integer> ts = TestObserver.create();
-        ap.subscribe(ts);
+        TestObserver<Integer> to = TestObserver.create();
+        ap.subscribe(to);
 
-        ts
+        to
                 .assertValueCount(3)
                 .assertComplete();
     }
@@ -231,12 +231,12 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
                 }
             });
 
-            final TestObserver<Object> ts = up.test();
+            final TestObserver<Object> to = up.test();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 
@@ -299,11 +299,11 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void rejectSyncFusion() {
         UnicastSubject<Object> p = UnicastSubject.create();
 
-        TestObserver<Object> ts = ObserverFusion.newTest(QueueDisposable.SYNC);
+        TestObserver<Object> to = ObserverFusion.newTest(QueueFuseable.SYNC);
 
-        p.subscribe(ts);
+        p.subscribe(to);
 
-        ObserverFusion.assertFusion(ts, QueueDisposable.NONE);
+        ObserverFusion.assertFusion(to, QueueFuseable.NONE);
     }
 
     @Test
@@ -317,7 +317,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void multiSubscriber() {
         UnicastSubject<Object> p = UnicastSubject.create();
 
-        TestObserver<Object> ts = p.test();
+        TestObserver<Object> to = p.test();
 
         p.test()
         .assertFailure(IllegalStateException.class);
@@ -325,7 +325,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         p.onNext(1);
         p.onComplete();
 
-        ts.assertResult(1);
+        to.assertResult(1);
     }
 
     @Test
@@ -333,9 +333,9 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final UnicastSubject<Object> p = UnicastSubject.create();
 
-            final TestObserver<Object> ts = ObserverFusion.newTest(QueueSubscription.ANY);
+            final TestObserver<Object> to = ObserverFusion.newTest(QueueFuseable.ANY);
 
-            p.subscribe(ts);
+            p.subscribe(to);
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -347,7 +347,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    ts.cancel();
+                    to.cancel();
                 }
             };
 
@@ -389,30 +389,30 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final UnicastSubject<Integer> us = UnicastSubject.create();
 
-            final TestObserver<Integer> ts1 = new TestObserver<Integer>();
-            final TestObserver<Integer> ts2 = new TestObserver<Integer>();
+            final TestObserver<Integer> to1 = new TestObserver<Integer>();
+            final TestObserver<Integer> to2 = new TestObserver<Integer>();
 
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    us.subscribe(ts1);
+                    us.subscribe(to1);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    us.subscribe(ts2);
+                    us.subscribe(to2);
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            if (ts1.errorCount() == 0) {
-                ts2.assertFailure(IllegalStateException.class);
+            if (to1.errorCount() == 0) {
+                to2.assertFailure(IllegalStateException.class);
             } else
-            if (ts2.errorCount() == 0) {
-                ts1.assertFailure(IllegalStateException.class);
+            if (to2.errorCount() == 0) {
+                to1.assertFailure(IllegalStateException.class);
             } else {
                 fail("Neither TestObserver failed");
             }
@@ -439,7 +439,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         UnicastSubject<Integer> us = UnicastSubject.create(false);
 
 
-        TestObserver<Integer> to = us.to(ObserverFusion.<Integer>test(QueueDisposable.ANY, false));
+        TestObserver<Integer> to = us.to(ObserverFusion.<Integer>test(QueueFuseable.ANY, false));
 
         us.done = true;
         us.drainFused(to);
@@ -452,7 +452,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         UnicastSubject<Integer> us = UnicastSubject.create(false);
 
 
-        TestObserver<Integer> to = us.to(ObserverFusion.<Integer>test(QueueDisposable.ANY, false));
+        TestObserver<Integer> to = us.to(ObserverFusion.<Integer>test(QueueFuseable.ANY, false));
 
         us.drainFused(to);
 

--- a/src/test/java/io/reactivex/subscribers/SubscriberFusion.java
+++ b/src/test/java/io/reactivex/subscribers/SubscriberFusion.java
@@ -32,12 +32,12 @@ public enum SubscriberFusion {
      * Use this as follows:
      * <pre>
      * source
-     * .to(SubscriberFusion.test(0, QueueSubscription.ANY, false))
+     * .to(SubscriberFusion.test(0, QueueFuseable.ANY, false))
      * .assertResult(0);
      * </pre>
      * @param <T> the value type
      * @param initialRequest the initial request amount, non-negative
-     * @param mode the fusion mode to request, see {@link QueueSubscription} constants.
+     * @param mode the fusion mode to request, see {@link QueueFuseable} constants.
      * @param cancelled should the TestSubscriber cancelled before the subscription even happens?
      * @return the new Function instance
      */
@@ -52,7 +52,7 @@ public enum SubscriberFusion {
      * Use this as follows:
      * <pre>
      * source
-     * .to(ObserverFusion.test(0, QueueDisposable.ANY, false))
+     * .to(ObserverFusion.test(0, QueueFuseable.ANY, false))
      * .assertOf(ObserverFusion.assertFuseable());
      * </pre>
      * @param <T> the value type
@@ -114,7 +114,7 @@ public enum SubscriberFusion {
      * Use this as follows:
      * <pre>
      * source
-     * .to(ObserverFusion.test(0, QueueDisposable.ANY, false))
+     * .to(ObserverFusion.test(0, QueueFuseable.ANY, false))
      * .assertOf(ObserverFusion.assertNotFuseable());
      * </pre>
      * @param <T> the value type
@@ -135,17 +135,17 @@ public enum SubscriberFusion {
 
     /**
      * Returns a Consumer that asserts on its TestSubscriber parameter that
-     * the upstream is Fuseable (sent a QueueSubscription subclass in onSubscribe)
+     * the upstream is Fuseable (sent a QueueFuseable.subclass in onSubscribe)
      * and the established the given fusion mode.
      * <p>
      * Use this as follows:
      * <pre>
      * source
-     * .to(SubscriberFusion.test(0, QueueSubscription.ANY, false))
-     * .assertOf(SubscriberFusion.assertFusionMode(QueueSubscription.SYNC));
+     * .to(SubscriberFusion.test(0, QueueFuseable.ANY, false))
+     * .assertOf(SubscriberFusion.assertFusionMode(QueueFuseable.SYNC));
      * </pre>
      * @param <T> the value type
-     * @param mode the expected established fusion mode, see {@link QueueSubscription} constants.
+     * @param mode the expected established fusion mode, see {@link QueueFuseable} constants.
      * @return the new Consumer instance
      */
     public static <T> Consumer<TestSubscriber<T>> assertFusionMode(final int mode) {
@@ -156,7 +156,7 @@ public enum SubscriberFusion {
      * Constructs a TestSubscriber with the given initial request and required fusion mode.
      * @param <T> the value type
      * @param initialRequest the initial request, non-negative
-     * @param mode the requested fusion mode, see {@link QueueSubscription} constants
+     * @param mode the requested fusion mode, see {@link QueueFuseable} constants
      * @return the new TestSubscriber
      */
     public static <T> TestSubscriber<T> newTest(long initialRequest, int mode) {
@@ -168,7 +168,7 @@ public enum SubscriberFusion {
     /**
      * Constructs a TestSubscriber with the given required fusion mode.
      * @param <T> the value type
-     * @param mode the requested fusion mode, see {@link QueueSubscription} constants
+     * @param mode the requested fusion mode, see {@link QueueFuseable} constants
      * @return the new TestSubscriber
      */
     public static <T> TestSubscriber<T> newTest(int mode) {
@@ -178,7 +178,7 @@ public enum SubscriberFusion {
     }
 
     /**
-     * Assert that the TestSubscriber received a fuseabe QueueSubscription and
+     * Assert that the TestSubscriber received a fuseabe QueueFuseable.and
      * is in the given fusion mode.
      * @param <T> the value type
      * @param ts the TestSubscriber instance


### PR DESCRIPTION
Add an unit test that scans the unit test files for common local variable misnaming due to copy-pasting between the types, such as:

- `TestObserver ts` <-> `TestSubscriber to`
- `PublishSubject pp` <-> `PublishProcessor ps`

See the new `CheckLocalVariablesInTests` for other patterns described with a regexp.