### PR TITLE
2.x: Adjust JavaDocs dl/dd entry stylesheet

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ javadoc {
     options.addStringOption("top").value = ""
     options.addStringOption("doctitle").value = ""
     options.addStringOption("header").value = ""
+    options.stylesheetFile = new File(projectDir, "gradle/stylesheet.css");
 
     options.links(
         "https://docs.oracle.com/javase/7/docs/api/",

--- a/gradle/stylesheet.css
+++ b/gradle/stylesheet.css
@@ -2,16 +2,19 @@
 /*
 Overall document style
 */
+
+@import url('resources/fonts/dejavu.css');
+
 body {
     background-color:#ffffff;
     color:#353833;
-    font-family:Arial, Helvetica, sans-serif;
-    font-size:76%;
+    font-family:'DejaVu Sans', Arial, Helvetica, sans-serif;
+    font-size:14px;
     margin:0;
 }
 a:link, a:visited {
     text-decoration:none;
-    color:#4c6b87;
+    color:#4A6782;
 }
 a:hover, a:focus {
     text-decoration:none;
@@ -19,7 +22,7 @@ a:hover, a:focus {
 }
 a:active {
     text-decoration:none;
-    color:#4c6b87;
+    color:#4A6782;
 }
 a[name] {
     color:#353833;
@@ -29,41 +32,51 @@ a[name]:hover {
     color:#353833;
 }
 pre {
-    font-size:1.3em;
+    font-family:'DejaVu Sans Mono', monospace;
+    font-size:14px;
 }
 h1 {
-    font-size:1.8em;
+    font-size:20px;
 }
 h2 {
-    font-size:1.5em;
+    font-size:18px;
 }
 h3 {
-    font-size:1.4em;
+    font-size:16px;
+    font-style:italic;
 }
 h4 {
-    font-size:1.3em;
+    font-size:13px;
 }
 h5 {
-    font-size:1.2em;
+    font-size:12px;
 }
 h6 {
-    font-size:1.1em;
+    font-size:11px;
 }
 ul {
     list-style-type:disc;
 }
 code, tt {
-    font-size:1.2em;
+    font-family:'DejaVu Sans Mono', monospace;
+    font-size:14px;
+    padding-top:4px;
+    margin-top:8px;
+    line-height:1.4em;
 }
 dt code {
-    font-size:1.2em;
+    font-family:'DejaVu Sans Mono', monospace;
+    font-size:14px;
+    padding-top:4px;
 }
 table tr td dt code {
-    font-size:1.2em;
+    font-family:'DejaVu Sans Mono', monospace;
+    font-size:14px;
     vertical-align:top;
+    padding-top:4px;
 }
 sup {
-    font-size:.6em;
+    font-size:8px;
 }
 /*
 Document title and Copyright styles
@@ -76,9 +89,9 @@ Document title and Copyright styles
 .aboutLanguage {
     float:right;
     padding:0px 21px;
-    font-size:.8em;
+    font-size:11px;
     z-index:200;
-    margin-top:-7px;
+    margin-top:-9px;
 }
 .legalCopy {
     margin-left:.5em;
@@ -92,9 +105,6 @@ Document title and Copyright styles
 }
 .tab {
     background-color:#0066FF;
-    background-image:url(resources/titlebar.gif);
-    background-position:left top;
-    background-repeat:no-repeat;
     color:#ffffff;
     padding:8px;
     width:5em;
@@ -104,17 +114,15 @@ Document title and Copyright styles
 Navigation bar styles
 */
 .bar {
-    background-image:url(resources/background.gif);
-    background-repeat:repeat-x;
+    background-color:#4D7A97;
     color:#FFFFFF;
     padding:.8em .5em .4em .8em;
     height:auto;/*height:1.8em;*/
-    font-size:1em;
+    font-size:11px;
     margin:0;
 }
 .topNav {
-    background-image:url(resources/background.gif);
-    background-repeat:repeat-x;
+    background-color:#4D7A97;
     color:#FFFFFF;
     float:left;
     padding:0;
@@ -123,11 +131,11 @@ Navigation bar styles
     height:2.8em;
     padding-top:10px;
     overflow:hidden;
+    font-size:12px; 
 }
 .bottomNav {
     margin-top:10px;
-    background-image:url(resources/background.gif);
-    background-repeat:repeat-x;
+    background-color:#4D7A97;
     color:#FFFFFF;
     float:left;
     padding:0;
@@ -136,18 +144,20 @@ Navigation bar styles
     height:2.8em;
     padding-top:10px;
     overflow:hidden;
+    font-size:12px;
 }
 .subNav {
     background-color:#dee3e9;
-    border-bottom:1px solid #9eadc0;
     float:left;
     width:100%;
     overflow:hidden;
+    font-size:12px;
 }
 .subNav div {
     clear:left;
     float:left;
     padding:0 0 5px 6px;
+    text-transform:uppercase;
 }
 ul.navList, ul.subNavList {
     float:left;
@@ -157,27 +167,33 @@ ul.navList, ul.subNavList {
 ul.navList li{
     list-style:none;
     float:left;
-    padding:3px 6px;
+    padding: 5px 6px;
+    text-transform:uppercase;
 }
 ul.subNavList li{
     list-style:none;
     float:left;
-    font-size:90%;
 }
 .topNav a:link, .topNav a:active, .topNav a:visited, .bottomNav a:link, .bottomNav a:active, .bottomNav a:visited {
     color:#FFFFFF;
     text-decoration:none;
+    text-transform:uppercase;
 }
 .topNav a:hover, .bottomNav a:hover {
     text-decoration:none;
     color:#bb7a2a;
+    text-transform:uppercase;
 }
 .navBarCell1Rev {
-    background-image:url(resources/tab.gif);
-    background-color:#a88834;
-    color:#FFFFFF;
+    background-color:#F8981D;
+    color:#253441;
     margin: auto 5px;
-    border:1px solid #c9aa44;
+}
+.skipNav {
+    position:absolute;
+    top:auto;
+    left:-9999px;
+    overflow:hidden;
 }
 /*
 Page header and footer styles
@@ -191,8 +207,11 @@ Page header and footer styles
     margin:10px;
     position:relative;
 }
+.indexHeader span{
+    margin-right:15px;
+}
 .indexHeader h1 {
-    font-size:1.3em;
+    font-size:13px;
 }
 .title {
     color:#2c4557;
@@ -202,7 +221,7 @@ Page header and footer styles
     margin:5px 0 0 0;
 }
 .header ul {
-    margin:0 0 25px 0;
+    margin:0 0 15px 0;
     padding:0;
 }
 .footer ul {
@@ -210,24 +229,22 @@ Page header and footer styles
 }
 .header ul li, .footer ul li {
     list-style:none;
-    font-size:1.2em;
+    font-size:13px;
 }
 /*
 Heading styles
 */
 div.details ul.blockList ul.blockList ul.blockList li.blockList h4, div.details ul.blockList ul.blockList ul.blockListLast li.blockList h4 {
     background-color:#dee3e9;
-    border-top:1px solid #9eadc0;
-    border-bottom:1px solid #9eadc0;
+    border:1px solid #d0d9e0;
     margin:0 0 6px -8px;
-    padding:2px 5px;
+    padding:7px 5px;
 }
 ul.blockList ul.blockList ul.blockList li.blockList h3 {
     background-color:#dee3e9;
-    border-top:1px solid #9eadc0;
-    border-bottom:1px solid #9eadc0;
+    border:1px solid #d0d9e0;
     margin:0 0 6px -8px;
-    padding:2px 5px;
+    padding:7px 5px;
 }
 ul.blockList ul.blockList li.blockList h3 {
     padding:0;
@@ -247,10 +264,10 @@ Page layout container styles
 .indexContainer {
     margin:10px;
     position:relative;
-    font-size:1.0em;
+    font-size:12px;
 }
 .indexContainer h2 {
-    font-size:1.1em;
+    font-size:13px;
     padding:0 0 3px 0;
 }
 .indexContainer ul {
@@ -259,15 +276,18 @@ Page layout container styles
 }
 .indexContainer ul li {
     list-style:none;
+    padding-top:2px;
 }
 .contentContainer .description dl dt, .contentContainer .details dl dt, .serializedFormContainer dl dt {
-    font-size:1.1em;
+    font-size:12px;
     font-weight:bold;
     margin:10px 0 0 0;
     color:#4E4E4E;
 }
-.contentContainer .description dl dd, .contentContainer .details dl dd, .serializedFormContainer dl dd {
-    margin:10px 0 10px 20px;
+/*.contentContainer .description dl dd, */.contentContainer .details dl dd, .serializedFormContainer dl dd {
+    margin:5px 0 10px 0px;
+    font-size:14px;
+    font-family:'DejaVu Sans Mono',monospace;
 }
 .serializedFormContainer dl.nameValue dt {
     margin-left:1px;
@@ -306,25 +326,24 @@ ul.blockList, ul.blockListLast {
 }
 ul.blockList li.blockList, ul.blockListLast li.blockList {
     list-style:none;
-    margin-bottom:25px;
+    margin-bottom:15px;
+    line-height:1.4;
 }
 ul.blockList ul.blockList li.blockList, ul.blockList ul.blockListLast li.blockList {
     padding:0px 20px 5px 10px;
-    border:1px solid #9eadc0;
-    background-color:#f9f9f9;
+    border:1px solid #ededed; 
+    background-color:#f8f8f8;
 }
 ul.blockList ul.blockList ul.blockList li.blockList, ul.blockList ul.blockList ul.blockListLast li.blockList {
     padding:0 0 5px 8px;
     background-color:#ffffff;
-    border:1px solid #9eadc0;
-    border-top:none;
+    border:none;
 }
 ul.blockList ul.blockList ul.blockList ul.blockList li.blockList {
     margin-left:0;
     padding-left:0;
     padding-bottom:15px;
     border:none;
-    border-bottom:1px solid #9eadc0;
 }
 ul.blockList ul.blockList ul.blockList ul.blockList li.blockListLast {
     list-style:none;
@@ -338,107 +357,155 @@ table tr td dl, table tr td dl dt, table tr td dl dd {
 /*
 Table styles
 */
-.contentContainer table, .classUseContainer table, .constantValuesContainer table {
-    border-bottom:1px solid #9eadc0;
+.overviewSummary, .memberSummary, .typeSummary, .useSummary, .constantsSummary, .deprecatedSummary {
     width:100%;
+    border-left:1px solid #EEE; 
+    border-right:1px solid #EEE; 
+    border-bottom:1px solid #EEE; 
 }
-.contentContainer ul li table, .classUseContainer ul li table, .constantValuesContainer ul li table {
-    width:100%;
+.overviewSummary, .memberSummary  {
+    padding:0px;
 }
-.contentContainer .description table, .contentContainer .details table {
-    border-bottom:none;
-}
-.contentContainer ul li table th.colOne, .contentContainer ul li table th.colFirst, .contentContainer ul li table th.colLast, .classUseContainer ul li table th, .constantValuesContainer ul li table th, .contentContainer ul li table td.colOne, .contentContainer ul li table td.colFirst, .contentContainer ul li table td.colLast, .classUseContainer ul li table td, .constantValuesContainer ul li table td{
-    vertical-align:top;
-    padding-right:20px;
-}
-.contentContainer ul li table th.colLast, .classUseContainer ul li table th.colLast,.constantValuesContainer ul li table th.colLast,
-.contentContainer ul li table td.colLast, .classUseContainer ul li table td.colLast,.constantValuesContainer ul li table td.colLast,
-.contentContainer ul li table th.colOne, .classUseContainer ul li table th.colOne,
-.contentContainer ul li table td.colOne, .classUseContainer ul li table td.colOne {
-    padding-right:3px;
-}
-.overviewSummary caption, .packageSummary caption, .contentContainer ul.blockList li.blockList caption, .summary caption, .classUseContainer caption, .constantValuesContainer caption {
+.overviewSummary caption, .memberSummary caption, .typeSummary caption,
+.useSummary caption, .constantsSummary caption, .deprecatedSummary caption {
     position:relative;
     text-align:left;
     background-repeat:no-repeat;
-    color:#FFFFFF;
+    color:#253441;
     font-weight:bold;
     clear:none;
     overflow:hidden;
     padding:0px;
+    padding-top:10px;
+    padding-left:1px;
     margin:0px;
+    white-space:pre;
 }
-caption a:link, caption a:hover, caption a:active, caption a:visited {
+.overviewSummary caption a:link, .memberSummary caption a:link, .typeSummary caption a:link,
+.useSummary caption a:link, .constantsSummary caption a:link, .deprecatedSummary caption a:link,
+.overviewSummary caption a:hover, .memberSummary caption a:hover, .typeSummary caption a:hover,
+.useSummary caption a:hover, .constantsSummary caption a:hover, .deprecatedSummary caption a:hover,
+.overviewSummary caption a:active, .memberSummary caption a:active, .typeSummary caption a:active,
+.useSummary caption a:active, .constantsSummary caption a:active, .deprecatedSummary caption a:active,
+.overviewSummary caption a:visited, .memberSummary caption a:visited, .typeSummary caption a:visited,
+.useSummary caption a:visited, .constantsSummary caption a:visited, .deprecatedSummary caption a:visited {
     color:#FFFFFF;
 }
-.overviewSummary caption span, .packageSummary caption span, .contentContainer ul.blockList li.blockList caption span, .summary caption span, .classUseContainer caption span, .constantValuesContainer caption span {
+.overviewSummary caption span, .memberSummary caption span, .typeSummary caption span,
+.useSummary caption span, .constantsSummary caption span, .deprecatedSummary caption span {
     white-space:nowrap;
-    padding-top:8px;
-    padding-left:8px;
-    display:block;
+    padding-top:5px;
+    padding-left:12px;
+    padding-right:12px;
+    padding-bottom:7px;
+    display:inline-block;
     float:left;
-    background-image:url(resources/titlebar.gif);
-    height:18px;
+    background-color:#F8981D;
+    border: none;
+    height:16px;
 }
-.overviewSummary .tabEnd, .packageSummary .tabEnd, .contentContainer ul.blockList li.blockList .tabEnd, .summary .tabEnd, .classUseContainer .tabEnd, .constantValuesContainer .tabEnd {
-    width:10px;
-    background-image:url(resources/titlebar_end.gif);
-    background-repeat:no-repeat;
-    background-position:top right;
+.memberSummary caption span.activeTableTab span {
+    white-space:nowrap;
+    padding-top:5px;
+    padding-left:12px;
+    padding-right:12px;
+    margin-right:3px;
+    display:inline-block;
+    float:left;
+    background-color:#F8981D;
+    height:16px;
+}
+.memberSummary caption span.tableTab span {
+    white-space:nowrap;
+    padding-top:5px;
+    padding-left:12px;
+    padding-right:12px;
+    margin-right:3px;
+    display:inline-block;
+    float:left;
+    background-color:#4D7A97;
+    height:16px;
+}
+.memberSummary caption span.tableTab, .memberSummary caption span.activeTableTab {
+    padding-top:0px;
+    padding-left:0px;
+    padding-right:0px;
+    background-image:none;
+    float:none;
+    display:inline;
+}
+.overviewSummary .tabEnd, .memberSummary .tabEnd, .typeSummary .tabEnd,
+.useSummary .tabEnd, .constantsSummary .tabEnd, .deprecatedSummary .tabEnd {
+    display:none;
+    width:5px;
     position:relative;
     float:left;
+    background-color:#F8981D;
 }
-ul.blockList ul.blockList li.blockList table {
-    margin:0 0 12px 0px;
-    width:100%;
+.memberSummary .activeTableTab .tabEnd {
+    display:none;
+    width:5px;
+    margin-right:3px;
+    position:relative; 
+    float:left;
+    background-color:#F8981D;
 }
-.tableSubHeadingColor {
-    background-color: #EEEEFF;
+.memberSummary .tableTab .tabEnd {
+    display:none;
+    width:5px;
+    margin-right:3px;
+    position:relative;
+    background-color:#4D7A97;
+    float:left;
+
 }
-.altColor {
-    background-color:#eeeeef;
-}
-.rowColor {
-    background-color:#ffffff;
-}
-.overviewSummary td, .packageSummary td, .contentContainer ul.blockList li.blockList td, .summary td, .classUseContainer td, .constantValuesContainer td {
+.overviewSummary td, .memberSummary td, .typeSummary td,
+.useSummary td, .constantsSummary td, .deprecatedSummary td {
     text-align:left;
-    padding:3px 3px 3px 7px;
+    padding:0px 0px 12px 10px;
 }
-th.colFirst, th.colLast, th.colOne, .constantValuesContainer th {
+th.colOne, th.colFirst, th.colLast, .useSummary th, .constantsSummary th,
+td.colOne, td.colFirst, td.colLast, .useSummary td, .constantsSummary td{
+    vertical-align:top;
+    padding-right:0px;
+    padding-top:8px;
+    padding-bottom:3px;
+}
+th.colFirst, th.colLast, th.colOne, .constantsSummary th {
     background:#dee3e9;
-    border-top:1px solid #9eadc0;
-    border-bottom:1px solid #9eadc0;
     text-align:left;
-    padding:3px 3px 3px 7px;
+    padding:8px 3px 3px 7px;
+}
+td.colFirst, th.colFirst {
+    white-space:nowrap;
+    font-size:13px;
+}
+td.colLast, th.colLast {
+    font-size:13px;
+}
+td.colOne, th.colOne {
+    font-size:13px;
+}
+.overviewSummary td.colFirst, .overviewSummary th.colFirst,
+.useSummary td.colFirst, .useSummary th.colFirst,
+.overviewSummary td.colOne, .overviewSummary th.colOne,
+.memberSummary td.colFirst, .memberSummary th.colFirst,
+.memberSummary td.colOne, .memberSummary th.colOne,
+.typeSummary td.colFirst{
+    width:25%;
+    vertical-align:top;
 }
 td.colOne a:link, td.colOne a:active, td.colOne a:visited, td.colOne a:hover, td.colFirst a:link, td.colFirst a:active, td.colFirst a:visited, td.colFirst a:hover, td.colLast a:link, td.colLast a:active, td.colLast a:visited, td.colLast a:hover, .constantValuesContainer td a:link, .constantValuesContainer td a:active, .constantValuesContainer td a:visited, .constantValuesContainer td a:hover {
     font-weight:bold;
 }
-td.colFirst, th.colFirst {
-    border-left:1px solid #9eadc0;
-    white-space:nowrap;
+.tableSubHeadingColor {
+    background-color:#EEEEFF;
 }
-td.colLast, th.colLast {
-    border-right:1px solid #9eadc0;
+.altColor {
+    background-color:#FFFFFF;
 }
-td.colOne, th.colOne {
-    border-right:1px solid #9eadc0;
-    border-left:1px solid #9eadc0;
-}
-table.overviewSummary  {
-    padding:0px;
-    margin-left:0px;
-}
-table.overviewSummary td.colFirst, table.overviewSummary th.colFirst,
-table.overviewSummary td.colOne, table.overviewSummary th.colOne {
-    width:25%;
-    vertical-align:middle;
-}
-table.packageSummary td.colFirst, table.overviewSummary th.colFirst {
-    width:25%;
-    vertical-align:middle;
+.rowColor {
+    background-color:#EEEEEF;
 }
 /*
 Content styles
@@ -453,6 +520,24 @@ Content styles
 .docSummary {
     padding:0;
 }
+
+ul.blockList ul.blockList ul.blockList li.blockList h3 {
+    font-style:normal;
+}
+
+div.block {
+    font-size:14px;
+    font-family:'DejaVu Serif', Georgia, "Times New Roman", Times, serif;
+}
+
+td.colLast div {
+    padding-top:0px;
+}
+
+
+td.colLast a {
+    padding-bottom:3px;
+}
 /*
 Formatting effect styles
 */
@@ -463,12 +548,27 @@ Formatting effect styles
 h1.hidden {
     visibility:hidden;
     overflow:hidden;
-    font-size:.9em;
+    font-size:10px;
 }
 .block {
     display:block;
-    margin:3px 0 0 0;
+    margin:3px 10px 2px 0px;
+    color:#474747;
 }
-.strong {
+.deprecatedLabel, .descfrmTypeLabel, .memberNameLabel, .memberNameLink,
+.overrideSpecifyLabel, .packageHierarchyLabel, .paramLabel, .returnLabel,
+.seeLabel, .simpleTagLabel, .throwsLabel, .typeNameLabel, .typeNameLink {
     font-weight:bold;
+}
+.deprecationComment, .emphasizedPhrase, .interfaceName {
+    font-style:italic;
+}
+
+div.block div.block span.deprecationComment, div.block div.block span.emphasizedPhrase,
+div.block div.block span.interfaceName {
+    font-style:normal;
+}
+
+div.contentContainer ul.blockList li.blockList h2{
+    padding-bottom:0px;
 }


### PR DESCRIPTION
The default JavaDocs stylesheet uses monospaced for the **Scheduler**/**Backpressure**/etc definitions list entries which practically makes any `{@code }` marking practically invisible. This PR set up a stylesheet with that specific style definition reverted to default. There was an unused `stylesheet.css` in the project from long before.

Before:

![image](https://user-images.githubusercontent.com/1269832/42266803-b4701698-7f77-11e8-8255-b5221f1f3e23.png)

After:

![image](https://user-images.githubusercontent.com/1269832/42266818-c0735f5e-7f77-11e8-8786-14ad4fc9a5a9.png)
