### PR TITLE
Add marble diagrams for Single.repeat operators

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2987,7 +2987,7 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Repeatedly re-subscribes to the current Single and emits each success value.
      * <p>
-     * <img width="640" height="457" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/Repeat.png" alt="">
+     * <img width="640" height="457" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.repeat.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
@@ -3007,7 +3007,7 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Re-subscribes to the current Single at most the given number of times and emits each success value.
      * <p>
-     * <img width="640" height="457" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/RepeatCount.png" alt="">
+     * <img width="640" height="457" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.repeat.n.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
@@ -3030,7 +3030,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * the Publisher returned by the handler function signals a value in response to a
      * value signalled through the Flowable the handle receives.
      * <p>
-     * <img width="640" height="1478" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/RepeatWhen.png" alt="">
+     * <img width="640" height="1478" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.repeatWhen.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2986,6 +2986,8 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Repeatedly re-subscribes to the current Single and emits each success value.
+     * <p>
+     * <img width="640" height="457" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/Repeat.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
@@ -3004,6 +3006,8 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Re-subscribes to the current Single at most the given number of times and emits each success value.
+     * <p>
+     * <img width="640" height="457" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/RepeatCount.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
@@ -3025,6 +3029,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * Re-subscribes to the current Single if
      * the Publisher returned by the handler function signals a value in response to a
      * value signalled through the Flowable the handle receives.
+     * <p>
+     * <img width="640" height="1478" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/RepeatWhen.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.


### PR DESCRIPTION
Here are marbles for `repeat`, `repeat(times)` and `repeatWhen` operator in #5788

Please let me know if I need to change anything on the diagram itself. If not, please send me URL when you upload image within the project so I can change URL for the marble in the PR.

I intentionally added two diagrams for `repeatWhen` as I would say its interesting case that people should be aware of.

**EDIT:**
Here are marbles

`repeat` operator:
![repeat](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/Repeat.png)

`repeat(count)` operator:
![repeat with count](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/RepeatCount.png)

`repeatWhen` operator:
![repeatWhen](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/RepeatWhen.png)