### PR TITLE
2.x: Add refCount with count & disconnect timeout

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -1216,6 +1216,38 @@ public class FlowableRefCountTest {
     }
 
     @Test
+    public void doubleOnXCount() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new BadFlowableDoubleOnX()
+            .refCount(1)
+            .test()
+            .assertResult();
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void doubleOnXTime() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new BadFlowableDoubleOnX()
+            .refCount(5, TimeUnit.SECONDS, Schedulers.single())
+            .test()
+            .assertResult();
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
     public void cancelTerminateStateExclusion() {
         FlowableRefCount<Object> o = (FlowableRefCount<Object>)PublishProcessor.create()
         .publish()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -1001,31 +1001,6 @@ public class FlowableRefCountTest {
         assertTrue(interrupted.get());
     }
 
-    static <T> FlowableTransformer<T, T> refCount(final int n) {
-        return refCount(n, 0, TimeUnit.NANOSECONDS, Schedulers.trampoline());
-    }
-
-    static <T> FlowableTransformer<T, T> refCount(final long time, final TimeUnit unit) {
-        return refCount(1, time, unit, Schedulers.computation());
-    }
-
-    static <T> FlowableTransformer<T, T> refCount(final long time, final TimeUnit unit, final Scheduler scheduler) {
-        return refCount(1, time, unit, scheduler);
-    }
-
-    static <T> FlowableTransformer<T, T> refCount(final int n, final long time, final TimeUnit unit) {
-        return refCount(1, time, unit, Schedulers.computation());
-    }
-
-    static <T> FlowableTransformer<T, T> refCount(final int n, final long time, final TimeUnit unit, final Scheduler scheduler) {
-        return new FlowableTransformer<T, T>() {
-            @Override
-            public Publisher<T> apply(Flowable<T> f) {
-                return new FlowableRefCount<T>((ConnectableFlowable<T>)f, n, time, unit, scheduler);
-            }
-        };
-    }
-
     @Test
     public void byCount() {
         final int[] subscriptions = { 0 };
@@ -1038,7 +1013,7 @@ public class FlowableRefCountTest {
             }
         })
         .publish()
-        .compose(FlowableRefCountTest.<Integer>refCount(2));
+        .refCount(2);
 
         for (int i = 0; i < 3; i++) {
             TestSubscriber<Integer> ts1 = source.test();
@@ -1068,7 +1043,7 @@ public class FlowableRefCountTest {
             }
         })
         .publish()
-        .compose(FlowableRefCountTest.<Integer>refCount(500, TimeUnit.MILLISECONDS));
+        .refCount(500, TimeUnit.MILLISECONDS);
 
         TestSubscriber<Integer> ts1 = source.test(0);
 
@@ -1111,7 +1086,7 @@ public class FlowableRefCountTest {
             }
         })
         .publish()
-        .compose(FlowableRefCountTest.<Integer>refCount(1, 100, TimeUnit.MILLISECONDS));
+        .refCount(1, 100, TimeUnit.MILLISECONDS);
 
         TestSubscriber<Integer> ts1 = source.test(0);
 
@@ -1130,16 +1105,9 @@ public class FlowableRefCountTest {
     public void error() {
         Flowable.<Integer>error(new IOException())
         .publish()
-        .compose(FlowableRefCountTest.<Integer>refCount(500, TimeUnit.MILLISECONDS))
+        .refCount(500, TimeUnit.MILLISECONDS)
         .test()
         .assertFailure(IOException.class);
-    }
-
-    @Test(expected = ClassCastException.class)
-    public void badUpstream() {
-        Flowable.range(1, 5)
-        .compose(FlowableRefCountTest.<Integer>refCount(500, TimeUnit.MILLISECONDS, Schedulers.single()))
-        ;
     }
 
     @Test
@@ -1148,7 +1116,7 @@ public class FlowableRefCountTest {
 
         Flowable<Integer> source = pp
         .publish()
-        .compose(FlowableRefCountTest.<Integer>refCount(1));
+        .refCount(1);
 
         TestSubscriber<Integer> ts1 = source.test(0);
 
@@ -1171,7 +1139,7 @@ public class FlowableRefCountTest {
 
             final Flowable<Integer> source = Flowable.range(1, 5)
                     .replay()
-                    .compose(FlowableRefCountTest.<Integer>refCount(1))
+                    .refCount(1)
                     ;
 
             final TestSubscriber<Integer> ts1 = source.test(0);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -985,31 +985,6 @@ public class ObservableRefCountTest {
         assertTrue(interrupted.get());
     }
 
-    static <T> ObservableTransformer<T, T> refCount(final int n) {
-        return refCount(n, 0, TimeUnit.NANOSECONDS, Schedulers.trampoline());
-    }
-
-    static <T> ObservableTransformer<T, T> refCount(final long time, final TimeUnit unit) {
-        return refCount(1, time, unit, Schedulers.computation());
-    }
-
-    static <T> ObservableTransformer<T, T> refCount(final long time, final TimeUnit unit, final Scheduler scheduler) {
-        return refCount(1, time, unit, scheduler);
-    }
-
-    static <T> ObservableTransformer<T, T> refCount(final int n, final long time, final TimeUnit unit) {
-        return refCount(1, time, unit, Schedulers.computation());
-    }
-
-    static <T> ObservableTransformer<T, T> refCount(final int n, final long time, final TimeUnit unit, final Scheduler scheduler) {
-        return new ObservableTransformer<T, T>() {
-            @Override
-            public Observable<T> apply(Observable<T> f) {
-                return new ObservableRefCount<T>((ConnectableObservable<T>)f, n, time, unit, scheduler);
-            }
-        };
-    }
-
     @Test
     public void byCount() {
         final int[] subscriptions = { 0 };
@@ -1022,7 +997,7 @@ public class ObservableRefCountTest {
             }
         })
         .publish()
-        .compose(ObservableRefCountTest.<Integer>refCount(2));
+        .refCount(2);
 
         for (int i = 0; i < 3; i++) {
             TestObserver<Integer> to1 = source.test();
@@ -1052,7 +1027,7 @@ public class ObservableRefCountTest {
             }
         })
         .publish()
-        .compose(ObservableRefCountTest.<Integer>refCount(500, TimeUnit.MILLISECONDS));
+        .refCount(500, TimeUnit.MILLISECONDS);
 
         TestObserver<Integer> to1 = source.test();
 
@@ -1095,7 +1070,7 @@ public class ObservableRefCountTest {
             }
         })
         .publish()
-        .compose(ObservableRefCountTest.<Integer>refCount(1, 100, TimeUnit.MILLISECONDS));
+        .refCount(1, 100, TimeUnit.MILLISECONDS);
 
         TestObserver<Integer> to1 = source.test();
 
@@ -1114,16 +1089,9 @@ public class ObservableRefCountTest {
     public void error() {
         Observable.<Integer>error(new IOException())
         .publish()
-        .compose(ObservableRefCountTest.<Integer>refCount(500, TimeUnit.MILLISECONDS))
+        .refCount(500, TimeUnit.MILLISECONDS)
         .test()
         .assertFailure(IOException.class);
-    }
-
-    @Test(expected = ClassCastException.class)
-    public void badUpstream() {
-        Observable.range(1, 5)
-        .compose(ObservableRefCountTest.<Integer>refCount(500, TimeUnit.MILLISECONDS, Schedulers.single()))
-        ;
     }
 
     @Test
@@ -1132,7 +1100,7 @@ public class ObservableRefCountTest {
 
         Observable<Integer> source = ps
         .publish()
-        .compose(ObservableRefCountTest.<Integer>refCount(1));
+        .refCount(1);
 
         TestObserver<Integer> to1 = source.test();
 
@@ -1155,7 +1123,7 @@ public class ObservableRefCountTest {
 
             final Observable<Integer> source = Observable.range(1, 5)
                     .replay()
-                    .compose(ObservableRefCountTest.<Integer>refCount(1))
+                    .refCount(1)
                     ;
 
             final TestObserver<Integer> to1 = source.test();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -1200,6 +1200,38 @@ public class ObservableRefCountTest {
     }
 
     @Test
+    public void doubleOnXCount() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new BadObservableDoubleOnX()
+            .refCount(1)
+            .test()
+            .assertResult();
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void doubleOnXTime() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new BadObservableDoubleOnX()
+            .refCount(5, TimeUnit.SECONDS, Schedulers.single())
+            .test()
+            .assertResult();
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
     public void cancelTerminateStateExclusion() {
         ObservableRefCount<Object> o = (ObservableRefCount<Object>)PublishSubject.create()
         .publish()


### PR DESCRIPTION
This PR exposes the additional `refCount` operation modes from #5975:

- Connect only when the specified number of `Subscriber`s/`Observer`s have subscribed
- Disconnect when the given amount of time elapsed since the very last `Subscriber`/`Observer` cancelled/disposed.
- The combination of both.

In addition, the original `refCount` received extra JavaDocs details.