### PR TITLE
2.x: More time to BehaviorProcessor & Interval TCK tests

### DIFF
--- a/src/test/java/io/reactivex/tck/BehaviorProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/tck/BehaviorProcessorAsPublisherTckTest.java
@@ -22,6 +22,10 @@ import io.reactivex.schedulers.Schedulers;
 @Test
 public class BehaviorProcessorAsPublisherTckTest extends BaseTck<Integer> {
 
+    public BehaviorProcessorAsPublisherTckTest() {
+        super(50);
+    }
+
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
         final BehaviorProcessor<Integer> pp = BehaviorProcessor.create();

--- a/src/test/java/io/reactivex/tck/IntervalTckTest.java
+++ b/src/test/java/io/reactivex/tck/IntervalTckTest.java
@@ -23,6 +23,10 @@ import io.reactivex.Flowable;
 @Test
 public class IntervalTckTest extends BaseTck<Long> {
 
+    public IntervalTckTest() {
+        super(50);
+    }
+
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return


### PR DESCRIPTION
This PR increases the timeout of the Reactive Streams TCK tests targeting `BehaviorProcessor` and `interval()` from 25ms to 50ms to have some slack on Travis-CI.