### PR TITLE
2.x: Adjust JavaDoc stylesheet of dt/dd within the method details

### DIFF
--- a/gradle/stylesheet.css
+++ b/gradle/stylesheet.css
@@ -284,10 +284,10 @@ Page layout container styles
     margin:10px 0 0 0;
     color:#4E4E4E;
 }
-/*.contentContainer .description dl dd, */.contentContainer .details dl dd, .serializedFormContainer dl dd {
-    margin:5px 0 10px 0px;
+.contentContainer .description dl dd, .contentContainer .details dl dd, .serializedFormContainer dl dd {
+    /* margin:5px 0 10px 0px; */
     font-size:14px;
-    font-family:'DejaVu Sans Mono',monospace;
+    font-family:'DejaVu Serif', Georgia, "Times New Roman", Times, serif;
 }
 .serializedFormContainer dl.nameValue dt {
     margin-left:1px;


### PR DESCRIPTION
This PR adjusts the JavaDoc stylesheet so that the `dt`/`dd` listings in the detailed method descriptions no longer use monospaced font (which should be generally reserved for `{@code }`s and {@link }`s) for better readability.

Before:

![image](https://user-images.githubusercontent.com/1269832/43001178-8edcff7c-8c24-11e8-9622-e7ee3515f0ca.png)

After:

![image](https://user-images.githubusercontent.com/1269832/43001192-9c937754-8c24-11e8-84b0-f23518ae8a40.png)

