### PR TITLE
2.x: Expand {X}Processor JavaDocs by syncing with {X}Subject docs

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -272,9 +272,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * Concatenate the single values, in a non-overlapping fashion, of the MaybeSource sources in the array.
-     * <dl>
      * <p>
      * <img width="640" height="526" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatArray.png" alt="">
+     * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      *  <dt><b>Scheduler:</b></dt>

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -13175,7 +13175,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * will be emitted by the resulting ObservableSource.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleWithTimeout.png" alt="">
-     * <p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code throttleWithTimeout} operates by default on the {@code computation} {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -28,9 +28,90 @@ import io.reactivex.plugins.RxJavaPlugins;
  * <p>
  * <img width="640" height="239" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/AsyncProcessor.png" alt="">
  * <p>
- * The implementation of onXXX methods are technically thread-safe but non-serialized calls
- * to them may lead to undefined state in the currently subscribed Subscribers.
+ * This processor does not have a public constructor by design; a new empty instance of this
+ * {@code AsyncProcessor} can be created via the {@link #create()} method.
+ * <p>
+ * Since a {@code AsyncProcessor} is a Reactive Streams {@code Processor} type,
+ * {@code null}s are not allowed (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">Rule 2.13</a>)
+ * as parameters to {@link #onNext(Object)} and {@link #onError(Throwable)}. Such calls will result in a
+ * {@link NullPointerException} being thrown and the processor's state is not changed.
+ * <p>
+ * {@code AsyncProcessor} is a {@link io.reactivex.Flowable} as well as a {@link FlowableProcessor} and supports backpressure from the downstream but
+ * its {@link Subscriber}-side consumes items in an unbounded manner.
+ * <p>
+ * When this {@code AsyncProcessor} is terminated via {@link #onError(Throwable)}, the
+ * last observed item (if any) is cleared and late {@link Subscriber}s only receive
+ * the {@code onError} event.
+ * <p>
+ * The {@code AsyncProcessor} caches the latest item internally and it emits this item only when {@code onComplete} is called.
+ * Therefore, it is not recommended to use this {@code Processor} with infinite or never-completing sources.
+ * <p>
+ * Even though {@code AsyncProcessor} implements the {@link Subscriber} interface, calling
+ * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
+ * if the processor is used as a standalone source. However, calling {@code onSubscribe}
+ * after the {@code AsyncProcessor} reached its terminal state will result in the
+ * given {@link Subscription} being canceled immediately.
+ * <p>
+ * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
+ * is required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * through external means of serialization). The {@link #toSerialized()} method available to all {@code FlowableProcessor}s
+ * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Subscriber}
+ * consuming this processor also wants to call {@link #onNext(Object)} on this processor recursively).
+ * The implementation of {@code onXXX} methods are technically thread-safe but non-serialized calls
+ * to them may lead to undefined state in the currently subscribed {@code Subscriber}s.
+ * <p>
+ * This {@code AsyncProcessor} supports the standard state-peeking methods {@link #hasComplete()}, {@link #hasThrowable()},
+ * {@link #getThrowable()} and {@link #hasSubscribers()} as well as means to read the very last observed value -
+ * after this {@code AsyncProcessor} has been completed - in a non-blocking and thread-safe
+ * manner via {@link #hasValue()}, {@link #getValue()}, {@link #getValues()} or {@link #getValues(Object[])}.
+ * <dl>
+ *  <dt><b>Backpressure:</b></dt>
+ *  <dd>The {@code AsyncProcessor} honors the backpressure of the downstream {@code Subscriber}s and won't emit
+ *  its single value to a particular {@code Subscriber} until that {@code Subscriber} has requested an item.
+ *  When the {@code AsyncProcessor} is subscribed to a {@link io.reactivex.Flowable}, the processor consumes this
+ *  {@code Flowable} in an unbounded manner (requesting `Long.MAX_VALUE`) as only the very last upstream item is
+ *  retained by it.
+ *  </dd>
+ *  <dt><b>Scheduler:</b></dt>
+ *  <dd>{@code AsyncProcessor} does not operate by default on a particular {@link io.reactivex.Scheduler} and
+ *  the {@code Subscriber}s get notified on the thread where the terminating {@code onError} or {@code onComplete}
+ *  methods were invoked.</dd>
+ *  <dt><b>Error handling:</b></dt>
+ *  <dd>When the {@link #onError(Throwable)} is called, the {@code AsyncProcessor} enters into a terminal state
+ *  and emits the same {@code Throwable} instance to the last set of {@code Subscriber}s. During this emission,
+ *  if one or more {@code Subscriber}s dispose their respective {@code Subscription}s, the
+ *  {@code Throwable} is delivered to the global error handler via
+ *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} (multiple times if multiple {@code Subscriber}s
+ *  cancel at once).
+ *  If there were no {@code Subscriber}s subscribed to this {@code AsyncProcessor} when the {@code onError()}
+ *  was called, the global error handler is not invoked.
+ *  </dd>
+ * </dl>
+ * <p>
+ * Example usage:
+ * <pre><code>
+ * AsyncProcessor&lt;Object&gt; processor = AsyncProcessor.create();
+ * 
+ * TestSubscriber&lt;Object&gt; ts1 = processor.test();
  *
+ * ts1.assertEmpty();
+ *
+ * processor.onNext(1);
+ *
+ * // AsyncProcessor only emits when onComplete was called.
+ * ts1.assertEmpty();
+ *
+ * processor.onNext(2);
+ * processor.onComplete();
+ *
+ * // onComplete triggers the emission of the last cached item and the onComplete event.
+ * ts1.assertResult(2);
+ *
+ * TestSubscriber&lt;Object&gt; ts2 = processor.test();
+ *
+ * // late Subscribers receive the last cached item too
+ * ts2.assertResult(2);
+ * </code></pre>
  * @param <T> the value type
  */
 public final class AsyncProcessor<T> extends FlowableProcessor<T> {
@@ -75,7 +156,7 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
             s.cancel();
             return;
         }
-        // PublishSubject doesn't bother with request coordination.
+        // AsyncProcessor doesn't bother with request coordination.
         s.request(Long.MAX_VALUE);
     }
 
@@ -168,9 +249,9 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
 
     /**
      * Tries to add the given subscriber to the subscribers array atomically
-     * or returns false if the subject has terminated.
+     * or returns false if the processor has terminated.
      * @param ps the subscriber to add
-     * @return true if successful, false if the subject has terminated
+     * @return true if successful, false if the processor has terminated
      */
     boolean add(AsyncSubscription<T> ps) {
         for (;;) {
@@ -192,8 +273,8 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
     }
 
     /**
-     * Atomically removes the given subscriber if it is subscribed to the subject.
-     * @param ps the subject to remove
+     * Atomically removes the given subscriber if it is subscribed to this processor.
+     * @param ps the subscriber's subscription wrapper to remove
      */
     @SuppressWarnings("unchecked")
     void remove(AsyncSubscription<T> ps) {
@@ -232,18 +313,18 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
     }
 
     /**
-     * Returns true if the subject has any value.
+     * Returns true if this processor has any value.
      * <p>The method is thread-safe.
-     * @return true if the subject has any value
+     * @return true if this processor has any value
      */
     public boolean hasValue() {
         return subscribers.get() == TERMINATED && value != null;
     }
 
     /**
-     * Returns a single value the Subject currently has or null if no such value exists.
+     * Returns a single value this processor currently has or null if no such value exists.
      * <p>The method is thread-safe.
-     * @return a single value the Subject currently has or null if no such value exists
+     * @return a single value this processor currently has or null if no such value exists
      */
     @Nullable
     public T getValue() {
@@ -251,9 +332,9 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
     }
 
     /**
-     * Returns an Object array containing snapshot all values of the Subject.
+     * Returns an Object array containing snapshot all values of this processor.
      * <p>The method is thread-safe.
-     * @return the array containing the snapshot of all values of the Subject
+     * @return the array containing the snapshot of all values of this processor
      * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
      */
     @Deprecated
@@ -263,7 +344,7 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
     }
 
     /**
-     * Returns a typed array containing a snapshot of all values of the Subject.
+     * Returns a typed array containing a snapshot of all values of this processor.
      * <p>The method follows the conventions of Collection.toArray by setting the array element
      * after the last value to null (if the capacity permits).
      * <p>The method is thread-safe.

--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -31,7 +31,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * This processor does not have a public constructor by design; a new empty instance of this
  * {@code AsyncProcessor} can be created via the {@link #create()} method.
  * <p>
- * Since a {@code AsyncProcessor} is a Reactive Streams {@code Processor} type,
+ * Since an {@code AsyncProcessor} is a Reactive Streams {@code Processor} type,
  * {@code null}s are not allowed (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">Rule 2.13</a>)
  * as parameters to {@link #onNext(Object)} and {@link #onError(Throwable)}. Such calls will result in a
  * {@link NullPointerException} being thrown and the processor's state is not changed.

--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -85,11 +85,13 @@ import io.reactivex.plugins.RxJavaPlugins;
  * after the {@code BehaviorProcessor} reached its terminal state will result in the
  * given {@code Subscription} being cancelled immediately.
  * <p>
- * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
+ * Calling {@link #onNext(Object)}, {@link #offer(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
  * is required to be serialized (called from the same thread or called non-overlappingly from different threads
  * through external means of serialization). The {@link #toSerialized()} method available to all {@code FlowableProcessor}s
  * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Subscriber}
  * consuming this processor also wants to call {@link #onNext(Object)} on this processor recursively).
+ * Note that serializing over {@link #offer(Object)} is not supported through {@code toSerialized()} because it is a method
+ * available on the {@code PublishProcessor} and {@code BehaviorProcessor} classes only.
  * <p>
  * This {@code BehaviorProcessor} supports the standard state-peeking methods {@link #hasComplete()}, {@link #hasThrowable()},
  * {@link #getThrowable()} and {@link #hasSubscribers()} as well as means to read the latest observed value
@@ -127,34 +129,34 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Example usage:
  * <pre> {@code
 
-  // observer will receive all events.
+  // subscriber will receive all events.
   BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
-  processor.subscribe(observer);
+  processor.subscribe(subscriber);
   processor.onNext("one");
   processor.onNext("two");
   processor.onNext("three");
 
-  // observer will receive the "one", "two" and "three" events, but not "zero"
+  // subscriber will receive the "one", "two" and "three" events, but not "zero"
   BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
   processor.onNext("zero");
   processor.onNext("one");
-  processor.subscribe(observer);
+  processor.subscribe(subscriber);
   processor.onNext("two");
   processor.onNext("three");
 
-  // observer will receive only onComplete
+  // subscriber will receive only onComplete
   BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
   processor.onNext("zero");
   processor.onNext("one");
   processor.onComplete();
-  processor.subscribe(observer);
+  processor.subscribe(subscriber);
 
-  // observer will receive only onError
+  // subscriber will receive only onError
   BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
   processor.onNext("zero");
   processor.onNext("one");
   processor.onError(new RuntimeException("error"));
-  processor.subscribe(observer);
+  processor.subscribe(subscriber);
   } </pre>
  *
  * @param <T>

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -56,19 +56,73 @@ import io.reactivex.plugins.RxJavaPlugins;
  * </li>
  * </ul>
  * <p>
- * The ReplayProcessor can be created in bounded and unbounded mode. It can be bounded by
+ * The {@code ReplayProcessor} can be created in bounded and unbounded mode. It can be bounded by
  * size (maximum number of elements retained at most) and/or time (maximum age of elements replayed).
- *
- * <p>This Processor respects the backpressure behavior of its Subscribers (individually) but
- * does not coordinate their request amounts towards the upstream (because there might not be any).
- *
- * <p>Note that Subscribers receive a continuous sequence of values after they subscribed even
- * if an individual item gets delayed due to backpressure.
- *
  * <p>
+ * Since a {@code ReplayProcessor} is a Reactive Streams {@code Processor},
+ * {@code null}s are not allowed (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">Rule 2.13</a>) as
+ * parameters to {@link #onNext(Object)} and {@link #onError(Throwable)}. Such calls will result in a
+ * {@link NullPointerException} being thrown and the processor's state is not changed.
+ * <p>
+ * This {@code ReplayProcessor} respects the individual backpressure behavior of its {@code Subscriber}s but
+ * does not coordinate their request amounts towards the upstream (because there might not be any) and
+ * consumes the upstream in an unbounded manner (requesting {@code Long.MAX_VALUE}).
+ * Note that {@code Subscriber}s receive a continuous sequence of values after they subscribed even
+ * if an individual item gets delayed due to backpressure.
  * Due to concurrency requirements, a size-bounded {@code ReplayProcessor} may hold strong references to more source
  * emissions than specified.
- *
+ * <p>
+ * When this {@code ReplayProcessor} is terminated via {@link #onError(Throwable)} or {@link #onComplete()},
+ * late {@link Subscriber}s will receive the retained/cached items first (if any) followed by the respective
+ * terminal event. If the {@code ReplayProcessor} has a time-bound, the age of the retained/cached items are still considered
+ * when replaying and thus it may result in no items being emitted before the terminal event.
+ * <p>
+ * Once an {@code Subscriber} has subscribed, it will receive items continuously from that point on. Bounds only affect how
+ * many past items a new {@code Subscriber} will receive before it catches up with the live event feed.
+ * <p>
+ * Even though {@code ReplayProcessor} implements the {@code Subscriber} interface, calling
+ * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
+ * if the processor is used as a standalone source. However, calling {@code onSubscribe}
+ * after the {@code ReplayProcessor} reached its terminal state will result in the
+ * given {@code Subscription} being canceled immediately.
+ * <p>
+ * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
+ * is required to be serialized (called from the same thread or called non-overlappingly from different threads
+ * through external means of serialization). The {@link #toSerialized()} method available to all {@code FlowableProcessor}s
+ * provides such serialization and also protects against reentrance (i.e., when a downstream {@code Subscriber}
+ * consuming this processor also wants to call {@link #onNext(Object)} on this processor recursively).
+ * <p>
+ * This {@code ReplayProcessor} supports the standard state-peeking methods {@link #hasComplete()}, {@link #hasThrowable()},
+ * {@link #getThrowable()} and {@link #hasSubscribers()} as well as means to read the retained/cached items
+ * in a non-blocking and thread-safe manner via {@link #hasValue()}, {@link #getValue()},
+ * {@link #getValues()} or {@link #getValues(Object[])}.
+ * <p>
+ * Note that due to concurrency requirements, a size- and time-bounded {@code ReplayProcessor} may hold strong references to more
+ * source emissions than specified while it isn't terminated yet. Use the {@link #cleanupBuffer()} to allow
+ * such inaccessible items to be cleaned up by GC once no consumer references them anymore.
+ * <dl>
+ *  <dt><b>Backpressure:</b></dt>
+ *  <dd>This {@code ReplayProcessor} respects the individual backpressure behavior of its {@codeSubscriber}s but
+ *  does not coordinate their request amounts towards the upstream (because there might not be any) and
+ *  consumes the upstream in an unbounded manner (requesting {@code Long.MAX_VALUE}).
+ *  Note that {@code Subscriber}s receive a continuous sequence of values after they subscribed even
+ *  if an individual item gets delayed due to backpressure.</dd>
+ *  <dt><b>Scheduler:</b></dt>
+ *  <dd>{@code ReplayProcessor} does not operate by default on a particular {@link io.reactivex.Scheduler} and
+ *  the {@code Subscriber}s get notified on the thread the respective {@code onXXX} methods were invoked.
+ *  Time-bound {@code ReplayProcessor}s use the given {@code Scheduler} in their {@code create} methods
+ *  as time source to timestamp of items received for the age checks.</dd>
+ *  <dt><b>Error handling:</b></dt>
+ *  <dd>When the {@link #onError(Throwable)} is called, the {@code ReplayProcessor} enters into a terminal state
+ *  and emits the same {@code Throwable} instance to the last set of {@code Subscriber}s. During this emission,
+ *  if one or more {@code Subscriber}s cancel their respective {@code Subscription}s, the
+ *  {@code Throwable} is delivered to the global error handler via
+ *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} (multiple times if multiple {@code Subscriber}s
+ *  cancel at once).
+ *  If there were no {@code Subscriber}s subscribed to this {@code ReplayProcessor} when the {@code onError()}
+ *  was called, the global error handler is not invoked.
+ *  </dd>
+ * </dl>
  * <p>
  * Example usage:
  * <pre> {@code
@@ -132,10 +186,10 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
      * due to frequent array-copying.
      *
      * @param <T>
-     *          the type of items observed and emitted by the Subject
+     *          the type of items observed and emitted by this type of processor
      * @param capacityHint
      *          the initial buffer capacity
-     * @return the created subject
+     * @return the created processor
      */
     @CheckReturnValue
     @NonNull
@@ -149,19 +203,19 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
      * In this setting, the {@code ReplayProcessor} holds at most {@code size} items in its internal buffer and
      * discards the oldest item.
      * <p>
-     * When observers subscribe to a terminated {@code ReplayProcessor}, they are guaranteed to see at most
+     * When {@code Subscriber}s subscribe to a terminated {@code ReplayProcessor}, they are guaranteed to see at most
      * {@code size} {@code onNext} events followed by a termination event.
      * <p>
-     * If an observer subscribes while the {@code ReplayProcessor} is active, it will observe all items in the
+     * If a {@code Subscriber} subscribes while the {@code ReplayProcessor} is active, it will observe all items in the
      * buffer at that point in time and each item observed afterwards, even if the buffer evicts items due to
-     * the size constraint in the mean time. In other words, once an Observer subscribes, it will receive items
+     * the size constraint in the mean time. In other words, once a {@coed Subscriber} subscribes, it will receive items
      * without gaps in the sequence.
      *
      * @param <T>
-     *          the type of items observed and emitted by the Subject
+     *          the type of items observed and emitted by this type of processor
      * @param maxSize
      *          the maximum number of buffered items
-     * @return the created subject
+     * @return the created processor
      */
     @CheckReturnValue
     @NonNull
@@ -179,8 +233,8 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
      * of the bounded implementations without the interference of the eviction policies.
      *
      * @param <T>
-     *          the type of items observed and emitted by the Subject
-     * @return the created subject
+     *          the type of items observed and emitted by this type of processor
+     * @return the created processor
      */
     /* test */ static <T> ReplayProcessor<T> createUnbounded() {
         return new ReplayProcessor<T>(new SizeBoundReplayBuffer<T>(Integer.MAX_VALUE));
@@ -194,29 +248,29 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
      * converted to milliseconds. For example, an item arrives at T=0 and the max age is set to 5; at T&gt;=5
      * this first item is then evicted by any subsequent item or termination event, leaving the buffer empty.
      * <p>
-     * Once the subject is terminated, observers subscribing to it will receive items that remained in the
+     * Once the processor is terminated, {@code Subscriber}s subscribing to it will receive items that remained in the
      * buffer after the terminal event, regardless of their age.
      * <p>
-     * If an observer subscribes while the {@code ReplayProcessor} is active, it will observe only those items
+     * If a {@code Subscriber} subscribes while the {@code ReplayProcessor} is active, it will observe only those items
      * from within the buffer that have an age less than the specified time, and each item observed thereafter,
-     * even if the buffer evicts items due to the time constraint in the mean time. In other words, once an
-     * observer subscribes, it observes items without gaps in the sequence except for any outdated items at the
+     * even if the buffer evicts items due to the time constraint in the mean time. In other words, once a
+     * {@code Subscriber} subscribes, it observes items without gaps in the sequence except for any outdated items at the
      * beginning of the sequence.
      * <p>
      * Note that terminal notifications ({@code onError} and {@code onComplete}) trigger eviction as well. For
      * example, with a max age of 5, the first item is observed at T=0, then an {@code onComplete} notification
-     * arrives at T=10. If an observer subscribes at T=11, it will find an empty {@code ReplayProcessor} with just
+     * arrives at T=10. If a {@code Subscriber} subscribes at T=11, it will find an empty {@code ReplayProcessor} with just
      * an {@code onComplete} notification.
      *
      * @param <T>
-     *          the type of items observed and emitted by the Subject
+     *          the type of items observed and emitted by this type of processor
      * @param maxAge
      *          the maximum age of the contained items
      * @param unit
      *          the time unit of {@code time}
      * @param scheduler
      *          the {@link Scheduler} that provides the current time
-     * @return the created subject
+     * @return the created processor
      */
     @CheckReturnValue
     @NonNull
@@ -232,22 +286,22 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
      * items from the start of the buffer if their age becomes less-than or equal to the supplied age in
      * milliseconds or the buffer reaches its {@code size} limit.
      * <p>
-     * When observers subscribe to a terminated {@code ReplayProcessor}, they observe the items that remained in
+     * When {@code Subscriber}s subscribe to a terminated {@code ReplayProcessor}, they observe the items that remained in
      * the buffer after the terminal notification, regardless of their age, but at most {@code size} items.
      * <p>
-     * If an observer subscribes while the {@code ReplayProcessor} is active, it will observe only those items
+     * If a {@code Subscriber} subscribes while the {@code ReplayProcessor} is active, it will observe only those items
      * from within the buffer that have age less than the specified time and each subsequent item, even if the
-     * buffer evicts items due to the time constraint in the mean time. In other words, once an observer
+     * buffer evicts items due to the time constraint in the mean time. In other words, once a {@code Subscriber}
      * subscribes, it observes items without gaps in the sequence except for the outdated items at the beginning
      * of the sequence.
      * <p>
      * Note that terminal notifications ({@code onError} and {@code onComplete}) trigger eviction as well. For
      * example, with a max age of 5, the first item is observed at T=0, then an {@code onComplete} notification
-     * arrives at T=10. If an observer subscribes at T=11, it will find an empty {@code ReplayProcessor} with just
+     * arrives at T=10. If a {@code Subscriber} subscribes at T=11, it will find an empty {@code ReplayProcessor} with just
      * an {@code onComplete} notification.
      *
      * @param <T>
-     *          the type of items observed and emitted by the Subject
+     *          the type of items observed and emitted by this type of processor
      * @param maxAge
      *          the maximum age of the contained items
      * @param unit
@@ -256,7 +310,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
      *          the maximum number of buffered items
      * @param scheduler
      *          the {@link Scheduler} that provides the current time
-     * @return the created subject
+     * @return the created processor
      */
     @CheckReturnValue
     @NonNull
@@ -387,18 +441,18 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     }
 
     /**
-     * Returns a single value the Subject currently has or null if no such value exists.
+     * Returns the latest value this processor has or null if no such value exists.
      * <p>The method is thread-safe.
-     * @return a single value the Subject currently has or null if no such value exists
+     * @return the latest value this processor currently has or null if no such value exists
      */
     public T getValue() {
         return buffer.getValue();
     }
 
     /**
-     * Returns an Object array containing snapshot all values of the Subject.
+     * Returns an Object array containing snapshot all values of this processor.
      * <p>The method is thread-safe.
-     * @return the array containing the snapshot of all values of the Subject
+     * @return the array containing the snapshot of all values of this processor
      */
     public Object[] getValues() {
         @SuppressWarnings("unchecked")
@@ -412,7 +466,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     }
 
     /**
-     * Returns a typed array containing a snapshot of all values of the Subject.
+     * Returns a typed array containing a snapshot of all values of this processor.
      * <p>The method follows the conventions of Collection.toArray by setting the array element
      * after the last value to null (if the capacity permits).
      * <p>The method is thread-safe.
@@ -436,9 +490,9 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     }
 
     /**
-     * Returns true if the subject has any value.
+     * Returns true if this processor has any value.
      * <p>The method is thread-safe.
-     * @return true if the subject has any value
+     * @return true if the processor has any value
      */
     public boolean hasValue() {
         return buffer.size() != 0; // NOPMD

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -102,7 +102,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * such inaccessible items to be cleaned up by GC once no consumer references them anymore.
  * <dl>
  *  <dt><b>Backpressure:</b></dt>
- *  <dd>This {@code ReplayProcessor} respects the individual backpressure behavior of its {@codeSubscriber}s but
+ *  <dd>This {@code ReplayProcessor} respects the individual backpressure behavior of its {@code Subscriber}s but
  *  does not coordinate their request amounts towards the upstream (because there might not be any) and
  *  consumes the upstream in an unbounded manner (requesting {@code Long.MAX_VALUE}).
  *  Note that {@code Subscriber}s receive a continuous sequence of values after they subscribed even
@@ -208,7 +208,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
      * <p>
      * If a {@code Subscriber} subscribes while the {@code ReplayProcessor} is active, it will observe all items in the
      * buffer at that point in time and each item observed afterwards, even if the buffer evicts items due to
-     * the size constraint in the mean time. In other words, once a {@coed Subscriber} subscribes, it will receive items
+     * the size constraint in the mean time. In other words, once a {@code Subscriber} subscribes, it will receive items
      * without gaps in the sequence.
      *
      * @param <T>

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -90,14 +90,13 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
  * <dl>
  *  <dt><b>Scheduler:</b></dt>
  *  <dd>{@code UnicastSubject} does not operate by default on a particular {@link io.reactivex.Scheduler} and
- *  the {@code Observer}s get notified on the thread the respective {@code onXXX} methods were invoked.</dd>
+ *  the single {@code Observer} gets notified on the thread the respective {@code onXXX} methods were invoked.</dd>
  *  <dt><b>Error handling:</b></dt>
  *  <dd>When the {@link #onError(Throwable)} is called, the {@code UnicastSubject} enters into a terminal state
- *  and emits the same {@code Throwable} instance to the last set of {@code Observer}s. During this emission,
- *  if one or more {@code Observer}s dispose their respective {@code Disposable}s, the
+ *  and emits the same {@code Throwable} instance to the current single {@code Observer}. During this emission,
+ *  if the single {@code Observer}s disposes its respective {@code Disposable}, the
  *  {@code Throwable} is delivered to the global error handler via
- *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} (multiple times if multiple {@code Observer}s
- *  cancel at once).
+ *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)}.
  *  If there were no {@code Observer}s subscribed to this {@code UnicastSubject} when the {@code onError()}
  *  was called, the global error handler is not invoked.
  *  </dd>
@@ -130,10 +129,10 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
  *
  * UnicastSubject&lt;Integer&gt; subject2 = UnicastSubject.create();
  *
- * // a UnicastSubject caches events util its single Observer subscribes
- * subject.onNext(1);
- * subject.onNext(2);
- * subject.onComplete();
+ * // a UnicastSubject caches events until its single Observer subscribes
+ * subject2.onNext(1);
+ * subject2.onNext(2);
+ * subject2.onComplete();
  *
  * TestObserver&lt;Integer&gt; to3 = subject2.test();
  *


### PR DESCRIPTION
This PR expands and adapts the JavaDocs of `AsyncProcessor`, `BehaviorProcessor`, `PublishProcessor`, `ReplayProcessor` and `UnicastProcessor` with the details of their already documented `Subject` variants.

In addition, some wording has been fixed with `UnicastSubject` as it was refering to plural `Observer`s in some sentences even though it only supports one.

Since the basis of this expansion is copy-paste, please read through the changes carefully to verify the terminology and described behavior matches what's usually expected from `Flowable`s/`FlowableProcessor`s (i.e., subjects don't have to deal with backpressure and thus nothing much to elaborate on that in a subject doc).