### PR TITLE
Implement 'toString' method for some Emitters

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableCreate.java
@@ -118,5 +118,10 @@ public final class CompletableCreate extends Completable {
         public boolean isDisposed() {
             return DisposableHelper.isDisposed(get());
         }
+
+        @Override
+        public String toString() {
+            return String.format("%s{%s}", getClass().getSimpleName(), super.toString());
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCreate.java
@@ -233,6 +233,11 @@ public final class FlowableCreate<T> extends Flowable<T> {
         public FlowableEmitter<T> serialize() {
             return this;
         }
+
+        @Override
+        public String toString() {
+            return emitter.toString();
+        }
     }
 
     abstract static class BaseEmitter<T>
@@ -337,6 +342,11 @@ public final class FlowableCreate<T> extends Flowable<T> {
         @Override
         public final FlowableEmitter<T> serialize() {
             return new SerializedEmitter<T>(this);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s{%s}", getClass().getSimpleName(), super.toString());
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeCreate.java
@@ -145,5 +145,10 @@ public final class MaybeCreate<T> extends Maybe<T> {
         public boolean isDisposed() {
             return DisposableHelper.isDisposed(get());
         }
+
+        @Override
+        public String toString() {
+            return String.format("%s{%s}", getClass().getSimpleName(), super.toString());
+        }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCreate.java
@@ -126,6 +126,11 @@ public final class ObservableCreate<T> extends Observable<T> {
         public boolean isDisposed() {
             return DisposableHelper.isDisposed(get());
         }
+
+        @Override
+        public String toString() {
+            return String.format("%s{%s}", getClass().getSimpleName(), super.toString());
+        }
     }
 
     /**
@@ -278,6 +283,11 @@ public final class ObservableCreate<T> extends Observable<T> {
         @Override
         public ObservableEmitter<T> serialize() {
             return this;
+        }
+
+        @Override
+        public String toString() {
+            return emitter.toString();
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleCreate.java
@@ -123,5 +123,10 @@ public final class SingleCreate<T> extends Single<T> {
         public boolean isDisposed() {
             return DisposableHelper.isDisposed(get());
         }
+
+        @Override
+        public String toString() {
+            return String.format("%s{%s}", getClass().getSimpleName(), super.toString());
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableCreateTest.java
@@ -297,4 +297,14 @@ public class CompletableCreateTest {
             RxJavaPlugins.reset();
         }
     }
+
+    @Test
+    public void emitterHasToString() {
+        Completable.create(new CompletableOnSubscribe() {
+            @Override
+            public void subscribe(CompletableEmitter emitter) throws Exception {
+                assertTrue(emitter.toString().contains(CompletableCreate.Emitter.class.getSimpleName()));
+            }
+        }).test().assertEmpty();
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -950,6 +950,7 @@ public class FlowableCreateTest {
                 @Override
                 public void subscribe(FlowableEmitter<Object> emitter) throws Exception {
                     assertTrue(emitter.toString().contains(entry.getValue().getSimpleName()));
+                    assertTrue(emitter.serialize().toString().contains(entry.getValue().getSimpleName()));
                 }
             }, entry.getKey()).test().assertEmpty();
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -942,7 +942,7 @@ public class FlowableCreateTest {
         emitterMap.put(BackpressureStrategy.MISSING, FlowableCreate.MissingEmitter.class);
         emitterMap.put(BackpressureStrategy.ERROR, FlowableCreate.ErrorAsyncEmitter.class);
         emitterMap.put(BackpressureStrategy.DROP, FlowableCreate.DropAsyncEmitter.class);
-        emitterMap.put(BackpressureStrategy.LATEST, FlowableCreate.DropAsyncEmitter.class);
+        emitterMap.put(BackpressureStrategy.LATEST, FlowableCreate.LatestAsyncEmitter.class);
         emitterMap.put(BackpressureStrategy.BUFFER, FlowableCreate.BufferAsyncEmitter.class);
 
         for (final Map.Entry<BackpressureStrategy, Class<? extends FlowableEmitter>> entry : emitterMap.entrySet()) {
@@ -951,7 +951,7 @@ public class FlowableCreateTest {
                 public void subscribe(FlowableEmitter<Object> emitter) throws Exception {
                     assertTrue(emitter.toString().contains(entry.getValue().getSimpleName()));
                 }
-            }, entry.getKey()).test();
+            }, entry.getKey()).test().assertEmpty();
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -16,7 +16,9 @@ package io.reactivex.internal.operators.flowable;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 import org.reactivestreams.*;
@@ -929,6 +931,27 @@ public class FlowableCreateTest {
             } finally {
                 RxJavaPlugins.reset();
             }
+        }
+    }
+
+    @Test
+    public void emittersHasToString() {
+        Map<BackpressureStrategy, Class<? extends FlowableEmitter>> emitterMap =
+                new HashMap<BackpressureStrategy, Class<? extends FlowableEmitter>>();
+
+        emitterMap.put(BackpressureStrategy.MISSING, FlowableCreate.MissingEmitter.class);
+        emitterMap.put(BackpressureStrategy.ERROR, FlowableCreate.ErrorAsyncEmitter.class);
+        emitterMap.put(BackpressureStrategy.DROP, FlowableCreate.DropAsyncEmitter.class);
+        emitterMap.put(BackpressureStrategy.LATEST, FlowableCreate.DropAsyncEmitter.class);
+        emitterMap.put(BackpressureStrategy.BUFFER, FlowableCreate.BufferAsyncEmitter.class);
+
+        for (final Map.Entry<BackpressureStrategy, Class<? extends FlowableEmitter>> entry : emitterMap.entrySet()) {
+            Flowable.create(new FlowableOnSubscribe<Object>() {
+                @Override
+                public void subscribe(FlowableEmitter<Object> emitter) throws Exception {
+                    assertTrue(emitter.toString().contains(entry.getValue().getSimpleName()));
+                }
+            }, entry.getKey()).test();
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCreateTest.java
@@ -335,4 +335,14 @@ public class MaybeCreateTest {
             RxJavaPlugins.reset();
         }
     }
+
+    @Test
+    public void emitterHasToString() {
+        Maybe.create(new MaybeOnSubscribe<Object>() {
+            @Override
+            public void subscribe(MaybeEmitter<Object> emitter) throws Exception {
+                assertTrue(emitter.toString().contains(MaybeCreate.Emitter.class.getSimpleName()));
+            }
+        }).test().assertEmpty();
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
@@ -650,6 +650,7 @@ public class ObservableCreateTest {
             @Override
             public void subscribe(ObservableEmitter<Object> emitter) throws Exception {
                 assertTrue(emitter.toString().contains(ObservableCreate.CreateEmitter.class.getSimpleName()));
+                assertTrue(emitter.serialize().toString().contains(ObservableCreate.CreateEmitter.class.getSimpleName()));
             }
         }).test().assertEmpty();
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
@@ -643,4 +643,14 @@ public class ObservableCreateTest {
             RxJavaPlugins.reset();
         }
     }
+
+    @Test
+    public void emitterHasToString() {
+        Observable.create(new ObservableOnSubscribe<Object>() {
+            @Override
+            public void subscribe(ObservableEmitter<Object> emitter) throws Exception {
+                assertTrue(emitter.toString().contains(ObservableCreate.CreateEmitter.class.getSimpleName()));
+            }
+        }).test();
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateTest.java
@@ -651,6 +651,6 @@ public class ObservableCreateTest {
             public void subscribe(ObservableEmitter<Object> emitter) throws Exception {
                 assertTrue(emitter.toString().contains(ObservableCreate.CreateEmitter.class.getSimpleName()));
             }
-        }).test();
+        }).test().assertEmpty();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleCreateTest.java
@@ -315,6 +315,6 @@ public class SingleCreateTest {
             public void subscribe(SingleEmitter<Object> emitter) throws Exception {
                 assertTrue(emitter.toString().contains(SingleCreate.Emitter.class.getSimpleName()));
             }
-        }).test();
+        }).test().assertEmpty();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleCreateTest.java
@@ -307,4 +307,14 @@ public class SingleCreateTest {
             RxJavaPlugins.reset();
         }
     }
+
+    @Test
+    public void emitterHasToString() {
+        Single.create(new SingleOnSubscribe<Object>() {
+            @Override
+            public void subscribe(SingleEmitter<Object> emitter) throws Exception {
+                assertTrue(emitter.toString().contains(SingleCreate.Emitter.class.getSimpleName()));
+            }
+        }).test();
+    }
 }


### PR DESCRIPTION
When use `.create` method it's unclear why `emitter` is null (if call `toString` or observe object via debugger). 
