### PR TITLE
2.x: Fix Completable.toMaybe() @return javadoc.

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -2182,7 +2182,8 @@ public abstract class Completable implements CompletableSource {
      * </dl>
      *
      * @param <T> the value type
-     * @return a {@link Maybe} that emits a single item T or an error.
+     * @return a {@link Maybe} that only calls {@code onComplete} or {@code onError}, based on which one is
+     *         called by the source Completable.
      */
     @CheckReturnValue
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Current javadoc:

```java
@return a {@link Maybe} that emits a single item T or an error.
```

But in reality, converting `Maybe` to `Completable` should never emit `item T`.