### PR TITLE
2.x: Fix concatMapSingle & concatMapMaybe dispose-cleanup crash

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybe.java
@@ -170,7 +170,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
             cancelled = true;
             upstream.cancel();
             inner.dispose();
-            if (getAndIncrement() != 0) {
+            if (getAndIncrement() == 0) {
                 queue.clear();
                 item = null;
             }

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingle.java
@@ -170,7 +170,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
             cancelled = true;
             upstream.cancel();
             inner.dispose();
-            if (getAndIncrement() != 0) {
+            if (getAndIncrement() == 0) {
                 queue.clear();
                 item = null;
             }

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybe.java
@@ -148,7 +148,7 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
             cancelled = true;
             upstream.dispose();
             inner.dispose();
-            if (getAndIncrement() != 0) {
+            if (getAndIncrement() == 0) {
                 queue.clear();
                 item = null;
             }

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingle.java
@@ -148,7 +148,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
             cancelled = true;
             upstream.dispose();
             inner.dispose();
-            if (getAndIncrement() != 0) {
+            if (getAndIncrement() == 0) {
                 queue.clear();
                 item = null;
             }


### PR DESCRIPTION
This PR fixes the accidental logical mistake in the `cancel`/`dispose` logic of the new `concatMapSingle` and `concatMapMaybe` operators of both `Flowable` and `Observable` where the internal queue cleanup should happen in a serialized fashion only, which is the state when the work-in-progress counter changes from 0 to 1 ensured by a `==` check.

Fixes #5927