### PR TITLE
2.x: deprecate getValues() in Subjects/Processors

### DIFF
--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -254,7 +254,9 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
      * Returns an Object array containing snapshot all values of the Subject.
      * <p>The method is thread-safe.
      * @return the array containing the snapshot of all values of the Subject
+     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
      */
+    @Deprecated
     public Object[] getValues() {
         T v = getValue();
         return v != null ? new Object[] { v } : new Object[0];
@@ -267,7 +269,9 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
      * <p>The method is thread-safe.
      * @param array the target array to copy values into if it fits
      * @return the given array if the values fit into it or a new array containing all values
+     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
      */
+    @Deprecated
     public T[] getValues(T[] array) {
         T v = getValue();
         if (v == null) {

--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -377,7 +377,9 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      * Returns an Object array containing snapshot all values of the BehaviorProcessor.
      * <p>The method is thread-safe.
      * @return the array containing the snapshot of all values of the BehaviorProcessor
+     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
      */
+    @Deprecated
     public Object[] getValues() {
         @SuppressWarnings("unchecked")
         T[] a = (T[])EMPTY_ARRAY;
@@ -396,7 +398,9 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      * <p>The method is thread-safe.
      * @param array the target array to copy values into if it fits
      * @return the given array if the values fit into it or a new array containing all values
+     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public T[] getValues(T[] array) {
         Object o = value.get();

--- a/src/main/java/io/reactivex/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/subjects/AsyncSubject.java
@@ -325,7 +325,9 @@ public final class AsyncSubject<T> extends Subject<T> {
      * Returns an Object array containing snapshot all values of the Subject.
      * <p>The method is thread-safe.
      * @return the array containing the snapshot of all values of the Subject
+     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
      */
+    @Deprecated
     public Object[] getValues() {
         T v = getValue();
         return v != null ? new Object[] { v } : new Object[0];
@@ -338,7 +340,9 @@ public final class AsyncSubject<T> extends Subject<T> {
      * <p>The method is thread-safe.
      * @param array the target array to copy values into if it fits
      * @return the given array if the values fit into it or a new array containing all values
+     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
      */
+    @Deprecated
     public T[] getValues(T[] array) {
         T v = getValue();
         if (v == null) {

--- a/src/main/java/io/reactivex/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/subjects/BehaviorSubject.java
@@ -331,7 +331,9 @@ public final class BehaviorSubject<T> extends Subject<T> {
      * Returns an Object array containing snapshot all values of the Subject.
      * <p>The method is thread-safe.
      * @return the array containing the snapshot of all values of the Subject
+     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
      */
+    @Deprecated
     public Object[] getValues() {
         @SuppressWarnings("unchecked")
         T[] a = (T[])EMPTY_ARRAY;
@@ -350,7 +352,9 @@ public final class BehaviorSubject<T> extends Subject<T> {
      * <p>The method is thread-safe.
      * @param array the target array to copy values into if it fits
      * @return the given array if the values fit into it or a new array containing all values
+     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public T[] getValues(T[] array) {
         Object o = value.get();

--- a/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
@@ -38,6 +38,7 @@ public class SerializedProcessorTest {
         ts.assertValue("hello");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueRelay() {
         AsyncProcessor<Integer> async = AsyncProcessor.create();
@@ -56,6 +57,8 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueEmpty() {
         AsyncProcessor<Integer> async = AsyncProcessor.create();
@@ -73,6 +76,8 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueError() {
         AsyncProcessor<Integer> async = AsyncProcessor.create();
@@ -91,6 +96,7 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testPublishSubjectValueRelay() {
         PublishProcessor<Integer> async = PublishProcessor.create();
@@ -128,6 +134,7 @@ public class SerializedProcessorTest {
         assertSame(te, serial.getThrowable());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectValueRelay() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
@@ -146,6 +153,8 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectValueRelayIncomplete() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
@@ -163,6 +172,8 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectIncompleteEmpty() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
@@ -179,6 +190,8 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectEmpty() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
@@ -196,6 +209,8 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectError() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();

--- a/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
@@ -39,6 +39,7 @@ public class SerializedSubjectTest {
         to.assertValue("hello");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueRelay() {
         AsyncSubject<Integer> async = AsyncSubject.create();
@@ -57,6 +58,8 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueEmpty() {
         AsyncSubject<Integer> async = AsyncSubject.create();
@@ -74,6 +77,8 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueError() {
         AsyncSubject<Integer> async = AsyncSubject.create();
@@ -92,6 +97,7 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testPublishSubjectValueRelay() {
         PublishSubject<Integer> async = PublishSubject.create();
@@ -129,6 +135,7 @@ public class SerializedSubjectTest {
         assertSame(te, serial.getThrowable());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectValueRelay() {
         BehaviorSubject<Integer> async = BehaviorSubject.create();
@@ -147,6 +154,8 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectValueRelayIncomplete() {
         BehaviorSubject<Integer> async = BehaviorSubject.create();
@@ -164,6 +173,8 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectIncompleteEmpty() {
         BehaviorSubject<Integer> async = BehaviorSubject.create();
@@ -180,6 +191,8 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectEmpty() {
         BehaviorSubject<Integer> async = BehaviorSubject.create();
@@ -197,6 +210,8 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectError() {
         BehaviorSubject<Integer> async = BehaviorSubject.create();
@@ -234,6 +249,7 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectValueRelayIncomplete() {
         ReplaySubject<Integer> async = ReplaySubject.create();


### PR DESCRIPTION
This PR deprecates the `getValues()` and `getValues(T[])` methods in `AsyncSubject`, `BehaviorSubject`, `AsyncProcessor` and `BehaviorProcessor`.

These methods were remnants of an early 2.x API design where `Subject` itself had these methods for the sake of `ReplaySubject`  and `SerializedSubject` and thus every other subject type had to implement them. The listed subjects and processors above have at most one value accessible via `getValue()` which can then be assigned to an array index manually if needed.