### PR TITLE
2.x: Add fusion support to ObservableSwitchMap inner source

### DIFF
--- a/src/jmh/java/io/reactivex/xmapz/ObservableSwitchMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/xmapz/ObservableSwitchMapCompletablePerf.java
@@ -32,9 +32,9 @@ public class ObservableSwitchMapCompletablePerf {
     @Param({ "1", "10", "100", "1000", "10000", "100000", "1000000" })
     public int count;
 
-    Observable<Integer> switchMapToObservableEmpty;
+    Observable<Integer> observableConvert;
 
-    Completable switchMapCompletableEmpty;
+    Completable observableDedicated;
 
     Observable<Integer> observablePlain;
 
@@ -53,7 +53,7 @@ public class ObservableSwitchMapCompletablePerf {
             }
         });
 
-        switchMapToObservableEmpty = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+        observableConvert = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
             public Observable<? extends Integer> apply(Integer v)
                     throws Exception {
@@ -61,7 +61,7 @@ public class ObservableSwitchMapCompletablePerf {
             }
         });
 
-        switchMapCompletableEmpty = source.switchMapCompletable(new Function<Integer, Completable>() {
+        observableDedicated = source.switchMapCompletable(new Function<Integer, Completable>() {
             @Override
             public Completable apply(Integer v)
                     throws Exception {
@@ -76,12 +76,12 @@ public class ObservableSwitchMapCompletablePerf {
     }
 
     @Benchmark
-    public Object switchMapToObservableEmpty(Blackhole bh) {
-        return switchMapToObservableEmpty.subscribeWith(new PerfConsumer(bh));
+    public Object observableConvert(Blackhole bh) {
+        return observableConvert.subscribeWith(new PerfConsumer(bh));
     }
 
     @Benchmark
-    public Object switchMapCompletableEmpty(Blackhole bh) {
-        return switchMapCompletableEmpty.subscribeWith(new PerfConsumer(bh));
+    public Object observableDedicated(Blackhole bh) {
+        return observableDedicated.subscribeWith(new PerfConsumer(bh));
     }
 }

--- a/src/main/java/io/reactivex/internal/observers/DeferredScalarDisposable.java
+++ b/src/main/java/io/reactivex/internal/observers/DeferredScalarDisposable.java
@@ -72,14 +72,15 @@ public class DeferredScalarDisposable<T> extends BasicIntQueueDisposable<T> {
         if ((state & (FUSED_READY | FUSED_CONSUMED | TERMINATED | DISPOSED)) != 0) {
             return;
         }
+        Observer<? super T> a = actual;
         if (state == FUSED_EMPTY) {
             this.value = value;
             lazySet(FUSED_READY);
+            a.onNext(null);
         } else {
             lazySet(TERMINATED);
+            a.onNext(value);
         }
-        Observer<? super T> a = actual;
-        a.onNext(value);
         if (get() != DISPOSED) {
             a.onComplete();
         }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableToObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableToObservable.java
@@ -15,6 +15,8 @@ package io.reactivex.internal.operators.completable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.observers.BasicQueueDisposable;
 
 /**
  * Wraps a Completable and exposes it as an Observable.
@@ -34,8 +36,12 @@ public final class CompletableToObservable<T> extends Observable<T> {
         source.subscribe(new ObserverCompletableObserver(observer));
     }
 
-    static final class ObserverCompletableObserver implements CompletableObserver {
-        private final Observer<?> observer;
+    static final class ObserverCompletableObserver extends BasicQueueDisposable<Void>
+    implements CompletableObserver {
+
+        final Observer<?> observer;
+
+        Disposable upstream;
 
         ObserverCompletableObserver(Observer<?> observer) {
             this.observer = observer;
@@ -53,7 +59,40 @@ public final class CompletableToObservable<T> extends Observable<T> {
 
         @Override
         public void onSubscribe(Disposable d) {
-            observer.onSubscribe(d);
+            if (DisposableHelper.validate(upstream, d)) {
+                this.upstream = d;
+                observer.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            return mode & ASYNC;
+        }
+
+        @Override
+        public Void poll() throws Exception {
+            return null; // always empty
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        public void clear() {
+            // always empty
+        }
+
+        @Override
+        public void dispose() {
+            upstream.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return upstream.isDisposed();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
@@ -21,7 +21,8 @@ import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.queue.*;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.util.AtomicThrowable;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -181,6 +182,8 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
             }
 
             final Observer<? super R> a = actual;
+            final AtomicReference<SwitchMapInnerObserver<T, R>> active = this.active;
+            final boolean delayErrors = this.delayErrors;
 
             int missing = 1;
 
@@ -218,66 +221,85 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
                 SwitchMapInnerObserver<T, R> inner = active.get();
 
                 if (inner != null) {
-                    SpscLinkedArrayQueue<R> q = inner.queue;
+                    SimpleQueue<R> q = inner.queue;
 
-                    if (inner.done) {
-                        boolean empty = q.isEmpty();
-                        if (delayErrors) {
-                            if (empty) {
-                                active.compareAndSet(inner, null);
-                                continue;
+                    if (q != null) {
+                        if (inner.done) {
+                            boolean empty = q.isEmpty();
+                            if (delayErrors) {
+                                if (empty) {
+                                    active.compareAndSet(inner, null);
+                                    continue;
+                                }
+                            } else {
+                                Throwable ex = errors.get();
+                                if (ex != null) {
+                                    a.onError(errors.terminate());
+                                    return;
+                                }
+                                if (empty) {
+                                    active.compareAndSet(inner, null);
+                                    continue;
+                                }
                             }
-                        } else {
-                            Throwable ex = errors.get();
-                            if (ex != null) {
-                                a.onError(errors.terminate());
+                        }
+
+                        boolean retry = false;
+
+                        for (;;) {
+                            if (cancelled) {
                                 return;
                             }
-                            if (empty) {
+                            if (inner != active.get()) {
+                                retry = true;
+                                break;
+                            }
+
+                            if (!delayErrors) {
+                                Throwable ex = errors.get();
+                                if (ex != null) {
+                                    a.onError(errors.terminate());
+                                    return;
+                                }
+                            }
+
+                            boolean d = inner.done;
+                            R v;
+
+                            try {
+                                v = q.poll();
+                            } catch (Throwable ex) {
+                                Exceptions.throwIfFatal(ex);
+                                errors.addThrowable(ex);
                                 active.compareAndSet(inner, null);
-                                continue;
+                                if (!delayErrors) {
+                                    disposeInner();
+                                    s.dispose();
+                                    done = true;
+                                } else {
+                                    inner.cancel();
+                                }
+                                v = null;
+                                retry = true;
                             }
-                        }
-                    }
+                            boolean empty = v == null;
 
-                    boolean retry = false;
-
-                    for (;;) {
-                        if (cancelled) {
-                            return;
-                        }
-                        if (inner != active.get()) {
-                            retry = true;
-                            break;
-                        }
-
-                        if (!delayErrors) {
-                            Throwable ex = errors.get();
-                            if (ex != null) {
-                                a.onError(errors.terminate());
-                                return;
+                            if (d && empty) {
+                                active.compareAndSet(inner, null);
+                                retry = true;
+                                break;
                             }
+
+                            if (empty) {
+                                break;
+                            }
+
+                            a.onNext(v);
                         }
 
-                        boolean d = inner.done;
-                        R v = q.poll();
-                        boolean empty = v == null;
-
-                        if (d && empty) {
-                            active.compareAndSet(inner, null);
-                            retry = true;
-                            break;
+                        if (retry) {
+                            continue;
                         }
-
-                        if (empty) {
-                            break;
-                        }
-
-                        a.onNext(v);
-                    }
-
-                    if (retry) {
-                        continue;
                     }
                 }
 
@@ -306,25 +328,49 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
         private static final long serialVersionUID = 3837284832786408377L;
         final SwitchMapObserver<T, R> parent;
         final long index;
-        final SpscLinkedArrayQueue<R> queue;
+
+        final int bufferSize;
+
+        volatile SimpleQueue<R> queue;
 
         volatile boolean done;
 
         SwitchMapInnerObserver(SwitchMapObserver<T, R> parent, long index, int bufferSize) {
             this.parent = parent;
             this.index = index;
-            this.queue = new SpscLinkedArrayQueue<R>(bufferSize);
+            this.bufferSize = bufferSize;
         }
 
         @Override
         public void onSubscribe(Disposable s) {
-            DisposableHelper.setOnce(this, s);
+            if (DisposableHelper.setOnce(this, s)) {
+                if (s instanceof QueueDisposable) {
+                    @SuppressWarnings("unchecked")
+                    QueueDisposable<R> qd = (QueueDisposable<R>) s;
+
+                    int m = qd.requestFusion(QueueDisposable.ANY);
+                    if (m == QueueDisposable.SYNC) {
+                        queue = qd;
+                        done = true;
+                        parent.drain();
+                        return;
+                    }
+                    if (m == QueueDisposable.ASYNC) {
+                        queue = qd;
+                        return;
+                    }
+                }
+
+                queue = new SpscLinkedArrayQueue<R>(bufferSize);
+            }
         }
 
         @Override
         public void onNext(R t) {
             if (index == parent.unique) {
-                queue.offer(t);
+                if (t != null) {
+                    queue.offer(t);
+                }
                 parent.drain();
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleToObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleToObservable.java
@@ -16,6 +16,7 @@ import io.reactivex.*;
 import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.observers.DeferredScalarDisposable;
 
 /**
  * Wraps a Single and exposes it as an Observable.
@@ -48,14 +49,14 @@ public final class SingleToObservable<T> extends Observable<T> {
     }
 
     static final class SingleToObservableObserver<T>
-    implements SingleObserver<T>, Disposable {
+    extends DeferredScalarDisposable<T>
+    implements SingleObserver<T> {
 
-        final Observer<? super T> actual;
-
+        private static final long serialVersionUID = 3786543492451018833L;
         Disposable d;
 
         SingleToObservableObserver(Observer<? super T> actual) {
-            this.actual = actual;
+            super(actual);
         }
 
         @Override
@@ -69,23 +70,19 @@ public final class SingleToObservable<T> extends Observable<T> {
 
         @Override
         public void onSuccess(T value) {
-            actual.onNext(value);
-            actual.onComplete();
+            complete(value);
         }
 
         @Override
         public void onError(Throwable e) {
-            actual.onError(e);
+            error(e);
         }
 
         @Override
         public void dispose() {
+            super.dispose();
             d.dispose();
         }
 
-        @Override
-        public boolean isDisposed() {
-            return d.isDisposed();
-        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableToObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableToObservableTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.fuseable.QueueFuseable;
+import io.reactivex.internal.operators.completable.CompletableToObservable.ObserverCompletableObserver;
+import io.reactivex.observers.TestObserver;
+
+public class CompletableToObservableTest {
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeCompletableToObservable(new Function<Completable, Observable<?>>() {
+            @Override
+            public Observable<?> apply(Completable c) throws Exception {
+                return c.toObservable();
+            }
+        });
+    }
+
+    @Test
+    public void fusion() throws Exception {
+        TestObserver<Void> to = new TestObserver<Void>();
+
+        ObserverCompletableObserver co = new ObserverCompletableObserver(to);
+
+        Disposable d = Disposables.empty();
+
+        co.onSubscribe(d);
+
+        assertEquals(QueueFuseable.NONE, co.requestFusion(QueueFuseable.SYNC));
+
+        assertEquals(QueueFuseable.ASYNC, co.requestFusion(QueueFuseable.ASYNC));
+
+        assertEquals(QueueFuseable.ASYNC, co.requestFusion(QueueFuseable.ANY));
+
+        assertTrue(co.isEmpty());
+
+        assertNull(co.poll());
+
+        co.clear();
+
+        assertFalse(co.isDisposed());
+
+        co.dispose();
+
+        assertTrue(d.isDisposed());
+
+        assertTrue(co.isDisposed());
+
+        TestHelper.assertNoOffer(co);
+    }
+}


### PR DESCRIPTION
This PR improves the performance of the `Observable.switchMap` operator by adding fusion support as well as upgrading the `Completable` and `Single` conversion to `Observable` to be fuseable. The PR also fixes an error in the `DeferredScalarDisposable` implementation as the protocol requires calling with `null`.

The plain (`Observable.switchMap(Observable)`) conversion has promising performance improvements:

![image](https://user-images.githubusercontent.com/1269832/37464461-ba6d5c0c-2858-11e8-8aa0-96d53350cfed.png)

The conversion `Observable.switchMap(Maybe.toObservable)` has promising performance improvements:

![image](https://user-images.githubusercontent.com/1269832/37464488-cf9b1290-2858-11e8-8ac7-462a58f61a13.png)

The conversion `Observable.switchMap(Completable.toObservable)` is also promising, but there is a 11% loss in the scalar case for some reason:

![image](https://user-images.githubusercontent.com/1269832/37464621-2ad6b1c8-2859-11e8-9a0a-d34c8ff8048b.png)

Finally, the conversion  `Observable.switchMap(Single.toObservable)` got a bigger hit for the scalar case, 21% loss, but the rest are impressive:

![image](https://user-images.githubusercontent.com/1269832/37464636-41ea983e-2859-11e8-9258-6c1c85ee8347.png)



