### PR TITLE
2.X: Fix disposed LambdaObserver onError to route to global error handler

### DIFF
--- a/src/main/java/io/reactivex/internal/observers/LambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/LambdaObserver.java
@@ -79,6 +79,8 @@ public final class LambdaObserver<T> extends AtomicReference<Disposable>
                 Exceptions.throwIfFatal(e);
                 RxJavaPlugins.onError(new CompositeException(t, e));
             }
+        } else {
+            RxJavaPlugins.onError(t);
         }
     }
 


### PR DESCRIPTION
Fix the behaviour of LambdaObserver when disposed to route to the global error handler

Fixes #6025 