### PR TITLE
Add marbles for Single.amb operators

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -63,6 +63,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Runs multiple SingleSources and signals the events of the first one that signals (cancelling
      * the rest).
+     * <p>
+     * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.amb.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -83,6 +85,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Runs multiple SingleSources and signals the events of the first one that signals (cancelling
      * the rest).
+     * <p>
+     * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.ambArray.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code ambArray} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
Here are operators for `amb` and `ambArray` from #5788 

Marble for `amb`:
![amb](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/amb.png)

Marble for `ambArray`:
![ambArray](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/ambArray.png)