### PR TITLE
2.x: Fix concatMap{Single|Maybe} null emission on dispose race

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybe.java
@@ -218,6 +218,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
                     if (cancelled) {
                         queue.clear();
                         item = null;
+                        break;
                     }
 
                     int s = state;

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingle.java
@@ -213,6 +213,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
                     if (cancelled) {
                         queue.clear();
                         item = null;
+                        break;
                     }
 
                     int s = state;

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybe.java
@@ -199,6 +199,7 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
                     if (cancelled) {
                         queue.clear();
                         item = null;
+                        break;
                     }
 
                     int s = state;

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingle.java
@@ -194,6 +194,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
                     if (cancelled) {
                         queue.clear();
                         item = null;
+                        break;
                     }
 
                     int s = state;


### PR DESCRIPTION
This PR fixes a bug in all 4 specialized `concatMap` implementation that allows `null` to be emitted when the success signal of the inner source races with the dispose signal of the sequence.

Likely fixes: #6059