### PR TITLE
Observable's javadoc cleanup

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -74,7 +74,7 @@ import io.reactivex.schedulers.*;
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");
  *         }
- *         &#64;Override public void onNext(Integer t) {
+ *         &#64;Override public void onNext(String t) {
  *             System.out.println(t);
  *         }
  *         &#64;Override public void onError(Throwable t) {


### PR DESCRIPTION
The sample code in the Observable javadoc erroneously uses `onNext(Integer t)` for a `DisposableObserver<String>`

This has been corrected to be `onNext(String t)`
