### PR TITLE
Add @Nullable annotations to Processors

### DIFF
--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -138,6 +138,7 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
+    @Nullable
     public Throwable getThrowable() {
         return subscribers.get() == TERMINATED ? error : null;
     }
@@ -244,6 +245,7 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
      * <p>The method is thread-safe.
      * @return a single value the Subject currently has or null if no such value exists
      */
+    @Nullable
     public T getValue() {
         return subscribers.get() == TERMINATED ? value : null;
     }

--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -348,6 +348,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
+    @Nullable
     public Throwable getThrowable() {
         Object o = value.get();
         if (NotificationLite.isError(o)) {
@@ -361,6 +362,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      * <p>The method is thread-safe.
      * @return a single value the BehaviorProcessor currently has or null if no such value exists
      */
+    @Nullable
     public T getValue() {
         Object o = value.get();
         if (NotificationLite.isComplete(o) || NotificationLite.isError(o)) {

--- a/src/main/java/io/reactivex/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/processors/PublishProcessor.java
@@ -261,6 +261,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
+    @Nullable
     public Throwable getThrowable() {
         if (subscribers.get() == TERMINATED) {
             return error;

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -354,6 +354,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
+    @Nullable
     public Throwable getThrowable() {
         ReplayBuffer<T> b = buffer;
         if (b.isDone()) {
@@ -510,6 +511,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
 
         int size();
 
+        @Nullable
         T getValue();
 
         T[] getValues(T[] array);
@@ -598,6 +600,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
         }
 
         @Override
+        @Nullable
         public T getValue() {
             int s = size;
             if (s == 0) {
@@ -1091,6 +1094,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
         }
 
         @Override
+        @Nullable
         public T getValue() {
             TimedNode<T> h = head;
 

--- a/src/main/java/io/reactivex/processors/SerializedProcessor.java
+++ b/src/main/java/io/reactivex/processors/SerializedProcessor.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.processors;
 
+import io.reactivex.annotations.Nullable;
 import org.reactivestreams.*;
 
 import io.reactivex.internal.util.*;
@@ -187,6 +188,7 @@ import io.reactivex.plugins.RxJavaPlugins;
     }
 
     @Override
+    @Nullable
     public Throwable getThrowable() {
         return actual.getThrowable();
     }

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -457,6 +457,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
+    @Nullable
     public Throwable getThrowable() {
         if (done) {
             return error;


### PR DESCRIPTION
Add `@Nullable` annotations to Processors. 

Updated our project to use 2.11.1, and discovered there's this PR https://github.com/ReactiveX/RxJava/pull/5890 which added `@Nullable` annotations to Subjects. Thought might as well add `@Nullable` to Processors.