### PR TITLE
Makes blockingGet on Single have an optional non-blocking fast return path

### DIFF
--- a/src/jmh/java/io/reactivex/BlockingGetPerf.java
+++ b/src/jmh/java/io/reactivex/BlockingGetPerf.java
@@ -13,6 +13,8 @@
 
 package io.reactivex;
 
+import io.reactivex.subjects.SingleSubject;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
@@ -29,6 +31,8 @@ public class BlockingGetPerf {
     Observable<Integer> observable;
 
     Single<Integer> single;
+    Single<Integer> singleDeferred;
+    SingleSubject<Integer> singleSubject;
 
     Maybe<Integer> maybe;
 
@@ -41,6 +45,15 @@ public class BlockingGetPerf {
         observable = Observable.just(1);
 
         single = Single.just(1);
+
+        singleDeferred = Single.defer(new Callable<Single<Integer>>() {
+          public Single<Integer> call() {
+            return Single.just(1);
+          }
+        });
+
+        singleSubject = SingleSubject.create();
+        singleDeferred.subscribe(singleSubject);
 
         maybe = Maybe.just(1);
 
@@ -70,6 +83,16 @@ public class BlockingGetPerf {
     @Benchmark
     public Object single() {
         return single.blockingGet();
+    }
+
+    @Benchmark
+    public Object singleDeferred() {
+        return singleDeferred.blockingGet();
+    }
+
+    @Benchmark
+    public Object singleSubject() {
+        return singleSubject.blockingGet();
     }
 
     @Benchmark

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2657,9 +2657,23 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingGet() {
+        T value = blockingGetStored();
+        if (value != null) {
+          return value;
+        }
         BlockingMultiObserver<T> observer = new BlockingMultiObserver<T>();
         subscribe(observer);
         return observer.blockingGet();
+    }
+
+    /**
+     * Returns the {@code Single}s already stored value, if implemented by a subclass. This may be
+     * used to quickly return known values immediately without creating a new blocking subscription
+     * in calls to {@link blockingGet}.
+     */
+    @Nullable
+    protected T blockingGetStored() {
+      return null;
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/single/SingleJust.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleJust.java
@@ -30,4 +30,9 @@ public final class SingleJust<T> extends Single<T> {
         s.onSuccess(value);
     }
 
+    @Override
+    protected T blockingGetStored() {
+      return value;
+    }
+
 }

--- a/src/main/java/io/reactivex/subjects/SingleSubject.java
+++ b/src/main/java/io/reactivex/subjects/SingleSubject.java
@@ -19,6 +19,7 @@ import io.reactivex.*;
 import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -122,6 +123,11 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
     SingleSubject() {
         once = new AtomicBoolean();
         observers = new AtomicReference<SingleDisposable<T>[]>(EMPTY);
+    }
+
+    @Override
+    protected final T blockingGetStored() {
+        return getValue();
     }
 
     @Override


### PR DESCRIPTION
Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

This allows blockingGet to quickly return known values instead of blocking and creating a Subscription. Implements first on SingleSubject and SingleJust. I imagine it will have a much greater effect on SingleSubject.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

N/A

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.

The existing unit tests seemed sufficient to verify current behavior. I did add some variations in the JMH benchmark tests to demonstrate usefulness of the change. The `Single.defer` behavior is essentially without the fast path, as it is wrapping the inner `Single` with one that does not have the fast path.

Local benchmark results show an order of magnitude improvement on `blockingGet` where this change applies.
```
Benchmark                        Mode  Cnt          Score         Error  Units
BlockingGetPerf.single          thrpt    5  325290806.912 ± 6329789.491  ops/s
BlockingGetPerf.singleDeferred  thrpt    5   29213041.202 ± 1734102.589  ops/s
BlockingGetPerf.singleSubject   thrpt    5  296488077.286 ± 9972222.042  ops/s
```