### PR TITLE
2.x: Fix some grammar mistakes

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -1397,7 +1397,7 @@ public abstract class Completable implements CompletableSource {
      * 
      * public final class CustomCompletableObserver implements CompletableObserver, Disposable {
      *
-     *     // The donstream's CompletableObserver that will receive the onXXX events
+     *     // The downstream's CompletableObserver that will receive the onXXX events
      *     final CompletableObserver downstream;
      *
      *     // The connection to the upstream source that will call this class' onXXX methods

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -149,7 +149,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * If the provided array of source Publishers is empty, the resulting sequence completes immediately without emitting
@@ -193,7 +193,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * If there are no source Publishers provided, the resulting sequence completes immediately without emitting
@@ -237,7 +237,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * If the provided array of source Publishers is empty, the resulting sequence completes immediately without emitting
@@ -289,7 +289,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * If the provided iterable of source Publishers is empty, the resulting sequence completes immediately without emitting
@@ -334,7 +334,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * If the provided iterable of source Publishers is empty, the resulting sequence completes immediately without emitting any items and
@@ -384,7 +384,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * If the provided array of source Publishers is empty, the resulting sequence completes immediately without emitting
@@ -430,7 +430,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * If there are no source Publishers provided, the resulting sequence completes immediately without emitting
@@ -476,7 +476,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * If there are no source Publishers provided, the resulting sequence completes immediately without emitting
@@ -524,7 +524,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * If the provided array of source Publishers is empty, the resulting sequence completes immediately without emitting
@@ -578,7 +578,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * If the provided iterable of source Publishers is empty, the resulting sequence completes immediately without emitting
@@ -624,7 +624,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * If the provided iterable of source Publishers is empty, the resulting sequence completes immediately without emitting
@@ -670,7 +670,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * aggregation is defined by a specified function.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/combineLatest.png" alt="">
@@ -715,7 +715,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * aggregation is defined by a specified function.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/combineLatest.png" alt="">
@@ -764,7 +764,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * aggregation is defined by a specified function.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/combineLatest.png" alt="">
@@ -817,7 +817,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * aggregation is defined by a specified function.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/combineLatest.png" alt="">
@@ -875,7 +875,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * aggregation is defined by a specified function.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/combineLatest.png" alt="">
@@ -937,7 +937,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * aggregation is defined by a specified function.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/combineLatest.png" alt="">
@@ -1004,7 +1004,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * aggregation is defined by a specified function.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/combineLatest.png" alt="">
@@ -1075,7 +1075,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * aggregation is defined by a specified function.
      * <p>
      * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
+     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/combineLatest.png" alt="">
@@ -1182,7 +1182,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Publisher}
      *  sources are expected to honor backpressure as well. If the outer violates this, a
-     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Publisher}s violates
+     *  {@code MissingBackpressureException} is signaled. If any of the inner {@code Publisher}s violates
      *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -1211,7 +1211,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Publisher}
      *  sources are expected to honor backpressure as well. If the outer violates this, a
-     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Publisher}s violates
+     *  {@code MissingBackpressureException} is signaled. If any of the inner {@code Publisher}s violates
      *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -1459,7 +1459,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T> the value type
      * @param sources a sequence of Publishers that need to be eagerly concatenated
      * @param maxConcurrency the maximum number of concurrent subscriptions at a time, Integer.MAX_VALUE
-     *                       is interpreted as indication to subscribe to all sources at once
+     *                       is interpreted as an indication to subscribe to all sources at once
      * @param prefetch the number of elements to prefetch from each Publisher source
      * @return the new Publisher instance with the specified concatenation behavior
      * @since 2.0
@@ -1483,7 +1483,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. Both the outer and inner {@code Publisher}
      *  sources are expected to honor backpressure as well. If the outer violates this, a
-     *  {@code MissingBackpressureException} is signalled. If any of the inner {@code Publisher}s violates
+     *  {@code MissingBackpressureException} is signaled. If any of the inner {@code Publisher}s violates
      *  this, it <em>may</em> throw an {@code IllegalStateException} when an inner {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -1730,7 +1730,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <img width="640" height="340" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/defer.png" alt="">
      * <p>
-     * The defer Subscriber allows you to defer or delay emitting items from a Publisher until such time as an
+     * The defer Subscriber allows you to defer or delay emitting items from a Publisher until such time as a
      * Subscriber subscribes to the Publisher. This allows a {@link Subscriber} to easily obtain updates or a
      * refreshed version of the sequence.
      * <dl>
@@ -1911,12 +1911,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/from.Future.png" alt="">
      * <p>
      * You can convert any object that supports the {@link Future} interface into a Publisher that emits the
-     * return value of the {@link Future#get} method of that object, by passing the object into the {@code from}
+     * return value of the {@link Future#get} method of that object by passing the object into the {@code from}
      * method.
      * <p>
      * <em>Important note:</em> This Publisher is blocking on the thread it gets subscribed on; you cannot cancel it.
      * <p>
-     * Unlike 1.x, cancelling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
+     * Unlike 1.x, canceling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futurePublisher.doOnCancel(() -> future.cancel(true));}.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -1947,10 +1947,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/from.Future.png" alt="">
      * <p>
      * You can convert any object that supports the {@link Future} interface into a Publisher that emits the
-     * return value of the {@link Future#get} method of that object, by passing the object into the {@code fromFuture}
+     * return value of the {@link Future#get} method of that object by passing the object into the {@code fromFuture}
      * method.
      * <p>
-     * Unlike 1.x, cancelling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
+     * Unlike 1.x, canceling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futurePublisher.doOnCancel(() -> future.cancel(true));}.
      * <p>
      * <em>Important note:</em> This Publisher is blocking on the thread it gets subscribed on; you cannot cancel it.
@@ -1988,10 +1988,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/from.Future.png" alt="">
      * <p>
      * You can convert any object that supports the {@link Future} interface into a Publisher that emits the
-     * return value of the {@link Future#get} method of that object, by passing the object into the {@code from}
+     * return value of the {@link Future#get} method of that object by passing the object into the {@code from}
      * method.
      * <p>
-     * Unlike 1.x, cancelling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
+     * Unlike 1.x, canceling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futurePublisher.doOnCancel(() -> future.cancel(true));}.
      * <p>
      * <em>Important note:</em> This Publisher is blocking; you cannot cancel it.
@@ -2032,10 +2032,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/from.Future.s.png" alt="">
      * <p>
      * You can convert any object that supports the {@link Future} interface into a Publisher that emits the
-     * return value of the {@link Future#get} method of that object, by passing the object into the {@code from}
+     * return value of the {@link Future#get} method of that object by passing the object into the {@code from}
      * method.
      * <p>
-     * Unlike 1.x, cancelling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
+     * Unlike 1.x, canceling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futurePublisher.doOnCancel(() -> future.cancel(true));}.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -2116,7 +2116,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T> the value type of the flow
      * @param source the Publisher to convert
      * @return the new Flowable instance
-     * @throws NullPointerException if publisher is null
+     * @throws NullPointerException if the {@code source} {@code Publisher} is null
      * @see #create(FlowableOnSubscribe, BackpressureStrategy)
      */
     @CheckReturnValue
@@ -2144,7 +2144,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T> the generated value type
      * @param generator the Consumer called whenever a particular downstream Subscriber has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
-     * {@code onComplete} to signal a value or a terminal event. Signalling multiple {@code onNext}
+     * {@code onComplete} to signal a value or a terminal event. Signaling multiple {@code onNext}
      * in a call will make the operator signal {@code IllegalStateException}.
      * @return the new Flowable instance
      */
@@ -2172,7 +2172,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param initialState the Callable to generate the initial state for each Subscriber
      * @param generator the Consumer called with the current state whenever a particular downstream Subscriber has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
-     * {@code onComplete} to signal a value or a terminal event. Signalling multiple {@code onNext}
+     * {@code onComplete} to signal a value or a terminal event. Signaling multiple {@code onNext}
      * in a call will make the operator signal {@code IllegalStateException}.
      * @return the new Flowable instance
      */
@@ -2199,10 +2199,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param initialState the Callable to generate the initial state for each Subscriber
      * @param generator the Consumer called with the current state whenever a particular downstream Subscriber has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
-     * {@code onComplete} to signal a value or a terminal event. Signalling multiple {@code onNext}
+     * {@code onComplete} to signal a value or a terminal event. Signaling multiple {@code onNext}
      * in a call will make the operator signal {@code IllegalStateException}.
      * @param disposeState the Consumer that is called with the current state when the generator
-     * terminates the sequence or it gets cancelled
+     * terminates the sequence or it gets canceled
      * @return the new Flowable instance
      */
     @CheckReturnValue
@@ -2229,7 +2229,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param generator the Function called with the current state whenever a particular downstream Subscriber has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event and should return a (new) state for
-     * the next invocation. Signalling multiple {@code onNext}
+     * the next invocation. Signaling multiple {@code onNext}
      * in a call will make the operator signal {@code IllegalStateException}.
      * @return the new Flowable instance
      */
@@ -2255,10 +2255,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param generator the Function called with the current state whenever a particular downstream Subscriber has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event and should return a (new) state for
-     * the next invocation. Signalling multiple {@code onNext}
+     * the next invocation. Signaling multiple {@code onNext}
      * in a call will make the operator signal {@code IllegalStateException}.
      * @param disposeState the Consumer that is called with the current state when the generator
-     * terminates the sequence or it gets cancelled
+     * terminates the sequence or it gets canceled
      * @return the new Flowable instance
      */
     @CheckReturnValue
@@ -2272,7 +2272,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits a {@code 0L} after the {@code initialDelay} and ever increasing numbers
+     * Returns a Flowable that emits a {@code 0L} after the {@code initialDelay} and ever-increasing numbers
      * after each {@code period} of time thereafter.
      * <p>
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.p.png" alt="">
@@ -2291,7 +2291,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the period of time between emissions of the subsequent numbers
      * @param unit
      *            the time unit for both {@code initialDelay} and {@code period}
-     * @return a Flowable that emits a 0L after the {@code initialDelay} and ever increasing numbers after
+     * @return a Flowable that emits a 0L after the {@code initialDelay} and ever-increasing numbers after
      *         each {@code period} of time thereafter
      * @see <a href="http://reactivex.io/documentation/operators/interval.html">ReactiveX operators documentation: Interval</a>
      * @since 1.0.12
@@ -2304,7 +2304,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Returns a Flowable that emits a {@code 0L} after the {@code initialDelay} and ever increasing numbers
+     * Returns a Flowable that emits a {@code 0L} after the {@code initialDelay} and ever-increasing numbers
      * after each {@code period} of time thereafter, on a specified {@link Scheduler}.
      * <p>
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.ps.png" alt="">
@@ -2325,7 +2325,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the time unit for both {@code initialDelay} and {@code period}
      * @param scheduler
      *            the Scheduler on which the waiting happens and items are emitted
-     * @return a Flowable that emits a 0L after the {@code initialDelay} and ever increasing numbers after
+     * @return a Flowable that emits a 0L after the {@code initialDelay} and ever-increasing numbers after
      *         each {@code period} of time thereafter, while running on the given Scheduler
      * @see <a href="http://reactivex.io/documentation/operators/interval.html">ReactiveX operators documentation: Interval</a>
      * @since 1.0.12
@@ -2407,7 +2407,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      * @param start that start value of the range
      * @param count the number of values to emit in total, if zero, the operator emits an onComplete after the initial delay.
-     * @param initialDelay the initial delay before signalling the first value (the start)
+     * @param initialDelay the initial delay before signaling the first value (the start)
      * @param period the period between subsequent values
      * @param unit the unit of measure of the initialDelay and period amounts
      * @return the new Flowable instance
@@ -2431,7 +2431,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      * @param start that start value of the range
      * @param count the number of values to emit in total, if zero, the operator emits an onComplete after the initial delay.
-     * @param initialDelay the initial delay before signalling the first value (the start)
+     * @param initialDelay the initial delay before signaling the first value (the start)
      * @param period the period between subsequent values
      * @param unit the unit of measure of the initialDelay and period amounts
      * @param scheduler the target scheduler where the values and terminal signals will be emitted
@@ -2899,13 +2899,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Iterable, int, int)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -2950,13 +2950,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeArrayDelayError(int, int, Publisher[])} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3000,13 +3000,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Iterable)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3045,13 +3045,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Iterable, int)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3095,13 +3095,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3140,13 +3140,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher, int)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3189,13 +3189,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeArrayDelayError(Publisher...)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3232,13 +3232,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher, Publisher)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3279,13 +3279,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher, Publisher, Publisher)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3329,13 +3329,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher, Publisher, Publisher, Publisher)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -4024,7 +4024,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * from the earlier-emitted Publisher and begins emitting items from the new one.
      * <p>
      * The resulting Publisher completes if both the outer Publisher and the last inner Publisher, if any, complete.
-     * If the outer Publisher signals an onError, the inner Publisher is cancelled and the error delivered in-sequence.
+     * If the outer Publisher signals an onError, the inner Publisher is canceled and the error delivered in-sequence.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed in an
@@ -4064,7 +4064,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * from the earlier-emitted Publisher and begins emitting items from the new one.
      * <p>
      * The resulting Publisher completes if both the outer Publisher and the last inner Publisher, if any, complete.
-     * If the outer Publisher signals an onError, the inner Publisher is cancelled and the error delivered in-sequence.
+     * If the outer Publisher signals an onError, the inner Publisher is canceled and the error delivered in-sequence.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed in an
@@ -4103,7 +4103,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * The resulting Publisher completes if both the main Publisher and the last inner Publisher, if any, complete.
      * If the main Publisher signals an onError, the termination of the last inner Publisher will emit that error as is
-     * or wrapped into a CompositeException along with the other possible errors the former inner Publishers signalled.
+     * or wrapped into a CompositeException along with the other possible errors the former inner Publishers signaled.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed in an
@@ -4142,7 +4142,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * The resulting Publisher completes if both the main Publisher and the last inner Publisher, if any, complete.
      * If the main Publisher signals an onError, the termination of the last inner Publisher will emit that error as is
-     * or wrapped into a CompositeException along with the other possible errors the former inner Publishers signalled.
+     * or wrapped into a CompositeException along with the other possible errors the former inner Publishers signaled.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed in an
@@ -4292,7 +4292,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Constructs a Publisher that creates a dependent resource object which is disposed of just before
      * termination if you have set {@code disposeEagerly} to {@code true} and cancellation does not occur
-     * before termination. Otherwise resource disposal will occur on cancellation.  Eager disposal is
+     * before termination. Otherwise, resource disposal will occur on cancellation.  Eager disposal is
      * particularly appropriate for a synchronous Publisher that reuses resources. {@code disposeAction} will
      * only be called once per subscription.
      * <p>
@@ -4344,8 +4344,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * The resulting {@code Publisher<R>} returned from {@code zip} will invoke {@code onNext} as many times as
      * the number of {@code onNext} invocations of the source Publisher that emits the fewest items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -4397,7 +4397,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * The resulting {@code Publisher<R>} returned from {@code zip} will invoke {@code onNext} as many times as
      * the number of {@code onNext} invocations of the source Publisher that emits the fewest items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
      * one of the sources is shorter than the rest while cancel the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
@@ -4454,8 +4454,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * as many times as the number of {@code onNext} invocations of the source Publisher that emits the fewest
      * items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -4514,8 +4514,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * as many times as the number of {@code onNext} invocations of the source Publisher that emits the fewest
      * items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -4576,8 +4576,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * as many times as the number of {@code onNext} invocations of the source Publisher that emits the fewest
      * items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -4639,8 +4639,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * as many times as the number of {@code onNext} invocations of the source Publisher that emits the fewest
      * items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -4704,8 +4704,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * as many times as the number of {@code onNext} invocations of the source Publisher that emits the fewest
      * items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -4774,8 +4774,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * as many times as the number of {@code onNext} invocations of the source Publisher that emits the fewest
      * items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -4847,8 +4847,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * as many times as the number of {@code onNext} invocations of the source Publisher that emits the fewest
      * items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -4924,8 +4924,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * as many times as the number of {@code onNext} invocations of the source Publisher that emits the fewest
      * items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -5006,8 +5006,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * as many times as the number of {@code onNext} invocations of the source Publisher that emits the fewest
      * items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -5092,8 +5092,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * as many times as the number of {@code onNext} invocations of the source Publisher that emits the fewest
      * items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -5180,8 +5180,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * The resulting {@code Publisher<R>} returned from {@code zip} will invoke {@code onNext} as many times as
      * the number of {@code onNext} invocations of the source Publisher that emits the fewest items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -5211,7 +5211,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            a function that, when applied to an item emitted by each of the source Publishers, results in
      *            an item that will be emitted by the resulting Publisher
      * @param delayError
-     *            delay errors signalled by any of the source Publisher until all Publishers terminate
+     *            delay errors signaled by any of the source Publisher until all Publishers terminate
      * @param bufferSize
      *            the number of elements to prefetch from each source Publisher
      * @return a Flowable that emits the zipped results
@@ -5242,8 +5242,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * The resulting {@code Publisher<R>} returned from {@code zip} will invoke {@code onNext} as many times as
      * the number of {@code onNext} invocations of the source Publisher that emits the fewest items.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -5271,7 +5271,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            a function that, when applied to an item emitted by each of the source Publishers, results in
      *            an item that will be emitted by the resulting Publisher
      * @param delayError
-     *            delay errors signalled by any of the source Publisher until all Publishers terminate
+     *            delay errors signaled by any of the source Publisher until all Publishers terminate
      * @param bufferSize
      *            the number of elements to prefetch from each source Publisher
      * @param <T> the common source value type
@@ -5358,7 +5358,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/exists.png" alt="">
      * <p>
-     * In Rx.Net this is the {@code any} Subscriber but we renamed it in RxJava to better match Java naming
+     * In Rx.Net this is the {@code any} operator but we renamed it in RxJava to better match Java naming
      * idioms.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -5776,7 +5776,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * If the {@link Flowable} emits more than one item, {@link java.util.concurrent.Future} will receive an
      * {@link java.lang.IllegalArgumentException}. If the {@link Flowable} is empty, {@link java.util.concurrent.Future}
-     * will receive an {@link java.util.NoSuchElementException}.
+     * will receive a {@link java.util.NoSuchElementException}.
      * <p>
      * If the {@code Flowable} may emit more than one item, use {@code Flowable.toList().toFuture()}.
      * <p>
@@ -7155,7 +7155,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the number of elements to prefetch from the current Flowable
      * @param tillTheEnd
      *            if true, all errors from the outer and inner Publisher sources are delayed until the end,
-     *            if false, an error from the main source is signalled when the current Publisher source terminates
+     *            if false, an error from the main source is signaled when the current Publisher source terminates
      * @return the new Publisher instance with the concatenation behavior
      */
     @CheckReturnValue
@@ -7256,7 +7256,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *               eagerly concatenated
      * @param tillTheEnd
      *            if true, all errors from the outer and inner Publisher sources are delayed until the end,
-     *            if false, an error from the main source is signalled when the current Publisher source terminates
+     *            if false, an error from the main source is signaled when the current Publisher source terminates
      * @return the new Publisher instance with the specified concatenation behavior
      * @since 2.0
      */
@@ -7684,7 +7684,7 @@ public abstract class Flowable<T> implements Publisher<T> {
 
     /**
      * Maps the upstream items into {@link SingleSource}s and subscribes to them one after the
-     * other succeeds or fails, emits their success values and optionally delays  errors
+     * other succeeds or fails, emits their success values and optionally delays errors
      * till both this {@code Flowable} and all inner {@code SingleSource}s terminate.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMap.png" alt="">
@@ -8007,7 +8007,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>If the source {@code Publisher} is empty, this operator is guaranteed to honor backpressure from downstream.
      *  If the source {@code Publisher} is non-empty, it is expected to honor backpressure as well; if the rule is violated,
-     *  a {@code MissingBackpressureException} <em>may</em> get signalled somewhere downstream.
+     *  a {@code MissingBackpressureException} <em>may</em> get signaled somewhere downstream.
      *  </dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code defaultIfEmpty} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8105,8 +8105,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param unit
      *            the {@link TimeUnit} in which {@code period} is defined
      * @param delayError
-     *            if true, the upstream exception is signalled with the given delay, after all preceding normal elements,
-     *            if false, the upstream exception is signalled immediately
+     *            if true, the upstream exception is signaled with the given delay, after all preceding normal elements,
+     *            if false, the upstream exception is signaled immediately
      * @return the source Publisher shifted in time by the specified delay
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      */
@@ -8164,8 +8164,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param scheduler
      *            the {@link Scheduler} to use for delaying
      * @param delayError
-     *            if true, the upstream exception is signalled with the given delay, after all preceding normal elements,
-     *            if false, the upstream exception is signalled immediately
+     *            if true, the upstream exception is signaled with the given delay, after all preceding normal elements,
+     *            if false, the upstream exception is signaled immediately
      * @return the source Publisher shifted in time by the specified delay
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      */
@@ -8353,7 +8353,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/distinct.png" alt="">
      * <p>
      * It is recommended the elements' class {@code T} in the flow overrides the default {@code Object.equals()} and {@link Object#hashCode()} to provide
-     * meaningful comparison between items as the default Java implementation only considers reference equivalence.
+     * a meaningful comparison between items as the default Java implementation only considers reference equivalence.
      * <p>
      * By default, {@code distinct()} uses an internal {@link java.util.HashSet} per Subscriber to remember
      * previously seen items and uses {@link java.util.Set#add(Object)} returning {@code false} as the
@@ -8395,7 +8395,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/distinct.key.png" alt="">
      * <p>
      * It is recommended the keys' class {@code K} overrides the default {@code Object.equals()} and {@link Object#hashCode()} to provide
-     * meaningful comparison between the key objects as the default Java implementation only considers reference equivalence.
+     * a meaningful comparison between the key objects as the default Java implementation only considers reference equivalence.
      * <p>
      * By default, {@code distinct()} uses an internal {@link java.util.HashSet} per Subscriber to remember
      * previously seen keys and uses {@link java.util.Set#add(Object)} returning {@code false} as the
@@ -8438,7 +8438,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/distinct.key.png" alt="">
      * <p>
      * It is recommended the keys' class {@code K} overrides the default {@code Object.equals()} and {@link Object#hashCode()} to provide
-     * meaningful comparison between the key objects as the default Java implementation only considers reference equivalence.
+     * a meaningful comparison between the key objects as the default Java implementation only considers reference equivalence.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s
@@ -8474,7 +8474,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/distinctUntilChanged.png" alt="">
      * <p>
      * It is recommended the elements' class {@code T} in the flow overrides the default {@code Object.equals()} to provide
-     * meaningful comparison between items as the default Java implementation only considers reference equivalence.
+     * a meaningful comparison between items as the default Java implementation only considers reference equivalence.
      * Alternatively, use the {@link #distinctUntilChanged(BiPredicate)} overload and provide a comparison function
      * in case the class {@code T} can't be overridden with custom {@code equals()} or the comparison itself
      * should happen on different terms or properties of the class {@code T}.
@@ -8509,7 +8509,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/distinctUntilChanged.key.png" alt="">
      * <p>
      * It is recommended the keys' class {@code K} overrides the default {@code Object.equals()} to provide
-     * meaningful comparison between the key objects as the default Java implementation only considers reference equivalence.
+     * a meaningful comparison between the key objects as the default Java implementation only considers reference equivalence.
      * Alternatively, use the {@link #distinctUntilChanged(BiPredicate)} overload and provide a comparison function
      * in case the class {@code K} can't be overridden with custom {@code equals()} or the comparison itself
      * should happen on different terms or properties of the item class {@code T} (for which the keys can be
@@ -8573,7 +8573,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Calls the specified action after this Flowable signals onError or onCompleted or gets cancelled by
+     * Calls the specified action after this Flowable signals onError or onCompleted or gets canceled by
      * the downstream.
      * <p>In case of a race between a terminal event and a cancellation, the provided {@code onFinally} action
      * is executed once per subscription.
@@ -8590,7 +8590,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  synchronous or asynchronous queue-fusion.</dd>
      * </dl>
      * <p>History: 2.0.1 - experimental
-     * @param onFinally the action called when this Flowable terminates or gets cancelled
+     * @param onFinally the action called when this Flowable terminates or gets canceled
      * @return the new Flowable instance
      * @since 2.1
      */
@@ -8661,7 +8661,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Calls the cancel {@code Action} if the downstream cancels the sequence.
      * <p>
      * The action is shared between subscriptions and thus may be called concurrently from multiple
-     * threads; the action must be thread safe.
+     * threads; the action must be thread-safe.
      * <p>
      * If the action throws a runtime exception, that exception is rethrown by the {@code onCancel()} call,
      * sometimes as a {@code CompositeException} if there were multiple exceptions along the way.
@@ -8678,7 +8678,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      *
      * @param onCancel
-     *            the action that gets called when the source {@code Publisher}'s Subscription is cancelled
+     *            the action that gets called when the source {@code Publisher}'s Subscription is canceled
      * @return the source {@code Publisher} modified so as to call this Action when appropriate
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      */
@@ -9226,7 +9226,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            Publisher
      * @param delayErrors
      *            if true, exceptions from the current Flowable and all inner Publishers are delayed until all of them terminate
-     *            if false, the first one signalling an exception will terminate the whole sequence immediately
+     *            if false, the first one signaling an exception will terminate the whole sequence immediately
      * @return a Flowable that emits the result of applying the transformation function to each item emitted
      *         by the source Publisher and merging the results of the Publishers obtained from this
      *         transformation
@@ -9300,7 +9300,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         the maximum number of Publishers that may be subscribed to concurrently
      * @param delayErrors
      *            if true, exceptions from the current Flowable and all inner Publishers are delayed until all of them terminate
-     *            if false, the first one signalling an exception will terminate the whole sequence immediately
+     *            if false, the first one signaling an exception will terminate the whole sequence immediately
      * @return a Flowable that emits the result of applying the transformation function to each item emitted
      *         by the source Publisher and merging the results of the Publishers obtained from this
      *         transformation
@@ -9339,7 +9339,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         the maximum number of Publishers that may be subscribed to concurrently
      * @param delayErrors
      *            if true, exceptions from the current Flowable and all inner Publishers are delayed until all of them terminate
-     *            if false, the first one signalling an exception will terminate the whole sequence immediately
+     *            if false, the first one signaling an exception will terminate the whole sequence immediately
      * @param bufferSize
      *            the number of elements to prefetch from each inner Publisher
      * @return a Flowable that emits the result of applying the transformation function to each item emitted
@@ -9519,7 +9519,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            returns an item to be emitted by the resulting Publisher
      * @param delayErrors
      *            if true, exceptions from the current Flowable and all inner Publishers are delayed until all of them terminate
-     *            if false, the first one signalling an exception will terminate the whole sequence immediately
+     *            if false, the first one signaling an exception will terminate the whole sequence immediately
      * @return a Flowable that emits the results of applying a function to a pair of values emitted by the
      *         source Publisher and the collection Publisher
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
@@ -9561,7 +9561,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         the maximum number of Publishers that may be subscribed to concurrently
      * @param delayErrors
      *            if true, exceptions from the current Flowable and all inner Publishers are delayed until all of them terminate
-     *            if false, the first one signalling an exception will terminate the whole sequence immediately
+     *            if false, the first one signaling an exception will terminate the whole sequence immediately
      * @return a Flowable that emits the results of applying a function to a pair of values emitted by the
      *         source Publisher and the collection Publisher
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
@@ -9604,7 +9604,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         the maximum number of Publishers that may be subscribed to concurrently
      * @param delayErrors
      *            if true, exceptions from the current Flowable and all inner Publishers are delayed until all of them terminate
-     *            if false, the first one signalling an exception will terminate the whole sequence immediately
+     *            if false, the first one signaling an exception will terminate the whole sequence immediately
      * @param bufferSize
      *            the number of elements to prefetch from the inner Publishers.
      * @return a Flowable that emits the results of applying a function to a pair of values emitted by the
@@ -9689,7 +9689,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>If {@code maxConcurrency == Integer.MAX_VALUE} the operator consumes the upstream in an unbounded manner.
-     *  Otherwise the operator expects the upstream to honor backpressure. If the upstream doesn't support backpressure
+     *  Otherwise, the operator expects the upstream to honor backpressure. If the upstream doesn't support backpressure
      *  the operator behaves as if {@code maxConcurrency == Integer.MAX_VALUE} was used.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -9879,7 +9879,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>If {@code maxConcurrency == Integer.MAX_VALUE} the operator consumes the upstream in an unbounded manner.
-     *  Otherwise the operator expects the upstream to honor backpressure. If the upstream doesn't support backpressure
+     *  Otherwise, the operator expects the upstream to honor backpressure. If the upstream doesn't support backpressure
      *  the operator behaves as if {@code maxConcurrency == Integer.MAX_VALUE} was used.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -9927,7 +9927,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>If {@code maxConcurrency == Integer.MAX_VALUE} the operator consumes the upstream in an unbounded manner.
-     *  Otherwise the operator expects the upstream to honor backpressure. If the upstream doesn't support backpressure
+     *  Otherwise, the operator expects the upstream to honor backpressure. If the upstream doesn't support backpressure
      *  the operator behaves as if {@code maxConcurrency == Integer.MAX_VALUE} was used.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -9963,7 +9963,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param onNext
      *            {@link Consumer} to execute for each item.
      * @return
-     *            a Disposable that allows cancelling an asynchronous sequence
+     *            a Disposable that allows canceling an asynchronous sequence
      * @throws NullPointerException
      *             if {@code onNext} is null
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
@@ -9993,7 +9993,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param onNext
      *            {@link Predicate} to execute for each item.
      * @return
-     *            a {@link Disposable} that allows cancelling an asynchronous sequence
+     *            a {@link Disposable} that allows canceling an asynchronous sequence
      * @throws NullPointerException
      *             if {@code onNext} is null
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
@@ -10021,7 +10021,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param onError
      *            {@link Consumer} to execute when an error is emitted.
      * @return
-     *            a {@link Disposable} that allows cancelling an asynchronous sequence
+     *            a {@link Disposable} that allows canceling an asynchronous sequence
      * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null
@@ -10050,9 +10050,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param onError
      *            {@link Consumer} to execute when an error is emitted.
      * @param onComplete
-     *            {@link Action} to execute when completion is signalled.
+     *            {@link Action} to execute when completion is signaled.
      * @return
-     *            a {@link Disposable} that allows cancelling an asynchronous sequence
+     *            a {@link Disposable} that allows canceling an asynchronous sequence
      * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null, or
@@ -10312,7 +10312,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code GroupedPublisher} emission. The {@code evictingMapFactory} is used to create a map that will
      * be used to hold the {@link GroupedFlowable}s by key. The evicting map created by this factory must
      * notify the provided {@code Consumer<Object>} with the entry value (not the key!) when an entry in this
-     * map has been evicted. The next source emission will bring about the  completion of the evicted
+     * map has been evicted. The next source emission will bring about the completion of the evicted
      * {@link GroupedFlowable}s and the arrival of an item with the same key as a completed {@link GroupedFlowable}
      * will prompt the creation and emission of a new {@link GroupedFlowable} with that key.
      * 
@@ -10676,7 +10676,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * 
      * public final class CustomSubscriber&lt;T&gt; implements FlowableSubscriber&lt;T&gt;, Subscription {
      *
-     *     // The donstream's Subscriber that will receive the onXXX events
+     *     // The downstream's Subscriber that will receive the onXXX events
      *     final Subscriber&lt;? super String&gt; downstream;
      *
      *     // The connection to the upstream source that will call this class' onXXX methods
@@ -10738,7 +10738,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *     // Some operators may use their own resources which should be cleaned up if
      *     // the downstream cancels the flow before it completed. Operators without
      *     // resources can simply forward the cancellation to the upstream.
-     *     // In some cases, a cancelled flag may be set by this method so that other parts
+     *     // In some cases, a canceled flag may be set by this method so that other parts
      *     // of this class may detect the cancellation and stop sending events
      *     // to the downstream.
      *     &#64;Override
@@ -10966,7 +10966,7 @@ public abstract class Flowable<T> implements Publisher<T> {
 
     /**
      * Merges the sequence of items of this Flowable with the success value of the other MaybeSource
-     * or waits both to complete normally if the MaybeSource is empty.
+     * or waits for both to complete normally if the MaybeSource is empty.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.png" alt="">
      * <p>
@@ -11195,7 +11195,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      * @param delayError
      *                if true, an exception from the current Flowable is delayed until all buffered elements have been
-     *                consumed by the downstream; if false, an exception is immediately signalled to the downstream, skipping
+     *                consumed by the downstream; if false, an exception is immediately signaled to the downstream, skipping
      *                any buffered element
      * @return the source Publisher modified to buffer items to the extent system resources allow
      * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
@@ -11209,9 +11209,9 @@ public abstract class Flowable<T> implements Publisher<T> {
 
     /**
      * Instructs a Publisher that is emitting items faster than its Subscriber can consume them to buffer up to
-     * a given amount of items until they can be emitted. The resulting Publisher will {@code onError} emitting
-     * a {@code BufferOverflowException} as soon as the buffer's capacity is exceeded, dropping all undelivered
-     * items, and cancelling the source.
+     * a given amount of items until they can be emitted. The resulting Publisher will signal
+     * a {@code BufferOverflowException} via {@code onError} as soon as the buffer's capacity is exceeded, dropping all undelivered
+     * items, and canceling the source.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
      * <dl>
@@ -11236,9 +11236,9 @@ public abstract class Flowable<T> implements Publisher<T> {
 
     /**
      * Instructs a Publisher that is emitting items faster than its Subscriber can consume them to buffer up to
-     * a given amount of items until they can be emitted. The resulting Publisher will {@code onError} emitting
-     * a {@code BufferOverflowException} as soon as the buffer's capacity is exceeded, dropping all undelivered
-     * items, and cancelling the source.
+     * a given amount of items until they can be emitted. The resulting Publisher will signal
+     * a {@code BufferOverflowException} via {@code onError} as soon as the buffer's capacity is exceeded, dropping all undelivered
+     * items, and canceling the source.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
      * <dl>
@@ -11252,7 +11252,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param capacity number of slots available in the buffer.
      * @param delayError
      *                if true, an exception from the current Flowable is delayed until all buffered elements have been
-     *                consumed by the downstream; if false, an exception is immediately signalled to the downstream, skipping
+     *                consumed by the downstream; if false, an exception is immediately signaled to the downstream, skipping
      *                any buffered element
      * @return the source {@code Publisher} modified to buffer items up to the given capacity.
      * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
@@ -11267,9 +11267,9 @@ public abstract class Flowable<T> implements Publisher<T> {
 
     /**
      * Instructs a Publisher that is emitting items faster than its Subscriber can consume them to buffer up to
-     * a given amount of items until they can be emitted. The resulting Publisher will {@code onError} emitting
-     * a {@code BufferOverflowException} as soon as the buffer's capacity is exceeded, dropping all undelivered
-     * items, and cancelling the source.
+     * a given amount of items until they can be emitted. The resulting Publisher will signal
+     * a {@code BufferOverflowException} via {@code onError} as soon as the buffer's capacity is exceeded, dropping all undelivered
+     * items, and canceling the source.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
      * <dl>
@@ -11283,7 +11283,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param capacity number of slots available in the buffer.
      * @param delayError
      *                if true, an exception from the current Flowable is delayed until all buffered elements have been
-     *                consumed by the downstream; if false, an exception is immediately signalled to the downstream, skipping
+     *                consumed by the downstream; if false, an exception is immediately signaled to the downstream, skipping
      *                any buffered element
      * @param unbounded
      *                if true, the capacity value is interpreted as the internal "island" size of the unbounded buffer
@@ -11301,9 +11301,9 @@ public abstract class Flowable<T> implements Publisher<T> {
 
     /**
      * Instructs a Publisher that is emitting items faster than its Subscriber can consume them to buffer up to
-     * a given amount of items until they can be emitted. The resulting Publisher will {@code onError} emitting
-     * a {@code BufferOverflowException} as soon as the buffer's capacity is exceeded, dropping all undelivered
-     * items, cancelling the source, and notifying the producer with {@code onOverflow}.
+     * a given amount of items until they can be emitted. The resulting Publisher will signal
+     * a {@code BufferOverflowException} via {@code onError} as soon as the buffer's capacity is exceeded, dropping all undelivered
+     * items, canceling the source, and notifying the producer with {@code onOverflow}.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
      * <dl>
@@ -11317,7 +11317,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param capacity number of slots available in the buffer.
      * @param delayError
      *                if true, an exception from the current Flowable is delayed until all buffered elements have been
-     *                consumed by the downstream; if false, an exception is immediately signalled to the downstream, skipping
+     *                consumed by the downstream; if false, an exception is immediately signaled to the downstream, skipping
      *                any buffered element
      * @param unbounded
      *                if true, the capacity value is interpreted as the internal "island" size of the unbounded buffer
@@ -11338,9 +11338,9 @@ public abstract class Flowable<T> implements Publisher<T> {
 
     /**
      * Instructs a Publisher that is emitting items faster than its Subscriber can consume them to buffer up to
-     * a given amount of items until they can be emitted. The resulting Publisher will {@code onError} emitting
-     * a {@code BufferOverflowException} as soon as the buffer's capacity is exceeded, dropping all undelivered
-     * items, cancelling the source, and notifying the producer with {@code onOverflow}.
+     * a given amount of items until they can be emitted. The resulting Publisher will signal
+     * a {@code BufferOverflowException} via {@code onError} as soon as the buffer's capacity is exceeded, dropping all undelivered
+     * items, canceling the source, and notifying the producer with {@code onOverflow}.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
      * <dl>
@@ -11370,10 +11370,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * by {@code overflowStrategy} if the buffer capacity is exceeded.
      *
      * <ul>
-     *     <li>{@code BackpressureOverflow.Strategy.ON_OVERFLOW_ERROR} (default) will {@code onError} dropping all undelivered items,
-     *     cancelling the source, and notifying the producer with {@code onOverflow}. </li>
+     *     <li>{@code BackpressureOverflow.Strategy.ON_OVERFLOW_ERROR} (default) will call {@code onError} dropping all undelivered items,
+     *     canceling the source, and notifying the producer with {@code onOverflow}. </li>
      *     <li>{@code BackpressureOverflow.Strategy.ON_OVERFLOW_DROP_LATEST} will drop any new items emitted by the producer while
-     *     the buffer is full, without generating any {@code onError}.  Each drop will however invoke {@code onOverflow}
+     *     the buffer is full, without generating any {@code onError}.  Each drop will, however, invoke {@code onOverflow}
      *     to signal the overflow to the producer.</li>
      *     <li>{@code BackpressureOverflow.Strategy.ON_OVERFLOW_DROP_OLDEST} will drop the oldest items in the buffer in order to make
      *     room for newly emitted ones. Overflow will not generate an{@code onError}, but each drop will invoke
@@ -11517,7 +11517,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  are expected to honor backpressure as well.
      *  If any of them violate this expectation, the operator <em>may</em> throw an
      *  {@code IllegalStateException} when the source {@code Publisher} completes or
-     *  a {@code MissingBackpressureException} is signalled somewhere downstream.</dd>
+     *  a {@code MissingBackpressureException} is signaled somewhere downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -11560,7 +11560,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  are expected to honor backpressure as well.
      *  If any of them violate this expectation, the operator <em>may</em> throw an
      *  {@code IllegalStateException} when the source {@code Publisher} completes or
-     *  {@code MissingBackpressureException} is signalled somewhere downstream.</dd>
+     *  {@code MissingBackpressureException} is signaled somewhere downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -11599,7 +11599,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream. The source {@code Publisher}s is expected to honor
      *  backpressure as well. If it this expectation is violated, the operator <em>may</em> throw
      *  {@code IllegalStateException} when the source {@code Publisher} completes or
-     *  {@code MissingBackpressureException} is signalled somewhere downstream.</dd>
+     *  {@code MissingBackpressureException} is signaled somewhere downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onErrorReturn} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -11638,7 +11638,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator honors backpressure from downstream. The source {@code Publisher}s is expected to honor
      *  backpressure as well. If it this expectation is violated, the operator <em>may</em> throw
      *  {@code IllegalStateException} when the source {@code Publisher} completes or
-     *  {@code MissingBackpressureException} is signalled somewhere downstream.</dd>
+     *  {@code MissingBackpressureException} is signaled somewhere downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onErrorReturnItem} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -11684,7 +11684,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  are expected to honor backpressure as well.
      *  If any of them violate this expectation, the operator <em>may</em> throw an
      *  {@code IllegalStateException} when the source {@code Publisher} completes or
-     *  {@code MissingBackpressureException} is signalled somewhere downstream.</dd>
+     *  {@code MissingBackpressureException} is signaled somewhere downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onExceptionResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -11857,7 +11857,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator expects the source {@code Publisher} to honor backpressure and if this expectation is
      *  violated, the operator will signal a {@code MissingBackpressureException} through the {@code Publisher}
      *  provided to the function. Since the {@code Publisher} returned by the {@code selector} may be
-     *  independent from the provided {@code Publisher} to the function, the output's backpressure behavior
+     *  independent of the provided {@code Publisher} to the function, the output's backpressure behavior
      *  is determined by this returned {@code Publisher}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code publish} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -11889,7 +11889,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>The operator expects the source {@code Publisher} to honor backpressure and if this expectation is
      *  violated, the operator will signal a {@code MissingBackpressureException} through the {@code Publisher}
      *  provided to the function. Since the {@code Publisher} returned by the {@code selector} may be
-     *  independent from the provided {@code Publisher} to the function, the output's backpressure behavior
+     *  independent of the provided {@code Publisher} to the function, the output's backpressure behavior
      *  is determined by this returned {@code Publisher}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code publish} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -11975,7 +11975,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Publisher into the same function, and so on until all items have been emitted by the finite source Publisher,
      * and emits the final result from the final call to your function as its sole item.
      * <p>
-     * If the source is empty, a {@code NoSuchElementException} is signalled.
+     * If the source is empty, a {@code NoSuchElementException} is signaled.
      * <p>
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/reduce.png" alt="">
      * <p>
@@ -13027,7 +13027,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that the inner {@code Publisher} returned by the handler function should signal
      * either {@code onNext}, {@code onError} or {@code onComplete} in response to the received
      * {@code Throwable} to indicate the operator should retry or terminate. If the upstream to
-     * the operator is asynchronous, signalling onNext followed by onComplete immediately may
+     * the operator is asynchronous, signaling onNext followed by onComplete immediately may
      * result in the sequence to be completed immediately. Similarly, if this inner
      * {@code Publisher} signals {@code onError} or {@code onComplete} while the upstream is
      * active, the sequence is terminated with the same signal immediately.
@@ -13314,7 +13314,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
-     *  Violating this expectation, a {@code MissingBackpressureException} <em>may</em> get signalled somewhere downstream.</dd>
+     *  Violating this expectation, a {@code MissingBackpressureException} <em>may</em> get signaled somewhere downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code scan} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -13363,7 +13363,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
-     *  Violating this expectation, a {@code MissingBackpressureException} <em>may</em> get signalled somewhere downstream.</dd>
+     *  Violating this expectation, a {@code MissingBackpressureException} <em>may</em> get signaled somewhere downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code scan} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -13402,7 +13402,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
-     *  Violating this expectation, a {@code MissingBackpressureException} <em>may</em> get signalled somewhere downstream.</dd>
+     *  Violating this expectation, a {@code MissingBackpressureException} <em>may</em> get signaled somewhere downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code scanWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -13460,14 +13460,14 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Returns a new {@link Publisher} that multicasts (and shares a single subscription to) the original {@link Publisher}. As long as
      * there is at least one {@link Subscriber} this {@link Publisher} will be subscribed and emitting data.
-     * When all subscribers have cancelled it will cancel the source {@link Publisher}.
+     * When all subscribers have canceled it will cancel the source {@link Publisher}.
      * <p>
      * This is an alias for {@link #publish()}.{@link ConnectableFlowable#refCount() refCount()}.
      * <p>
      * <img width="640" height="510" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/publishRefCount.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure and and expects the source {@code Publisher} to honor backpressure as well.
+     *  <dd>The operator honors backpressure and expects the source {@code Publisher} to honor backpressure as well.
      *  If this expectation is violated, the operator will signal a {@code MissingBackpressureException} to
      *  its {@code Subscriber}s.</dd>
      *  <dt><b>Scheduler:</b></dt>
@@ -13512,7 +13512,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Returns a Single that emits the single item emitted by the source Publisher, if that Publisher
      * emits only a single item, or a default item if the source Publisher emits no items. If the source
-     * Publisher emits more than one item, an {@code IllegalArgumentException} is signalled instead.
+     * Publisher emits more than one item, an {@code IllegalArgumentException} is signaled instead.
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleOrDefault.png" alt="">
      * <dl>
@@ -13540,8 +13540,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Returns a Single that emits the single item emitted by this Flowable, if this Flowable
      * emits only a single item, otherwise
-     * if this Flowable completes without emitting any items a {@link NoSuchElementException} will be signalled and
-     * if this Flowable emits more than one item, an {@code IllegalArgumentException} will be signalled.
+     * if this Flowable completes without emitting any items a {@link NoSuchElementException} will be signaled and
+     * if this Flowable emits more than one item, an {@code IllegalArgumentException} will be signaled.
      * <p>
      * <img width="640" height="205" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleOrError.png" alt="">
      * <dl>
@@ -13598,7 +13598,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/skip.t.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator doesn't support backpressure as it uses time to skip arbitrary number of elements and
+     *  <dd>The operator doesn't support backpressure as it uses time to skip an arbitrary number of elements and
      *  thus has to consume the source {@code Publisher} in an unbounded manner (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code skip} does not operate on any particular scheduler but uses the current time
@@ -13627,7 +13627,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/skip.ts.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator doesn't support backpressure as it uses time to skip arbitrary number of elements and
+     *  <dd>The operator doesn't support backpressure as it uses time to skip an arbitrary number of elements and
      *  thus has to consume the source {@code Publisher} in an unbounded manner (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use for the timed skipping</dd>
@@ -13697,7 +13697,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note: this action will cache the latest items arriving in the specified time window.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator doesn't support backpressure as it uses time to skip arbitrary number of elements and
+     *  <dd>The operator doesn't support backpressure as it uses time to skip an arbitrary number of elements and
      *  thus has to consume the source {@code Publisher} in an unbounded manner (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code skipLast} does not operate on any particular scheduler but uses the current time
@@ -13728,7 +13728,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note: this action will cache the latest items arriving in the specified time window.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator doesn't support backpressure as it uses time to skip arbitrary number of elements and
+     *  <dd>The operator doesn't support backpressure as it uses time to skip an arbitrary number of elements and
      *  thus has to consume the source {@code Publisher} in an unbounded manner (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code skipLast} does not operate on any particular scheduler but uses the current time
@@ -13740,8 +13740,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param unit
      *            the time unit of {@code time}
      * @param delayError
-     *            if true, an exception signalled by the current Flowable is delayed until the regular elements are consumed
-     *            by the downstream; if false, an exception is immediately signalled and all regular elements dropped
+     *            if true, an exception signaled by the current Flowable is delayed until the regular elements are consumed
+     *            by the downstream; if false, an exception is immediately signaled and all regular elements dropped
      * @return a Flowable that drops those items emitted by the source Publisher in a time window before the
      *         source completes defined by {@code time}
      * @see <a href="http://reactivex.io/documentation/operators/skiplast.html">ReactiveX operators documentation: SkipLast</a>
@@ -13762,7 +13762,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note: this action will cache the latest items arriving in the specified time window.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator doesn't support backpressure as it uses time to skip arbitrary number of elements and
+     *  <dd>The operator doesn't support backpressure as it uses time to skip an arbitrary number of elements and
      *  thus has to consume the source {@code Publisher} in an unbounded manner (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use for tracking the current time</dd>
@@ -13794,7 +13794,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note: this action will cache the latest items arriving in the specified time window.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator doesn't support backpressure as it uses time to skip arbitrary number of elements and
+     *  <dd>The operator doesn't support backpressure as it uses time to skip an arbitrary number of elements and
      *  thus has to consume the source {@code Publisher} in an unbounded manner (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use to track the current time</dd>
@@ -13807,8 +13807,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param scheduler
      *            the scheduler used as the time source
      * @param delayError
-     *            if true, an exception signalled by the current Flowable is delayed until the regular elements are consumed
-     *            by the downstream; if false, an exception is immediately signalled and all regular elements dropped
+     *            if true, an exception signaled by the current Flowable is delayed until the regular elements are consumed
+     *            by the downstream; if false, an exception is immediately signaled and all regular elements dropped
      * @return a Flowable that drops those items emitted by the source Publisher in a time window before the
      *         source completes defined by {@code time} and {@code scheduler}
      * @see <a href="http://reactivex.io/documentation/operators/skiplast.html">ReactiveX operators documentation: SkipLast</a>
@@ -13829,7 +13829,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note: this action will cache the latest items arriving in the specified time window.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator doesn't support backpressure as it uses time to skip arbitrary number of elements and
+     *  <dd>The operator doesn't support backpressure as it uses time to skip an arbitrary number of elements and
      *  thus has to consume the source {@code Publisher} in an unbounded manner (i.e., no backpressure applied to it).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -13842,8 +13842,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param scheduler
      *            the scheduler used as the time source
      * @param delayError
-     *            if true, an exception signalled by the current Flowable is delayed until the regular elements are consumed
-     *            by the downstream; if false, an exception is immediately signalled and all regular elements dropped
+     *            if true, an exception signaled by the current Flowable is delayed until the regular elements are consumed
+     *            by the downstream; if false, an exception is immediately signaled and all regular elements dropped
      * @param bufferSize
      *            the hint about how many elements to expect to be skipped
      * @return a Flowable that drops those items emitted by the source Publisher in a time window before the
@@ -14456,7 +14456,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>If the source {@code Publisher} is empty, the alternate {@code Publisher} is expected to honor backpressure.
      *  If the source {@code Publisher} is non-empty, it is expected to honor backpressure as instead.
      *  In either case, if violated, a {@code MissingBackpressureException} <em>may</em> get
-     *  signalled somewhere downstream.
+     *  signaled somewhere downstream.
      *  </dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code switchIfEmpty} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -14482,7 +14482,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * of these Publishers.
      * <p>
      * The resulting Publisher completes if both the upstream Publisher and the last inner Publisher, if any, complete.
-     * If the upstream Publisher signals an onError, the inner Publisher is cancelled and the error delivered in-sequence.
+     * If the upstream Publisher signals an onError, the inner Publisher is canceled and the error delivered in-sequence.
      * <p>
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
      * <dl>
@@ -14515,7 +14515,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * of these Publishers.
      * <p>
      * The resulting Publisher completes if both the upstream Publisher and the last inner Publisher, if any, complete.
-     * If the upstream Publisher signals an onError, the inner Publisher is cancelled and the error delivered in-sequence.
+     * If the upstream Publisher signals an onError, the inner Publisher is canceled and the error delivered in-sequence.
      * <p>
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
      * <dl>
@@ -14570,7 +14570,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  If they fail concurrently, the operator may combine the {@code Throwable}s into a
      *  {@link io.reactivex.exceptions.CompositeException CompositeException}
      *  and signal it to the downstream instead. If any inactivated (switched out) {@code CompletableSource}
-     *  signals an {@code onError} late, the {@code Throwable}s will be signalled to the global error handler via
+     *  signals an {@code onError} late, the {@code Throwable}s will be signaled to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors.
      *  </dd>
      * </dl>
@@ -14612,11 +14612,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>Errors of this {@code Flowable} and all the {@code CompletableSource}s, who had the chance
      *  to run to their completion, are delayed until
      *  all of them terminate in some fashion. At this point, if there was only one failure, the respective
-     *  {@code Throwable} is emitted to the dowstream. It there were more than one failures, the
+     *  {@code Throwable} is emitted to the downstream. If there was more than one failure, the
      *  operator combines all {@code Throwable}s into a {@link io.reactivex.exceptions.CompositeException CompositeException}
      *  and signals that to the downstream.
      *  If any inactivated (switched out) {@code CompletableSource}
-     *  signals an {@code onError} late, the {@code Throwable}s will be signalled to the global error handler via
+     *  signals an {@code onError} late, the {@code Throwable}s will be signaled to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors.
      *  </dd>
      * </dl>
@@ -14643,7 +14643,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * The resulting Publisher completes if both the upstream Publisher and the last inner Publisher, if any, complete.
      * If the upstream Publisher signals an onError, the termination of the last inner Publisher will emit that error as is
-     * or wrapped into a CompositeException along with the other possible errors the former inner Publishers signalled.
+     * or wrapped into a CompositeException along with the other possible errors the former inner Publishers signaled.
      * <p>
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
      * <dl>
@@ -14678,7 +14678,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * The resulting Publisher completes if both the upstream Publisher and the last inner Publisher, if any, complete.
      * If the upstream Publisher signals an onError, the termination of the last inner Publisher will emit that error as is
-     * or wrapped into a CompositeException along with the other possible errors the former inner Publishers signalled.
+     * or wrapped into a CompositeException along with the other possible errors the former inner Publishers signaled.
      * <p>
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.png" alt="">
      * <dl>
@@ -15086,8 +15086,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param scheduler
      *            the {@link Scheduler} that provides the timestamps for the observed items
      * @param delayError
-     *            if true, an exception signalled by the current Flowable is delayed until the regular elements are consumed
-     *            by the downstream; if false, an exception is immediately signalled and all regular elements dropped
+     *            if true, an exception signaled by the current Flowable is delayed until the regular elements are consumed
+     *            by the downstream; if false, an exception is immediately signaled and all regular elements dropped
      * @param bufferSize
      *            the hint about how many elements to expect to be last
      * @return a Flowable that emits at most {@code count} items from the source Publisher that were emitted
@@ -15160,8 +15160,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param unit
      *            the time unit of {@code time}
      * @param delayError
-     *            if true, an exception signalled by the current Flowable is delayed until the regular elements are consumed
-     *            by the downstream; if false, an exception is immediately signalled and all regular elements dropped
+     *            if true, an exception signaled by the current Flowable is delayed until the regular elements are consumed
+     *            by the downstream; if false, an exception is immediately signaled and all regular elements dropped
      * @return a Flowable that emits the items from the source Publisher that were emitted in the window of
      *         time before the Publisher completed specified by {@code time}
      * @see <a href="http://reactivex.io/documentation/operators/takelast.html">ReactiveX operators documentation: TakeLast</a>
@@ -15230,8 +15230,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param scheduler
      *            the Scheduler that provides the timestamps for the Observed items
      * @param delayError
-     *            if true, an exception signalled by the current Flowable is delayed until the regular elements are consumed
-     *            by the downstream; if false, an exception is immediately signalled and all regular elements dropped
+     *            if true, an exception signaled by the current Flowable is delayed until the regular elements are consumed
+     *            by the downstream; if false, an exception is immediately signaled and all regular elements dropped
      * @return a Flowable that emits the items from the source Publisher that were emitted in the window of
      *         time before the Publisher completed specified by {@code time}, where the timing information is
      *         provided by {@code scheduler}
@@ -15267,8 +15267,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param scheduler
      *            the Scheduler that provides the timestamps for the Observed items
      * @param delayError
-     *            if true, an exception signalled by the current Flowable is delayed until the regular elements are consumed
-     *            by the downstream; if false, an exception is immediately signalled and all regular elements dropped
+     *            if true, an exception signaled by the current Flowable is delayed until the regular elements are consumed
+     *            by the downstream; if false, an exception is immediately signaled and all regular elements dropped
      * @param bufferSize
      *            the hint about how many elements to expect to be last
      * @return a Flowable that emits the items from the source Publisher that were emitted in the window of
@@ -15377,7 +15377,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Returns a Flowable that emits only the first item emitted by the source Publisher during sequential
      * time windows of a specified duration.
      * <p>
-     * This differs from {@link #throttleLast} in that this only tracks passage of time whereas
+     * This differs from {@link #throttleLast} in that this only tracks the passage of time whereas
      * {@link #throttleLast} ticks at scheduled intervals.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleFirst.png" alt="">
@@ -15407,7 +15407,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Returns a Flowable that emits only the first item emitted by the source Publisher during sequential
      * time windows of a specified duration, where the windows are managed by a specified Scheduler.
      * <p>
-     * This differs from {@link #throttleLast} in that this only tracks passage of time whereas
+     * This differs from {@link #throttleLast} in that this only tracks the passage of time whereas
      * {@link #throttleLast} ticks at scheduled intervals.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleFirst.s.png" alt="">
@@ -15443,7 +15443,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * time windows of a specified duration.
      * <p>
      * This differs from {@link #throttleFirst} in that this ticks along at a scheduled interval whereas
-     * {@link #throttleFirst} does not tick, it just tracks passage of time.
+     * {@link #throttleFirst} does not tick, it just tracks the passage of time.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLast.png" alt="">
      * <dl>
@@ -15475,7 +15475,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * time windows of a specified duration, where the duration is governed by a specified Scheduler.
      * <p>
      * This differs from {@link #throttleFirst} in that this ticks along at a scheduled interval whereas
-     * {@link #throttleFirst} does not tick, it just tracks passage of time.
+     * {@link #throttleFirst} does not tick, it just tracks the passage of time.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLast.s.png" alt="">
      * <dl>
@@ -15868,7 +15868,7 @@ public abstract class Flowable<T> implements Publisher<T> {
 
     /**
      * Returns a Flowable that mirrors the source Publisher but applies a timeout policy for each emitted
-     * item, where this policy is governed on a specified Scheduler. If the next item isn't emitted within the
+     * item, where this policy is governed by a specified Scheduler. If the next item isn't emitted within the
      * specified timeout duration starting from its predecessor, the resulting Publisher terminates and
      * notifies Subscribers of a {@code TimeoutException}.
      * <p>
@@ -15910,7 +15910,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  are expected to honor backpressure as well. If any of then violates this rule, it <em>may</em> throw an
      *  {@code IllegalStateException} when the {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code timeout} does not operates by default on any {@link Scheduler}.</dd>
+     *  <dd>{@code timeout} does not operate by default on any {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <U>
@@ -15951,7 +15951,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  If any of the source {@code Publisher}s violate this, it <em>may</em> throw an
      *  {@code IllegalStateException} when the source {@code Publisher} completes.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code timeout} does not operates by default on any {@link Scheduler}.</dd>
+     *  <dd>{@code timeout} does not operate by default on any {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <U>
@@ -17668,8 +17668,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Returns a Flowable that emits items that are the result of applying a specified function to pairs of
      * values, one each from the source Publisher and another specified Publisher.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -17715,8 +17715,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Returns a Flowable that emits items that are the result of applying a specified function to pairs of
      * values, one each from the source Publisher and another specified Publisher.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -17765,8 +17765,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Returns a Flowable that emits items that are the result of applying a specified function to pairs of
      * values, one each from the source Publisher and another specified Publisher.
      * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while cancelling the other sources. Therefore, it
+     * The operator subscribes to its sources in the order they are specified and completes eagerly if
+     * one of the sources is shorter than the rest while canceling the other sources. Therefore, it
      * is possible those other sources will never be able to run to completion (and thus not calling
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
@@ -17870,7 +17870,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param initialRequest the initial request amount, positive
-     * @param cancel should the TestSubscriber be cancelled before the subscription?
+     * @param cancel should the TestSubscriber be canceled before the subscription?
      * @return the new TestSubscriber instance
      * @since 2.0
      */

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -6885,7 +6885,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the type of the inner Publisher sources and thus the output type
      * @param mapper
-     *            a function that, when applied to an item emitted by the source Publisher, returns an
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
      *            Publisher
      * @return a Flowable that emits the result of applying the transformation function to each item emitted
      *         by the source Publisher and concatenating the Publishers obtained from this transformation
@@ -6917,7 +6917,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the type of the inner Publisher sources and thus the output type
      * @param mapper
-     *            a function that, when applied to an item emitted by the source Publisher, returns an
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
      *            Publisher
      * @param prefetch
      *            the number of elements to prefetch from the current Flowable
@@ -9190,7 +9190,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the value type of the inner Publishers and the output type
      * @param mapper
-     *            a function that, when applied to an item emitted by the source Publisher, returns an
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
      *            Publisher
      * @return a Flowable that emits the result of applying the transformation function to each item emitted
      *         by the source Publisher and merging the results of the Publishers obtained from this
@@ -9222,7 +9222,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the value type of the inner Publishers and the output type
      * @param mapper
-     *            a function that, when applied to an item emitted by the source Publisher, returns an
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
      *            Publisher
      * @param delayErrors
      *            if true, exceptions from the current Flowable and all inner Publishers are delayed until all of them terminate
@@ -9258,7 +9258,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the value type of the inner Publishers and the output type
      * @param mapper
-     *            a function that, when applied to an item emitted by the source Publisher, returns an
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
      *            Publisher
      * @param maxConcurrency
      *         the maximum number of Publishers that may be subscribed to concurrently
@@ -9294,7 +9294,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the value type of the inner Publishers and the output type
      * @param mapper
-     *            a function that, when applied to an item emitted by the source Publisher, returns an
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
      *            Publisher
      * @param maxConcurrency
      *         the maximum number of Publishers that may be subscribed to concurrently
@@ -9333,7 +9333,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the value type of the inner Publishers and the output type
      * @param mapper
-     *            a function that, when applied to an item emitted by the source Publisher, returns an
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
      *            Publisher
      * @param maxConcurrency
      *         the maximum number of Publishers that may be subscribed to concurrently
@@ -14497,7 +14497,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the element type of the inner Publishers and the output
      * @param mapper
-     *            a function that, when applied to an item emitted by the source Publisher, returns an
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
      *            Publisher
      * @return a Flowable that emits the items emitted by the Publisher returned from applying {@code func} to the most recently emitted item emitted by the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
@@ -14530,7 +14530,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the element type of the inner Publishers and the output
      * @param mapper
-     *            a function that, when applied to an item emitted by the source Publisher, returns an
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
      *            Publisher
      * @param bufferSize
      *            the number of elements to prefetch from the current active inner Publisher
@@ -14658,7 +14658,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the element type of the inner Publishers and the output
      * @param mapper
-     *            a function that, when applied to an item emitted by the source Publisher, returns an
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
      *            Publisher
      * @return a Flowable that emits the items emitted by the Publisher returned from applying {@code func} to the most recently emitted item emitted by the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
@@ -14693,7 +14693,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the element type of the inner Publishers and the output
      * @param mapper
-     *            a function that, when applied to an item emitted by the source Publisher, returns an
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
      *            Publisher
      * @param bufferSize
      *            the number of elements to prefetch from the current active inner Publisher

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2978,7 +2978,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <R> the result value type
      * @param mapper
-     *            a function that, when applied to the item emitted by the source Maybe, returns an
+     *            a function that, when applied to the item emitted by the source Maybe, returns a
      *            Flowable
      * @return the Flowable returned from {@code func} when applied to the item emitted by the source Maybe
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3139,7 +3139,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * 
      * public final class CustomMaybeObserver&lt;T&gt; implements MaybeObserver&lt;T&gt;, Disposable {
      *
-     *     // The donstream's MaybeObserver that will receive the onXXX events
+     *     // The downstream's MaybeObserver that will receive the onXXX events
      *     final MaybeObserver&lt;? super String&gt; downstream;
      *
      *     // The connection to the upstream source that will call this class' onXXX methods

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -9386,7 +9386,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * 
      * public final class CustomObserver&lt;T&gt; implements Observer&lt;T&gt;, Disposable {
      *
-     *     // The donstream's Observer that will receive the onXXX events
+     *     // The downstream's Observer that will receive the onXXX events
      *     final Observer&lt;? super String&gt; downstream;
      *
      *     // The connection to the upstream source that will call this class' onXXX methods
@@ -12250,7 +12250,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>Errors of this {@code Observable} and all the {@code CompletableSource}s, who had the chance
      *  to run to their completion, are delayed until
      *  all of them terminate in some fashion. At this point, if there was only one failure, the respective
-     *  {@code Throwable} is emitted to the dowstream. It there were more than one failures, the
+     *  {@code Throwable} is emitted to the downstream. It there were more than one failures, the
      *  operator combines all {@code Throwable}s into a {@link io.reactivex.exceptions.CompositeException CompositeException}
      *  and signals that to the downstream.
      *  If any inactivated (switched out) {@code CompletableSource}

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2365,7 +2365,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *
      * @param <R> the result value type
      * @param mapper
-     *            a function that, when applied to the item emitted by the source Single, returns an
+     *            a function that, when applied to the item emitted by the source Single, returns a
      *            Flowable
      * @return the Flowable returned from {@code func} when applied to the item emitted by the source Single
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2517,7 +2517,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * 
      * public final class CustomSingleObserver&lt;T&gt; implements SingleObserver&lt;T&gt;, Disposable {
      *
-     *     // The donstream's SingleObserver that will receive the onXXX events
+     *     // The downstream's SingleObserver that will receive the onXXX events
      *     final SingleObserver&lt;? super String&gt; downstream;
      *
      *     // The connection to the upstream source that will call this class' onXXX methods

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletable.java
@@ -31,7 +31,7 @@ import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
- * Maps the upstream intems into {@link CompletableSource}s and subscribes to them one after the
+ * Maps the upstream items into {@link CompletableSource}s and subscribes to them one after the
  * other completes or terminates (in error-delaying mode).
  * @param <T> the upstream value type
  * @since 2.1.11 - experimental

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletable.java
@@ -28,7 +28,7 @@ import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
- * Maps the upstream intems into {@link CompletableSource}s and subscribes to them one after the
+ * Maps the upstream items into {@link CompletableSource}s and subscribes to them one after the
  * other completes or terminates (in error-delaying mode).
  * @param <T> the upstream value type
  * @since 2.1.11 - experimental

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -49,7 +49,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * <p>
  * <img width="640" height="415" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/ReplayProcessor.t.png" alt="">
  * </li>
- * <li>{@link #createWithTimeAndSize(long, TimeUnit, Scheduler, int)}: retaims no more than the given number of items
+ * <li>{@link #createWithTimeAndSize(long, TimeUnit, Scheduler, int)}: retains no more than the given number of items
  * which are also no older than the specified time and replays them to new {@code Subscriber}s (which could mean all items age out).
  * <p>
  * <img width="640" height="404" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/ReplayProcessor.nt.png" alt="">

--- a/src/test/java/io/reactivex/JavadocWording.java
+++ b/src/test/java/io/reactivex/JavadocWording.java
@@ -816,6 +816,7 @@ public class JavadocWording {
             }
         }
 
+        jdx = 0;
         for (;;) {
             idx = m.javadoc.indexOf(wrongPre + " {@link " + word, jdx);
             if (idx >= 0) {
@@ -832,6 +833,7 @@ public class JavadocWording {
             }
         }
 
+        jdx = 0;
         for (;;) {
             idx = m.javadoc.indexOf(wrongPre + " {@linkplain " + word, jdx);
             if (idx >= 0) {
@@ -848,6 +850,7 @@ public class JavadocWording {
             }
         }
 
+        jdx = 0;
         for (;;) {
             idx = m.javadoc.indexOf(wrongPre + " {@code " + word, jdx);
             if (idx >= 0) {
@@ -863,7 +866,41 @@ public class JavadocWording {
                 break;
             }
         }
+        
+        // remove linebreaks and multi-spaces
+        String javadoc2 = m.javadoc.replace("\n", " ").replace("\r", " ").replaceAll("\\s+", " ");
+        
+        // strip {@xxx } tags
+        int kk = 0;
+        for (;;) {
+            int jj = javadoc2.indexOf("{@", kk);
+            if (jj < 0) {
+                break;
+            }
+            int nn = javadoc2.indexOf(" ", jj + 2);
+            int mm = javadoc2.indexOf("}", jj + 2);
+            
+            javadoc2 = javadoc2.substring(0, jj) + javadoc2.substring(nn + 1, mm) + javadoc2.substring(mm + 1);
 
+            kk = mm + 1;
+        }
+        
+        jdx = 0;
+        for (;;) {
+            idx = javadoc2.indexOf(wrongPre + " " + word, jdx);
+            if (idx >= 0) {
+                e.append("java.lang.RuntimeException: a/an typo ")
+                .append(word)
+                .append("\r\n at io.reactivex.")
+                .append(baseTypeName)
+                .append(" (")
+                .append(baseTypeName)
+                .append(".java:").append(m.javadocLine).append(")\r\n\r\n");
+                jdx = idx + wrongPre.length() + 1 + word.length();
+            } else {
+                break;
+            }
+        }
     }
 
     static void missingClosingDD(StringBuilder e, RxMethod m, String baseTypeName) {

--- a/src/test/java/io/reactivex/JavadocWording.java
+++ b/src/test/java/io/reactivex/JavadocWording.java
@@ -868,7 +868,9 @@ public class JavadocWording {
         }
         
         // remove linebreaks and multi-spaces
-        String javadoc2 = m.javadoc.replace("\n", " ").replace("\r", " ").replaceAll("\\s+", " ");
+        String javadoc2 = m.javadoc.replace("\n", " ").replace("\r", " ")
+                .replace(" * ", " ")
+                .replaceAll("\\s+", " ");
         
         // strip {@xxx } tags
         int kk = 0;


### PR DESCRIPTION
This PR fixes a bunch of typos (in many files) and grammar mistakes in `Flowable` (based on Grammarly checks).

The PR also fixes the `JavadocWording` checks to start from the beginning of the method's javadoc as well as checking for cross-line a/an typos.