### PR TITLE
Fix Flowable.blockingSubscribe is unbounded and can lead to OOME

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -5856,6 +5856,38 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Subscribes to the source and calls the given callbacks <strong>on the current thread</strong>.
      * <p>
+     * If the Flowable emits an error, it is wrapped into an
+     * {@link io.reactivex.exceptions.OnErrorNotImplementedException OnErrorNotImplementedException}
+     * and routed to the RxJavaPlugins.onError handler.
+     * Using the overloads {@link #blockingSubscribe(Consumer, Consumer)}
+     * or {@link #blockingSubscribe(Consumer, Consumer, Action)} instead is recommended.
+     * <p>
+     * Note that calling this method will block the caller thread until the upstream terminates
+     * normally or with an error. Therefore, calling this method from special threads such as the
+     * Android Main Thread or the Swing Event Dispatch Thread is not recommended.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator consumes the source {@code Flowable} in an bounded manner (up to bufferSize
+     *  outstanding request amount for items).</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onNext the callback action for each source value
+     * @param bufferSize the size of the buffer
+     * @since 2.1.15 - experimental
+     * @see #blockingSubscribe(Consumer, Consumer)
+     * @see #blockingSubscribe(Consumer, Consumer, Action)
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final void blockingSubscribe(Consumer<? super T> onNext, int bufferSize) {
+        FlowableBlockingSubscribe.subscribe(this, onNext, Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION, bufferSize);
+    }
+
+    /**
+     * Subscribes to the source and calls the given callbacks <strong>on the current thread</strong>.
+     * <p>
      * Note that calling this method will block the caller thread until the upstream terminates
      * normally or with an error. Therefore, calling this method from special threads such as the
      * Android Main Thread or the Swing Event Dispatch Thread is not recommended.
@@ -5877,6 +5909,32 @@ public abstract class Flowable<T> implements Publisher<T> {
         FlowableBlockingSubscribe.subscribe(this, onNext, onError, Functions.EMPTY_ACTION);
     }
 
+    /**
+     * Subscribes to the source and calls the given callbacks <strong>on the current thread</strong>.
+     * <p>
+     * Note that calling this method will block the caller thread until the upstream terminates
+     * normally or with an error. Therefore, calling this method from special threads such as the
+     * Android Main Thread or the Swing Event Dispatch Thread is not recommended.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator consumes the source {@code Flowable} in an bounded manner (up to bufferSize
+     *  outstanding request amount for items).</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onNext the callback action for each source value
+     * @param onError the callback action for an error event
+     * @param bufferSize the size of the buffer
+     * @since 2.1.15 - experimental
+     * @see #blockingSubscribe(Consumer, Consumer, Action)
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
+        int bufferSize) {
+        FlowableBlockingSubscribe.subscribe(this, onNext, onError, Functions.EMPTY_ACTION, bufferSize);
+    }
 
     /**
      * Subscribes to the source and calls the given callbacks <strong>on the current thread</strong>.
@@ -5900,6 +5958,33 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete) {
         FlowableBlockingSubscribe.subscribe(this, onNext, onError, onComplete);
+    }
+
+    /**
+     * Subscribes to the source and calls the given callbacks <strong>on the current thread</strong>.
+     * <p>
+     * Note that calling this method will block the caller thread until the upstream terminates
+     * normally or with an error. Therefore, calling this method from special threads such as the
+     * Android Main Thread or the Swing Event Dispatch Thread is not recommended.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator consumes the source {@code Flowable} in an bounded manner (up to bufferSize
+     *  outstanding request amount for items).</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param onNext the callback action for each source value
+     * @param onError the callback action for an error event
+     * @param onComplete the callback action for the completion event.
+     * @param bufferSize the size of the buffer
+     * @since 2.1.15 - experimental
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete,
+        int bufferSize) {
+        FlowableBlockingSubscribe.subscribe(this, onNext, onError, onComplete, bufferSize);
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/internal/functions/Functions.java
@@ -745,4 +745,23 @@ public final class Functions {
             t.request(Long.MAX_VALUE);
         }
     }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Consumer<T> boundedConsumer(int bufferSize) {
+        return (Consumer<T>) new BoundedConsumer(bufferSize);
+    }
+
+    public static class BoundedConsumer implements Consumer<Subscription> {
+
+        final int bufferSize;
+
+        BoundedConsumer(int bufferSize) {
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public void accept(Subscription s) throws Exception {
+            s.request(bufferSize);
+        }
+    }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBlockingSubscribe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBlockingSubscribe.java
@@ -108,4 +108,23 @@ public final class FlowableBlockingSubscribe {
         ObjectHelper.requireNonNull(onComplete, "onComplete is null");
         subscribe(o, new LambdaSubscriber<T>(onNext, onError, onComplete, Functions.REQUEST_MAX));
     }
+
+    /**
+     * Subscribes to the source and calls the given actions on the current thread.
+     * @param o the source publisher
+     * @param onNext the callback action for each source value
+     * @param onError the callback action for an error event
+     * @param onComplete the callback action for the completion event.
+     * @param bufferSize the number of elements to prefetch from the source Publisher
+     * @param <T> the value type
+     */
+    public static <T> void subscribe(Publisher<? extends T> o, final Consumer<? super T> onNext,
+        final Consumer<? super Throwable> onError, final Action onComplete, int bufferSize) {
+        ObjectHelper.requireNonNull(onNext, "onNext is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.verifyPositive(bufferSize, "number > 0 required");
+        subscribe(o, new BoundedSubscriber<T>(onNext, onError, onComplete, Functions.boundedConsumer(bufferSize),
+                bufferSize));
+    }
 }

--- a/src/main/java/io/reactivex/internal/subscribers/BoundedSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/BoundedSubscriber.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers;
+
+import io.reactivex.FlowableSubscriber;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Action;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.observers.LambdaConsumerIntrospection;
+import io.reactivex.plugins.RxJavaPlugins;
+import org.reactivestreams.Subscription;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class BoundedSubscriber<T> extends AtomicReference<Subscription>
+        implements FlowableSubscriber<T>, Subscription, Disposable, LambdaConsumerIntrospection {
+
+    private static final long serialVersionUID = -7251123623727029452L;
+    final Consumer<? super T> onNext;
+    final Consumer<? super Throwable> onError;
+    final Action onComplete;
+    final Consumer<? super Subscription> onSubscribe;
+
+    final int bufferSize;
+    int consumed;
+    final int limit;
+
+    public BoundedSubscriber(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
+                            Action onComplete, Consumer<? super Subscription> onSubscribe, int bufferSize) {
+        super();
+        this.onNext = onNext;
+        this.onError = onError;
+        this.onComplete = onComplete;
+        this.onSubscribe = onSubscribe;
+        this.bufferSize = bufferSize;
+        this.limit = bufferSize - (bufferSize >> 2);
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        if (SubscriptionHelper.setOnce(this, s)) {
+            try {
+                onSubscribe.accept(this);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                s.cancel();
+                onError(e);
+            }
+        }
+    }
+
+    @Override
+    public void onNext(T t) {
+        if (!isDisposed()) {
+            try {
+                onNext.accept(t);
+
+                int c = consumed + 1;
+                if (c == limit) {
+                    consumed = 0;
+                    get().request(limit);
+                } else {
+                    consumed = c;
+                }
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                get().cancel();
+                onError(e);
+            }
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        if (get() != SubscriptionHelper.CANCELLED) {
+            lazySet(SubscriptionHelper.CANCELLED);
+            try {
+                onError.accept(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                RxJavaPlugins.onError(new CompositeException(t, e));
+            }
+        } else {
+            RxJavaPlugins.onError(t);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        if (get() != SubscriptionHelper.CANCELLED) {
+            lazySet(SubscriptionHelper.CANCELLED);
+            try {
+                onComplete.run();
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                RxJavaPlugins.onError(e);
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        cancel();
+    }
+
+    @Override
+    public boolean isDisposed() {
+        return get() == SubscriptionHelper.CANCELLED;
+    }
+
+    @Override
+    public void request(long n) {
+        get().request(n);
+    }
+
+    @Override
+    public void cancel() {
+        SubscriptionHelper.cancel(this);
+    }
+
+    @Override
+    public boolean hasCustomOnError() {
+        return onError != Functions.ON_ERROR_MISSING;
+    }
+}

--- a/src/test/java/io/reactivex/exceptions/OnErrorNotImplementedExceptionTest.java
+++ b/src/test/java/io/reactivex/exceptions/OnErrorNotImplementedExceptionTest.java
@@ -67,6 +67,12 @@ public class OnErrorNotImplementedExceptionTest {
     }
 
     @Test
+    public void flowableBoundedBlockingSubscribe1() {
+        Flowable.error(new TestException())
+                .blockingSubscribe(Functions.emptyConsumer(), 128);
+    }
+
+    @Test
     public void observableSubscribe0() {
         Observable.error(new TestException())
         .subscribe();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
@@ -63,6 +63,38 @@ public class FlowableBlockingTest {
     }
 
     @Test
+    public void boundedBlockingSubscribeConsumer() {
+        final List<Integer> list = new ArrayList<Integer>();
+
+        Flowable.range(1, 5)
+                .subscribeOn(Schedulers.computation())
+                .blockingSubscribe(new Consumer<Integer>() {
+                    @Override
+                    public void accept(Integer v) throws Exception {
+                        list.add(v);
+                    }
+                }, 128);
+
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
+    }
+
+    @Test
+    public void boundedBlockingSubscribeConsumerBufferExceed() {
+        final List<Integer> list = new ArrayList<Integer>();
+
+        Flowable.range(1, 5)
+                .subscribeOn(Schedulers.computation())
+                .blockingSubscribe(new Consumer<Integer>() {
+                    @Override
+                    public void accept(Integer v) throws Exception {
+                        list.add(v);
+                    }
+                }, 3);
+
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
+    }
+
+    @Test
     public void blockingSubscribeConsumerConsumer() {
         final List<Object> list = new ArrayList<Object>();
 
@@ -74,6 +106,38 @@ public class FlowableBlockingTest {
                 list.add(v);
             }
         }, Functions.emptyConsumer());
+
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
+    }
+
+    @Test
+    public void boundedBlockingSubscribeConsumerConsumer() {
+        final List<Object> list = new ArrayList<Object>();
+
+        Flowable.range(1, 5)
+                .subscribeOn(Schedulers.computation())
+                .blockingSubscribe(new Consumer<Integer>() {
+                    @Override
+                    public void accept(Integer v) throws Exception {
+                        list.add(v);
+                    }
+                }, Functions.emptyConsumer(), 128);
+
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
+    }
+
+    @Test
+    public void boundedBlockingSubscribeConsumerConsumerBufferExceed() {
+        final List<Object> list = new ArrayList<Object>();
+
+        Flowable.range(1, 5)
+                .subscribeOn(Schedulers.computation())
+                .blockingSubscribe(new Consumer<Integer>() {
+                    @Override
+                    public void accept(Integer v) throws Exception {
+                        list.add(v);
+                    }
+                }, Functions.emptyConsumer(), 3);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -99,6 +163,26 @@ public class FlowableBlockingTest {
     }
 
     @Test
+    public void boundedBlockingSubscribeConsumerConsumerError() {
+        final List<Object> list = new ArrayList<Object>();
+
+        TestException ex = new TestException();
+
+        Consumer<Object> cons = new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                list.add(v);
+            }
+        };
+
+        Flowable.range(1, 5).concatWith(Flowable.<Integer>error(ex))
+                .subscribeOn(Schedulers.computation())
+                .blockingSubscribe(cons, cons, 128);
+
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, ex), list);
+    }
+
+    @Test
     public void blockingSubscribeConsumerConsumerAction() {
         final List<Object> list = new ArrayList<Object>();
 
@@ -119,6 +203,81 @@ public class FlowableBlockingTest {
         });
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
+    }
+
+    @Test
+    public void boundedBlockingSubscribeConsumerConsumerAction() {
+        final List<Object> list = new ArrayList<Object>();
+
+        Consumer<Object> cons = new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                list.add(v);
+            }
+        };
+
+        Action action = new Action() {
+            @Override
+            public void run() throws Exception {
+                list.add(100);
+            }
+        };
+
+        Flowable.range(1, 5)
+                .subscribeOn(Schedulers.computation())
+                .blockingSubscribe(cons, cons, action, 128);
+
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
+    }
+
+    @Test
+    public void boundedBlockingSubscribeConsumerConsumerActionBufferExceed() {
+        final List<Object> list = new ArrayList<Object>();
+
+        Consumer<Object> cons = new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                list.add(v);
+            }
+        };
+
+        Action action = new Action() {
+            @Override
+            public void run() throws Exception {
+                list.add(100);
+            }
+        };
+
+        Flowable.range(1, 5)
+                .subscribeOn(Schedulers.computation())
+                .blockingSubscribe(cons, cons, action, 3);
+
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
+    }
+
+    @Test
+    public void boundedBlockingSubscribeConsumerConsumerActionBufferExceedMillionItem() {
+        final List<Object> list = new ArrayList<Object>();
+
+        Consumer<Object> cons = new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                list.add(v);
+            }
+        };
+
+        Action action = new Action() {
+            @Override
+            public void run() throws Exception {
+                list.add(1000001);
+            }
+        };
+
+        Flowable.range(1, 1000000)
+                .subscribeOn(Schedulers.computation())
+                .blockingSubscribe(cons, cons, action, 128);
+
+        assertEquals(1000000 + 1, list.size());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/subscribers/BoundedSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/BoundedSubscriberTest.java
@@ -1,0 +1,388 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.subscribers;
+
+import io.reactivex.Flowable;
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.PublishProcessor;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BoundedSubscriberTest {
+
+    @Test
+    public void onSubscribeThrows() {
+        final List<Object> received = new ArrayList<Object>();
+
+        BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+            @Override
+            public void accept(Object o) throws Exception {
+                received.add(o);
+            }
+        }, new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable throwable) throws Exception {
+                received.add(throwable);
+            }
+        }, new Action() {
+            @Override
+            public void run() throws Exception {
+                received.add(1);
+            }
+        }, new Consumer<Subscription>() {
+            @Override
+            public void accept(Subscription subscription) throws Exception {
+                throw new TestException();
+            }
+        }, 128);
+
+        assertFalse(o.isDisposed());
+
+        Flowable.just(1).subscribe(o);
+
+        assertTrue(received.toString(), received.get(0) instanceof TestException);
+        assertEquals(received.toString(), 1, received.size());
+
+        assertTrue(o.isDisposed());
+    }
+
+    @Test
+    public void onNextThrows() {
+        final List<Object> received = new ArrayList<Object>();
+
+        BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+            @Override
+            public void accept(Object o) throws Exception {
+                throw new TestException();
+            }
+        }, new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable throwable) throws Exception {
+                received.add(throwable);
+            }
+        }, new Action() {
+            @Override
+            public void run() throws Exception {
+                received.add(1);
+            }
+        }, new Consumer<Subscription>() {
+            @Override
+            public void accept(Subscription subscription) throws Exception {
+                subscription.request(128);
+            }
+        }, 128);
+
+        assertFalse(o.isDisposed());
+
+        Flowable.just(1).subscribe(o);
+
+        assertTrue(received.toString(), received.get(0) instanceof TestException);
+        assertEquals(received.toString(), 1, received.size());
+
+        assertTrue(o.isDisposed());
+    }
+
+    @Test
+    public void onErrorThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            final List<Object> received = new ArrayList<Object>();
+
+            BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+                @Override
+                public void accept(Object o) throws Exception {
+                    received.add(o);
+                }
+            }, new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable throwable) throws Exception {
+                    throw new TestException("Inner");
+                }
+            }, new Action() {
+                @Override
+                public void run() throws Exception {
+                    received.add(1);
+                }
+            }, new Consumer<Subscription>() {
+                @Override
+                public void accept(Subscription subscription) throws Exception {
+                    subscription.request(128);
+                }
+            }, 128);
+
+            assertFalse(o.isDisposed());
+
+            Flowable.<Integer>error(new TestException("Outer")).subscribe(o);
+
+            assertTrue(received.toString(), received.isEmpty());
+
+            assertTrue(o.isDisposed());
+
+            TestHelper.assertError(errors, 0, CompositeException.class);
+            List<Throwable> ce = TestHelper.compositeList(errors.get(0));
+            TestHelper.assertError(ce, 0, TestException.class, "Outer");
+            TestHelper.assertError(ce, 1, TestException.class, "Inner");
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+
+        try {
+            final List<Object> received = new ArrayList<Object>();
+
+            BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+                @Override
+                public void accept(Object o) throws Exception {
+                    received.add(o);
+                }
+            }, new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable throwable) throws Exception {
+                    received.add(throwable);
+                }
+            }, new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new TestException();
+                }
+            }, new Consumer<Subscription>() {
+                @Override
+                public void accept(Subscription subscription) throws Exception {
+                    subscription.request(128);
+                }
+            }, 128);
+
+            assertFalse(o.isDisposed());
+
+            Flowable.<Integer>empty().subscribe(o);
+
+            assertTrue(received.toString(), received.isEmpty());
+
+            assertTrue(o.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onNextThrowsCancelsUpstream() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final List<Throwable> errors = new ArrayList<Throwable>();
+
+        BoundedSubscriber<Integer> s = new BoundedSubscriber<Integer>(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+                throw new TestException();
+            }
+        }, new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                errors.add(e);
+            }
+        }, new Action() {
+            @Override
+            public void run() throws Exception {
+
+            }
+        }, new Consumer<Subscription>() {
+            @Override
+            public void accept(Subscription subscription) throws Exception {
+                subscription.request(128);
+            }
+        }, 128);
+
+        pp.subscribe(s);
+
+        assertTrue("No observers?!", pp.hasSubscribers());
+        assertTrue("Has errors already?!", errors.isEmpty());
+
+        pp.onNext(1);
+
+        assertFalse("Has observers?!", pp.hasSubscribers());
+        assertFalse("No errors?!", errors.isEmpty());
+
+        assertTrue(errors.toString(), errors.get(0) instanceof TestException);
+    }
+
+    @Test
+    public void onSubscribeThrowsCancelsUpstream() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final List<Throwable> errors = new ArrayList<Throwable>();
+
+        BoundedSubscriber<Integer> s = new BoundedSubscriber<Integer>(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer v) throws Exception {
+            }
+        }, new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                errors.add(e);
+            }
+        }, new Action() {
+            @Override
+            public void run() throws Exception {
+            }
+        }, new Consumer<Subscription>() {
+            @Override
+            public void accept(Subscription s) throws Exception {
+                throw new TestException();
+            }
+        }, 128);
+
+        pp.subscribe(s);
+
+        assertFalse("Has observers?!", pp.hasSubscribers());
+        assertFalse("No errors?!", errors.isEmpty());
+
+        assertTrue(errors.toString(), errors.get(0) instanceof TestException);
+    }
+
+    @Test
+    public void badSourceOnSubscribe() {
+        Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> s) {
+                BooleanSubscription s1 = new BooleanSubscription();
+                s.onSubscribe(s1);
+                BooleanSubscription s2 = new BooleanSubscription();
+                s.onSubscribe(s2);
+
+                assertFalse(s1.isCancelled());
+                assertTrue(s2.isCancelled());
+
+                s.onNext(1);
+                s.onComplete();
+            }
+        });
+
+        final List<Object> received = new ArrayList<Object>();
+
+        BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                received.add(v);
+            }
+        }, new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                received.add(e);
+            }
+        }, new Action() {
+            @Override
+            public void run() throws Exception {
+                received.add(100);
+            }
+        }, new Consumer<Subscription>() {
+            @Override
+            public void accept(Subscription s) throws Exception {
+                s.request(128);
+            }
+        }, 128);
+
+        source.subscribe(o);
+
+        assertEquals(Arrays.asList(1, 100), received);
+    }
+
+    @Test
+    public void badSourceEmitAfterDone() {
+        Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> s) {
+                BooleanSubscription s1 = new BooleanSubscription();
+                s.onSubscribe(s1);
+
+                s.onNext(1);
+                s.onComplete();
+                s.onNext(2);
+                s.onError(new TestException());
+                s.onComplete();
+            }
+        });
+
+        final List<Object> received = new ArrayList<Object>();
+
+        BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+            @Override
+            public void accept(Object v) throws Exception {
+                received.add(v);
+            }
+        }, new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable e) throws Exception {
+                received.add(e);
+            }
+        }, new Action() {
+            @Override
+            public void run() throws Exception {
+                received.add(100);
+            }
+        }, new Consumer<Subscription>() {
+            @Override
+            public void accept(Subscription s) throws Exception {
+                s.request(128);
+            }
+        }, 128);
+
+        source.subscribe(o);
+
+        assertEquals(Arrays.asList(1, 100), received);
+    }
+
+    @Test
+    public void onErrorMissingShouldReportNoCustomOnError() {
+        BoundedSubscriber<Integer> o = new BoundedSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+                Functions.ON_ERROR_MISSING,
+                Functions.EMPTY_ACTION,
+                Functions.<Subscription>boundedConsumer(128), 128);
+
+        assertFalse(o.hasCustomOnError());
+    }
+
+    @Test
+    public void customOnErrorShouldReportCustomOnError() {
+        BoundedSubscriber<Integer> o = new BoundedSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+                Functions.<Throwable>emptyConsumer(),
+                Functions.EMPTY_ACTION,
+                Functions.<Subscription>boundedConsumer(128), 128);
+
+        assertTrue(o.hasCustomOnError());
+    }
+}


### PR DESCRIPTION
Create and bound new `blockingSubscribe` overloads to `bufferSize`.
* Create new overloads with `bufferSize`
* Create a `boundedConsumer`
* Create a `BoundedSubsciber`

Close: #5988 
