### PR TITLE
2.x: Add assertValueSetOnly and assertValueSequenceOnly to TestObserver + TestSubscriber

### DIFF
--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -591,7 +591,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * Assert that the TestObserver/TestSubscriber received only the specified values in any order without terminating.
      * @param expected the collection of values expected in any order
      * @return this;
-     * @since 2.1.14
+     * @since 2.1.14 - Experimental
      */
     @SuppressWarnings("unchecked")
     @Experimental
@@ -644,7 +644,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order without terminating.
      * @param sequence the sequence of expected values in order
      * @return this;
-     * @since 2.1.14
+     * @since 2.1.14 - Experimental
      */
     @SuppressWarnings("unchecked")
     @Experimental

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -588,6 +588,21 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     }
 
     /**
+     * Assert that the TestObserver/TestSubscriber received only the specified values in any order without terminating.
+     * @param expected the collection of values expected in any order
+     * @return this;
+     * @since 2.1.14
+     */
+    @SuppressWarnings("unchecked")
+    @Experimental
+    public final U assertValueSetOnly(Collection<? extends T> expected) {
+        return assertSubscribed()
+                .assertValueSet(expected)
+                .assertNoErrors()
+                .assertNotComplete();
+    }
+
+    /**
      * Assert that the TestObserver/TestSubscriber received only the specified sequence of values in the same order.
      * @param sequence the sequence of expected values in order
      * @return this;
@@ -623,6 +638,21 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
             throw fail("Fewer values received than expected (" + i + ")");
         }
         return (U)this;
+    }
+
+    /**
+     * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order without terminating.
+     * @param sequence the sequence of expected values in order
+     * @return this;
+     * @since 2.1.14
+     */
+    @SuppressWarnings("unchecked")
+    @Experimental
+    public final U assertValueSequenceOnly(Iterable<? extends T> sequence) {
+        return assertSubscribed()
+                .assertValueSequence(sequence)
+                .assertNoErrors()
+                .assertNotComplete();
     }
 
     /**

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -591,7 +591,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * Assert that the TestObserver/TestSubscriber received only the specified values in any order without terminating.
      * @param expected the collection of values expected in any order
      * @return this;
-     * @since 2.1.14 - Experimental
+     * @since 2.1.14 - experimental
      */
     @SuppressWarnings("unchecked")
     @Experimental
@@ -644,7 +644,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order without terminating.
      * @param sequence the sequence of expected values in order
      * @return this;
-     * @since 2.1.14 - Experimental
+     * @since 2.1.14 - experimental
      */
     @SuppressWarnings("unchecked")
     @Experimental

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -1434,7 +1434,7 @@ public class TestObserverTest {
                 .assertResult(1)
                 ;
             }
-            fail("Should have thrown!");
+            throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             assertTrue(ex.toString(), ex.toString().contains("testing with item=2"));
         }
@@ -1466,7 +1466,7 @@ public class TestObserverTest {
 
         try {
             to.assertValuesOnly(5);
-            fail();
+            throw new RuntimeException();
         } catch (AssertionError ex) {
             // expected
         }
@@ -1481,7 +1481,7 @@ public class TestObserverTest {
 
         try {
             to.assertValuesOnly();
-            fail();
+            throw new RuntimeException();
         } catch (AssertionError ex) {
             // expected
         }
@@ -1496,7 +1496,131 @@ public class TestObserverTest {
 
         try {
             to.assertValuesOnly();
-            fail();
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSetOnly() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+        to.assertValueSetOnly(Collections.<Integer>emptySet());
+
+        to.onNext(5);
+        to.assertValueSetOnly(Collections.singleton(5));
+
+        to.onNext(-1);
+        to.assertValueSetOnly(new HashSet<Integer>(Arrays.asList(5, -1)));
+    }
+
+    @Test
+    public void assertValueSetOnlyThrowsOnUnexpectedValue() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+        to.assertValueSetOnly(Collections.<Integer>emptySet());
+
+        to.onNext(5);
+        to.assertValueSetOnly(Collections.singleton(5));
+
+        to.onNext(-1);
+
+        try {
+            to.assertValueSetOnly(Collections.singleton(5));
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSetOnlyThrowsWhenCompleted() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+
+        to.onComplete();
+
+        try {
+            to.assertValueSetOnly(Collections.<Integer>emptySet());
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSetOnlyThrowsWhenErrored() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+
+        to.onError(new TestException());
+
+        try {
+            to.assertValueSetOnly(Collections.<Integer>emptySet());
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSequenceOnly() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+        to.assertValueSequenceOnly(Collections.<Integer>emptyList());
+
+        to.onNext(5);
+        to.assertValueSequenceOnly(Collections.singletonList(5));
+
+        to.onNext(-1);
+        to.assertValueSequenceOnly(Arrays.asList(5, -1));
+    }
+
+    @Test
+    public void assertValueSequenceOnlyThrowsOnUnexpectedValue() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+        to.assertValueSequenceOnly(Collections.<Integer>emptyList());
+
+        to.onNext(5);
+        to.assertValueSequenceOnly(Collections.singletonList(5));
+
+        to.onNext(-1);
+
+        try {
+            to.assertValueSequenceOnly(Collections.singletonList(5));
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSequenceOnlyThrowsWhenCompleted() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+
+        to.onComplete();
+
+        try {
+            to.assertValueSequenceOnly(Collections.<Integer>emptyList());
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSequenceOnlyThrowsWhenErrored() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+
+        to.onError(new TestException());
+
+        try {
+            to.assertValueSequenceOnly(Collections.<Integer>emptyList());
+            throw new RuntimeException();
         } catch (AssertionError ex) {
             // expected
         }

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -624,7 +624,7 @@ public class TestSubscriberTest {
 
         try {
             ts.assertNotTerminated();
-            fail("Failed to report there were terminal event(s)!");
+            throw new RuntimeException("Failed to report there were terminal event(s)!");
         } catch (AssertionError ex) {
             // expected
         }
@@ -638,7 +638,7 @@ public class TestSubscriberTest {
 
         try {
             ts.assertNotTerminated();
-            fail("Failed to report there were terminal event(s)!");
+            throw new RuntimeException("Failed to report there were terminal event(s)!");
         } catch (AssertionError ex) {
             // expected
         }
@@ -653,7 +653,7 @@ public class TestSubscriberTest {
 
         try {
             ts.assertNotTerminated();
-            fail("Failed to report there were terminal event(s)!");
+            throw new RuntimeException("Failed to report there were terminal event(s)!");
         } catch (AssertionError ex) {
             // expected
         }
@@ -669,7 +669,7 @@ public class TestSubscriberTest {
 
         try {
             ts.assertNotTerminated();
-            fail("Failed to report there were terminal event(s)!");
+            throw new RuntimeException("Failed to report there were terminal event(s)!");
         } catch (AssertionError ex) {
             // expected
             Throwable e = ex.getCause();
@@ -688,7 +688,7 @@ public class TestSubscriberTest {
 
         try {
             ts.assertNoValues();
-            fail("Failed to report there were values!");
+            throw new RuntimeException("Failed to report there were values!");
         } catch (AssertionError ex) {
             // expected
         }
@@ -702,7 +702,7 @@ public class TestSubscriberTest {
 
         try {
             ts.assertValueCount(3);
-            fail("Failed to report there were values!");
+            throw new RuntimeException("Failed to report there were values!");
         } catch (AssertionError ex) {
             // expected
         }
@@ -1790,7 +1790,7 @@ public class TestSubscriberTest {
                 .assertResult(1)
                 ;
             }
-            fail("Should have thrown!");
+            throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             assertTrue(ex.toString(), ex.toString().contains("testing with item=2"));
         }
@@ -1806,7 +1806,7 @@ public class TestSubscriberTest {
 
         try {
             ts.assertResult(1);
-            fail("Should have thrown!");
+            throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             assertTrue(ex.toString(), ex.toString().contains("timeout!"));
         }
@@ -1820,7 +1820,7 @@ public class TestSubscriberTest {
             .awaitDone(1, TimeUnit.MILLISECONDS)
             .assertResult(1);
 
-            fail("Should have thrown!");
+            throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             assertTrue(ex.toString(), ex.toString().contains("timeout!"));
         }
@@ -1835,7 +1835,7 @@ public class TestSubscriberTest {
 
         try {
             ts.assertResult(1);
-            fail("Should have thrown!");
+            throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             assertTrue(ex.toString(), ex.toString().contains("timeout!"));
         }
@@ -1848,7 +1848,7 @@ public class TestSubscriberTest {
 
         try {
             ts.assertResult(1);
-            fail("Should have thrown!");
+            throw new RuntimeException("Should have thrown!");
         } catch (Throwable ex) {
             assertTrue(ex.toString(), ex.toString().contains("disposed!"));
         }
@@ -1930,7 +1930,7 @@ public class TestSubscriberTest {
             .test()
             .awaitCount(1, TestWaitStrategy.SLEEP_1MS, 50)
             .assertTimeout();
-            fail("Should have thrown!");
+            throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             assertTrue(ex.toString(), ex.getMessage().contains("No timeout?!"));
         }
@@ -1951,7 +1951,7 @@ public class TestSubscriberTest {
             .test()
             .awaitCount(1, TestWaitStrategy.SLEEP_1MS, 50)
             .assertNoTimeout();
-            fail("Should have thrown!");
+            throw new RuntimeException("Should have thrown!");
         } catch (AssertionError ex) {
             assertTrue(ex.toString(), ex.getMessage().contains("Timeout?!"));
         }
@@ -1968,7 +1968,7 @@ public class TestSubscriberTest {
                     throw new IllegalArgumentException();
                 }
             });
-            fail("Should have thrown!");
+            throw new RuntimeException("Should have thrown!");
         } catch (IllegalArgumentException ex) {
             // expected
         }
@@ -1985,7 +1985,7 @@ public class TestSubscriberTest {
                     throw new IllegalArgumentException();
                 }
             });
-            fail("Should have thrown!");
+            throw new RuntimeException("Should have thrown!");
         } catch (IllegalArgumentException ex) {
             // expected
         }
@@ -2024,7 +2024,7 @@ public class TestSubscriberTest {
 
         try {
             ts.assertValuesOnly(5);
-            fail();
+            throw new RuntimeException();
         } catch (AssertionError ex) {
             // expected
         }
@@ -2039,7 +2039,7 @@ public class TestSubscriberTest {
 
         try {
             ts.assertValuesOnly();
-            fail();
+            throw new RuntimeException();
         } catch (AssertionError ex) {
             // expected
         }
@@ -2054,7 +2054,131 @@ public class TestSubscriberTest {
 
         try {
             ts.assertValuesOnly();
-            fail();
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSetOnly() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+        ts.assertValueSetOnly(Collections.<Integer>emptySet());
+
+        ts.onNext(5);
+        ts.assertValueSetOnly(Collections.singleton(5));
+
+        ts.onNext(-1);
+        ts.assertValueSetOnly(new HashSet<Integer>(Arrays.asList(5, -1)));
+    }
+
+    @Test
+    public void assertValueSetOnlyThrowsOnUnexpectedValue() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+        ts.assertValueSetOnly(Collections.<Integer>emptySet());
+
+        ts.onNext(5);
+        ts.assertValueSetOnly(Collections.singleton(5));
+
+        ts.onNext(-1);
+
+        try {
+            ts.assertValueSetOnly(Collections.singleton(5));
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSetOnlyThrowsWhenCompleted() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+
+        ts.onComplete();
+
+        try {
+            ts.assertValueSetOnly(Collections.<Integer>emptySet());
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSetOnlyThrowsWhenErrored() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+
+        ts.onError(new TestException());
+
+        try {
+            ts.assertValueSetOnly(Collections.<Integer>emptySet());
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSequenceOnly() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+        ts.assertValueSequenceOnly(Collections.<Integer>emptyList());
+
+        ts.onNext(5);
+        ts.assertValueSequenceOnly(Collections.singletonList(5));
+
+        ts.onNext(-1);
+        ts.assertValueSequenceOnly(Arrays.asList(5, -1));
+    }
+
+    @Test
+    public void assertValueSequenceOnlyThrowsOnUnexpectedValue() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+        ts.assertValueSequenceOnly(Collections.<Integer>emptyList());
+
+        ts.onNext(5);
+        ts.assertValueSequenceOnly(Collections.singletonList(5));
+
+        ts.onNext(-1);
+
+        try {
+            ts.assertValueSequenceOnly(Collections.singletonList(5));
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSequenceOnlyThrowsWhenCompleted() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+
+        ts.onComplete();
+
+        try {
+            ts.assertValueSequenceOnly(Collections.<Integer>emptyList());
+            throw new RuntimeException();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValueSequenceOnlyThrowsWhenErrored() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+
+        ts.onError(new TestException());
+
+        try {
+            ts.assertValueSequenceOnly(Collections.<Integer>emptyList());
+            throw new RuntimeException();
         } catch (AssertionError ex) {
             // expected
         }


### PR DESCRIPTION
This basically copies the behavior of `assertValuesOnly` to the `assertValueSet` and `assertValueSequence` equivalent methods.

Coped the tests exactly from `assertValuesOnly` and adjusted them with the new added methods.