### PR TITLE
Stops Integer boxing via null checks in Observable.concatEager

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1455,8 +1455,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatEager(ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
-        ObjectHelper.requireNonNull(maxConcurrency, "maxConcurrency is null");
-        ObjectHelper.requireNonNull(prefetch, "prefetch is null");
+        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
         return wrap(sources).concatMapEager((Function)Functions.identity(), maxConcurrency, prefetch);
     }
 
@@ -1507,8 +1507,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatEager(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
-        ObjectHelper.requireNonNull(maxConcurrency, "maxConcurrency is null");
-        ObjectHelper.requireNonNull(prefetch, "prefetch is null");
+        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
         return fromIterable(sources).concatMapEagerDelayError((Function)Functions.identity(), maxConcurrency, prefetch, false);
     }
 


### PR DESCRIPTION
Replaces with verifyPositive as in other similar methods.

This seems to be a trivial change and makes this more consistent with other areas of the code. Let me know if it needs its own issue or any specific tests. Given the methods only accept primitive ints, and passing a null Integer would throw a runtime exception, I'm not sure there's anything needed outside of the already present testing.