### PR TITLE
Add marbles for Single.timer, Single.defer and Single.toXXX operators

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -436,6 +436,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Calls a {@link Callable} for each individual {@link SingleObserver} to return the actual {@link SingleSource} to
      * be subscribed to.
+     * <p>
+     * <img width="640" height="423" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.defer.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -1179,6 +1181,8 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Signals success with 0L value after the given delay for each SingleObserver.
+     * <p>
+     * <img width="640" height="292" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.timer.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code timer} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -1196,6 +1200,8 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Signals success with 0L value after the given delay for each SingleObserver.
+     * <p>
+     * <img width="640" height="292" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.timer.s.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>you specify the {@link Scheduler} to signal on.</dd>
@@ -3624,7 +3630,7 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Converts this Single into a {@link Flowable}.
      * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toObservable.png" alt="">
+     * <img width="640" height="462" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toFlowable.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
@@ -3648,7 +3654,7 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Returns a {@link Future} representing the single value emitted by this {@code Single}.
      * <p>
-     * <img width="640" height="395" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/B.toFuture.png" alt="">
+     * <img width="640" height="463" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Single.toFuture.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toFuture} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3666,7 +3672,7 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Converts this Single into a {@link Maybe}.
      * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toObservable.png" alt="">
+     * <img width="640" height="463" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toMaybe.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code toMaybe} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -437,7 +437,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Calls a {@link Callable} for each individual {@link SingleObserver} to return the actual {@link SingleSource} to
      * be subscribed to.
      * <p>
-     * <img width="640" height="423" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.defer.png" alt="">
+     * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.defer.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3654,7 +3654,7 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Returns a {@link Future} representing the single value emitted by this {@code Single}.
      * <p>
-     * <img width="640" height="463" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Single.toFuture.png" alt="">
+     * <img width="640" height="467" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Single.toFuture.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toFuture} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
Here are marbles for `defer`, `timer(delay, unit)`, `timer(delay, unit, scheduler)`, `toFlowable`, `toMaybe`, `toFuture` operators in #5788 

Marble for `defer`:
![defer](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/Defer.png)

Marble for `timer(delay, unit)`:
![timer](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/Timer.png)

Marble for `timer(delay, unit, scheduler)`:
![timerScheduler](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/TimerScheduler.png)

Marble for `toFuture`, although for this one I believe we should add case when there is no event sent from Single as there will be timeout exception thrown:
![toFuture](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/toFuture.png)

Marble for `toMaybe`:
![toMaybe](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/toMaybe.png)

Marble for `toFlowable`, although here I didnt figured out what will happen if we request more than 1 event from flowable:
![toFlowable](https://raw.githubusercontent.com/UMFsimke/RxJava/Images/Images/toFlowable.png)