### PR TITLE
2.x: Add Single.ignoreElement, deprecate toCompletable

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3084,7 +3084,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Ignores the item emitted by the source Maybe and only calls {@code onComplete} or {@code onError}.
      * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/ignoreElements.png" alt="">
+     * <img width="640" height="389" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.ignoreElement.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code ignoreElement} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -3517,7 +3517,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="436" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.ignoreElement.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code toCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code ignoreElement} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @return a {@link Completable} that calls {@code onComplete} on it's observer when the source {@link Single}

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -3523,11 +3523,10 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a {@link Completable} that calls {@code onComplete} on it's observer when the source {@link Single}
      *         calls {@code onSuccess}.
      * @see <a href="http://reactivex.io/documentation/completable.html">ReactiveX documentation: Completable</a>
-     * @since 2.1.13 - experimental
+     * @since 2.1.13
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Completable ignoreElement() {
         return RxJavaPlugins.onAssembly(new CompletableFromSingle<T>(this));
     }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -3491,9 +3491,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * and calls {@code onComplete} when this source {@link Single} calls
      * {@code onSuccess}. Error terminal event is propagated.
      * <p>
-     * <img width="640" height="295" src=
-     * "https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.toCompletable.png"
-     * alt="">
+     * <img width="640" height="436" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toCompletable.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code toCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3503,10 +3501,34 @@ public abstract class Single<T> implements SingleSource<T> {
      *         calls {@code onSuccess}.
      * @see <a href="http://reactivex.io/documentation/completable.html">ReactiveX documentation: Completable</a>
      * @since 2.0
+     * @deprecated see {@link #ignoreElement()} instead, will be removed in 3.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @Deprecated
     public final Completable toCompletable() {
+        return RxJavaPlugins.onAssembly(new CompletableFromSingle<T>(this));
+    }
+
+    /**
+     * Returns a {@link Completable} that ignores the success value of this {@link Single}
+     * and calls {@code onComplete} instead on the returned {@code Completable}.
+     * <p>
+     * <img width="640" height="436" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.ignoreElement.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code toCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @return a {@link Completable} that calls {@code onComplete} on it's observer when the source {@link Single}
+     *         calls {@code onSuccess}.
+     * @see <a href="http://reactivex.io/documentation/completable.html">ReactiveX documentation: Completable</a>
+     * @since 2.1.13 - experimental
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final Completable ignoreElement() {
         return RxJavaPlugins.onAssembly(new CompletableFromSingle<T>(this));
     }
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
@@ -254,6 +254,7 @@ public class SingleMiscTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void toCompletable() {
         Single.just(1)
         .toCompletable()
@@ -262,6 +263,19 @@ public class SingleMiscTest {
 
         Single.error(new TestException())
         .toCompletable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void ignoreElement() {
+        Single.just(1)
+        .ignoreElement()
+        .test()
+        .assertResult();
+
+        Single.error(new TestException())
+        .ignoreElement()
         .test()
         .assertFailure(TestException.class);
     }


### PR DESCRIPTION
Rename-deprecate `Single.toCompletable` to `ignoreElement` to be in line with the same operator in the other classes and also indicate more clearly in the method name that it ignores the element.

In addition, the marbles have been updated on both `Single` and `Maybe` of this operator.

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.ignoreElement.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.ignoreElement.png)