### PR TITLE
2.x: Workaround for Objects.requireNonNull inserted by javac

### DIFF
--- a/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
@@ -430,7 +430,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     public void unicastSubscriptionBadRequest() {
         UnicastProcessor<Integer> us = UnicastProcessor.create(false);
 
-        UnicastProcessor<Integer>.UnicastQueueSubscription usc = us.new UnicastQueueSubscription();
+        UnicastProcessor<Integer>.UnicastQueueSubscription usc = (UnicastProcessor<Integer>.UnicastQueueSubscription)us.wip;
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {


### PR DESCRIPTION
For some reason, when compiling RxJava with Java 9 or 10 and target 8, there is an implicit `Objects.requireNonNull` added by the compiler to `us.new X` which makes AnimalSniffer detect a non-Java 6 API usage. Interestingly, this does not happen with:

- Java 8 target 6, 
- Java 8 target 8, 
- Java 9 target 6, 
- Java 9 target 9, 
- Java 10 target 6, 
- Java 10 target 9,
- Java 10 target 10

or AnimalSniffer doesn't detect it for non-8 targets somehow. I know that the latest AnimalSniffer doesn't work with (some?) Java 9 class files, but it doesn't explain why the fully supported Java 8 target 8 does not trigger this error but Java 9 target 8 does.

I have reported this anomaly as a potential javac bug.

The build matrices and outcomes for RxJava 2 can be found here: https://travis-ci.org/akarnokd/RxJava2_9/builds