### PR TITLE
Add marble diagram for Single.repeatUntil operator

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -3049,7 +3049,7 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Re-subscribes to the current Single until the given BooleanSupplier returns true.
      * <p>
-     * <img width="640" height="463" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/RepeatUntil.png" alt="">
+     * <img width="640" height="463" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.repeatUntil.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -3048,6 +3048,8 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Re-subscribes to the current Single until the given BooleanSupplier returns true.
+     * <p>
+     * <img width="640" height="463" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/RepeatUntil.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>


### PR DESCRIPTION
Here is marble for `repeatUntil` operator in #5788

![repeatUntil](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/RepeatUntil.png)
Please let me know if I need to change anything on the diagram itself. If not, please send me URL when you upload image within the project so I can change URL for the marble in the PR.