### PR TITLE
2.x: Dedicated {Single|Maybe}.flatMap{Publisher|Observable} & andThen(Observable|Publisher) implementations

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -24,9 +24,8 @@ import io.reactivex.internal.functions.*;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.observers.*;
 import io.reactivex.internal.operators.completable.*;
-import io.reactivex.internal.operators.flowable.FlowableDelaySubscriptionOther;
 import io.reactivex.internal.operators.maybe.*;
-import io.reactivex.internal.operators.observable.ObservableDelaySubscriptionOther;
+import io.reactivex.internal.operators.mixed.*;
 import io.reactivex.internal.operators.single.SingleDelayWithCompletable;
 import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observers.TestObserver;
@@ -872,7 +871,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Observable<T> andThen(ObservableSource<T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
-        return RxJavaPlugins.onAssembly(new ObservableDelaySubscriptionOther<T, Object>(next, toObservable()));
+        return RxJavaPlugins.onAssembly(new CompletableAndThenObservable<T>(this, next));
     }
 
     /**
@@ -897,7 +896,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Flowable<T> andThen(Publisher<T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
-        return RxJavaPlugins.onAssembly(new FlowableDelaySubscriptionOther<T, Object>(next, toFlowable()));
+        return RxJavaPlugins.onAssembly(new CompletableAndThenPublisher<T>(this, next));
     }
 
     /**

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -27,6 +27,7 @@ import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.observers.BlockingMultiObserver;
 import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.operators.maybe.*;
+import io.reactivex.internal.operators.mixed.*;
 import io.reactivex.internal.util.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -2961,7 +2962,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMapObservable(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
-        return toObservable().flatMap(mapper);
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapObservable<T, R>(this, mapper));
     }
 
     /**
@@ -2987,7 +2989,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> flatMapPublisher(Function<? super T, ? extends Publisher<? extends R>> mapper) {
-        return toFlowable().flatMap(mapper);
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapPublisher<T, R>(this, mapper));
     }
 
     /**

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -28,6 +28,7 @@ import io.reactivex.internal.observers.*;
 import io.reactivex.internal.operators.completable.*;
 import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.operators.maybe.*;
+import io.reactivex.internal.operators.mixed.*;
 import io.reactivex.internal.operators.observable.*;
 import io.reactivex.internal.operators.single.*;
 import io.reactivex.internal.util.*;
@@ -2535,7 +2536,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMapObservable(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
-        return toObservable().flatMap(mapper);
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
+        return RxJavaPlugins.onAssembly(new SingleFlatMapObservable<T, R>(this, mapper));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservable.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+/**
+ * After Completable completes, it relays the signals
+ * of the ObservableSource to the downstream observer.
+ * 
+ * @param <R> the result type of the ObservableSource and this operator
+ * @since 2.1.15
+ */
+public final class CompletableAndThenObservable<R> extends Observable<R> {
+
+    final CompletableSource source;
+
+    final ObservableSource<? extends R> other;
+
+    public CompletableAndThenObservable(CompletableSource source,
+            ObservableSource<? extends R> other) {
+        this.source = source;
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super R> s) {
+        AndThenObservableObserver<R> parent = new AndThenObservableObserver<R>(s, other);
+        s.onSubscribe(parent);
+        source.subscribe(parent);
+    }
+
+    static final class AndThenObservableObserver<R>
+    extends AtomicReference<Disposable>
+    implements Observer<R>, CompletableObserver, Disposable {
+
+        private static final long serialVersionUID = -8948264376121066672L;
+
+        final Observer<? super R> downstream;
+
+        ObservableSource<? extends R> other;
+
+        AndThenObservableObserver(Observer<? super R> downstream, ObservableSource<? extends R> other) {
+            this.other = other;
+            this.downstream = downstream;
+        }
+
+        @Override
+        public void onNext(R t) {
+            downstream.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            downstream.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            ObservableSource<? extends R> p = other;
+            if (p == null) {
+                downstream.onComplete();
+            } else {
+                other = null;
+                p.subscribe(this);
+            }
+        }
+
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.replace(this, d);
+        }
+
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservable.java
@@ -72,12 +72,12 @@ public final class CompletableAndThenObservable<R> extends Observable<R> {
 
         @Override
         public void onComplete() {
-            ObservableSource<? extends R> p = other;
-            if (p == null) {
+            ObservableSource<? extends R> o = other;
+            if (o == null) {
                 downstream.onComplete();
             } else {
                 other = null;
-                p.subscribe(this);
+                o.subscribe(this);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/CompletableAndThenPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/CompletableAndThenPublisher.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+/**
+ * After Completable completes, it relays the signals
+ * of the Publisher to the downstream subscriber.
+ * 
+ * @param <R> the result type of the Publisher and this operator
+ * @since 2.1.15
+ */
+public final class CompletableAndThenPublisher<R> extends Flowable<R> {
+
+    final CompletableSource source;
+
+    final Publisher<? extends R> other;
+
+    public CompletableAndThenPublisher(CompletableSource source,
+            Publisher<? extends R> other) {
+        this.source = source;
+        this.other = other;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+        source.subscribe(new AndThenPublisherSubscriber<R>(s, other));
+    }
+
+    static final class AndThenPublisherSubscriber<R>
+    extends AtomicReference<Subscription>
+    implements FlowableSubscriber<R>, CompletableObserver, Subscription {
+
+        private static final long serialVersionUID = -8948264376121066672L;
+
+        final Subscriber<? super R> downstream;
+
+        Publisher<? extends R> other;
+
+        Disposable upstream;
+
+        final AtomicLong requested;
+
+        AndThenPublisherSubscriber(Subscriber<? super R> downstream, Publisher<? extends R> other) {
+            this.downstream = downstream;
+            this.other = other;
+            this.requested = new AtomicLong();
+        }
+
+        @Override
+        public void onNext(R t) {
+            downstream.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            downstream.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            Publisher<? extends R> p = other;
+            if (p == null) {
+                downstream.onComplete();
+            } else {
+                other = null;
+                p.subscribe(this);
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            SubscriptionHelper.deferredRequest(this, requested, n);
+        }
+
+        @Override
+        public void cancel() {
+            upstream.dispose();
+            SubscriptionHelper.cancel(this);
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(upstream, d)) {
+                this.upstream = d;
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            SubscriptionHelper.deferredSetOnce(this, requested, s);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/mixed/MaybeFlatMapObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/MaybeFlatMapObservable.java
@@ -96,17 +96,17 @@ public final class MaybeFlatMapObservable<T, R> extends Observable<R> {
 
         @Override
         public void onSuccess(T t) {
-            ObservableSource<? extends R> p;
+            ObservableSource<? extends R> o;
 
             try {
-                p = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
+                o = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 downstream.onError(ex);
                 return;
             }
 
-            p.subscribe(this);
+            o.subscribe(this);
         }
 
     }

--- a/src/main/java/io/reactivex/internal/operators/mixed/MaybeFlatMapObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/MaybeFlatMapObservable.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import java.util.concurrent.atomic.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+
+/**
+ * Maps the success value of a Maybe onto an ObservableSource and
+ * relays its signals to the downstream observer.
+ * 
+ * @param <T> the success value type of the Maybe source
+ * @param <R> the result type of the ObservableSource and this operator
+ * @since 2.1.15
+ */
+public final class MaybeFlatMapObservable<T, R> extends Observable<R> {
+
+    final MaybeSource<T> source;
+
+    final Function<? super T, ? extends ObservableSource<? extends R>> mapper;
+
+    public MaybeFlatMapObservable(MaybeSource<T> source,
+            Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super R> s) {
+        FlatMapObserver<T, R> parent = new FlatMapObserver<T, R>(s, mapper);
+        s.onSubscribe(parent);
+        source.subscribe(parent);
+    }
+
+    static final class FlatMapObserver<T, R>
+    extends AtomicReference<Disposable>
+    implements Observer<R>, MaybeObserver<T>, Disposable {
+
+        private static final long serialVersionUID = -8948264376121066672L;
+
+        final Observer<? super R> downstream;
+
+        final Function<? super T, ? extends ObservableSource<? extends R>> mapper;
+
+        FlatMapObserver(Observer<? super R> downstream, Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void onNext(R t) {
+            downstream.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            downstream.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            downstream.onComplete();
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.replace(this, d);
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            ObservableSource<? extends R> p;
+
+            try {
+                p = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                downstream.onError(ex);
+                return;
+            }
+
+            p.subscribe(this);
+        }
+
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/mixed/MaybeFlatMapPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/MaybeFlatMapPublisher.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import java.util.concurrent.atomic.*;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+/**
+ * Maps the success value of a Maybe onto a Publisher and
+ * relays its signals to the downstream subscriber.
+ * 
+ * @param <T> the success value type of the Maybe source
+ * @param <R> the result type of the Publisher and this operator
+ * @since 2.1.15
+ */
+public final class MaybeFlatMapPublisher<T, R> extends Flowable<R> {
+
+    final MaybeSource<T> source;
+
+    final Function<? super T, ? extends Publisher<? extends R>> mapper;
+
+    public MaybeFlatMapPublisher(MaybeSource<T> source,
+            Function<? super T, ? extends Publisher<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+        source.subscribe(new FlatMapPublisherSubscriber<T, R>(s, mapper));
+    }
+
+    static final class FlatMapPublisherSubscriber<T, R>
+    extends AtomicReference<Subscription>
+    implements FlowableSubscriber<R>, MaybeObserver<T>, Subscription {
+
+        private static final long serialVersionUID = -8948264376121066672L;
+
+        final Subscriber<? super R> downstream;
+
+        final Function<? super T, ? extends Publisher<? extends R>> mapper;
+
+        Disposable upstream;
+
+        final AtomicLong requested;
+
+        FlatMapPublisherSubscriber(Subscriber<? super R> downstream, Function<? super T, ? extends Publisher<? extends R>> mapper) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+            this.requested = new AtomicLong();
+        }
+
+        @Override
+        public void onNext(R t) {
+            downstream.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            downstream.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            downstream.onComplete();
+        }
+
+        @Override
+        public void request(long n) {
+            SubscriptionHelper.deferredRequest(this, requested, n);
+        }
+
+        @Override
+        public void cancel() {
+            upstream.dispose();
+            SubscriptionHelper.cancel(this);
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(upstream, d)) {
+                this.upstream = d;
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            Publisher<? extends R> p;
+
+            try {
+                p = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                downstream.onError(ex);
+                return;
+            }
+
+            p.subscribe(this);
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            SubscriptionHelper.deferredSetOnce(this, requested, s);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/mixed/SingleFlatMapObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/SingleFlatMapObservable.java
@@ -96,17 +96,17 @@ public final class SingleFlatMapObservable<T, R> extends Observable<R> {
 
         @Override
         public void onSuccess(T t) {
-            ObservableSource<? extends R> p;
+            ObservableSource<? extends R> o;
 
             try {
-                p = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
+                o = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 downstream.onError(ex);
                 return;
             }
 
-            p.subscribe(this);
+            o.subscribe(this);
         }
 
     }

--- a/src/main/java/io/reactivex/internal/operators/mixed/SingleFlatMapObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/SingleFlatMapObservable.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import java.util.concurrent.atomic.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+
+/**
+ * Maps the success value of a Single onto an ObservableSource and
+ * relays its signals to the downstream observer.
+ * 
+ * @param <T> the success value type of the Single source
+ * @param <R> the result type of the ObservableSource and this operator
+ * @since 2.1.15
+ */
+public final class SingleFlatMapObservable<T, R> extends Observable<R> {
+
+    final SingleSource<T> source;
+
+    final Function<? super T, ? extends ObservableSource<? extends R>> mapper;
+
+    public SingleFlatMapObservable(SingleSource<T> source,
+            Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super R> s) {
+        FlatMapObserver<T, R> parent = new FlatMapObserver<T, R>(s, mapper);
+        s.onSubscribe(parent);
+        source.subscribe(parent);
+    }
+
+    static final class FlatMapObserver<T, R>
+    extends AtomicReference<Disposable>
+    implements Observer<R>, SingleObserver<T>, Disposable {
+
+        private static final long serialVersionUID = -8948264376121066672L;
+
+        final Observer<? super R> downstream;
+
+        final Function<? super T, ? extends ObservableSource<? extends R>> mapper;
+
+        FlatMapObserver(Observer<? super R> downstream, Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void onNext(R t) {
+            downstream.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            downstream.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            downstream.onComplete();
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(get());
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.replace(this, d);
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            ObservableSource<? extends R> p;
+
+            try {
+                p = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                downstream.onError(ex);
+                return;
+            }
+
+            p.subscribe(this);
+        }
+
+    }
+}

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.completable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -26,7 +27,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.*;
@@ -4428,6 +4429,7 @@ public class CompletableTest {
         Completable.unsafeCreate(new CompletableSource() {
                 @Override
                 public void subscribe(CompletableObserver cs) {
+                    cs.onSubscribe(Disposables.empty());
                     cs.onError(e);
                 }
             })

--- a/src/test/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservableTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.subjects.*;
+
+public class CompletableAndThenObservableTest {
+
+    @Test
+    public void cancelMain() {
+        CompletableSubject cs = CompletableSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = cs.andThen(ps)
+                .test();
+
+        assertTrue(cs.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        to.cancel();
+
+        assertFalse(cs.hasObservers());
+        assertFalse(ps.hasObservers());
+    }
+
+    @Test
+    public void cancelOther() {
+        CompletableSubject cs = CompletableSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = cs.andThen(ps)
+                .test();
+
+        assertTrue(cs.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        cs.onComplete();
+
+        assertFalse(cs.hasObservers());
+        assertTrue(ps.hasObservers());
+
+        to.cancel();
+
+        assertFalse(cs.hasObservers());
+        assertFalse(ps.hasObservers());
+    }
+
+
+    @Test
+    public void errorMain() {
+        CompletableSubject cs = CompletableSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = cs.andThen(ps)
+                .test();
+
+        assertTrue(cs.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        cs.onError(new TestException());
+
+        assertFalse(cs.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorOther() {
+        CompletableSubject cs = CompletableSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = cs.andThen(ps)
+                .test();
+
+        assertTrue(cs.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        cs.onComplete();
+
+        assertFalse(cs.hasObservers());
+        assertTrue(ps.hasObservers());
+
+        ps.onError(new TestException());
+
+        assertFalse(cs.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void isDisposed() {
+        TestHelper.checkDisposed(Completable.never().andThen(Observable.never()));
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/operators/mixed/CompletableAndThenPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/CompletableAndThenPublisherTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.functions.Function;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subjects.CompletableSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class CompletableAndThenPublisherTest {
+
+    @Test
+    public void cancelMain() {
+        CompletableSubject cs = CompletableSubject.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = cs.andThen(pp)
+                .test();
+
+        assertTrue(cs.hasObservers());
+        assertFalse(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(cs.hasObservers());
+        assertFalse(pp.hasSubscribers());
+    }
+
+    @Test
+    public void cancelOther() {
+        CompletableSubject cs = CompletableSubject.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = cs.andThen(pp)
+                .test();
+
+        assertTrue(cs.hasObservers());
+        assertFalse(pp.hasSubscribers());
+
+        cs.onComplete();
+
+        assertFalse(cs.hasObservers());
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(cs.hasObservers());
+        assertFalse(pp.hasSubscribers());
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeCompletableToFlowable(new Function<Completable, Publisher<Object>>() {
+            @Override
+            public Publisher<Object> apply(Completable m) throws Exception {
+                return m.andThen(Flowable.never());
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/mixed/MaybeFlatMapObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/MaybeFlatMapObservableTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.subjects.*;
+
+public class MaybeFlatMapObservableTest {
+
+    @Test
+    public void cancelMain() {
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ms.flatMapObservable(Functions.justFunction(ps))
+                .test();
+
+        assertTrue(ms.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        to.cancel();
+
+        assertFalse(ms.hasObservers());
+        assertFalse(ps.hasObservers());
+    }
+
+    @Test
+    public void cancelOther() {
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ms.flatMapObservable(Functions.justFunction(ps))
+                .test();
+
+        assertTrue(ms.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        ms.onSuccess(1);
+
+        assertFalse(ms.hasObservers());
+        assertTrue(ps.hasObservers());
+
+        to.cancel();
+
+        assertFalse(ms.hasObservers());
+        assertFalse(ps.hasObservers());
+    }
+
+    @Test
+    public void mapperCrash() {
+        Maybe.just(1).flatMapObservable(new Function<Integer, ObservableSource<? extends Object>>() {
+            @Override
+            public ObservableSource<? extends Object> apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void isDisposed() {
+        TestHelper.checkDisposed(Maybe.never().flatMapObservable(Functions.justFunction(Observable.never())));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/mixed/MaybeFlatMapPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/MaybeFlatMapPublisherTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subjects.MaybeSubject;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class MaybeFlatMapPublisherTest {
+
+    @Test
+    public void cancelMain() {
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = ms.flatMapPublisher(Functions.justFunction(pp))
+                .test();
+
+        assertTrue(ms.hasObservers());
+        assertFalse(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(ms.hasObservers());
+        assertFalse(pp.hasSubscribers());
+    }
+
+    @Test
+    public void cancelOther() {
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = ms.flatMapPublisher(Functions.justFunction(pp))
+                .test();
+
+        assertTrue(ms.hasObservers());
+        assertFalse(pp.hasSubscribers());
+
+        ms.onSuccess(1);
+
+        assertFalse(ms.hasObservers());
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(ms.hasObservers());
+        assertFalse(pp.hasSubscribers());
+    }
+
+    @Test
+    public void mapperCrash() {
+        Maybe.just(1).flatMapPublisher(new Function<Integer, Publisher<? extends Object>>() {
+            @Override
+            public Publisher<? extends Object> apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybeToFlowable(new Function<Maybe<Object>, Publisher<Object>>() {
+            @Override
+            public Publisher<Object> apply(Maybe<Object> m) throws Exception {
+                return m.flatMapPublisher(Functions.justFunction(Flowable.never()));
+            }
+        });
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/mixed/SingleFlatMapObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/SingleFlatMapObservableTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.mixed;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.subjects.*;
+
+public class SingleFlatMapObservableTest {
+
+    @Test
+    public void cancelMain() {
+        SingleSubject<Integer> ss = SingleSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ss.flatMapObservable(Functions.justFunction(ps))
+                .test();
+
+        assertTrue(ss.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        to.cancel();
+
+        assertFalse(ss.hasObservers());
+        assertFalse(ps.hasObservers());
+    }
+
+    @Test
+    public void cancelOther() {
+        SingleSubject<Integer> ss = SingleSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ss.flatMapObservable(Functions.justFunction(ps))
+                .test();
+
+        assertTrue(ss.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        ss.onSuccess(1);
+
+        assertFalse(ss.hasObservers());
+        assertTrue(ps.hasObservers());
+
+        to.cancel();
+
+        assertFalse(ss.hasObservers());
+        assertFalse(ps.hasObservers());
+    }
+
+    @Test
+    public void errorMain() {
+        SingleSubject<Integer> ss = SingleSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ss.flatMapObservable(Functions.justFunction(ps))
+                .test();
+
+        assertTrue(ss.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        ss.onError(new TestException());
+
+        assertFalse(ss.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorOther() {
+        SingleSubject<Integer> ss = SingleSubject.create();
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ss.flatMapObservable(Functions.justFunction(ps))
+                .test();
+
+        assertTrue(ss.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        ss.onSuccess(1);
+
+        assertFalse(ss.hasObservers());
+        assertTrue(ps.hasObservers());
+
+        ps.onError(new TestException());
+
+        assertFalse(ss.hasObservers());
+        assertFalse(ps.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapperCrash() {
+        Single.just(1).flatMapObservable(new Function<Integer, ObservableSource<? extends Object>>() {
+            @Override
+            public ObservableSource<? extends Object> apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void isDisposed() {
+        TestHelper.checkDisposed(Single.never().flatMapObservable(Functions.justFunction(Observable.never())));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapTest.java
@@ -129,16 +129,16 @@ public class SingleFlatMapTest {
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
-    
+
     @Test(expected = NullPointerException.class)
     public void flatMapPublisherMapperNull() {
         Single.just(1).flatMapPublisher(null);
     }
-    
+
     @Test
     public void flatMapPublisherMapperThrows() {
         final TestException ex = new TestException();
-        Single.just(1) 
+        Single.just(1)
         .flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer v) throws Exception {
@@ -149,11 +149,11 @@ public class SingleFlatMapTest {
         .assertNoValues()
         .assertError(ex);
     }
-    
+
     @Test
     public void flatMapPublisherSingleError() {
         final TestException ex = new TestException();
-        Single.<Integer>error(ex) 
+        Single.<Integer>error(ex)
         .flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer v) throws Exception {
@@ -164,7 +164,7 @@ public class SingleFlatMapTest {
         .assertNoValues()
         .assertError(ex);
     }
-    
+
     @Test
     public void flatMapPublisherCancelDuringSingle() {
         final AtomicBoolean disposed = new AtomicBoolean();
@@ -182,18 +182,18 @@ public class SingleFlatMapTest {
             }
         })
         .test()
-        .assertNoValues() 
+        .assertNoValues()
         .assertNotTerminated();
         assertFalse(disposed.get());
         ts.cancel();
         assertTrue(disposed.get());
         ts.assertNotTerminated();
     }
-    
+
     @Test
     public void flatMapPublisherCancelDuringFlowable() {
         final AtomicBoolean disposed = new AtomicBoolean();
-        TestSubscriber<Integer> ts = 
+        TestSubscriber<Integer> ts =
         Single.just(1)
         .flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
             @Override
@@ -208,7 +208,7 @@ public class SingleFlatMapTest {
             }
         })
         .test()
-        .assertNoValues() 
+        .assertNoValues()
         .assertNotTerminated();
         assertFalse(disposed.get());
         ts.cancel();


### PR DESCRIPTION
This PR implements the following operators directly instead of conversions between base types:

- `Single.flatMapObservable`
- `Maybe.flatMapObservable`
- `Maybe.flatMapPublisher`
- `Completable.andThen(Observable)`
- `Completable.andThen(Publisher)`

The `Single.flatMapPublisher` was reimplemented in #6021 already.