### PR TITLE
AppendOnlyLinkedArrayList#forEachWhile is not breaking iteration properly

### DIFF
--- a/src/main/java/io/reactivex/internal/util/AppendOnlyLinkedArrayList.java
+++ b/src/main/java/io/reactivex/internal/util/AppendOnlyLinkedArrayList.java
@@ -91,7 +91,7 @@ public class AppendOnlyLinkedArrayList<T> {
                     break;
                 }
                 if (consumer.test((T)o)) {
-                    break;
+                    return;
                 }
             }
             a = (Object[])a[c];

--- a/src/test/java/io/reactivex/internal/util/MiscUtilTest.java
+++ b/src/test/java/io/reactivex/internal/util/MiscUtilTest.java
@@ -75,6 +75,27 @@ public class MiscUtilTest {
 
         final List<Integer> out = new ArrayList<Integer>();
 
+        list.forEachWhile(new NonThrowingPredicate<Integer>() {
+            @Override
+            public boolean test(Integer t2) {
+                out.add(t2);
+                return t2 == 2;
+            }
+        });
+
+        assertEquals(Arrays.asList(1, 2), out);
+    }
+
+    @Test
+    public void appendOnlyLinkedArrayListForEachWhileBi() throws Exception {
+        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(2);
+
+        list.add(1);
+        list.add(2);
+        list.add(3);
+
+        final List<Integer> out = new ArrayList<Integer>();
+
         list.forEachWhile(2, new BiPredicate<Integer, Integer>() {
             @Override
             public boolean test(Integer t1, Integer t2) throws Exception {
@@ -85,7 +106,6 @@ public class MiscUtilTest {
 
         assertEquals(Arrays.asList(1, 2), out);
     }
-
 
     @Test
     public void appendOnlyLinkedArrayListForEachWhilePreGrow() throws Exception {


### PR DESCRIPTION
`AppendOnlyLinkedArrayList#forEachWhile(NonThrowingPredicate)` was `break`-ing from inner loop instead of `return`-ing when predicate returned `true`.

This caused iteration to continue with items from the next array bucket.