### PR TITLE
Add createScan operator to Observable

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1558,6 +1558,41 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new ObservableCreate<T>(source));
     }
+    
+    /**
+     * Returns an Observable that applies a specified {@code accumulator} function to the {@code seed} value
+     * then feeds the result of that function into the same function, and so on until the subscription is disposed,
+     * emitting the result of each of these iterations.
+     * <p>
+     * Note that the ObservableSource that results from this method will emit {@code seed} as its first
+     * emitted item.
+     * <p>
+     * Note that the {@code seed} is shared among all subscribers to the resulting ObservableSource
+     * and may cause problems if it is mutable. To make sure each subscriber gets its own value, defer
+     * the application of this operator via {@link #defer(Callable)}:
+     * <pre><code>
+     * Observable.defer(
+     *         () -&gt; Observable.createScan(new ArrayList&lt;&gt;(), list -&gt; list.add(0)));
+     * </code></pre>
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code scan} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param seed the initial value to be emitted and fed into the {@code accumulator}
+     * @param accumulator an accumulator function to be sequentially invoked with the {@code seed},
+     * with the result of that call, with that result, and so on
+     * @param <T> the type of the seed, the accumulated value, and the emitted items
+     * @return an Observable that emits {@code seed} followed by the results of each call to the
+     * accumulator function
+     * @see #scan(Object, BiFunction)
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Observable<T> createScan(T seed, Function<T, T> accumulator) {
+        ObjectHelper.requireNonNull(seed, "seed is null");
+        ObjectHelper.requireNonNull(accumulator, "accumulator is null");
+        return RxJavaPlugins.onAssembly(new ObservableCreateScan<T>(seed, accumulator));
+    }
 
     /**
      * Returns an Observable that calls an ObservableSource factory to create an ObservableSource for each new Observer

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCreateScan.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCreateScan.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.observers.DeferredScalarDisposable;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class ObservableCreateScan<T> extends Observable<T> {
+    private final T seed;
+    private final Function<T, T> accumulator;
+
+    public ObservableCreateScan(T seed, Function<T, T> accumulator) {
+        this.seed = seed;
+        this.accumulator = accumulator;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+
+        DeferredScalarDisposable<T> disposable = new DeferredScalarDisposable<T>(observer);
+        observer.onSubscribe(disposable);
+        
+        try {
+            for(T accumulatedValue = seed; true; accumulatedValue = accumulator.apply(accumulatedValue)) {
+                
+                // Make sure the accumulator did not return null
+                ObjectHelper.requireNonNull(accumulatedValue, "The accumulator returned a null value");
+                
+                // Check if the observer is still subscribed
+                if (disposable.isDisposed()) {
+                    return;
+                }
+                
+                observer.onNext(accumulatedValue);
+            }
+        } catch (Throwable e) {
+            
+            Exceptions.throwIfFatal(e);
+            
+            if (!disposable.isDisposed()) {
+                observer.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+    }   
+}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCreateScanTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import java.util.List;
+import org.junit.Test;
+
+import io.reactivex.Observable;
+import io.reactivex.TestHelper;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public class ObservableCreateScanTest {
+
+    @Test
+    public void take() {
+        Observable.createScan(1, new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t) throws Exception {
+                return t + 1;
+            }
+        })
+                .take(5)
+                .test()
+                .assertValues(1, 2, 3, 4, 5);
+    }
+    
+    @Test
+    public void disposedOnApply() {
+        final TestObserver<Integer> to = new TestObserver<Integer>();
+    
+        Observable.createScan(1, new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t) throws Exception {
+                to.cancel();
+                return t + 1;
+            }
+        })
+                .subscribe(to);
+    
+        to.assertValue(1);
+    }
+    
+    @Test
+    public void disposedOnApplyThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final TestObserver<Integer> to = new TestObserver<Integer>();
+
+            Observable.createScan(1, new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer t) throws Exception {
+                    to.cancel();
+                    throw new TestException();
+                }
+            })
+                    .subscribe(to);
+
+            to.assertValue(1);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}


### PR DESCRIPTION
Imagine a situation when your app has some state and wants it to be synchronized with the state of a server. The app sends its state to the server and gets back the difference between that state and the actual state of the server. Then, it applies the difference to its current state, sends the new state to the server and so on. This algorithm may be implemented using Observable.scan() operator. However, this operator seems to be redundant for the task because it acts on an upstream. In this example we will need to use a dummy Observable.range(...) stream as the upstream for Observable.scan(). The proposed operator provides a more elegant solution for the described problem and perhaps for some other problems.

Observable.scan() based solution:
```Java
Observable<State> streamOfAppStates =
        Observable.range(0, Long.MAX_VALUE - 1)
                .scan(initialState, (dummyLong, state) -> state.applyDiff(makeRequest(state)));
```

Observable.createScan() based solution:
```Java
Observable<State> streamOfAppStates =
        Observable.createScan(initialState, state -> state.applyDiff(makeRequest(state)));
```

![createscan](https://user-images.githubusercontent.com/4264235/41943446-22a52d64-79ac-11e8-8553-a5173961cf75.png)
