### PR TITLE
2.x: Javadoc space cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -369,3 +369,4 @@ if (rootProject.hasProperty("releaseMode")) {
    }
 }
 
+apply from: file("gradle/javadoc_cleanup.gradle")

--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -14,9 +14,17 @@ def fixJavadocFile(file) {
     println("Cleaning up: " + file);
     String fileContents = file.getText('UTF-8')
 
+    // lots of spaces after the previous method argument
     fileContents = fileContents.replaceAll(",\\s{4,}", ",\n        ");
+
+    // lots of spaces after the @NonNull annotations
+    fileContents = fileContents.replaceAll("@NonNull</a>\\s{4,}", "@NonNull</a> ");
+
+    // lots of spaces after the @Nullable annotations
+    fileContents = fileContents.replaceAll("@Nullable</a>\\s{4,}", "@Nullable</a> ");
 
     file.setText(fileContents, 'UTF-8');
 }
 
+javadocJar.dependsOn javadocCleanup
 build.dependsOn javadocCleanup 

--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -8,6 +8,9 @@ task javadocCleanup(dependsOn: "javadoc") doLast {
 
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/flowables/ConnectableFlowable.html'));
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/observables/ConnectableObservable.html'));
+
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/subjects/ReplaySubject.html'));
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/processors/ReplayProcessor.html'));
 }
 
 def fixJavadocFile(file) {

--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -1,0 +1,22 @@
+// remove the excessive whitespaces between method arguments in the javadocs
+task javadocCleanup(dependsOn: "javadoc") doLast {
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/Flowable.html'));
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/Observable.html'));
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/Single.html'));
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/Maybe.html'));
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/Completable.html'));
+
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/flowables/ConnectableFlowable.html'));
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/observables/ConnectableObservable.html'));
+}
+
+def fixJavadocFile(file) {
+    println("Cleaning up: " + file);
+    String fileContents = file.getText('UTF-8')
+
+    fileContents = fileContents.replaceAll(",\\s{4,}", ",\n        ");
+
+    file.setText(fileContents, 'UTF-8');
+}
+
+build.dependsOn javadocCleanup 


### PR DESCRIPTION
This PR adds a gradle task to replace the excessive whitespaces generated into the Javadocs between method arguments and after method argument annotations.

This task should run before the javadoc gets packaged up for maven and before it gets pushed back to the gh-pages.

(This was created as a repo branch so that the snapshot pushback is triggered, see the comparison links below.)

Resolves: #6004

#### Comparison

Multiple parameters before: [combineLatest](http://reactivex.io/RxJava/2.x/javadoc/2.1.13/io/reactivex/Flowable.html#combineLatest-io.reactivex.functions.Function-org.reactivestreams.Publisher...-)

![image](https://user-images.githubusercontent.com/1269832/39813943-b841e820-5392-11e8-9a01-8f79b521f76b.png)

Multiple parameters after: [combineLatest snapshot](http://reactivex.io/RxJava/2.x/javadoc/snapshot/io/reactivex/Flowable.html#combineLatest-io.reactivex.functions.Function-org.reactivestreams.Publisher...-)

![image](https://user-images.githubusercontent.com/1269832/39813959-cc80385a-5392-11e8-8084-7ca89c0686d7.png)

----------------

Newline after parameter annotation before: [as](http://reactivex.io/RxJava/2.x/javadoc/2.1.13/io/reactivex/Flowable.html#as-io.reactivex.FlowableConverter-)

![image](https://user-images.githubusercontent.com/1269832/39813894-86bc22c0-5392-11e8-8748-aba6a214d4fc.png)

Newline after parameter annotation after: [as snapshot](http://reactivex.io/RxJava/2.x/javadoc/snapshot/io/reactivex/Flowable.html#as-io.reactivex.FlowableConverter-)

![image](https://user-images.githubusercontent.com/1269832/39813906-97f7aca8-5392-11e8-981f-9ff93396c35f.png)
