### PR TITLE
2.x: Fix & prevent null checks on primitives

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1455,8 +1455,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatEager(ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
-        ObjectHelper.requireNonNull(maxConcurrency, "maxConcurrency is null");
-        ObjectHelper.requireNonNull(prefetch, "prefetch is null");
         return wrap(sources).concatMapEager((Function)Functions.identity(), maxConcurrency, prefetch);
     }
 
@@ -1507,8 +1505,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatEager(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
-        ObjectHelper.requireNonNull(maxConcurrency, "maxConcurrency is null");
-        ObjectHelper.requireNonNull(prefetch, "prefetch is null");
         return fromIterable(sources).concatMapEagerDelayError((Function)Functions.identity(), maxConcurrency, prefetch, false);
     }
 

--- a/src/main/java/io/reactivex/internal/functions/ObjectHelper.java
+++ b/src/main/java/io/reactivex/internal/functions/ObjectHelper.java
@@ -128,4 +128,17 @@ public final class ObjectHelper {
             return ObjectHelper.equals(o1, o2);
         }
     }
+
+    /**
+     * Trap null-check attempts on primitives.
+     * @param value the value to check
+     * @param message the message to print
+     * @return the value
+     * @deprecated this method should not be used as there is no need
+     * to check primitives for nullness.
+     */
+    @Deprecated
+    public static long requireNonNull(long value, String message) {
+        throw new InternalError("Null check on a primitive: " + message);
+    }
 }

--- a/src/test/java/io/reactivex/internal/functions/ObjectHelperTest.java
+++ b/src/test/java/io/reactivex/internal/functions/ObjectHelperTest.java
@@ -65,4 +65,10 @@ public class ObjectHelperTest {
         assertEquals(0, ObjectHelper.compare(0L, 0L));
         assertEquals(1, ObjectHelper.compare(2L, 0L));
     }
+
+    @SuppressWarnings("deprecation")
+    @Test(expected = InternalError.class)
+    public void requireNonNullPrimitive() {
+        ObjectHelper.requireNonNull(0, "value");
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -934,6 +934,7 @@ public class FlowableCreateTest {
         }
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void emittersHasToString() {
         Map<BackpressureStrategy, Class<? extends FlowableEmitter>> emitterMap =


### PR DESCRIPTION
This PR removes the accidental null checks on primitives in two `Observable` methods and adds a trap method to `ObjectHelper` to both highlight and fail the tests in case the null checks are still attempted. The method is marked as deprecated so it will also show up in (Eclipse's) problems window.

Replaces #6012 
Resolves #6013