### PR TITLE
2.x: Maybe/Single Javadoc; annotation cleanup

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3503,7 +3503,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Instructs a Maybe to pass control to another MaybeSource rather than invoking
+     * Instructs a Maybe to pass control to another {@link MaybeSource} rather than invoking
      * {@link MaybeObserver#onError onError} if it encounters an error.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
@@ -3516,7 +3516,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param next
-     *            the next Maybe source that will take over if the source Maybe encounters
+     *            the next {@code MaybeSource} that will take over if the source Maybe encounters
      *            an error
      * @return the new Maybe instance
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
@@ -4348,14 +4348,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * If this Maybe source didn't signal an event before the timeoutIndicator MaybeSource signals, a
-     * TimeoutException is signalled instead.
+     * If the current {@code Maybe} didn't signal an event before the {@code timeoutIndicator} {@link MaybeSource} signals, a
+     * {@link TimeoutException} is signaled instead.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeout} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <U> the value type of the
-     * @param timeoutIndicator the MaybeSource that indicates the timeout by signalling onSuccess
+     * @param timeoutIndicator the {@code MaybeSource} that indicates the timeout by signaling onSuccess
      * or onComplete.
      * @return the new Maybe instance
      */
@@ -4367,17 +4367,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * If the current Maybe source didn't signal an event before the timeoutIndicator MaybeSource signals,
-     * the current Maybe is cancelled and the {@code fallback} MaybeSource subscribed to
+     * If the current {@code Maybe} didn't signal an event before the {@code timeoutIndicator} {@link MaybeSource} signals,
+     * the current {@code Maybe} is cancelled and the {@code fallback} {@code MaybeSource} subscribed to
      * as a continuation.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeout} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <U> the value type of the
-     * @param timeoutIndicator the MaybeSource that indicates the timeout by signalling onSuccess
-     * or onComplete.
-     * @param fallback the MaybeSource that is subscribed to if the current Maybe times out
+     * @param timeoutIndicator the {@code MaybeSource} that indicates the timeout by signaling {@code onSuccess}
+     * or {@code onComplete}.
+     * @param fallback the {@code MaybeSource} that is subscribed to if the current {@code Maybe} times out
      * @return the new Maybe instance
      */
     @CheckReturnValue
@@ -4389,8 +4389,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * If this Maybe source didn't signal an event before the timeoutIndicator Publisher signals, a
-     * TimeoutException is signalled instead.
+     * If the current {@code Maybe} source didn't signal an event before the {@code timeoutIndicator} {@link Publisher} signals, a
+     * {@link TimeoutException} is signaled instead.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The {@code timeoutIndicator} {@link Publisher} is consumed in an unbounded manner and
@@ -4399,8 +4399,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code timeout} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <U> the value type of the
-     * @param timeoutIndicator the MaybeSource that indicates the timeout by signalling onSuccess
-     * or onComplete.
+     * @param timeoutIndicator the {@code MaybeSource} that indicates the timeout by signaling {@code onSuccess}
+     * or {@code onComplete}.
      * @return the new Maybe instance
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
@@ -4412,8 +4412,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * If the current Maybe source didn't signal an event before the timeoutIndicator Publisher signals,
-     * the current Maybe is cancelled and the {@code fallback} MaybeSource subscribed to
+     * If the current {@code Maybe} didn't signal an event before the {@code timeoutIndicator} {@link Publisher} signals,
+     * the current {@code Maybe} is cancelled and the {@code fallback} {@code MaybeSource} subscribed to
      * as a continuation.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -4423,9 +4423,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code timeout} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <U> the value type of the
-     * @param timeoutIndicator the MaybeSource that indicates the timeout by signalling onSuccess
-     * or onComplete
-     * @param fallback the MaybeSource that is subscribed to if the current Maybe times out
+     * @param timeoutIndicator the {@code MaybeSource} that indicates the timeout by signaling {@code onSuccess}
+     * or {@code onComplete}
+     * @param fallback the {@code MaybeSource} that is subscribed to if the current {@code Maybe} times out
      * @return the new Maybe instance
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -336,7 +336,6 @@ public abstract class Single<T> implements SingleSource<T> {
      * @param sources a sequence of Single that need to be eagerly concatenated
      * @return the new Flowable instance with the specified concatenation behavior
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -362,7 +361,6 @@ public abstract class Single<T> implements SingleSource<T> {
      * @param sources a sequence of Publishers that need to be eagerly concatenated
      * @return the new Publisher instance with the specified concatenation behavior
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -386,7 +384,6 @@ public abstract class Single<T> implements SingleSource<T> {
      * @param sources a sequence of SingleSource that need to be eagerly concatenated
      * @return the new Flowable instance with the specified concatenation behavior
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -436,14 +433,14 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Calls a Callable for each individual SingleObserver to return the actual Single source to
+     * Calls a {@link Callable} for each individual {@link SingleObserver} to return the actual {@link SingleSource} to
      * be subscribed to.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param singleSupplier the Callable that is called for each individual SingleObserver and
+     * @param singleSupplier the {@code Callable} that is called for each individual {@code SingleObserver} and
      * returns a SingleSource instance to subscribe to
      * @return the new Single instance
      */

--- a/src/test/java/io/reactivex/JavadocWording.java
+++ b/src/test/java/io/reactivex/JavadocWording.java
@@ -866,12 +866,12 @@ public class JavadocWording {
                 break;
             }
         }
-        
+
         // remove linebreaks and multi-spaces
         String javadoc2 = m.javadoc.replace("\n", " ").replace("\r", " ")
                 .replace(" * ", " ")
                 .replaceAll("\\s+", " ");
-        
+
         // strip {@xxx } tags
         int kk = 0;
         for (;;) {
@@ -881,12 +881,12 @@ public class JavadocWording {
             }
             int nn = javadoc2.indexOf(" ", jj + 2);
             int mm = javadoc2.indexOf("}", jj + 2);
-            
+
             javadoc2 = javadoc2.substring(0, jj) + javadoc2.substring(nn + 1, mm) + javadoc2.substring(mm + 1);
 
             kk = mm + 1;
         }
-        
+
         jdx = 0;
         for (;;) {
             idx = javadoc2.indexOf(wrongPre + " " + word, jdx);

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -403,7 +403,7 @@ public class ObservableConcatMapMaybeTest {
     @Test
     public void checkUnboundedInnerQueue() {
         MaybeSubject<Integer> ms = MaybeSubject.create();
-        
+
         @SuppressWarnings("unchecked")
         TestObserver<Integer> to = Observable
                 .fromArray(ms, Maybe.just(2), Maybe.just(3), Maybe.just(4))

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -340,7 +340,7 @@ public class ObservableConcatMapSingleTest {
     @Test
     public void checkUnboundedInnerQueue() {
         SingleSubject<Integer> ss = SingleSubject.create();
-        
+
         @SuppressWarnings("unchecked")
         TestObserver<Integer> to = Observable
                 .fromArray(ss, Single.just(2), Single.just(3), Single.just(4))

--- a/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
@@ -108,7 +108,6 @@ public class SingleConcatTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatEagerPublisherTest() {
         PublishProcessor<String> pp1 = PublishProcessor.create();


### PR DESCRIPTION
The PR cleans up some wording around "Single source" and "Maybe source", plus removes some unnecessary annotations.