### PR TITLE
1.x: fix and deprecate evicting groupBy and add new overload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'com.google.guava:guava:19.0'
+    testCompile 'com.google.guava:guava:24.0-jre'
     testCompile 'com.pushtorefresh.java-private-constructor-checker:checker:1.2.0'
 
     perfCompile 'org.openjdk.jmh:jmh-core:1.11.3'

--- a/src/main/java/rx/internal/operators/OperatorGroupBy.java
+++ b/src/main/java/rx/internal/operators/OperatorGroupBy.java
@@ -246,7 +246,11 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 K evictedKey;
                 while ((evictedKey = evictedKeys.poll()) != null) {
                     GroupedUnicast<K, V> g = groupsCopy.remove(evictedKey);
-                    g.onComplete();
+                    // do a null check on g because cancel(K) could have cleared
+                    // the map
+                    if (g != null) {
+                        g.onComplete();
+                    }
                 }
             }
 

--- a/src/main/java/rx/internal/operators/OperatorGroupByEvicting.java
+++ b/src/main/java/rx/internal/operators/OperatorGroupByEvicting.java
@@ -1,12 +1,12 @@
 /**
- * Copyright 2014 Netflix, Inc.
- *
+ * Copyright 2018 Netflix, Inc.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,8 +26,8 @@ import rx.functions.*;
 import rx.internal.producers.ProducerArbiter;
 import rx.internal.util.*;
 import rx.observables.GroupedObservable;
-import rx.observers.Subscribers;
 import rx.plugins.RxJavaHooks;
+import rx.observers.Subscribers;
 import rx.subscriptions.Subscriptions;
 
 /**
@@ -42,50 +42,58 @@ import rx.subscriptions.Subscriptions;
  *            the source and group value type
  * @param <V>
  *            the value type of the groups
- * @deprecated 
- *            since 1.3.7, use {@link OperatorGroupByEvicting} instead
  */
-@Deprecated
-public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservable<K, V>, T> {
+public final class OperatorGroupByEvicting<T, K, V> implements Operator<GroupedObservable<K, V>, T>{
+    
     final Func1<? super T, ? extends K> keySelector;
     final Func1<? super T, ? extends V> valueSelector;
     final int bufferSize;
     final boolean delayError;
-    final Func1<Action1<K>, Map<K, Object>> mapFactory; //nullable
-
+    final Func1<Action1<Object>, Map<K, Object>> mapFactory; //nullable
+    
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public OperatorGroupBy(Func1<? super T, ? extends K> keySelector) {
+    public OperatorGroupByEvicting(Func1<? super T, ? extends K> keySelector) {
         this(keySelector, (Func1)UtilityFunctions.<T>identity(), RxRingBuffer.SIZE, false, null);
     }
 
-    public OperatorGroupBy(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector) {
+    public OperatorGroupByEvicting(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector) {
         this(keySelector, valueSelector, RxRingBuffer.SIZE, false, null);
     }
-
-    public OperatorGroupBy(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector, Func1<Action1<K>, Map<K, Object>> mapFactory) {
-        this(keySelector, valueSelector, RxRingBuffer.SIZE, false, mapFactory);
-    }
-
-    public OperatorGroupBy(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError, Func1<Action1<K>, Map<K, Object>> mapFactory) {
+    
+    public OperatorGroupByEvicting(Func1<? super T, ? extends K> keySelector, Func1<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError, Func1<Action1<Object>, Map<K, Object>> mapFactory) {
         this.keySelector = keySelector;
         this.valueSelector = valueSelector;
         this.bufferSize = bufferSize;
         this.delayError = delayError;
         this.mapFactory = mapFactory;
     }
-
+    
+    @SuppressWarnings("unchecked")
     @Override
     public Subscriber<? super T> call(Subscriber<? super GroupedObservable<K, V>> child) {
-        final GroupBySubscriber<T, K, V> parent; // NOPMD
-        try {
-            parent = new GroupBySubscriber<T, K, V>(child, keySelector, valueSelector, bufferSize, delayError, mapFactory);
-        } catch (Throwable ex) {
-            //Can reach here because mapFactory.call() may throw in constructor of GroupBySubscriber
-            Exceptions.throwOrReport(ex, child);
-            Subscriber<? super T> parent2 = Subscribers.empty();
-            parent2.unsubscribe();
-            return parent2;
+        Map<K, GroupedUnicast<K, V>> groups;
+        Queue<GroupedUnicast<K, V>> evictedGroups;
+        
+        if (mapFactory == null) {
+            evictedGroups = null;
+            groups = new ConcurrentHashMap<K, GroupedUnicast<K, V>>();
+        } else {
+            evictedGroups = new ConcurrentLinkedQueue<GroupedUnicast<K, V>>();
+            Action1<Object> evictionAction = (Action1<Object>)(Action1<?>) 
+                    new EvictionAction<K, V>(evictedGroups);
+            try {
+                groups = (Map<K, GroupedUnicast<K,V>>)(Map<Object, ?>) 
+                        mapFactory.call((Action1<Object>)(Action1<?>) evictionAction);
+            } catch (Throwable ex) {
+                //Can reach here because mapFactory.call() may throw
+                Exceptions.throwOrReport(ex, child);
+                Subscriber<? super T> parent2 = Subscribers.empty();
+                parent2.unsubscribe();
+                return parent2;
+            }
         }
+        final GroupBySubscriber<T, K, V> parent = new GroupBySubscriber<T, K, V>(
+                child, keySelector, valueSelector, bufferSize, delayError, groups, evictedGroups);
 
         child.add(Subscriptions.create(new Action0() {
             @Override
@@ -95,13 +103,13 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
         }));
 
         child.setProducer(parent.producer);
-
+        
         return parent;
     }
 
     public static final class GroupByProducer implements Producer {
         final GroupBySubscriber<?, ?, ?> parent;
-
+        
         public GroupByProducer(GroupBySubscriber<?, ?, ?> parent) {
             this.parent = parent;
         }
@@ -110,47 +118,43 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
             parent.requestMore(n);
         }
     }
-
-    public static final class GroupBySubscriber<T, K, V>
+    
+    public static final class GroupBySubscriber<T, K, V> 
     extends Subscriber<T> {
         final Subscriber<? super GroupedObservable<K, V>> actual;
         final Func1<? super T, ? extends K> keySelector;
         final Func1<? super T, ? extends V> valueSelector;
         final int bufferSize;
         final boolean delayError;
-        final Map<Object, GroupedUnicast<K, V>> groups;
-        
-        // double store the groups to workaround the bug in the 
-        // signature of groupBy with evicting map factory
-        final Map<Object, GroupedUnicast<K, V>> groupsCopy;
-        final Queue<GroupedObservable<K, V>> queue;
+        final Map<K, GroupedUnicast<K, V>> groups;
+        final Queue<GroupedUnicast<K, V>> queue;
         final GroupByProducer producer;
-        final Queue<K> evictedKeys;
-
+        final Queue<GroupedUnicast<K, V>> evictedGroups;
+        
         static final Object NULL_KEY = new Object();
-
+        
         final ProducerArbiter s;
-
+        
         final AtomicBoolean cancelled;
 
         final AtomicLong requested;
 
         final AtomicInteger groupCount;
-
+        
         Throwable error;
         volatile boolean done;
 
         final AtomicInteger wip;
         
-        public GroupBySubscriber(Subscriber<? super GroupedObservable<K, V>> actual, Func1<? super T, ? extends K> keySelector,
-                Func1<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError,
-                Func1<Action1<K>, Map<K, Object>> mapFactory) {
+        public GroupBySubscriber(Subscriber<? super GroupedObservable<K, V>> actual, Func1<? super T, ? extends K> keySelector, 
+                Func1<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError, Map<K, GroupedUnicast<K, V>> groups, 
+                Queue<GroupedUnicast<K, V>> evictedGroups) {
             this.actual = actual;
             this.keySelector = keySelector;
             this.valueSelector = valueSelector;
             this.bufferSize = bufferSize;
             this.delayError = delayError;
-            this.queue = new ConcurrentLinkedQueue<GroupedObservable<K, V>>();
+            this.queue = new ConcurrentLinkedQueue<GroupedUnicast<K, V>>();
             this.s = new ProducerArbiter();
             this.s.request(bufferSize);
             this.producer = new GroupByProducer(this);
@@ -158,47 +162,22 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
             this.requested = new AtomicLong();
             this.groupCount = new AtomicInteger(1);
             this.wip = new AtomicInteger();
-            if (mapFactory == null) {
-                this.groups = new ConcurrentHashMap<Object, GroupedUnicast<K, V>>();
-                this.evictedKeys = null;
-            } else {
-                this.evictedKeys = new ConcurrentLinkedQueue<K>();
-                this.groups = createMap(mapFactory, new EvictionAction<K>(evictedKeys));
-            }
-            this.groupsCopy = new ConcurrentHashMap<Object, GroupedUnicast<K, V>>();
+            this.groups = groups;
+            this.evictedGroups = evictedGroups;
         }
-
-        static class EvictionAction<K> implements Action1<K> {
-
-            final Queue<K> evictedKeys;
-
-            EvictionAction(Queue<K> evictedKeys) {
-                this.evictedKeys = evictedKeys;
-            }
-
-            @Override
-            public void call(K key) {
-                evictedKeys.offer(key);
-            }
-        }
-
-        @SuppressWarnings("unchecked")
-        private Map<Object, GroupedUnicast<K, V>> createMap(Func1<Action1<K>, Map<K, Object>> mapFactory, Action1<K> evictionAction) {
-            return (Map<Object, GroupedUnicast<K,V>>)(Map<Object, ?>) mapFactory.call(evictionAction);
-        }
-
+        
         @Override
         public void setProducer(Producer s) {
             this.s.setProducer(s);
         }
-
+        
         @Override
         public void onNext(T t) {
             if (done) {
                 return;
             }
 
-            final Queue<GroupedObservable<K, V>> q = this.queue;
+            final Queue<GroupedUnicast<K, V>> q = this.queue;
             final Subscriber<? super GroupedObservable<K, V>> a = this.actual;
 
             K key;
@@ -209,9 +188,10 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 errorAll(a, q, ex);
                 return;
             }
-
+            
             boolean newGroup = false;
-            Object mapKey = key != null ? key : NULL_KEY;
+            @SuppressWarnings("unchecked")
+            K mapKey = key != null ? key : (K) NULL_KEY;
             GroupedUnicast<K, V> group = groups.get(mapKey);
             if (group == null) {
                 // if the main has been cancelled, stop creating groups
@@ -219,18 +199,17 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 if (!cancelled.get()) {
                     group = GroupedUnicast.createWith(key, bufferSize, this, delayError);
                     groups.put(mapKey, group);
-                    if (evictedKeys != null) {
-                        groupsCopy.put(mapKey, group);
-                    }
-
+                    
                     groupCount.getAndIncrement();
-
-                    newGroup = true;
+                    
+                    newGroup = false;
+                    q.offer(group);
+                    drain();
                 } else {
                     return;
                 }
             }
-
+            
             V v;
             try {
                 v = valueSelector.call(t);
@@ -241,12 +220,11 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
             }
 
             group.onNext(v);
-
-            if (evictedKeys != null) {
-                K evictedKey;
-                while ((evictedKey = evictedKeys.poll()) != null) {
-                    GroupedUnicast<K, V> g = groupsCopy.remove(evictedKey);
-                    g.onComplete();
+            
+            if (evictedGroups != null) {
+                GroupedUnicast<K, V> evictedGroup;
+                while ((evictedGroup = evictedGroups.poll()) != null) {
+                    evictedGroup.onComplete();
                 }
             }
 
@@ -255,7 +233,7 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 drain();
             }
         }
-
+        
         @Override
         public void onError(Throwable t) {
             if (done) {
@@ -267,7 +245,7 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
             groupCount.decrementAndGet();
             drain();
         }
-
+        
         @Override
         public void onCompleted() {
             if (done) {
@@ -278,9 +256,8 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 e.onComplete();
             }
             groups.clear();
-            if (evictedKeys != null) {
-                groupsCopy.clear();
-                evictedKeys.clear();
+            if (evictedGroups != null) {
+                evictedGroups.clear();
             }
 
             done = true;
@@ -292,11 +269,11 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
             if (n < 0) {
                 throw new IllegalArgumentException("n >= 0 required but it was " + n);
             }
-
+            
             BackpressureUtils.getAndAddRequest(requested, n);
             drain();
         }
-
+        
         public void cancel() {
             // cancelling the main source means we don't want any more groups
             // but running groups still require new values
@@ -306,7 +283,7 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 }
             }
         }
-
+        
         public void cancel(K key) {
             Object mapKey = key != null ? key : NULL_KEY;
             if (groups.remove(mapKey) != null) {
@@ -314,81 +291,79 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                     unsubscribe();
                 }
             }
-            if (evictedKeys != null) {
-                groupsCopy.remove(mapKey);
-            }
         }
-
+        
         void drain() {
             if (wip.getAndIncrement() != 0) {
                 return;
             }
-
+            
             int missed = 1;
-
-            final Queue<GroupedObservable<K, V>> q = this.queue;
+            
+            final Queue<GroupedUnicast<K, V>> q = this.queue;
             final Subscriber<? super GroupedObservable<K, V>> a = this.actual;
-
+            
             for (;;) {
-
+                
                 if (checkTerminated(done, q.isEmpty(), a, q)) {
                     return;
                 }
-
+                
                 long r = requested.get();
+                boolean unbounded = r == Long.MAX_VALUE;
                 long e = 0L;
-
-                while (e != r) {
+                
+                while (r != 0) {
                     boolean d = done;
-
+                    
                     GroupedObservable<K, V> t = q.poll();
-
+                    
                     boolean empty = t == null;
-
+                    
                     if (checkTerminated(d, empty, a, q)) {
                         return;
                     }
-
+                    
                     if (empty) {
                         break;
                     }
 
                     a.onNext(t);
-
-                    e++;
+                    
+                    r--;
+                    e--;
                 }
-
+                
                 if (e != 0L) {
-                    if (r != Long.MAX_VALUE) {
-                        BackpressureUtils.produced(requested, e);
+                    if (!unbounded) {
+                        requested.addAndGet(e);
                     }
-                    s.request(e);
+                    s.request(-e);
                 }
-
+                
                 missed = wip.addAndGet(-missed);
                 if (missed == 0) {
                     break;
                 }
             }
         }
-
+        
         void errorAll(Subscriber<? super GroupedObservable<K, V>> a, Queue<?> q, Throwable ex) {
             q.clear();
             List<GroupedUnicast<K, V>> list = new ArrayList<GroupedUnicast<K, V>>(groups.values());
             groups.clear();
-            if (evictedKeys != null) {
-                groupsCopy.clear();
-                evictedKeys.clear();
+            if (evictedGroups != null) { 
+                evictedGroups.clear();
             }
-
+            
             for (GroupedUnicast<K, V> e : list) {
                 e.onError(ex);
             }
-
+            
             a.onError(ex);
         }
-
-        boolean checkTerminated(boolean d, boolean empty,
+        
+        boolean checkTerminated(boolean d, boolean empty, 
                 Subscriber<? super GroupedObservable<K, V>> a, Queue<?> q) {
             if (d) {
                 Throwable err = error;
@@ -404,34 +379,48 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
             return false;
         }
     }
+    
+    static class EvictionAction<K, V> implements Action1<GroupedUnicast<K, V>> {
 
+        final Queue<GroupedUnicast<K, V>> evictedGroups;
+
+        EvictionAction(Queue<GroupedUnicast<K, V>> evictedGroups) {
+            this.evictedGroups = evictedGroups;
+        }
+        
+        @Override
+        public void call(GroupedUnicast<K, V> group) {
+            evictedGroups.offer(group);
+        }
+    }
+    
     static final class GroupedUnicast<K, T> extends GroupedObservable<K, T> {
-        final State<T, K> state;
-
-
+        
         public static <T, K> GroupedUnicast<K, T> createWith(K key, int bufferSize, GroupBySubscriber<?, K, T> parent, boolean delayError) {
             State<T, K> state = new State<T, K>(bufferSize, parent, key, delayError);
             return new GroupedUnicast<K, T>(key, state);
         }
-
+        
+        final State<T, K> state;
+        
         protected GroupedUnicast(K key, State<T, K> state) {
             super(key, state);
             this.state = state;
         }
-
+        
         public void onNext(T t) {
             state.onNext(t);
         }
-
+        
         public void onError(Throwable e) {
             state.onError(e);
         }
-
+        
         public void onComplete() {
             state.onComplete();
         }
     }
-
+    
     static final class State<T, K> extends AtomicInteger implements Producer, Subscription, OnSubscribe<T> {
         /** */
         private static final long serialVersionUID = -3852313036005250360L;
@@ -440,20 +429,20 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
         final Queue<Object> queue;
         final GroupBySubscriber<?, K, T> parent;
         final boolean delayError;
-
+        
         final AtomicLong requested;
-
+        
         volatile boolean done;
         Throwable error;
-
+        
         final AtomicBoolean cancelled;
 
         final AtomicReference<Subscriber<? super T>> actual;
 
         final AtomicBoolean once;
 
-
-        public State(int bufferSize, GroupBySubscriber<?, K, T> parent, K key, boolean delayError) { // NOPMD
+        
+        public State(int bufferSize, GroupBySubscriber<?, K, T> parent, K key, boolean delayError) {
             this.queue = new ConcurrentLinkedQueue<Object>();
             this.parent = parent;
             this.key = key;
@@ -463,7 +452,7 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
             this.once = new AtomicBoolean();
             this.requested = new AtomicLong();
         }
-
+        
         @Override
         public void request(long n) {
             if (n < 0) {
@@ -474,12 +463,12 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 drain();
             }
         }
-
+        
         @Override
         public boolean isUnsubscribed() {
             return cancelled.get();
         }
-
+        
         @Override
         public void unsubscribe() {
             if (cancelled.compareAndSet(false, true)) {
@@ -488,7 +477,7 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 }
             }
         }
-
+        
         @Override
         public void call(Subscriber<? super T> s) {
             if (once.compareAndSet(false, true)) {
@@ -510,13 +499,13 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
             }
             drain();
         }
-
+        
         public void onError(Throwable e) {
             error = e;
             done = true;
             drain();
         }
-
+        
         public void onComplete() {
             done = true;
             drain();
@@ -527,7 +516,7 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 return;
             }
             int missed = 1;
-
+            
             final Queue<Object> q = queue;
             final boolean delayError = this.delayError;
             Subscriber<? super T> a = actual.get();
@@ -536,36 +525,38 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                     if (checkTerminated(done, q.isEmpty(), a, delayError)) {
                         return;
                     }
-
+                    
                     long r = requested.get();
+                    boolean unbounded = r == Long.MAX_VALUE;
                     long e = 0;
-
-                    while (e != r) {
+                    
+                    while (r != 0L) {
                         boolean d = done;
                         Object v = q.poll();
                         boolean empty = v == null;
-
+                        
                         if (checkTerminated(d, empty, a, delayError)) {
                             return;
                         }
-
+                        
                         if (empty) {
                             break;
                         }
-
+                        
                         a.onNext(NotificationLite.<T>getValue(v));
-
-                        e++;
+                        
+                        r--;
+                        e--;
                     }
-
+                    
                     if (e != 0L) {
-                        if (r != Long.MAX_VALUE) {
-                            BackpressureUtils.produced(requested, e);
+                        if (!unbounded) {
+                            requested.addAndGet(e);
                         }
-                        parent.s.request(e);
+                        parent.s.request(-e);
                     }
                 }
-
+                
                 missed = addAndGet(-missed);
                 if (missed == 0) {
                     break;
@@ -575,14 +566,14 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                 }
             }
         }
-
+        
         boolean checkTerminated(boolean d, boolean empty, Subscriber<? super T> a, boolean delayError) {
             if (cancelled.get()) {
                 queue.clear();
                 parent.cancel(key);
                 return true;
             }
-
+            
             if (d) {
                 if (delayError) {
                     if (empty) {
@@ -607,7 +598,7 @@ public final class OperatorGroupBy<T, K, V> implements Operator<GroupedObservabl
                     }
                 }
             }
-
+            
             return false;
         }
     }


### PR DESCRIPTION
See #5868

There is a problem with the existing 1.x `Observable.groupBy` overload with an evicting map factory where depending on the eviction behaviour of the supplied map factory, groups may not be completed and may leak memory. The problem extends to the method signature in that the eviction action should report the evicted `GroupedObservable` not the corresponding key.

This PR

* fixes the existing method at the expense of doubling up the internal map `groups` ( into `groupsCopy`) so that we can always successfully lookup the evicted group from the `groupsCopy` map. Evictions from `groups` are mirrored in `groupsCopy` after the lookup.
* deprecates the problematic overload indicating that it uses more memory than the preferred new overload
* adds a new method `groupBy` that has the corrected signature and offers `bufferSize` and `delayError` parameters for a bit more flexibility and to differentiate the erased signature from the deprecated method
* adds tests that were ported from the 2.x tests


