### PR TITLE
fix MulticastProcessor javadoc comment

### DIFF
--- a/src/main/java/io/reactivex/processors/MulticastProcessor.java
+++ b/src/main/java/io/reactivex/processors/MulticastProcessor.java
@@ -43,7 +43,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *      the given prefetch amount and no reference counting behavior.</li>
  * <li>{@link #create(boolean)}: create an empty {@code MulticastProcessor} with
  *      {@link io.reactivex.Flowable#bufferSize() Flowable.bufferSize()} prefetch amount
- *      and no reference counting behavior.</li>
+ *      and an optional reference counting behavior.</li>
  * <li>{@link #create(int, boolean)}: create an empty {@code MulticastProcessor} with
  *      the given prefetch amount and an optional reference counting behavior.</li>
  * </ul>
@@ -174,7 +174,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
 
     /**
      * Constructs a fresh instance with the default Flowable.bufferSize() prefetch
-     * amount and no refCount-behavior.
+     * amount and the optional refCount-behavior.
      * @param <T> the input and output value type
      * @param refCount if true and if all Subscribers have canceled, the upstream
      * is cancelled


### PR DESCRIPTION
fix wrong javadoc comment of MulticastProcessor. 
I think `#create(boolean)` is an optional refcount behavior.
