### PR TITLE
2.x: Inline CompositeDisposable JavaDoc

### DIFF
--- a/src/main/java/io/reactivex/disposables/CompositeDisposable.java
+++ b/src/main/java/io/reactivex/disposables/CompositeDisposable.java
@@ -85,6 +85,12 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
         return disposed;
     }
 
+    /**
+     * Adds a disposable to this container or disposes it if the
+     * container has been disposed.
+     * @param d the disposable to add, not null
+     * @return true if successful, false if this container has been disposed
+     */
     @Override
     public boolean add(@NonNull Disposable d) {
         ObjectHelper.requireNonNull(d, "d is null");
@@ -135,6 +141,12 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
         return false;
     }
 
+    /**
+     * Removes and disposes the given disposable if it is part of this
+     * container.
+     * @param d the disposable to remove and dispose, not null
+     * @return true if the operation was successful
+     */
     @Override
     public boolean remove(@NonNull Disposable d) {
         if (delete(d)) {
@@ -144,6 +156,12 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
         return false;
     }
 
+    /**
+     * Removes (but does not dispose) the given disposable if it is part of this
+     * container.
+     * @param d the disposable to remove, not null
+     * @return true if the operation was successful
+     */
     @Override
     public boolean delete(@NonNull Disposable d) {
         ObjectHelper.requireNonNull(d, "Disposable item is null");


### PR DESCRIPTION
Normally, overriding a method will reuse the JavaDoc unless specified directly on the new method. Unfortunately, when the base type is part of a javadoc exclude, such as everything below `**/internal`, the documentation is not copied and public facing methods have no HTML documentation:

![image](https://user-images.githubusercontent.com/1269832/40828381-b8cdd07e-6580-11e8-84cf-783f1cf892f9.png)

This PR copies the javadoc of the internal `DisposableContainer` onto `CompositeDisposable` so it shows up properly:

![image](https://user-images.githubusercontent.com/1269832/40828451-ea8c4122-6580-11e8-8ad9-e2cd606d6a39.png)


The IDEs still show the documentation correctly.