### PR TITLE
2.x: Add throttleLatest operator

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -15506,6 +15506,158 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
+     * Throttles items from the upstream {@code Flowable} by first emitting the next
+     * item from upstream, then periodically emitting the latest item (if any) when
+     * the specified timeout elapses between them.
+     * <p>
+     * <img width="640" height="325" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLatest.png" alt="">
+     * <p>
+     * Unlike the option with {@link #throttleLatest(long, TimeUnit, boolean)}, the very last item being held back
+     * (if any) is not emitted when the upstream completes.
+     * <p>
+     * If no items were emitted from the upstream during this timeout phase, the next
+     * upstream item is emitted immediately and the timeout window starts from then.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator does not support backpressure as it uses time to control data flow.
+     *  If the downstream is not ready to receive items, a
+     *  {@link io.reactivex.exceptions.MissingBackpressureException MissingBackpressureException}
+     *  will be signaled.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code throttleLatest} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
+     * @param timeout the time to wait after an item emission towards the downstream
+     *                before trying to emit the latest item from upstream again
+     * @param unit    the time unit
+     * @return the new Flowable instance
+     * @since 2.1.14 - experimental
+     * @see #throttleLatest(long, TimeUnit, boolean)
+     * @see #throttleLatest(long, TimeUnit, Scheduler)
+     */
+    @Experimental
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.ERROR)
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
+    public final Flowable<T> throttleLatest(long timeout, TimeUnit unit) {
+        return throttleLatest(timeout, unit, Schedulers.computation(), false);
+    }
+
+    /**
+     * Throttles items from the upstream {@code Flowable} by first emitting the next
+     * item from upstream, then periodically emitting the latest item (if any) when
+     * the specified timeout elapses between them.
+     * <p>
+     * <img width="640" height="325" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLatest.e.png" alt="">
+     * <p>
+     * If no items were emitted from the upstream during this timeout phase, the next
+     * upstream item is emitted immediately and the timeout window starts from then.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator does not support backpressure as it uses time to control data flow.
+     *  If the downstream is not ready to receive items, a
+     *  {@link io.reactivex.exceptions.MissingBackpressureException MissingBackpressureException}
+     *  will be signaled.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code throttleLatest} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
+     * @param timeout the time to wait after an item emission towards the downstream
+     *                before trying to emit the latest item from upstream again
+     * @param unit    the time unit
+     * @param emitLast If {@code true}, the very last item from the upstream will be emitted
+     *                 immediately when the upstream completes, regardless if there is
+     *                 a timeout window active or not. If {@code false}, the very last
+     *                 upstream item is ignored and the flow terminates.
+     * @return the new Flowable instance
+     * @since 2.1.14 - experimental
+     * @see #throttleLatest(long, TimeUnit, Scheduler, boolean)
+     */
+    @Experimental
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.ERROR)
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
+    public final Flowable<T> throttleLatest(long timeout, TimeUnit unit, boolean emitLast) {
+        return throttleLatest(timeout, unit, Schedulers.computation(), emitLast);
+    }
+
+    /**
+     * Throttles items from the upstream {@code Flowable} by first emitting the next
+     * item from upstream, then periodically emitting the latest item (if any) when
+     * the specified timeout elapses between them.
+     * <p>
+     * <img width="640" height="325" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLatest.s.png" alt="">
+     * <p>
+     * Unlike the option with {@link #throttleLatest(long, TimeUnit, Scheduler, boolean)}, the very last item being held back
+     * (if any) is not emitted when the upstream completes.
+     * <p>
+     * If no items were emitted from the upstream during this timeout phase, the next
+     * upstream item is emitted immediately and the timeout window starts from then.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator does not support backpressure as it uses time to control data flow.
+     *  If the downstream is not ready to receive items, a
+     *  {@link io.reactivex.exceptions.MissingBackpressureException MissingBackpressureException}
+     *  will be signaled.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
+     * </dl>
+     * @param timeout the time to wait after an item emission towards the downstream
+     *                before trying to emit the latest item from upstream again
+     * @param unit    the time unit
+     * @param scheduler the {@link Scheduler} where the timed wait and latest item
+     *                  emission will be performed
+     * @return the new Flowable instance
+     * @since 2.1.14 - experimental
+     * @see #throttleLatest(long, TimeUnit, Scheduler, boolean)
+     */
+    @Experimental
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.ERROR)
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    public final Flowable<T> throttleLatest(long timeout, TimeUnit unit, Scheduler scheduler) {
+        return throttleLatest(timeout, unit, scheduler, false);
+    }
+
+    /**
+     * Throttles items from the upstream {@code Flowable} by first emitting the next
+     * item from upstream, then periodically emitting the latest item (if any) when
+     * the specified timeout elapses between them.
+     * <p>
+     * <img width="640" height="325" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLatest.se.png" alt="">
+     * <p>
+     * If no items were emitted from the upstream during this timeout phase, the next
+     * upstream item is emitted immediately and the timeout window starts from then.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator does not support backpressure as it uses time to control data flow.
+     *  If the downstream is not ready to receive items, a
+     *  {@link io.reactivex.exceptions.MissingBackpressureException MissingBackpressureException}
+     *  will be signaled.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
+     * </dl>
+     * @param timeout the time to wait after an item emission towards the downstream
+     *                before trying to emit the latest item from upstream again
+     * @param unit    the time unit
+     * @param scheduler the {@link Scheduler} where the timed wait and latest item
+     *                  emission will be performed
+     * @param emitLast If {@code true}, the very last item from the upstream will be emitted
+     *                 immediately when the upstream completes, regardless if there is
+     *                 a timeout window active or not. If {@code false}, the very last
+     *                 upstream item is ignored and the flow terminates.
+     * @return the new Flowable instance
+     * @since 2.1.14 - experimental
+     */
+    @Experimental
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.ERROR)
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    public final Flowable<T> throttleLatest(long timeout, TimeUnit unit, Scheduler scheduler, boolean emitLast) {
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        return RxJavaPlugins.onAssembly(new FlowableThrottleLatest<T>(this, timeout, unit, scheduler, emitLast));
+    }
+
+    /**
      * Returns a Flowable that only emits those items emitted by the source Publisher that are not followed
      * by another emitted item within a specified time window.
      * <p>

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -13025,6 +13025,134 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
+     * Throttles items from the upstream {@code Observable} by first emitting the next
+     * item from upstream, then periodically emitting the latest item (if any) when
+     * the specified timeout elapses between them.
+     * <p>
+     * <img width="640" height="325" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLatest.png" alt="">
+     * <p>
+     * Unlike the option with {@link #throttleLatest(long, TimeUnit, boolean)}, the very last item being held back
+     * (if any) is not emitted when the upstream completes.
+     * <p>
+     * If no items were emitted from the upstream during this timeout phase, the next
+     * upstream item is emitted immediately and the timeout window starts from then.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code throttleLatest} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
+     * @param timeout the time to wait after an item emission towards the downstream
+     *                before trying to emit the latest item from upstream again
+     * @param unit    the time unit
+     * @return the new Observable instance
+     * @since 2.1.14 - experimental
+     * @see #throttleLatest(long, TimeUnit, boolean)
+     * @see #throttleLatest(long, TimeUnit, Scheduler)
+     */
+    @Experimental
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
+    public final Observable<T> throttleLatest(long timeout, TimeUnit unit) {
+        return throttleLatest(timeout, unit, Schedulers.computation(), false);
+    }
+
+    /**
+     * Throttles items from the upstream {@code Observable} by first emitting the next
+     * item from upstream, then periodically emitting the latest item (if any) when
+     * the specified timeout elapses between them.
+     * <p>
+     * <img width="640" height="325" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLatest.e.png" alt="">
+     * <p>
+     * If no items were emitted from the upstream during this timeout phase, the next
+     * upstream item is emitted immediately and the timeout window starts from then.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code throttleLatest} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
+     * @param timeout the time to wait after an item emission towards the downstream
+     *                before trying to emit the latest item from upstream again
+     * @param unit    the time unit
+     * @param emitLast If {@code true}, the very last item from the upstream will be emitted
+     *                 immediately when the upstream completes, regardless if there is
+     *                 a timeout window active or not. If {@code false}, the very last
+     *                 upstream item is ignored and the flow terminates.
+     * @return the new Observable instance
+     * @since 2.1.14 - experimental
+     * @see #throttleLatest(long, TimeUnit, Scheduler, boolean)
+     */
+    @Experimental
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
+    public final Observable<T> throttleLatest(long timeout, TimeUnit unit, boolean emitLast) {
+        return throttleLatest(timeout, unit, Schedulers.computation(), emitLast);
+    }
+
+    /**
+     * Throttles items from the upstream {@code Observable} by first emitting the next
+     * item from upstream, then periodically emitting the latest item (if any) when
+     * the specified timeout elapses between them.
+     * <p>
+     * <img width="640" height="325" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLatest.s.png" alt="">
+     * <p>
+     * Unlike the option with {@link #throttleLatest(long, TimeUnit, Scheduler, boolean)}, the very last item being held back
+     * (if any) is not emitted when the upstream completes.
+     * <p>
+     * If no items were emitted from the upstream during this timeout phase, the next
+     * upstream item is emitted immediately and the timeout window starts from then.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
+     * </dl>
+     * @param timeout the time to wait after an item emission towards the downstream
+     *                before trying to emit the latest item from upstream again
+     * @param unit    the time unit
+     * @param scheduler the {@link Scheduler} where the timed wait and latest item
+     *                  emission will be performed
+     * @return the new Observable instance
+     * @since 2.1.14 - experimental
+     * @see #throttleLatest(long, TimeUnit, Scheduler, boolean)
+     */
+    @Experimental
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    public final Observable<T> throttleLatest(long timeout, TimeUnit unit, Scheduler scheduler) {
+        return throttleLatest(timeout, unit, scheduler, false);
+    }
+
+    /**
+     * Throttles items from the upstream {@code Observable} by first emitting the next
+     * item from upstream, then periodically emitting the latest item (if any) when
+     * the specified timeout elapses between them.
+     * <p>
+     * <img width="640" height="325" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLatest.se.png" alt="">
+     * <p>
+     * If no items were emitted from the upstream during this timeout phase, the next
+     * upstream item is emitted immediately and the timeout window starts from then.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
+     * </dl>
+     * @param timeout the time to wait after an item emission towards the downstream
+     *                before trying to emit the latest item from upstream again
+     * @param unit    the time unit
+     * @param scheduler the {@link Scheduler} where the timed wait and latest item
+     *                  emission will be performed
+     * @param emitLast If {@code true}, the very last item from the upstream will be emitted
+     *                 immediately when the upstream completes, regardless if there is
+     *                 a timeout window active or not. If {@code false}, the very last
+     *                 upstream item is ignored and the flow terminates.
+     * @return the new Observable instance
+     * @since 2.1.14 - experimental
+     */
+    @Experimental
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    public final Observable<T> throttleLatest(long timeout, TimeUnit unit, Scheduler scheduler, boolean emitLast) {
+        ObjectHelper.requireNonNull(unit, "unit is null");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        return RxJavaPlugins.onAssembly(new ObservableThrottleLatest<T>(this, timeout, unit, scheduler, emitLast));
+    }
+
+    /**
      * Returns an Observable that only emits those items emitted by the source ObservableSource that are not followed
      * by another emitted item within a specified time window.
      * <p>

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatest.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.BackpressureHelper;
+
+/**
+ * Emits the next or latest item when the given time elapses.
+ * <p>
+ * The operator emits the next item, then starts a timer. When the timer fires,
+ * it tries to emit the latest item from upstream. If there was no upstream item,
+ * in the meantime, the next upstream item is emitted immediately and the
+ * timed process repeats.
+ *
+ * @param <T> the upstream and downstream value type
+ * @since 2.1.14 - experimental
+ */
+@Experimental
+public final class FlowableThrottleLatest<T> extends AbstractFlowableWithUpstream<T, T> {
+
+    final long timeout;
+
+    final TimeUnit unit;
+
+    final Scheduler scheduler;
+
+    final boolean emitLast;
+
+    public FlowableThrottleLatest(Flowable<T> source,
+            long timeout, TimeUnit unit, Scheduler scheduler,
+            boolean emitLast) {
+        super(source);
+        this.timeout = timeout;
+        this.unit = unit;
+        this.scheduler = scheduler;
+        this.emitLast = emitLast;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        source.subscribe(new ThrottleLatestSubscriber<T>(s, timeout, unit, scheduler.createWorker(), emitLast));
+    }
+
+    static final class ThrottleLatestSubscriber<T>
+    extends AtomicInteger
+    implements FlowableSubscriber<T>, Subscription, Runnable {
+
+        private static final long serialVersionUID = -8296689127439125014L;
+
+        final Subscriber<? super T> downstream;
+
+        final long timeout;
+
+        final TimeUnit unit;
+
+        final Scheduler.Worker worker;
+
+        final boolean emitLast;
+
+        final AtomicReference<T> latest;
+
+        final AtomicLong requested;
+
+        Subscription upstream;
+
+        volatile boolean done;
+        Throwable error;
+
+        volatile boolean cancelled;
+
+        volatile boolean timerFired;
+
+        long emitted;
+
+        boolean timerRunning;
+
+        ThrottleLatestSubscriber(Subscriber<? super T> downstream,
+                long timeout, TimeUnit unit, Scheduler.Worker worker,
+                boolean emitLast) {
+            this.downstream = downstream;
+            this.timeout = timeout;
+            this.unit = unit;
+            this.worker = worker;
+            this.emitLast = emitLast;
+            this.latest = new AtomicReference<T>();
+            this.requested = new AtomicLong();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(upstream, s)) {
+                upstream = s;
+                downstream.onSubscribe(this);
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            latest.set(t);
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+            upstream.cancel();
+            worker.dispose();
+            if (getAndIncrement() == 0) {
+                latest.lazySet(null);
+            }
+        }
+
+        @Override
+        public void run() {
+            timerFired = true;
+            drain();
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+
+            AtomicReference<T> latest = this.latest;
+            AtomicLong requested = this.requested;
+            Subscriber<? super T> downstream = this.downstream;
+
+            for (;;) {
+
+                for (;;) {
+                    if (cancelled) {
+                        latest.lazySet(null);
+                        return;
+                    }
+
+                    boolean d = done;
+
+                    if (d && error != null) {
+                        latest.lazySet(null);
+                        downstream.onError(error);
+                        worker.dispose();
+                        return;
+                    }
+
+                    T v = latest.get();
+                    boolean empty = v == null;
+
+                    if (d) {
+                        if (!empty && emitLast) {
+                            v = latest.getAndSet(null);
+                            long e = emitted;
+                            if (e != requested.get()) {
+                                emitted = e + 1;
+                                downstream.onNext(v);
+                                downstream.onComplete();
+                            } else {
+                                downstream.onError(new MissingBackpressureException(
+                                        "Could not emit final value due to lack of requests"));
+                            }
+                        } else {
+                            latest.lazySet(null);
+                            downstream.onComplete();
+                        }
+                        worker.dispose();
+                        return;
+                    }
+
+                    if (empty) {
+                        if (timerFired) {
+                            timerRunning = false;
+                            timerFired = false;
+                        }
+                        break;
+                    }
+
+                    if (!timerRunning || timerFired) {
+                        v = latest.getAndSet(null);
+                        long e = emitted;
+                        if (e != requested.get()) {
+                            downstream.onNext(v);
+                            emitted = e + 1;
+                        } else {
+                            upstream.cancel();
+                            downstream.onError(new MissingBackpressureException(
+                                    "Could not emit value due to lack of requests"));
+                            worker.dispose();
+                            return;
+                        }
+
+                        timerFired = false;
+                        timerRunning = true;
+                        worker.schedule(this, timeout, unit);
+                    } else {
+                        break;
+                    }
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleLatest.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.*;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * Emits the next or latest item when the given time elapses.
+ * <p>
+ * The operator emits the next item, then starts a timer. When the timer fires,
+ * it tries to emit the latest item from upstream. If there was no upstream item,
+ * in the meantime, the next upstream item is emitted immediately and the
+ * timed process repeats.
+ *
+ * @param <T> the upstream and downstream value type
+ * @since 2.1.14 - experimental
+ */
+@Experimental
+public final class ObservableThrottleLatest<T> extends AbstractObservableWithUpstream<T, T> {
+
+    final long timeout;
+
+    final TimeUnit unit;
+
+    final Scheduler scheduler;
+
+    final boolean emitLast;
+
+    public ObservableThrottleLatest(Observable<T> source,
+            long timeout, TimeUnit unit, Scheduler scheduler,
+            boolean emitLast) {
+        super(source);
+        this.timeout = timeout;
+        this.unit = unit;
+        this.scheduler = scheduler;
+        this.emitLast = emitLast;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> s) {
+        source.subscribe(new ThrottleLatestObserver<T>(s, timeout, unit, scheduler.createWorker(), emitLast));
+    }
+
+    static final class ThrottleLatestObserver<T>
+    extends AtomicInteger
+    implements Observer<T>, Disposable, Runnable {
+
+        private static final long serialVersionUID = -8296689127439125014L;
+
+        final Observer<? super T> downstream;
+
+        final long timeout;
+
+        final TimeUnit unit;
+
+        final Scheduler.Worker worker;
+
+        final boolean emitLast;
+
+        final AtomicReference<T> latest;
+
+        Disposable upstream;
+
+        volatile boolean done;
+        Throwable error;
+
+        volatile boolean cancelled;
+
+        volatile boolean timerFired;
+
+        boolean timerRunning;
+
+        ThrottleLatestObserver(Observer<? super T> downstream,
+                long timeout, TimeUnit unit, Scheduler.Worker worker,
+                boolean emitLast) {
+            this.downstream = downstream;
+            this.timeout = timeout;
+            this.unit = unit;
+            this.worker = worker;
+            this.emitLast = emitLast;
+            this.latest = new AtomicReference<T>();
+        }
+
+        @Override
+        public void onSubscribe(Disposable s) {
+            if (DisposableHelper.validate(upstream, s)) {
+                upstream = s;
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            latest.set(t);
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void dispose() {
+            cancelled = true;
+            upstream.dispose();
+            worker.dispose();
+            if (getAndIncrement() == 0) {
+                latest.lazySet(null);
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return cancelled;
+        }
+
+        @Override
+        public void run() {
+            timerFired = true;
+            drain();
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+
+            AtomicReference<T> latest = this.latest;
+            Observer<? super T> downstream = this.downstream;
+
+            for (;;) {
+
+                for (;;) {
+                    if (cancelled) {
+                        latest.lazySet(null);
+                        return;
+                    }
+
+                    boolean d = done;
+
+                    if (d && error != null) {
+                        latest.lazySet(null);
+                        downstream.onError(error);
+                        worker.dispose();
+                        return;
+                    }
+
+                    T v = latest.get();
+                    boolean empty = v == null;
+
+                    if (d) {
+                        v = latest.getAndSet(null);
+                        if (!empty && emitLast) {
+                            downstream.onNext(v);
+                        }
+                        downstream.onComplete();
+                        worker.dispose();
+                        return;
+                    }
+
+                    if (empty) {
+                        if (timerFired) {
+                            timerRunning = false;
+                            timerFired = false;
+                        }
+                        break;
+                    }
+
+                    if (!timerRunning || timerFired) {
+                        v = latest.getAndSet(null);
+                        downstream.onNext(v);
+
+                        timerFired = false;
+                        timerRunning = true;
+                        worker.schedule(this, timeout, unit);
+                    } else {
+                        break;
+                    }
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/ParamValidationCheckerTest.java
@@ -226,6 +226,11 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "throttleLast", Long.TYPE, TimeUnit.class));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "throttleLast", Long.TYPE, TimeUnit.class, Scheduler.class));
 
+        // negative time is considered as zero time
+        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class));
+        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Scheduler.class));
+        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Boolean.TYPE));
+        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE));
 
         // negative buffer time is considered as zero buffer time
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "window", Long.TYPE, TimeUnit.class));
@@ -470,6 +475,11 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "throttleLast", Long.TYPE, TimeUnit.class));
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "throttleLast", Long.TYPE, TimeUnit.class, Scheduler.class));
 
+        // negative time is considered as zero time
+        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class));
+        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Scheduler.class));
+        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Boolean.TYPE));
+        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE));
 
         // negative buffer time is considered as zero buffer time
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "window", Long.TYPE, TimeUnit.class));

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatestTest.java
@@ -1,0 +1,281 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class FlowableThrottleLatestTest {
+
+    @Test
+    public void just() {
+        Flowable.just(1)
+        .throttleLatest(1, TimeUnit.MINUTES)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void range() {
+        Flowable.range(1, 5)
+        .throttleLatest(1, TimeUnit.MINUTES)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void rangeEmitLatest() {
+        Flowable.range(1, 5)
+        .throttleLatest(1, TimeUnit.MINUTES, true)
+        .test()
+        .assertResult(1, 5);
+    }
+
+    @Test
+    public void error() {
+        Flowable.error(new TestException())
+        .throttleLatest(1, TimeUnit.MINUTES)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
+            @Override
+            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
+                return f.throttleLatest(1, TimeUnit.MINUTES);
+            }
+        });
+    }
+
+    @Test
+    public void badRequest() {
+        TestHelper.assertBadRequestReported(
+                Flowable.never()
+                .throttleLatest(1, TimeUnit.MINUTES)
+        );
+    }
+
+    @Test
+    public void normal() {
+        TestScheduler sch = new TestScheduler();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp.throttleLatest(1, TimeUnit.SECONDS, sch).test();
+
+        pp.onNext(1);
+
+        ts.assertValuesOnly(1);
+
+        pp.onNext(2);
+
+        ts.assertValuesOnly(1);
+
+        pp.onNext(3);
+
+        ts.assertValuesOnly(1);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertValuesOnly(1, 3);
+
+        pp.onNext(4);
+
+        ts.assertValuesOnly(1, 3);
+
+        pp.onNext(5);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertValuesOnly(1, 3, 5);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertValuesOnly(1, 3, 5);
+
+        pp.onNext(6);
+
+        ts.assertValuesOnly(1, 3, 5, 6);
+
+        pp.onNext(7);
+        pp.onComplete();
+
+        ts.assertResult(1, 3, 5, 6);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertResult(1, 3, 5, 6);
+    }
+
+
+    @Test
+    public void normalEmitLast() {
+        TestScheduler sch = new TestScheduler();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp.throttleLatest(1, TimeUnit.SECONDS, sch, true).test();
+
+        pp.onNext(1);
+
+        ts.assertValuesOnly(1);
+
+        pp.onNext(2);
+
+        ts.assertValuesOnly(1);
+
+        pp.onNext(3);
+
+        ts.assertValuesOnly(1);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertValuesOnly(1, 3);
+
+        pp.onNext(4);
+
+        ts.assertValuesOnly(1, 3);
+
+        pp.onNext(5);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertValuesOnly(1, 3, 5);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertValuesOnly(1, 3, 5);
+
+        pp.onNext(6);
+
+        ts.assertValuesOnly(1, 3, 5, 6);
+
+        pp.onNext(7);
+        pp.onComplete();
+
+        ts.assertResult(1, 3, 5, 6, 7);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertResult(1, 3, 5, 6, 7);
+    }
+
+    @Test
+    public void missingBackpressureExceptionFirst() throws Exception {
+        TestScheduler sch = new TestScheduler();
+        Action onCancel = mock(Action.class);
+
+        Flowable.just(1, 2)
+        .doOnCancel(onCancel)
+        .throttleLatest(1, TimeUnit.MINUTES, sch)
+        .test(0)
+        .assertFailure(MissingBackpressureException.class);
+
+        verify(onCancel).run();
+    }
+
+    @Test
+    public void missingBackpressureExceptionLatest() throws Exception {
+        TestScheduler sch = new TestScheduler();
+        Action onCancel = mock(Action.class);
+
+        TestSubscriber<Integer> ts = Flowable.just(1, 2)
+        .concatWith(Flowable.<Integer>never())
+        .doOnCancel(onCancel)
+        .throttleLatest(1, TimeUnit.SECONDS, sch, true)
+        .test(1);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertFailure(MissingBackpressureException.class, 1);
+
+        verify(onCancel).run();
+    }
+
+    @Test
+    public void missingBackpressureExceptionLatestComplete() throws Exception {
+        TestScheduler sch = new TestScheduler();
+        Action onCancel = mock(Action.class);
+
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp
+        .doOnCancel(onCancel)
+        .throttleLatest(1, TimeUnit.SECONDS, sch, true)
+        .test(1);
+
+        pp.onNext(1);
+        pp.onNext(2);
+
+        ts.assertValuesOnly(1);
+
+        pp.onComplete();
+
+        ts.assertFailure(MissingBackpressureException.class, 1);
+
+        verify(onCancel, never()).run();
+    }
+
+    @Test
+    public void take() throws Exception {
+        Action onCancel = mock(Action.class);
+
+        Flowable.range(1, 5)
+        .doOnCancel(onCancel)
+        .throttleLatest(1, TimeUnit.MINUTES)
+        .take(1)
+        .test()
+        .assertResult(1);
+
+        verify(onCancel).run();
+    }
+
+    @Test
+    public void reentrantComplete() {
+        TestScheduler sch = new TestScheduler();
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    pp.onNext(2);
+                }
+                if (t == 2) {
+                    pp.onComplete();
+                }
+            }
+        };
+
+        pp.throttleLatest(1, TimeUnit.SECONDS, sch).subscribe(ts);
+
+        pp.onNext(1);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        ts.assertResult(1, 2);
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleLatestTest.java
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.*;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subjects.PublishSubject;
+
+public class ObservableThrottleLatestTest {
+
+    @Test
+    public void just() {
+        Observable.just(1)
+        .throttleLatest(1, TimeUnit.MINUTES)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void range() {
+        Observable.range(1, 5)
+        .throttleLatest(1, TimeUnit.MINUTES)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void rangeEmitLatest() {
+        Observable.range(1, 5)
+        .throttleLatest(1, TimeUnit.MINUTES, true)
+        .test()
+        .assertResult(1, 5);
+    }
+
+    @Test
+    public void error() {
+        Observable.error(new TestException())
+        .throttleLatest(1, TimeUnit.MINUTES)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, Observable<Object>>() {
+            @Override
+            public Observable<Object> apply(Observable<Object> f) throws Exception {
+                return f.throttleLatest(1, TimeUnit.MINUTES);
+            }
+        });
+    }
+
+    @Test
+    public void disposed() {
+        TestHelper.checkDisposed(
+                Observable.never()
+                .throttleLatest(1, TimeUnit.MINUTES)
+        );
+    }
+
+    @Test
+    public void normal() {
+        TestScheduler sch = new TestScheduler();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps.throttleLatest(1, TimeUnit.SECONDS, sch).test();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(1);
+
+        ps.onNext(3);
+
+        to.assertValuesOnly(1);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        to.assertValuesOnly(1, 3);
+
+        ps.onNext(4);
+
+        to.assertValuesOnly(1, 3);
+
+        ps.onNext(5);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        to.assertValuesOnly(1, 3, 5);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        to.assertValuesOnly(1, 3, 5);
+
+        ps.onNext(6);
+
+        to.assertValuesOnly(1, 3, 5, 6);
+
+        ps.onNext(7);
+        ps.onComplete();
+
+        to.assertResult(1, 3, 5, 6);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        to.assertResult(1, 3, 5, 6);
+    }
+
+
+    @Test
+    public void normalEmitLast() {
+        TestScheduler sch = new TestScheduler();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps.throttleLatest(1, TimeUnit.SECONDS, sch, true).test();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(1);
+
+        ps.onNext(3);
+
+        to.assertValuesOnly(1);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        to.assertValuesOnly(1, 3);
+
+        ps.onNext(4);
+
+        to.assertValuesOnly(1, 3);
+
+        ps.onNext(5);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        to.assertValuesOnly(1, 3, 5);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        to.assertValuesOnly(1, 3, 5);
+
+        ps.onNext(6);
+
+        to.assertValuesOnly(1, 3, 5, 6);
+
+        ps.onNext(7);
+        ps.onComplete();
+
+        to.assertResult(1, 3, 5, 6, 7);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        to.assertResult(1, 3, 5, 6, 7);
+    }
+
+    @Test
+    public void take() throws Exception {
+        Action onCancel = mock(Action.class);
+
+        Observable.range(1, 5)
+        .doOnDispose(onCancel)
+        .throttleLatest(1, TimeUnit.MINUTES)
+        .take(1)
+        .test()
+        .assertResult(1);
+
+        verify(onCancel).run();
+    }
+
+    @Test
+    public void reentrantComplete() {
+        TestScheduler sch = new TestScheduler();
+        final PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = new TestObserver<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    ps.onNext(2);
+                }
+                if (t == 2) {
+                    ps.onComplete();
+                }
+            }
+        };
+
+        ps.throttleLatest(1, TimeUnit.SECONDS, sch).subscribe(to);
+
+        ps.onNext(1);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        to.assertResult(1, 2);
+    }
+}


### PR DESCRIPTION
This PR adds the `throttleLatest` operator to `Observable` and `Flowable`, also known as `conflate` (#4856): it is a combination of `throttleFirst` and `sample` whereby frequent items are sampled but the first item outside the sampling window will be emitted immediately:

![throttleLatest](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLatest.png)

![throttleLatest](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLatest.se.png)

Resolves: #4856
Replaces: #5968