### PR TITLE
2.x: Fix switchMap to indicate boundary fusion

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
@@ -359,7 +359,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
                     @SuppressWarnings("unchecked")
                     QueueSubscription<R> qs = (QueueSubscription<R>) s;
 
-                    int m = qs.requestFusion(QueueSubscription.ANY);
+                    int m = qs.requestFusion(QueueSubscription.ANY | QueueSubscription.BOUNDARY);
                     if (m == QueueSubscription.SYNC) {
                         fusionMode = m;
                         queue = qs;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
@@ -348,7 +348,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
                     @SuppressWarnings("unchecked")
                     QueueDisposable<R> qd = (QueueDisposable<R>) s;
 
-                    int m = qd.requestFusion(QueueDisposable.ANY);
+                    int m = qd.requestFusion(QueueDisposable.ANY | QueueDisposable.BOUNDARY);
                     if (m == QueueDisposable.SYNC) {
                         queue = qd;
                         done = true;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
@@ -26,15 +27,14 @@ import org.mockito.InOrder;
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subjects.PublishSubject;
+import io.reactivex.schedulers.*;
+import io.reactivex.subjects.*;
 
 public class ObservableSwitchTest {
 
@@ -1121,6 +1121,7 @@ public class ObservableSwitchTest {
                         throw new TestException();
                     }
                 })
+                .compose(TestHelper.<Integer>observableStripBoundary())
         ))
         .test();
 
@@ -1148,6 +1149,7 @@ public class ObservableSwitchTest {
                         throw new TestException();
                     }
                 })
+                .compose(TestHelper.<Integer>observableStripBoundary())
         ))
         .test();
 
@@ -1165,5 +1167,31 @@ public class ObservableSwitchTest {
         .assertFailure(TestException.class);
 
         assertFalse(ps.hasObservers());
+    }
+
+    @Test
+    public void fusedBoundary() {
+        String thread = Thread.currentThread().getName();
+
+        Observable.range(1, 10000)
+        .switchMap(new Function<Integer, ObservableSource<? extends Object>>() {
+            @Override
+            public ObservableSource<? extends Object> apply(Integer v)
+                    throws Exception {
+                return Observable.just(2).hide()
+                .observeOn(Schedulers.single())
+                .map(new Function<Integer, Object>() {
+                    @Override
+                    public Object apply(Integer w) throws Exception {
+                        return Thread.currentThread().getName();
+                    }
+                });
+            }
+        })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertNever(thread)
+        .assertNoErrors()
+        .assertComplete();
     }
 }


### PR DESCRIPTION
Fix `Flowable.switchMap` and `Observable.switchMap` to request for boundary fusion in order to prevent a thread-confined but otherwise fusion-capable sub-sequence from running on the unintended thread.

Fixes: #5990