### PR TITLE
2.x: Fix Single.takeUntil, Maybe.takeUntil dispose behavior

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisher.java
@@ -137,6 +137,7 @@ public final class MaybeTakeUntilPublisher<T, U> extends AbstractMaybeWithUpstre
 
             @Override
             public void onNext(Object value) {
+                SubscriptionHelper.cancel(this);
                 parent.otherComplete();
             }
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTakeUntil.java
@@ -69,6 +69,7 @@ public final class SingleTakeUntil<T, U> extends Single<T> {
         @Override
         public void dispose() {
             DisposableHelper.dispose(this);
+            other.dispose();
         }
 
         @Override

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableAmbTest.java
@@ -186,4 +186,78 @@ public class CompletableAmbTest {
             RxJavaPlugins.reset();
         }
     }
+
+
+    @Test
+    public void untilCompletableMainComplete() {
+        CompletableSubject main = CompletableSubject.create();
+        CompletableSubject other = CompletableSubject.create();
+
+        TestObserver<Void> to = main.ambWith(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onComplete();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult();
+    }
+
+    @Test
+    public void untilCompletableMainError() {
+        CompletableSubject main = CompletableSubject.create();
+        CompletableSubject other = CompletableSubject.create();
+
+        TestObserver<Void> to = main.ambWith(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilCompletableOtherOnComplete() {
+        CompletableSubject main = CompletableSubject.create();
+        CompletableSubject other = CompletableSubject.create();
+
+        TestObserver<Void> to = main.ambWith(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onComplete();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult();
+    }
+
+    @Test
+    public void untilCompletableOtherError() {
+        CompletableSubject main = CompletableSubject.create();
+        CompletableSubject other = CompletableSubject.create();
+
+        TestObserver<Void> to = main.ambWith(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
@@ -293,4 +294,133 @@ public class FlowableTakeUntilTest {
             }
         });
     }
+
+    @Test
+    public void untilPublisherMainSuccess() {
+        PublishProcessor<Integer> main = PublishProcessor.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = main.takeUntil(other).test();
+
+        assertTrue("Main no subscribers?", main.hasSubscribers());
+        assertTrue("Other no subscribers?", other.hasSubscribers());
+
+        main.onNext(1);
+        main.onNext(2);
+        main.onComplete();
+
+        assertFalse("Main has subscribers?", main.hasSubscribers());
+        assertFalse("Other has subscribers?", other.hasSubscribers());
+
+        ts.assertResult(1, 2);
+    }
+
+    @Test
+    public void untilPublisherMainComplete() {
+        PublishProcessor<Integer> main = PublishProcessor.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = main.takeUntil(other).test();
+
+        assertTrue("Main no subscribers?", main.hasSubscribers());
+        assertTrue("Other no subscribers?", other.hasSubscribers());
+
+        main.onComplete();
+
+        assertFalse("Main has subscribers?", main.hasSubscribers());
+        assertFalse("Other has subscribers?", other.hasSubscribers());
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void untilPublisherMainError() {
+        PublishProcessor<Integer> main = PublishProcessor.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = main.takeUntil(other).test();
+
+        assertTrue("Main no subscribers?", main.hasSubscribers());
+        assertTrue("Other no subscribers?", other.hasSubscribers());
+
+        main.onError(new TestException());
+
+        assertFalse("Main has subscribers?", main.hasSubscribers());
+        assertFalse("Other has subscribers?", other.hasSubscribers());
+
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilPublisherOtherOnNext() {
+        PublishProcessor<Integer> main = PublishProcessor.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = main.takeUntil(other).test();
+
+        assertTrue("Main no subscribers?", main.hasSubscribers());
+        assertTrue("Other no subscribers?", other.hasSubscribers());
+
+        other.onNext(1);
+
+        assertFalse("Main has subscribers?", main.hasSubscribers());
+        assertFalse("Other has subscribers?", other.hasSubscribers());
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void untilPublisherOtherOnComplete() {
+        PublishProcessor<Integer> main = PublishProcessor.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = main.takeUntil(other).test();
+
+        assertTrue("Main no subscribers?", main.hasSubscribers());
+        assertTrue("Other no subscribers?", other.hasSubscribers());
+
+        other.onComplete();
+
+        assertFalse("Main has subscribers?", main.hasSubscribers());
+        assertFalse("Other has subscribers?", other.hasSubscribers());
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void untilPublisherOtherError() {
+        PublishProcessor<Integer> main = PublishProcessor.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = main.takeUntil(other).test();
+
+        assertTrue("Main no subscribers?", main.hasSubscribers());
+        assertTrue("Other no subscribers?", other.hasSubscribers());
+
+        other.onError(new TestException());
+
+        assertFalse("Main has subscribers?", main.hasSubscribers());
+        assertFalse("Other has subscribers?", other.hasSubscribers());
+
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilPublisherDispose() {
+        PublishProcessor<Integer> main = PublishProcessor.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = main.takeUntil(other).test();
+
+        assertTrue("Main no subscribers?", main.hasSubscribers());
+        assertTrue("Other no subscribers?", other.hasSubscribers());
+
+        ts.dispose();
+
+        assertFalse("Main has subscribers?", main.hasSubscribers());
+        assertFalse("Other has subscribers?", other.hasSubscribers());
+
+        ts.assertEmpty();
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilTest.java
@@ -25,6 +25,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subjects.MaybeSubject;
 
 public class MaybeTakeUntilTest {
 
@@ -210,5 +211,257 @@ public class MaybeTakeUntilTest {
 
             to.assertResult();
         }
+    }
+
+    @Test
+    public void untilMaybeMainSuccess() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        MaybeSubject<Integer> other = MaybeSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onSuccess(1);
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult(1);
+    }
+
+    @Test
+    public void untilMaybeMainComplete() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        MaybeSubject<Integer> other = MaybeSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onComplete();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult();
+    }
+
+    @Test
+    public void untilMaybeMainError() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        MaybeSubject<Integer> other = MaybeSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilMaybeOtherSuccess() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        MaybeSubject<Integer> other = MaybeSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onSuccess(1);
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult();
+    }
+
+    @Test
+    public void untilMaybeOtherComplete() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        MaybeSubject<Integer> other = MaybeSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onComplete();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult();
+    }
+
+    @Test
+    public void untilMaybeOtherError() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        MaybeSubject<Integer> other = MaybeSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilMaybeDispose() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        MaybeSubject<Integer> other = MaybeSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        to.dispose();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void untilPublisherMainSuccess() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        main.onSuccess(1);
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertResult(1);
+    }
+
+    @Test
+    public void untilPublisherMainComplete() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        main.onComplete();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertResult();
+    }
+
+    @Test
+    public void untilPublisherMainError() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        main.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilPublisherOtherOnNext() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        other.onNext(1);
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertResult();
+    }
+
+    @Test
+    public void untilPublisherOtherOnComplete() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        other.onComplete();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertResult();
+    }
+
+    @Test
+    public void untilPublisherOtherError() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        other.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilPublisherDispose() {
+        MaybeSubject<Integer> main = MaybeSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        to.dispose();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertEmpty();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.PublishSubject;
@@ -271,4 +272,134 @@ public class ObservableTakeUntilTest {
             }
         });
     }
+
+
+    @Test
+    public void untilPublisherMainSuccess() {
+        PublishSubject<Integer> main = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onNext(1);
+        main.onNext(2);
+        main.onComplete();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult(1, 2);
+    }
+
+    @Test
+    public void untilPublisherMainComplete() {
+        PublishSubject<Integer> main = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onComplete();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult();
+    }
+
+    @Test
+    public void untilPublisherMainError() {
+        PublishSubject<Integer> main = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilPublisherOtherOnNext() {
+        PublishSubject<Integer> main = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onNext(1);
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult();
+    }
+
+    @Test
+    public void untilPublisherOtherOnComplete() {
+        PublishSubject<Integer> main = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onComplete();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult();
+    }
+
+    @Test
+    public void untilPublisherOtherError() {
+        PublishSubject<Integer> main = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilPublisherDispose() {
+        PublishSubject<Integer> main = PublishSubject.create();
+        PublishSubject<Integer> other = PublishSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        to.dispose();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertEmpty();
+    }
+
 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.internal.operators.single;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.List;
 import java.util.concurrent.CancellationException;
@@ -27,6 +27,7 @@ import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subjects.*;
 
 public class SingleTakeUntilTest {
 
@@ -290,5 +291,293 @@ public class SingleTakeUntilTest {
         })
         .test()
         .assertFailure(CancellationException.class);
+    }
+
+    @Test
+    public void untilSingleMainSuccess() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        SingleSubject<Integer> other = SingleSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onSuccess(1);
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult(1);
+    }
+
+    @Test
+    public void untilSingleMainError() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        SingleSubject<Integer> other = SingleSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilSingleOtherSuccess() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        SingleSubject<Integer> other = SingleSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onSuccess(1);
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(CancellationException.class);
+    }
+
+    @Test
+    public void untilSingleOtherError() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        SingleSubject<Integer> other = SingleSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilSingleDispose() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        SingleSubject<Integer> other = SingleSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        to.dispose();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void untilPublisherMainSuccess() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        main.onSuccess(1);
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertResult(1);
+    }
+
+    @Test
+    public void untilPublisherMainError() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        main.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilPublisherOtherOnNext() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        other.onNext(1);
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertFailure(CancellationException.class);
+    }
+
+    @Test
+    public void untilPublisherOtherOnComplete() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        other.onComplete();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertFailure(CancellationException.class);
+    }
+
+    @Test
+    public void untilPublisherOtherError() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        other.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilPublisherDispose() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        PublishProcessor<Integer> other = PublishProcessor.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasSubscribers());
+
+        to.dispose();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasSubscribers());
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void untilCompletableMainSuccess() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        CompletableSubject other = CompletableSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onSuccess(1);
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertResult(1);
+    }
+
+    @Test
+    public void untilCompletableMainError() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        CompletableSubject other = CompletableSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        main.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilCompletableOtherOnComplete() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        CompletableSubject other = CompletableSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onComplete();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(CancellationException.class);
+    }
+
+    @Test
+    public void untilCompletableOtherError() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        CompletableSubject other = CompletableSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        other.onError(new TestException());
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void untilCompletableDispose() {
+        SingleSubject<Integer> main = SingleSubject.create();
+        CompletableSubject other = CompletableSubject.create();
+
+        TestObserver<Integer> to = main.takeUntil(other).test();
+
+        assertTrue("Main no observers?", main.hasObservers());
+        assertTrue("Other no observers?", other.hasObservers());
+
+        to.dispose();
+
+        assertFalse("Main has observers?", main.hasObservers());
+        assertFalse("Other has observers?", other.hasObservers());
+
+        to.assertEmpty();
     }
 }


### PR DESCRIPTION
Fix the dispose behavior of the `Single.takeUntil` and `Maybe.takeUntil` operators.

Tests were also added to the other 3 `takeUntil` variants (for `Completable`, it is delegated to `amb`).

Fixes: #6018