### PR TITLE
2.x: Fix Flowable.take to route post-cancel errors to RxJavaPlugins.onError

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTake.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTake.java
@@ -19,6 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.internal.subscriptions.*;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
     final long limit;
@@ -75,6 +76,8 @@ public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
                 done = true;
                 subscription.cancel();
                 actual.onError(t);
+            } else {
+                RxJavaPlugins.onError(t);
             }
         }
         @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableLimitTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableLimitTest.java
@@ -207,4 +207,19 @@ public class FlowableLimitTest implements LongConsumer, Action {
             ts.assertResult(1, 2, 3, 4, 5);
         }
     }
+
+    @Test
+    public void errorAfterLimitReached() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.error(new TestException())
+            .limit(0)
+            .test()
+            .assertResult();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
@@ -14,9 +14,10 @@
 package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.util.Arrays;
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
@@ -28,6 +29,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
@@ -493,6 +495,21 @@ public class FlowableTakeTest {
             TestHelper.race(r1, r1);
 
             ts.assertResult(1, 2);
+        }
+    }
+
+    @Test
+    public void errorAfterLimitReached() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.error(new TestException())
+            .take(0)
+            .test()
+            .assertResult();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
@@ -14,9 +14,10 @@
 package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.util.Arrays;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.*;
 
@@ -24,10 +25,13 @@ import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
@@ -388,5 +392,20 @@ public class ObservableTakeTest {
                 return o.take(2);
             }
         });
+    }
+
+    @Test
+    public void errorAfterLimitReached() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable.error(new TestException())
+            .take(0)
+            .test()
+            .assertResult();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }


### PR DESCRIPTION
This PR makes sure errors emitted by the upstream just after the `Flowable.take` has received the specified amount of items get routed to `RxJavaPlugins.onError`.

`Observable.take()` and `Flowable.limit()` were already doing this. Added unit tests to verify the behavior across the board.