### PR TITLE
Add marble diagram to the Single.filter method

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2371,7 +2371,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Filters the success item of the Single via a predicate function and emitting it if the predicate
      * returns true, completing otherwise.
      * <p>
-     * <img width="640" height="457" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/Filter2.png" alt="">
+     * <img width="640" height="457" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.filter.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code filter} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2371,7 +2371,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Filters the success item of the Single via a predicate function and emitting it if the predicate
      * returns true, completing otherwise.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/filter.png" alt="">
+     * <img width="640" height="457" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/Filter2.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code filter} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
Hopefully this should tick off the `filter` operator in #5788

Please let me know if I need to change anything on the diagram itself. If not, please send me URL when you upload image within the project so I can change URL for the marble in the PR.

Although, I had a doubt and wanted to double check. Operator `filter` returns `Maybe` which essentially will call `onSuccess` or `onComplete`. By running jUnit tests, I could observe that this is a behavior but if I use `TestObserver` then both `assertValue()` and `assertComplete()` are invoked when there are elements that satisfy `filter` condition.