### PR TITLE
2.x: Allow @SchedulerSupport on constructors.

### DIFF
--- a/src/main/java/io/reactivex/annotations/SchedulerSupport.java
+++ b/src/main/java/io/reactivex/annotations/SchedulerSupport.java
@@ -28,7 +28,7 @@ import io.reactivex.schedulers.Schedulers;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE})
 public @interface SchedulerSupport {
     /**
      * A special value indicating the operator/class doesn't use schedulers.


### PR DESCRIPTION
Motivation behind this is having a class which takes multiple constructor parameters where one can be a Scheduler with a default and a custom overload. In both cases I'd want to slam `@SchedulerSupport` on it so it can be handled properly by static analysis as well.