### PR TITLE
2.x: Benchmark X-Map-Z operators

### DIFF
--- a/src/jmh/java/io/reactivex/FlattenRangePerf.java
+++ b/src/jmh/java/io/reactivex/FlattenRangePerf.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlattenRangePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int times;
+
+    Flowable<Integer> flowable;
+
+    Observable<Integer> observable;
+
+    @Setup
+    public void setup() {
+        Integer[] array = new Integer[times];
+        Arrays.fill(array, 777);
+
+        final Iterable<Integer> list = Arrays.asList(1, 2);
+
+        flowable = Flowable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) throws Exception {
+                return list;
+            }
+        });
+
+        observable = Observable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> apply(Integer v) throws Exception {
+                return list;
+            }
+        });
+    }
+
+    @Benchmark
+    public void flowable(Blackhole bh) {
+        flowable.subscribe(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public void observable(Blackhole bh) {
+        observable.subscribe(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/FlowableFlatMapCompletableAsyncPerf.java
+++ b/src/jmh/java/io/reactivex/FlowableFlatMapCompletableAsyncPerf.java
@@ -29,7 +29,7 @@ import io.reactivex.schedulers.Schedulers;
 @OutputTimeUnit(TimeUnit.SECONDS)
 @Fork(value = 1)
 @State(Scope.Thread)
-public class FlowableFlatMapCompletablePerf implements Action {
+public class FlowableFlatMapCompletableAsyncPerf implements Action {
 
     @Param({"1", "10", "100", "1000", "10000", "100000", "1000000"})
     int items;

--- a/src/jmh/java/io/reactivex/MemoryPerf.java
+++ b/src/jmh/java/io/reactivex/MemoryPerf.java
@@ -1,0 +1,517 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.Callable;
+
+import org.reactivestreams.Subscription;
+
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.*;
+
+/**
+ * Measure various prepared flows about their memory usage and print the result
+ * in a JMH compatible format; run {@link #main(String[])}.
+ */
+public final class MemoryPerf {
+
+    private MemoryPerf() { }
+
+    static long memoryUse() {
+        return ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+    }
+
+    static final class MyRx2Subscriber implements FlowableSubscriber<Object> {
+
+        org.reactivestreams.Subscription s;
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            this.s = s;
+        }
+
+        @Override
+        public void onComplete() {
+
+        }
+
+        @Override
+        public void onError(Throwable e) {
+
+        }
+
+        @Override
+        public void onNext(Object t) {
+
+        }
+    }
+
+    static final class MyRx2Observer implements io.reactivex.Observer<Object>, io.reactivex.SingleObserver<Object>,
+    io.reactivex.MaybeObserver<Object>, io.reactivex.CompletableObserver {
+
+        Disposable s;
+
+        @Override
+        public void onSubscribe(Disposable s) {
+            this.s = s;
+        }
+
+        @Override
+        public void onComplete() {
+
+        }
+
+        @Override
+        public void onError(Throwable e) {
+
+        }
+
+        @Override
+        public void onNext(Object t) {
+
+        }
+
+        @Override
+        public void onSuccess(Object value) {
+
+        }
+    }
+    static <U> void checkMemory(Callable<U> item, String name, String typeLib) throws Exception {
+        checkMemory(item, name, typeLib, 1000000);
+    }
+
+    static <U> void checkMemory(Callable<U> item, String name, String typeLib, int n) throws Exception {
+        // make sure classes are initialized
+        item.call();
+
+        Object[] array = new Object[n];
+
+        Thread.sleep(100);
+        System.gc();
+        Thread.sleep(100);
+
+        long before = memoryUse();
+
+        for (int i = 0; i < n; i++) {
+            array[i] = item.call();
+        }
+
+        Thread.sleep(100);
+        System.gc();
+        Thread.sleep(100);
+
+        long after = memoryUse();
+
+        double use = Math.max(0.0, (after - before) / 1024.0 / 1024.0);
+
+        System.out.print(name);
+        System.out.print(" ");
+        System.out.print(typeLib);
+        System.out.print("     thrpt ");
+        System.out.print(n);
+        System.out.printf("           %.3f  0.000 MB%n", use);
+
+        if (array.hashCode() == 1) {
+            System.out.print("");
+        }
+
+        array = null;
+        item = null;
+
+        Thread.sleep(100);
+        System.gc();
+        Thread.sleep(100);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        System.out.println("Benchmark  (lib-type)   Mode  Cnt       Score       Error  Units");
+
+        // ---------------------------------------------------------------------------------------------------------------------
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Observable.just(1);
+            }
+        }, "just", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Observable.range(1, 10);
+            }
+        }, "range", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Observable.empty();
+            }
+        }, "empty", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Observable.fromCallable(new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        return 1;
+                    }
+                });
+            }
+        }, "fromCallable", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return new MyRx2Observer();
+            }
+        }, "consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return new io.reactivex.observers.TestObserver<Object>();
+            }
+        }, "test-consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Observable.just(1).subscribeWith(new MyRx2Observer());
+            }
+        }, "just+consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Observable.range(1, 10).subscribeWith(new MyRx2Observer());
+            }
+        }, "range+consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Observable.range(1, 10).map(new Function<Integer, Object>() {
+                    @Override
+                    public Object apply(Integer v) throws Exception {
+                        return v;
+                    }
+                }).subscribeWith(new MyRx2Observer());
+            }
+        }, "range+map+consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Observable.range(1, 10).map(new Function<Integer, Object>() {
+                    @Override
+                    public Object apply(Integer v) throws Exception {
+                        return v;
+                    }
+                }).filter(new Predicate<Object>() {
+                    @Override
+                    public boolean test(Object v) throws Exception {
+                        return true;
+                    }
+                }).subscribeWith(new MyRx2Observer());
+            }
+        }, "range+map+filter+consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Observable.range(1, 10).subscribeOn(io.reactivex.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Observer());
+            }
+        }, "range+subscribeOn+consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Observable.range(1, 10).observeOn(io.reactivex.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Observer());
+            }
+        }, "range+observeOn+consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Observable.range(1, 10).subscribeOn(io.reactivex.schedulers.Schedulers.computation()).observeOn(io.reactivex.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Observer());
+            }
+        }, "range+subscribeOn+observeOn+consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.subjects.AsyncSubject.create();
+            }
+        }, "Async", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.subjects.PublishSubject.create();
+            }
+        }, "Publish", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.subjects.ReplaySubject.create();
+            }
+        }, "Replay", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.subjects.BehaviorSubject.create();
+            }
+        }, "Behavior", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.subjects.UnicastSubject.create();
+            }
+        }, "Unicast", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.subjects.AsyncSubject.create().subscribeWith(new MyRx2Observer());
+            }
+        }, "Async+consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.subjects.PublishSubject.create().subscribeWith(new MyRx2Observer());
+            }
+        }, "Publish+consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.subjects.ReplaySubject.create().subscribeWith(new MyRx2Observer());
+            }
+        }, "Replay+consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.subjects.BehaviorSubject.create().subscribeWith(new MyRx2Observer());
+            }
+        }, "Behavior+consumer", "Rx2Observable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.subjects.UnicastSubject.create().subscribeWith(new MyRx2Observer());
+            }
+        }, "Unicast+consumer", "Rx2Observable");
+
+        // ---------------------------------------------------------------------------------------------------------------------
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.just(1);
+            }
+        }, "just", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.range(1, 10);
+            }
+        }, "range", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.empty();
+            }
+        }, "empty", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.empty();
+            }
+        }, "empty", "Rx2Flowable", 10000000);
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.fromCallable(new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        return 1;
+                    }
+                });
+            }
+        }, "fromCallable", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return new MyRx2Subscriber();
+            }
+        }, "consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return new io.reactivex.observers.TestObserver<Object>();
+            }
+        }, "test-consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.just(1).subscribeWith(new MyRx2Subscriber());
+            }
+        }, "just+consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.range(1, 10).subscribeWith(new MyRx2Subscriber());
+            }
+        }, "range+consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.range(1, 10).map(new Function<Integer, Object>() {
+                    @Override
+                    public Object apply(Integer v) throws Exception {
+                        return v;
+                    }
+                }).subscribeWith(new MyRx2Subscriber());
+            }
+        }, "range+map+consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.range(1, 10).map(new Function<Integer, Object>() {
+                    @Override
+                    public Object apply(Integer v) throws Exception {
+                        return v;
+                    }
+                }).filter(new Predicate<Object>() {
+                    @Override
+                    public boolean test(Object v) throws Exception {
+                        return true;
+                    }
+                }).subscribeWith(new MyRx2Subscriber());
+            }
+        }, "range+map+filter+consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.range(1, 10).subscribeOn(io.reactivex.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Subscriber());
+            }
+        }, "range+subscribeOn+consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.range(1, 10).observeOn(io.reactivex.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Subscriber());
+            }
+        }, "range+observeOn+consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.Flowable.range(1, 10).subscribeOn(io.reactivex.schedulers.Schedulers.computation()).observeOn(io.reactivex.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Subscriber());
+            }
+        }, "range+subscribeOn+observeOn+consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.processors.AsyncProcessor.create();
+            }
+        }, "Async", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.processors.PublishProcessor.create();
+            }
+        }, "Publish", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.processors.ReplayProcessor.create();
+            }
+        }, "Replay", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.processors.BehaviorProcessor.create();
+            }
+        }, "Behavior", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.processors.UnicastProcessor.create();
+            }
+        }, "Unicast", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.processors.AsyncProcessor.create().subscribeWith(new MyRx2Subscriber());
+            }
+        }, "Async+consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.processors.PublishProcessor.create().subscribeWith(new MyRx2Subscriber());
+            }
+        }, "Publish+consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.processors.ReplayProcessor.create().subscribeWith(new MyRx2Subscriber());
+            }
+        }, "Replay+consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.processors.BehaviorProcessor.create().subscribeWith(new MyRx2Subscriber());
+            }
+        }, "Behavior+consumer", "Rx2Flowable");
+
+        checkMemory(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return io.reactivex.processors.UnicastProcessor.create().subscribeWith(new MyRx2Subscriber());
+            }
+        }, "Unicast+consumer", "Rx2Flowable");
+
+        // ---------------------------------------------------------------------------------------------------------------------
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableConcatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableConcatMapCompletablePerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableConcatMapCompletablePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> flowableConvert;
+
+    Completable flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.empty();
+            }
+        });
+
+        flowableConvert = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Completable.complete().toFlowable();
+            }
+        });
+
+        flowableDedicated = source.concatMapCompletable(new Function<Integer, Completable>() {
+            @Override
+            public Completable apply(Integer v)
+                    throws Exception {
+                return Completable.complete();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return flowableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableConcatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableConcatMapMaybeEmptyPerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableConcatMapMaybeEmptyPerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> concatMapToFlowableEmpty;
+
+    Flowable<Integer> flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.empty();
+            }
+        });
+
+        concatMapToFlowableEmpty = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.<Integer>empty().toFlowable();
+            }
+        });
+
+        flowableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.empty();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return concatMapToFlowableEmpty.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableConcatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableConcatMapMaybePerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableConcatMapMaybePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> flowableConvert;
+
+    Flowable<Integer> flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.just(v);
+            }
+        });
+
+        flowableConvert = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v).toFlowable();
+            }
+        });
+
+        flowableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return flowableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableConcatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableConcatMapSinglePerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableConcatMapSinglePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> flowableConvert;
+
+    Flowable<Integer> flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.just(v);
+            }
+        });
+
+        flowableConvert = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v).toFlowable();
+            }
+        });
+
+        flowableDedicated = source.concatMapSingle(new Function<Integer, Single<? extends Integer>>() {
+            @Override
+            public Single<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return flowableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableFlatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableFlatMapCompletablePerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableFlatMapCompletablePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> flowableConvert;
+
+    Completable flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.empty();
+            }
+        });
+
+        flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Completable.complete().toFlowable();
+            }
+        });
+
+        flowableDedicated = source.flatMapCompletable(new Function<Integer, Completable>() {
+            @Override
+            public Completable apply(Integer v)
+                    throws Exception {
+                return Completable.complete();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return flowableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableFlatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableFlatMapMaybeEmptyPerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableFlatMapMaybeEmptyPerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> flowableConvert;
+
+    Flowable<Integer> flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.empty();
+            }
+        });
+
+        flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.<Integer>empty().toFlowable();
+            }
+        });
+
+        flowableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.empty();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return flowableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableFlatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableFlatMapMaybePerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableFlatMapMaybePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> flowableConvert;
+
+    Flowable<Integer> flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.just(v);
+            }
+        });
+
+        flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v).toFlowable();
+            }
+        });
+
+        flowableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return flowableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableFlatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableFlatMapSinglePerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableFlatMapSinglePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> flowableConvert;
+
+    Flowable<Integer> flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.just(v);
+            }
+        });
+
+        flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v).toFlowable();
+            }
+        });
+
+        flowableDedicated = source.flatMapSingle(new Function<Integer, Single<? extends Integer>>() {
+            @Override
+            public Single<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return flowableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableSwitchMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableSwitchMapCompletablePerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableSwitchMapCompletablePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> flowableConvert;
+
+    Completable flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.empty();
+            }
+        });
+
+        flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Completable.complete().toFlowable();
+            }
+        });
+
+        flowableDedicated = source.switchMapCompletable(new Function<Integer, Completable>() {
+            @Override
+            public Completable apply(Integer v)
+                    throws Exception {
+                return Completable.complete();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return flowableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableSwitchMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableSwitchMapMaybeEmptyPerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableSwitchMapMaybeEmptyPerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> flowableConvert;
+
+    Flowable<Integer> flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.empty();
+            }
+        });
+
+        flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.<Integer>empty().toFlowable();
+            }
+        });
+
+        flowableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.empty();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return flowableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableSwitchMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableSwitchMapMaybePerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableSwitchMapMaybePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> flowableConvert;
+
+    Flowable<Integer> flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.just(v);
+            }
+        });
+
+        flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v).toFlowable();
+            }
+        });
+
+        flowableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return flowableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/FlowableSwitchMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/FlowableSwitchMapSinglePerf.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class FlowableSwitchMapSinglePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Flowable<Integer> flowableConvert;
+
+    Flowable<Integer> flowableDedicated;
+
+    Flowable<Integer> flowablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Flowable<Integer> source = Flowable.fromArray(sourceArray);
+
+        flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.just(v);
+            }
+        });
+
+        flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
+            @Override
+            public Publisher<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v).toFlowable();
+            }
+        });
+
+        flowableDedicated = source.switchMapSingle(new Function<Integer, Single<? extends Integer>>() {
+            @Override
+            public Single<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object flowablePlain(Blackhole bh) {
+        return flowablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableConvert(Blackhole bh) {
+        return flowableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object flowableDedicated(Blackhole bh) {
+        return flowableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableConcatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableConcatMapCompletablePerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableConcatMapCompletablePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> observableConvert;
+
+    Completable observableDedicated;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.empty();
+            }
+        });
+
+        observableConvert = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Completable.complete().toObservable();
+            }
+        });
+
+        observableDedicated = source.concatMapCompletable(new Function<Integer, Completable>() {
+            @Override
+            public Completable apply(Integer v)
+                    throws Exception {
+                return Completable.complete();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableConvert(Blackhole bh) {
+        return observableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableConcatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableConcatMapMaybeEmptyPerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableConcatMapMaybeEmptyPerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> concatMapToObservableEmpty;
+
+    Observable<Integer> observableDedicated;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.empty();
+            }
+        });
+
+        concatMapToObservableEmpty = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.<Integer>empty().toObservable();
+            }
+        });
+
+        observableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.empty();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableConvert(Blackhole bh) {
+        return concatMapToObservableEmpty.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableConcatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableConcatMapMaybePerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableConcatMapMaybePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> observableConvert;
+
+    Observable<Integer> observableDedicated;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.just(v);
+            }
+        });
+
+        observableConvert = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v).toObservable();
+            }
+        });
+
+        observableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableConvert(Blackhole bh) {
+        return observableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableConcatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableConcatMapSinglePerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableConcatMapSinglePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> observableConvert;
+
+    Observable<Integer> observableDedicated;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.just(v);
+            }
+        });
+
+        observableConvert = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v).toObservable();
+            }
+        });
+
+        observableDedicated = source.concatMapSingle(new Function<Integer, Single<? extends Integer>>() {
+            @Override
+            public Single<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableConvert(Blackhole bh) {
+        return observableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableFlatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableFlatMapCompletablePerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableFlatMapCompletablePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> observableConvert;
+
+    Completable observableDedicated;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.empty();
+            }
+        });
+
+        observableConvert = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Completable.complete().toObservable();
+            }
+        });
+
+        observableDedicated = source.flatMapCompletable(new Function<Integer, Completable>() {
+            @Override
+            public Completable apply(Integer v)
+                    throws Exception {
+                return Completable.complete();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableConvert(Blackhole bh) {
+        return observableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableFlatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableFlatMapMaybeEmptyPerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableFlatMapMaybeEmptyPerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> observableConvert;
+
+    Observable<Integer> observableDedicated;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.empty();
+            }
+        });
+
+        observableConvert = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.<Integer>empty().toObservable();
+            }
+        });
+
+        observableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.empty();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableConvert(Blackhole bh) {
+        return observableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableFlatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableFlatMapMaybePerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableFlatMapMaybePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> observableConvert;
+
+    Observable<Integer> observableDedicated;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.just(v);
+            }
+        });
+
+        observableConvert = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v).toObservable();
+            }
+        });
+
+        observableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableConvert(Blackhole bh) {
+        return observableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableFlatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableFlatMapSinglePerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableFlatMapSinglePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> observableConvert;
+
+    Observable<Integer> observableDedicated;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.just(v);
+            }
+        });
+
+        observableConvert = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v).toObservable();
+            }
+        });
+
+        observableDedicated = source.flatMapSingle(new Function<Integer, Single<? extends Integer>>() {
+            @Override
+            public Single<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableConvert(Blackhole bh) {
+        return observableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableSwitchMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableSwitchMapCompletablePerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableSwitchMapCompletablePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> switchMapToObservableEmpty;
+
+    Completable switchMapCompletableEmpty;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.empty();
+            }
+        });
+
+        switchMapToObservableEmpty = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Completable.complete().toObservable();
+            }
+        });
+
+        switchMapCompletableEmpty = source.switchMapCompletable(new Function<Integer, Completable>() {
+            @Override
+            public Completable apply(Integer v)
+                    throws Exception {
+                return Completable.complete();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object switchMapToObservableEmpty(Blackhole bh) {
+        return switchMapToObservableEmpty.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object switchMapCompletableEmpty(Blackhole bh) {
+        return switchMapCompletableEmpty.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableSwitchMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableSwitchMapMaybeEmptyPerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableSwitchMapMaybeEmptyPerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> observableConvert;
+
+    Observable<Integer> observableDedicated;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.empty();
+            }
+        });
+
+        observableConvert = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.<Integer>empty().toObservable();
+            }
+        });
+
+        observableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.empty();
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableConvert(Blackhole bh) {
+        return observableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableSwitchMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableSwitchMapMaybePerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableSwitchMapMaybePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> observableConvert;
+
+    Observable<Integer> observableDedicated;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.just(v);
+            }
+        });
+
+        observableConvert = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v).toObservable();
+            }
+        });
+
+        observableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+            @Override
+            public Maybe<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Maybe.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableConvert(Blackhole bh) {
+        return observableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}

--- a/src/jmh/java/io/reactivex/xmapz/ObservableSwitchMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableSwitchMapSinglePerf.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.xmapz;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class ObservableSwitchMapSinglePerf {
+    @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
+    public int count;
+
+    Observable<Integer> observableConvert;
+
+    Observable<Integer> observableDedicated;
+
+    Observable<Integer> observablePlain;
+
+    @Setup
+    public void setup() {
+        Integer[] sourceArray = new Integer[count];
+        Arrays.fill(sourceArray, 777);
+
+        Observable<Integer> source = Observable.fromArray(sourceArray);
+
+        observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.just(v);
+            }
+        });
+
+        observableConvert = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+            @Override
+            public Observable<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v).toObservable();
+            }
+        });
+
+        observableDedicated = source.switchMapSingle(new Function<Integer, Single<? extends Integer>>() {
+            @Override
+            public Single<? extends Integer> apply(Integer v)
+                    throws Exception {
+                return Single.just(v);
+            }
+        });
+    }
+
+    @Benchmark
+    public Object observablePlain(Blackhole bh) {
+        return observablePlain.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableConvert(Blackhole bh) {
+        return observableConvert.subscribeWith(new PerfConsumer(bh));
+    }
+
+    @Benchmark
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
+    }
+}


### PR DESCRIPTION
This PR adds JMH benchmarks to measure operators mapping onto other types, such as `flatMapCompletable`, `concatMapSingle`, etc. In addition, two new benchmarks were added to measure the `flatMapIterable` performance in additional situations.

#### Baseline results

i7 4770K, Windows 7 x64, Java 8u162

[JMH Compare GUI](https://github.com/akarnokd/jmh-compare-gui/releases/tag/v1.3.2) workspace file: [xmapz_ws.xml](https://gist.github.com/akarnokd/317e2d38128f45c8fbb1ec8ebd20d970)

The first diagram compares the dedicated, plain (same inner type as the outer type) and conversion-based flows:

![image](https://user-images.githubusercontent.com/1269832/37431058-6df2d0f2-27d4-11e8-9d6a-b9d8a0f34e0b.png)

The switchMap-based `Observable` operators look like they could use some optimizations. Overall, `count == 1` is not optimized with the dedicated versions.

From the `Observable`'s perspective:

![image](https://user-images.githubusercontent.com/1269832/37431169-c1f69d46-27d4-11e8-8159-c598e7f50e68.png)

Looks like the `concatMapX` operators could use some optimizations.

The `flatMapIterable` measures are as follows:

![image](https://user-images.githubusercontent.com/1269832/37431246-00fab8ba-27d5-11e8-94b5-67b94e1869a7.png)

The `Flowable` version seem to be considerably slower, probably not explainable due to backpressure overhead.