### PR TITLE
Removed TERMINATED check in onNext

### DIFF
--- a/src/main/java/io/reactivex/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/processors/PublishProcessor.java
@@ -189,9 +189,6 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
     @Override
     public void onNext(T t) {
         ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
-        if (subscribers.get() == TERMINATED) {
-            return;
-        }
         for (PublishSubscription<T> s : subscribers.get()) {
             s.onNext(t);
         }

--- a/src/main/java/io/reactivex/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/subjects/PublishSubject.java
@@ -225,10 +225,6 @@ public final class PublishSubject<T> extends Subject<T> {
     @Override
     public void onNext(T t) {
         ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
-
-        if (subscribers.get() == TERMINATED) {
-            return;
-        }
         for (PublishDisposable<T> s : subscribers.get()) {
             s.onNext(t);
         }


### PR DESCRIPTION
`TERMINATED` is an empty array, so iterating over it would be harmless. The cost of the check is probably minuscule, but it was imposed on the common case where the subject is not terminated. In essence, it was optimizing for misuse of the API.