### PR TITLE
Single error operators marbles

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2852,7 +2852,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Instructs a Single to emit an item (returned by a specified function) rather than invoking
      * {@link SingleObserver#onError onError} if it encounters an error.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onErrorReturn.png" alt="">
+     * <img width="640" height="451" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorReturn.png" alt="">
      * <p>
      * By default, when a Single encounters an error that prevents it from emitting the expected item to its
      * subscriber, the Single invokes its subscriber's {@link SingleObserver#onError} method, and then quits
@@ -2883,6 +2883,8 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Signals the specified value as success in case the current Single signals an error.
+     * <p>
+     * <img width="640" height="451" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorReturnItem.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code onErrorReturnItem} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2902,7 +2904,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Instructs a Single to pass control to another Single rather than invoking
      * {@link SingleObserver#onError(Throwable)} if it encounters an error.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
+     * <img width="640" height="451" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorResumeNext.png" alt="">
      * <p>
      * By default, when a Single encounters an error that prevents it from emitting the expected item to
      * its {@link SingleObserver}, the Single invokes its SingleObserver's {@code onError} method, and then quits
@@ -2936,7 +2938,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Instructs a Single to pass control to another Single rather than invoking
      * {@link SingleObserver#onError(Throwable)} if it encounters an error.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
+     * <img width="640" height="451" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorResumeNextWithFn.png" alt="">
      * <p>
      * By default, when a Single encounters an error that prevents it from emitting the expected item to
      * its {@link SingleObserver}, the Single invokes its SingleObserver's {@code onError} method, and then quits

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -455,7 +455,7 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Signals a Throwable returned by the callback function for each individual SingleObserver.
      * <p>
-     * <img width="640" height="283" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/ErrorCallable.png" alt="">
+     * <img width="640" height="283" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.error.c.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -476,7 +476,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Returns a Single that invokes a subscriber's {@link SingleObserver#onError onError} method when the
      * subscriber subscribes to it.
      * <p>
-     * <img width="640" height="283" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/Error.png" alt="">
+     * <img width="640" height="283" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.error.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2852,7 +2852,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Instructs a Single to emit an item (returned by a specified function) rather than invoking
      * {@link SingleObserver#onError onError} if it encounters an error.
      * <p>
-     * <img width="640" height="451" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorReturn.png" alt="">
+     * <img width="640" height="451" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onErrorReturn.png" alt="">
      * <p>
      * By default, when a Single encounters an error that prevents it from emitting the expected item to its
      * subscriber, the Single invokes its subscriber's {@link SingleObserver#onError} method, and then quits
@@ -2884,7 +2884,7 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Signals the specified value as success in case the current Single signals an error.
      * <p>
-     * <img width="640" height="451" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorReturnItem.png" alt="">
+     * <img width="640" height="451" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onErrorReturnItem.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code onErrorReturnItem} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2904,7 +2904,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Instructs a Single to pass control to another Single rather than invoking
      * {@link SingleObserver#onError(Throwable)} if it encounters an error.
      * <p>
-     * <img width="640" height="451" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorResumeNext.png" alt="">
+     * <img width="640" height="451" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onErrorResumeNext.png" alt="">
      * <p>
      * By default, when a Single encounters an error that prevents it from emitting the expected item to
      * its {@link SingleObserver}, the Single invokes its SingleObserver's {@code onError} method, and then quits
@@ -2938,7 +2938,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Instructs a Single to pass control to another Single rather than invoking
      * {@link SingleObserver#onError(Throwable)} if it encounters an error.
      * <p>
-     * <img width="640" height="451" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorResumeNextWithFn.png" alt="">
+     * <img width="640" height="451" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onErrorResumeNext.f.png" alt="">
      * <p>
      * By default, when a Single encounters an error that prevents it from emitting the expected item to
      * its {@link SingleObserver}, the Single invokes its SingleObserver's {@code onError} method, and then quits

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -454,6 +454,8 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Signals a Throwable returned by the callback function for each individual SingleObserver.
+     * <p>
+     * <img width="640" height="283" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/ErrorCallable.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -474,7 +476,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Returns a Single that invokes a subscriber's {@link SingleObserver#onError onError} method when the
      * subscriber subscribes to it.
      * <p>
-     * <img width="640" height="190" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.error.png" alt="">
+     * <img width="640" height="283" src="https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/Error.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
Here are marbles for #5788 

For `error(Callable)`
![errorCallable](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/ErrorCallable.png)

For `error(Throwable)`, only added error event to be red:
![errorThrowable](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/Error.png)

For `onErrorReturn`
![onErrorReturn](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorReturn.png)

For `onErrorReturnItem`
![onErrorReturnItem](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorReturnItem.png)

For `onErrorResumeNext(SingleSource)`
![onErrorResumeNext](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorResumeNext.png)

For `onErrorResumeNext(Function)`
![onErrorResumeNextFn](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/onErrorResumeNextWithFn.png)