### PR TITLE
Add marble diagrams to a few Single.doOnX methods.

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2174,7 +2174,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>Note that the {@code onFinally} action is shared between subscriptions and as such
      * should be thread-safe.
      * <p>
-     * <img width="1040" height="472" src="https://user-images.githubusercontent.com/4089934/39448132-dca93836-4cbb-11e8-9b13-ce078a8ba206.png" alt="">
+     * <img width="640" height="291" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.doFinally.png" alt="">
      * </p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -2196,7 +2196,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Calls the shared consumer with the Disposable sent through the onSubscribe for each
      * SingleObserver that subscribes to the current Single.
      * <p>
-     * <img width="640" height="437" src="https://user-images.githubusercontent.com/4089934/39448136-dd05bcbe-4cbb-11e8-823d-d9d0c3501f24.png" alt="">
+     * <img width="640" height="347" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.doOnSubscribe.png" alt="">
      * </p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -2217,7 +2217,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Calls the shared consumer with the success value sent via onSuccess for each
      * SingleObserver that subscribes to the current Single.
      * <p>
-     * <img width="640" height="346" src="https://user-images.githubusercontent.com/4089934/39448137-dd21fdca-4cbb-11e8-848d-45c3af91b76f.png" alt="">
+     * <img width="640" height="347" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.doOnSuccess.2.png" alt="">
      * </p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -2256,7 +2256,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Calls the shared consumer with the error sent via onError for each
      * SingleObserver that subscribes to the current Single.
      * <p>
-     * <img width="640" height="350" src="https://user-images.githubusercontent.com/4089934/39448135-dce99bce-4cbb-11e8-9d52-8e30084f9aa4.png" alt="">
+     * <img width="640" height="349" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.doOnError.2.png" alt="">
      * </p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -2277,7 +2277,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Calls the shared {@code Action} if a SingleObserver subscribed to the current Single
      * disposes the common Disposable it received via onSubscribe.
      * <p>
-     * <img width="640" height="350" src="https://user-images.githubusercontent.com/4089934/39448133-dcca516a-4cbb-11e8-9143-b935cf0dd64c.png" alt="">
+     * <img width="640" height="332" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.doOnDispose.png" alt="">
      * </p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2173,6 +2173,9 @@ public abstract class Single<T> implements SingleSource<T> {
      * is executed once per subscription.
      * <p>Note that the {@code onFinally} action is shared between subscriptions and as such
      * should be thread-safe.
+     * <p>
+     * <img width="1040" height="472" src="https://user-images.githubusercontent.com/4089934/39448132-dca93836-4cbb-11e8-9b13-ce078a8ba206.png" alt="">
+     * </p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code doFinally} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2192,6 +2195,9 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Calls the shared consumer with the Disposable sent through the onSubscribe for each
      * SingleObserver that subscribes to the current Single.
+     * <p>
+     * <img width="640" height="437" src="https://user-images.githubusercontent.com/4089934/39448136-dd05bcbe-4cbb-11e8-823d-d9d0c3501f24.png" alt="">
+     * </p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2210,6 +2216,9 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Calls the shared consumer with the success value sent via onSuccess for each
      * SingleObserver that subscribes to the current Single.
+     * <p>
+     * <img width="640" height="346" src="https://user-images.githubusercontent.com/4089934/39448137-dd21fdca-4cbb-11e8-848d-45c3af91b76f.png" alt="">
+     * </p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnSuccess} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2246,6 +2255,9 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Calls the shared consumer with the error sent via onError for each
      * SingleObserver that subscribes to the current Single.
+     * <p>
+     * <img width="640" height="350" src="https://user-images.githubusercontent.com/4089934/39448135-dce99bce-4cbb-11e8-9d52-8e30084f9aa4.png" alt="">
+     * </p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnError} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2264,6 +2276,9 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Calls the shared {@code Action} if a SingleObserver subscribed to the current Single
      * disposes the common Disposable it received via onSubscribe.
+     * <p>
+     * <img width="640" height="350" src="https://user-images.githubusercontent.com/4089934/39448133-dcca516a-4cbb-11e8-9143-b935cf0dd64c.png" alt="">
+     * </p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnDispose} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
This should tick a few tasks from this issue: https://github.com/ReactiveX/RxJava/issues/5788.

The urls are a bit ugly, as they're from the uploads in the issue. I'm happy to update the urls with different ones if there's a better place to upload the diagrams.