### PR TITLE
2.x: Optimize ObservableConcatMapCompletable

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletable.java
@@ -13,16 +13,17 @@
 
 package io.reactivex.internal.operators.mixed;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
 import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.*;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.fuseable.SimplePlainQueue;
+import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -56,7 +57,9 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
 
     @Override
     protected void subscribeActual(CompletableObserver s) {
-        source.subscribe(new ConcatMapCompletableObserver<T>(s, mapper, errorMode, prefetch));
+        if (!tryScalarSource(source, mapper, s)) {
+            source.subscribe(new ConcatMapCompletableObserver<T>(s, mapper, errorMode, prefetch));
+        }
     }
 
     static final class ConcatMapCompletableObserver<T>
@@ -77,7 +80,7 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
 
         final int prefetch;
 
-        final SimplePlainQueue<T> queue;
+        SimpleQueue<T> queue;
 
         Disposable upstream;
 
@@ -96,20 +99,40 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
             this.prefetch = prefetch;
             this.errors = new AtomicThrowable();
             this.inner = new ConcatMapInnerObserver(this);
-            this.queue = new SpscLinkedArrayQueue<T>(prefetch);
         }
 
         @Override
         public void onSubscribe(Disposable s) {
             if (DisposableHelper.validate(upstream, s)) {
                 this.upstream = s;
+                if (s instanceof QueueDisposable) {
+                    @SuppressWarnings("unchecked")
+                    QueueDisposable<T> qd = (QueueDisposable<T>) s;
+
+                    int m = qd.requestFusion(QueueDisposable.ANY);
+                    if (m == QueueDisposable.SYNC) {
+                        queue = qd;
+                        done = true;
+                        downstream.onSubscribe(this);
+                        drain();
+                        return;
+                    }
+                    if (m == QueueDisposable.ASYNC) {
+                        queue = qd;
+                        downstream.onSubscribe(this);
+                        return;
+                    }
+                }
+                queue = new SpscLinkedArrayQueue<T>(prefetch);
                 downstream.onSubscribe(this);
             }
         }
 
         @Override
         public void onNext(T t) {
-            queue.offer(t);
+            if (t != null) {
+                queue.offer(t);
+            }
             drain();
         }
 
@@ -187,6 +210,9 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
                 return;
             }
 
+            AtomicThrowable errors = this.errors;
+            ErrorMode errorMode = this.errorMode;
+
             do {
                 if (disposed) {
                     queue.clear();
@@ -206,8 +232,24 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
                     }
 
                     boolean d = done;
-                    T v = queue.poll();
-                    boolean empty = v == null;
+                    boolean empty = true;
+                    CompletableSource cs = null;
+                    try {
+                        T v = queue.poll();
+                        if (v != null) {
+                            cs = ObjectHelper.requireNonNull(mapper.apply(v), "The mapper returned a null CompletableSource");
+                            empty = false;
+                        }
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        disposed = true;
+                        queue.clear();
+                        upstream.dispose();
+                        errors.addThrowable(ex);
+                        ex = errors.terminate();
+                        downstream.onError(ex);
+                        return;
+                    }
 
                     if (d && empty) {
                         disposed = true;
@@ -221,21 +263,6 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
                     }
 
                     if (!empty) {
-
-                        CompletableSource cs;
-
-                        try {
-                            cs = ObjectHelper.requireNonNull(mapper.apply(v), "The mapper returned a null CompletableSource");
-                        } catch (Throwable ex) {
-                            Exceptions.throwIfFatal(ex);
-                            disposed = true;
-                            queue.clear();
-                            upstream.dispose();
-                            errors.addThrowable(ex);
-                            ex = errors.terminate();
-                            downstream.onError(ex);
-                            return;
-                        }
                         active = true;
                         cs.subscribe(inner);
                     }
@@ -273,5 +300,31 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
                 DisposableHelper.dispose(this);
             }
         }
+    }
+
+    static <T> boolean tryScalarSource(Observable<T> source, Function<? super T, ? extends CompletableSource> mapper, CompletableObserver observer) {
+        if (source instanceof Callable) {
+            @SuppressWarnings("unchecked")
+            Callable<T> call = (Callable<T>) source;
+            CompletableSource cs = null;
+            try {
+                T item = call.call();
+                if (item != null) {
+                    cs = ObjectHelper.requireNonNull(mapper.apply(item), "The mapper returned a null CompletableSource");
+                }
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                EmptyDisposable.error(ex, observer);
+                return true;
+            }
+
+            if (cs == null) {
+                EmptyDisposable.complete(observer);
+            } else {
+                cs.subscribe(observer);
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -2827,4 +2827,99 @@ public enum TestHelper {
             tss[i].assertFailure(IllegalArgumentException.class);
         }
     }
+
+    public static <T> Observable<T> rejectObservableFusion() {
+        return new Observable<T>() {
+            @Override
+            protected void subscribeActual(Observer<? super T> observer) {
+                observer.onSubscribe(new QueueDisposable<T>() {
+
+                    @Override
+                    public int requestFusion(int mode) {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean offer(T value) {
+                        throw new IllegalStateException();
+                    }
+
+                    @Override
+                    public boolean offer(T v1, T v2) {
+                        throw new IllegalStateException();
+                    }
+
+                    @Override
+                    public T poll() throws Exception {
+                        return null;
+                    }
+
+                    @Override
+                    public boolean isEmpty() {
+                        return true;
+                    }
+
+                    @Override
+                    public void clear() {
+                    }
+
+                    @Override
+                    public void dispose() {
+                    }
+
+                    @Override
+                    public boolean isDisposed() {
+                        return false;
+                    }
+                });
+            }
+        };
+    }
+
+    public static <T> Flowable<T> rejectFlowableFusion() {
+        return new Flowable<T>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super T> observer) {
+                observer.onSubscribe(new QueueSubscription<T>() {
+
+                    @Override
+                    public int requestFusion(int mode) {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean offer(T value) {
+                        throw new IllegalStateException();
+                    }
+
+                    @Override
+                    public boolean offer(T v1, T v2) {
+                        throw new IllegalStateException();
+                    }
+
+                    @Override
+                    public T poll() throws Exception {
+                        return null;
+                    }
+
+                    @Override
+                    public boolean isEmpty() {
+                        return true;
+                    }
+
+                    @Override
+                    public void clear() {
+                    }
+
+                    @Override
+                    public void cancel() {
+                    }
+
+                    @Override
+                    public void request(long n) {
+                    }
+                });
+            }
+        };
+    }
 }


### PR DESCRIPTION
This PR reduces the overhead in the `Observable.concatMapCompletable` operator by:

- adding front-queue fusion to eliminate queue allocations (although this didn't improve the performance beyond a +/- 3% noise),
- moving the `error` and `errorMode` fields into local variables, saving on the mandatory volatile re-read of other fields,
- adding a scalar shortcut in case the upstream is known to be 0-1.

#### Benchmark comparison:

i7 4770K, Windows 7 x64, Java 8u162

The PR improves the dedicated case considerably:

![image](https://user-images.githubusercontent.com/1269832/37437588-44960732-27ee-11e8-9f91-00c3313ac60b.png)

and it is now better across the board compared to a `toFlowable` conversion and the main `concatMap`:

![image](https://user-images.githubusercontent.com/1269832/37437618-7490a244-27ee-11e8-99de-cb20d5828555.png)
