### PR TITLE
2.2: Promote all Experimental/Beta API to standard

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -458,10 +458,12 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.17 - beta
      * @param <T> the value type of the {@link MaybeSource} element
      * @param maybe the Maybe instance to subscribe to, not null
      * @return the new Completable instance
      * @throws NullPointerException if single is null
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -1138,14 +1140,13 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type
      * @param converter the function that receives the current Completable instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
-     * @since 2.1.7 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(@NonNull CompletableConverter<? extends R> converter) {
@@ -1827,11 +1828,11 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.5 - experimental
      * @return a Completable which nulls out references to the upstream producer and downstream CompletableObserver if
      * the sequence is terminated or downstream calls dispose()
-     * @since 2.1.5 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable onTerminateDetach() {
@@ -1975,15 +1976,15 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.8 - experimental
      * @param times the number of times the returned Completable should retry this Completable
      * @param predicate the predicate that is called with the latest throwable and should return
      * true to indicate the returned Completable should resubscribe to this Completable.
      * @return the new Completable instance
      * @throws NullPointerException if predicate is null
      * @throws IllegalArgumentException if times is negative
-     * @since 2.1.8 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable retry(long times, Predicate<? super Throwable> predicate) {
@@ -2304,12 +2305,12 @@ public abstract class Completable implements CompletableSource {
      *  is signaled to the downstream and the other error is signaled to the global
      *  error handler via {@link RxJavaPlugins#onError(Throwable)}.</dd>
      * </dl>
+     * <p>History: 2.1.17 - experimental
      * @param other the other completable source to observe for the terminal signals
      * @return the new Completable instance
-     * @since 2.1.17 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable takeUntil(CompletableSource other) {
         ObjectHelper.requireNonNull(other, "other is null");

--- a/src/main/java/io/reactivex/CompletableConverter.java
+++ b/src/main/java/io/reactivex/CompletableConverter.java
@@ -18,11 +18,10 @@ import io.reactivex.annotations.*;
 /**
  * Convenience interface and callback used by the {@link Completable#as} operator to turn a Completable into another
  * value fluently.
- *
+ * <p>History: 2.1.7 - experimental
  * @param <R> the output type
- * @since 2.1.7 - experimental
+ * @since 2.2
  */
-@Experimental
 public interface CompletableConverter<R> {
     /**
      * Applies a function to the upstream Completable and returns a converted value of type {@code R}.

--- a/src/main/java/io/reactivex/CompletableEmitter.java
+++ b/src/main/java/io/reactivex/CompletableEmitter.java
@@ -88,11 +88,11 @@ public interface CompletableEmitter {
      * <p>
      * Unlike {@link #onError(Throwable)}, the {@code RxJavaPlugins.onError} is not called
      * if the error could not be delivered.
+     * <p>History: 2.1.1 - experimental
      * @param t the throwable error to signal if possible
      * @return true if successful, false if the downstream is not able to accept further
      * events
-     * @since 2.1.1 - experimental
+     * @since 2.2
      */
-    @Experimental
     boolean tryOnError(@NonNull Throwable t);
 }

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -5392,14 +5392,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type
      * @param converter the function that receives the current Flowable instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
-     * @since 2.1.7 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -5870,15 +5869,15 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.15 - experimental
      * @param onNext the callback action for each source value
      * @param bufferSize the size of the buffer
-     * @since 2.1.15 - experimental
      * @see #blockingSubscribe(Consumer, Consumer)
      * @see #blockingSubscribe(Consumer, Consumer, Action)
+     * @since 2.2
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final void blockingSubscribe(Consumer<? super T> onNext, int bufferSize) {
         FlowableBlockingSubscribe.subscribe(this, onNext, Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION, bufferSize);
     }
@@ -5920,15 +5919,15 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.15 - experimental
      * @param onNext the callback action for each source value
      * @param onError the callback action for an error event
      * @param bufferSize the size of the buffer
-     * @since 2.1.15 - experimental
+     * @since 2.2
      * @see #blockingSubscribe(Consumer, Consumer, Action)
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
         int bufferSize) {
         FlowableBlockingSubscribe.subscribe(this, onNext, onError, Functions.EMPTY_ACTION, bufferSize);
@@ -5971,15 +5970,15 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code blockingSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.15 - experimental
      * @param onNext the callback action for each source value
      * @param onError the callback action for an error event
      * @param onComplete the callback action for the completion event.
      * @param bufferSize the size of the buffer
-     * @since 2.1.15 - experimental
+     * @since 2.2
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete,
         int bufferSize) {
         FlowableBlockingSubscribe.subscribe(this, onNext, onError, onComplete, bufferSize);
@@ -7067,17 +7066,17 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with the upstream item and should return
      *               a {@code CompletableSource} to become the next source to
      *               be subscribed to
      * @return a new Completable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapCompletableDelayError(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    @Experimental
     public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper) {
         return concatMapCompletable(mapper, 2);
     }
@@ -7094,6 +7093,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with the upstream item and should return
      *               a {@code CompletableSource} to become the next source to
      *               be subscribed to
@@ -7102,13 +7102,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                 The operator replenishes after half of the prefetch amount has been consumed
      *                 and turned into {@code CompletableSource}s.
      * @return a new Completable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapCompletableDelayError(Function, boolean, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    @Experimental
     public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -7128,17 +7127,17 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapCompletableDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with the upstream item and should return
      *               a {@code CompletableSource} to become the next source to
      *               be subscribed to
      * @return a new Completable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapCompletable(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    @Experimental
     public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper) {
         return concatMapCompletableDelayError(mapper, true, 2);
     }
@@ -7156,6 +7155,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapCompletableDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with the upstream item and should return
      *               a {@code CompletableSource} to become the next source to
      *               be subscribed to
@@ -7166,13 +7166,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                   {@code CompletableSource} terminates and only then is
      *                   it emitted to the downstream.
      * @return a new Completable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapCompletable(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    @Experimental
     public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd) {
         return concatMapCompletableDelayError(mapper, tillTheEnd, 2);
     }
@@ -7190,6 +7189,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapCompletableDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with the upstream item and should return
      *               a {@code CompletableSource} to become the next source to
      *               be subscribed to
@@ -7204,13 +7204,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                 The operator replenishes after half of the prefetch amount has been consumed
      *                 and turned into {@code CompletableSource}s.
      * @return a new Completable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapCompletable(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    @Experimental
     public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -7495,19 +7494,19 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code MaybeSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code MaybeSource} to become the next source to
      *               be subscribed to
      * @return a new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapMaybeDelayError(Function)
      * @see #concatMapMaybe(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> concatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         return concatMapMaybe(mapper, 2);
     }
@@ -7526,6 +7525,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code MaybeSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code MaybeSource} to become the next source to
@@ -7535,14 +7535,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                 The operator replenishes after half of the prefetch amount has been consumed
      *                 and turned into {@code MaybeSource}s.
      * @return a new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapMaybe(Function)
      * @see #concatMapMaybeDelayError(Function, boolean, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> concatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -7563,19 +7562,19 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code MaybeSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code MaybeSource} to become the next source to
      *               be subscribed to
      * @return a new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapMaybe(Function)
      * @see #concatMapMaybeDelayError(Function, boolean)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         return concatMapMaybeDelayError(mapper, true, 2);
     }
@@ -7594,6 +7593,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code MaybeSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code MaybeSource} to become the next source to
@@ -7605,14 +7605,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                   {@code MaybeSource} terminates and only then is
      *                   it emitted to the downstream.
      * @return a new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapMaybe(Function, int)
      * @see #concatMapMaybeDelayError(Function, boolean, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd) {
         return concatMapMaybeDelayError(mapper, tillTheEnd, 2);
     }
@@ -7631,6 +7630,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code MaybeSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code MaybeSource} to become the next source to
@@ -7646,13 +7646,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                 The operator replenishes after half of the prefetch amount has been consumed
      *                 and turned into {@code MaybeSource}s.
      * @return a new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapMaybe(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -7673,19 +7672,19 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code SingleSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code SingleSource} to become the next source to
      *               be subscribed to
      * @return a new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapSingleDelayError(Function)
      * @see #concatMapSingle(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> concatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return concatMapSingle(mapper, 2);
     }
@@ -7704,6 +7703,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code SingleSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code SingleSource} to become the next source to
@@ -7713,14 +7713,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                 The operator replenishes after half of the prefetch amount has been consumed
      *                 and turned into {@code SingleSource}s.
      * @return a new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapSingle(Function)
      * @see #concatMapSingleDelayError(Function, boolean, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> concatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -7741,19 +7740,19 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code SingleSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code SingleSource} to become the next source to
      *               be subscribed to
      * @return a new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapSingle(Function)
      * @see #concatMapSingleDelayError(Function, boolean)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return concatMapSingleDelayError(mapper, true, 2);
     }
@@ -7772,6 +7771,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code SingleSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code SingleSource} to become the next source to
@@ -7783,14 +7783,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                   {@code SingleSource} terminates and only then is
      *                   it emitted to the downstream.
      * @return a new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapSingle(Function, int)
      * @see #concatMapSingleDelayError(Function, boolean, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd) {
         return concatMapSingleDelayError(mapper, tillTheEnd, 2);
     }
@@ -7809,6 +7808,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code SingleSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code SingleSource} to become the next source to
@@ -7824,13 +7824,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                 The operator replenishes after half of the prefetch amount has been consumed
      *                 and turned into {@code SingleSource}s.
      * @return a new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapSingle(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -7877,14 +7876,14 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.10 - experimental
      * @param other the SingleSource whose signal should be emitted after this {@code Flowable} completes normally.
      * @return the new Flowable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Flowable<T> concatWith(@NonNull SingleSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new FlowableConcatWithSingle<T>(this, other));
@@ -7902,14 +7901,14 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.10 - experimental
      * @param other the MaybeSource whose signal should be emitted after this Flowable completes normally.
      * @return the new Flowable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Flowable<T> concatWith(@NonNull MaybeSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new FlowableConcatWithMaybe<T>(this, other));
@@ -7929,14 +7928,14 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.10 - experimental
      * @param other the {@code CompletableSource} to subscribe to once the current {@code Flowable} completes normally
      * @return the new Flowable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Flowable<T> concatWith(@NonNull CompletableSource other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new FlowableConcatWithCompletable<T>(this, other));
@@ -10468,7 +10467,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.10 - beta
      * @param keySelector
      *            a function that extracts the key for each item
      * @param valueSelector
@@ -10493,12 +10492,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
      *
-     * @since 2.1.10
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Beta
     public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
             Function<? super T, ? extends V> valueSelector,
             boolean delayError, int bufferSize,
@@ -10936,16 +10934,15 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code limit} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-
+     * <p>History: 2.1.6 - experimental
      * @param count the maximum number of items and the total request amount, non-negative.
      *              Zero will immediately cancel the upstream on subscription and complete
      *              the downstream.
      * @return the new Flowable instance
      * @see #take(long)
      * @see #rebatchRequests(int)
-     * @since 2.1.6 - experimental
+     * @since 2.2
      */
-    @Experimental
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
@@ -11050,15 +11047,14 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.10 - experimental
      * @param other the {@code SingleSource} whose success value to merge with
      * @return the new Flowable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Flowable<T> mergeWith(@NonNull SingleSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new FlowableMergeWithSingle<T>(this, other));
@@ -11079,15 +11075,14 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.10 - experimental
      * @param other the {@code MaybeSource} which provides a success value to merge with or completes
      * @return the new Flowable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Flowable<T> mergeWith(@NonNull MaybeSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new FlowableMergeWithMaybe<T>(this, other));
@@ -11105,15 +11100,14 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.10 - experimental
      * @param other the {@code CompletableSource} to await for completion
      * @return the new Flowable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Flowable<T> mergeWith(@NonNull CompletableSource other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new FlowableMergeWithCompletable<T>(this, other));
@@ -11842,14 +11836,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code parallel} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * <p>History: 2.0.5 - experimental
+     * <p>History: 2.0.5 - experimental; 2.1 - beta
      * @return the new ParallelFlowable instance
-     * @since 2.1 - beta
+     * @since 2.2
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
-    @Beta
     public final ParallelFlowable<T> parallel() {
         return ParallelFlowable.from(this);
     }
@@ -11872,15 +11865,14 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code parallel} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * <p>History: 2.0.5 - experimental
+     * <p>History: 2.0.5 - experimental; 2.1 - beta
      * @param parallelism the number of 'rails' to use
      * @return the new ParallelFlowable instance
-     * @since 2.1 - beta
+     * @since 2.2
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
-    @Beta
     public final ParallelFlowable<T> parallel(int parallelism) {
         ObjectHelper.verifyPositive(parallelism, "parallelism");
         return ParallelFlowable.from(this, parallelism);
@@ -11905,16 +11897,15 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code parallel} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * <p>History: 2.0.5 - experimental
+     * <p>History: 2.0.5 - experimental; 2.1 - beta
      * @param parallelism the number of 'rails' to use
      * @param prefetch the number of items each 'rail' should prefetch
      * @return the new ParallelFlowable instance
-     * @since 2.1 - beta
+     * @since 2.2
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
-    @Beta
     public final ParallelFlowable<T> parallel(int parallelism, int prefetch) {
         ObjectHelper.verifyPositive(parallelism, "parallelism");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -14402,13 +14393,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * <p>History: 2.0.7 - experimental
+     * <p>History: 2.0.7 - experimental; 2.1 - beta
      * @param s the FlowableSubscriber that will consume signals from this Flowable
-     * @since 2.1 - beta
+     * @since 2.2
      */
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Beta
     public final void subscribe(FlowableSubscriber<? super T> s) {
         ObjectHelper.requireNonNull(s, "s is null");
         try {
@@ -14525,7 +14515,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.1 - experimental
      * @param scheduler
      *            the {@link Scheduler} to perform subscription actions on
      * @param requestOn if true, requests are rerouted to the given Scheduler as well (strong pipelining)
@@ -14536,12 +14526,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/subscribeon.html">ReactiveX operators documentation: SubscribeOn</a>
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #observeOn
-     * @since 2.1.1 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    @Experimental
     public final Flowable<T> subscribeOn(@NonNull Scheduler scheduler, boolean requestOn) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new FlowableSubscribeOn<T>(this, scheduler, requestOn));
@@ -14675,17 +14664,17 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors.
      *  </dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with each upstream item and should return a
      *               {@link CompletableSource} to be subscribed to and awaited for
      *               (non blockingly) for its terminal event
      * @return the new Completable instance
-     * @since 2.1.11 - experimental
      * @see #switchMapCompletableDelayError(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Completable switchMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new FlowableSwitchMapCompletable<T>(this, mapper, false));
@@ -14721,17 +14710,17 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors.
      *  </dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with each upstream item and should return a
      *               {@link CompletableSource} to be subscribed to and awaited for
      *               (non blockingly) for its terminal event
      * @return the new Completable instance
-     * @since 2.1.11 - experimental
      * @see #switchMapCompletableDelayError(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Completable switchMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new FlowableSwitchMapCompletable<T>(this, mapper, true));
@@ -14846,18 +14835,18 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} as
      *  {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the output value type
      * @param mapper the function called with the current upstream event and should
      *               return a {@code MaybeSource} to replace the current active inner source
      *               and get subscribed to.
      * @return the new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #switchMapMaybe(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> switchMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new FlowableSwitchMapMaybe<T, R>(this, mapper, false));
@@ -14876,18 +14865,18 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code switchMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the output value type
      * @param mapper the function called with the current upstream event and should
      *               return a {@code MaybeSource} to replace the current active inner source
      *               and get subscribed to.
      * @return the new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #switchMapMaybe(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> switchMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new FlowableSwitchMapMaybe<T, R>(this, mapper, true));
@@ -14916,18 +14905,18 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} as
      *  {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the output value type
      * @param mapper the function called with the current upstream event and should
      *               return a {@code SingleSource} to replace the current active inner source
      *               and get subscribed to.
      * @return the new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #switchMapSingle(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> switchMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new FlowableSwitchMapSingle<T, R>(this, mapper, false));
@@ -14946,18 +14935,18 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code switchMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the output value type
      * @param mapper the function called with the current upstream event and should
      *               return a {@code SingleSource} to replace the current active inner source
      *               and get subscribed to.
      * @return the new Flowable instance
-     * @since 2.1.11 - experimental
      * @see #switchMapSingle(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Flowable<R> switchMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new FlowableSwitchMapSingle<T, R>(this, mapper, true));
@@ -15627,15 +15616,15 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code throttleLatest} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait after an item emission towards the downstream
      *                before trying to emit the latest item from upstream again
      * @param unit    the time unit
      * @return the new Flowable instance
-     * @since 2.1.14 - experimental
+     * @since 2.2
      * @see #throttleLatest(long, TimeUnit, boolean)
      * @see #throttleLatest(long, TimeUnit, Scheduler)
      */
-    @Experimental
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
@@ -15661,6 +15650,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code throttleLatest} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait after an item emission towards the downstream
      *                before trying to emit the latest item from upstream again
      * @param unit    the time unit
@@ -15669,10 +15659,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                 a timeout window active or not. If {@code false}, the very last
      *                 upstream item is ignored and the flow terminates.
      * @return the new Flowable instance
-     * @since 2.1.14 - experimental
      * @see #throttleLatest(long, TimeUnit, Scheduler, boolean)
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
@@ -15701,16 +15690,16 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait after an item emission towards the downstream
      *                before trying to emit the latest item from upstream again
      * @param unit    the time unit
      * @param scheduler the {@link Scheduler} where the timed wait and latest item
      *                  emission will be performed
      * @return the new Flowable instance
-     * @since 2.1.14 - experimental
      * @see #throttleLatest(long, TimeUnit, Scheduler, boolean)
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
@@ -15736,6 +15725,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait after an item emission towards the downstream
      *                before trying to emit the latest item from upstream again
      * @param unit    the time unit
@@ -15746,9 +15736,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                 a timeout window active or not. If {@code false}, the very last
      *                 upstream item is ignored and the flow terminates.
      * @return the new Flowable instance
-     * @since 2.1.14 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)

--- a/src/main/java/io/reactivex/FlowableConverter.java
+++ b/src/main/java/io/reactivex/FlowableConverter.java
@@ -18,12 +18,11 @@ import io.reactivex.annotations.*;
 /**
  * Convenience interface and callback used by the {@link Flowable#as} operator to turn a Flowable into another
  * value fluently.
- *
+ * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type
  * @param <R> the output type
- * @since 2.1.7 - experimental
+ * @since 2.2
  */
-@Experimental
 public interface FlowableConverter<T, R> {
     /**
      * Applies a function to the upstream Flowable and returns a converted value of type {@code R}.

--- a/src/main/java/io/reactivex/FlowableEmitter.java
+++ b/src/main/java/io/reactivex/FlowableEmitter.java
@@ -94,11 +94,11 @@ public interface FlowableEmitter<T> extends Emitter<T> {
      * <p>
      * Unlike {@link #onError(Throwable)}, the {@code RxJavaPlugins.onError} is not called
      * if the error could not be delivered.
+     * <p>History: 2.1.1 - experimental
      * @param t the throwable error to signal if possible
      * @return true if successful, false if the downstream is not able to accept further
      * events
-     * @since 2.1.1 - experimental
+     * @since 2.2
      */
-    @Experimental
     boolean tryOnError(@NonNull Throwable t);
 }

--- a/src/main/java/io/reactivex/FlowableSubscriber.java
+++ b/src/main/java/io/reactivex/FlowableSubscriber.java
@@ -20,11 +20,10 @@ import org.reactivestreams.*;
  * Represents a Reactive-Streams inspired Subscriber that is RxJava 2 only
  * and weakens rules §1.3 and §3.9 of the specification for gaining performance.
  *
- * <p>History: 2.0.7 - experimental
+ * <p>History: 2.0.7 - experimental; 2.1 - beta
  * @param <T> the value type
- * @since 2.1 - beta
+ * @since 2.2
  */
-@Beta
 public interface FlowableSubscriber<T> extends Subscriber<T> {
 
     /**

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -1331,7 +1331,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.9 - experimental
      * @param <T> the common element base type
      * @param sources
      *            a Publisher that emits MaybeSources
@@ -1339,13 +1339,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Flowable that emits all of the items emitted by the Publishers emitted by the
      *         {@code source} Publisher
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @since 2.1.9 - experimental
+     * @since 2.2
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public static <T> Flowable<T> mergeDelayError(Publisher<? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
         ObjectHelper.requireNonNull(sources, "source is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
@@ -2241,14 +2240,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type
      * @param converter the function that receives the current Maybe instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
-     * @since 2.1.7 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(@NonNull MaybeConverter<T, ? extends R> converter) {
@@ -4259,14 +4257,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code switchIfEmpty} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.4 - experimental
      * @param other
      *              the alternate SingleSource to subscribe to if the main does not emit any items
      * @return  a Single that emits the items emitted by the source Maybe or the item of an
      *          alternate SingleSource if the source Maybe is empty.
-     * @since 2.1.4 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> switchIfEmpty(SingleSource<? extends T> other) {

--- a/src/main/java/io/reactivex/MaybeConverter.java
+++ b/src/main/java/io/reactivex/MaybeConverter.java
@@ -18,12 +18,11 @@ import io.reactivex.annotations.*;
 /**
  * Convenience interface and callback used by the {@link Maybe#as} operator to turn a Maybe into another
  * value fluently.
- *
+ * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type
  * @param <R> the output type
- * @since 2.1.7 - experimental
+ * @since 2.2
  */
-@Experimental
 public interface MaybeConverter<T, R> {
     /**
      * Applies a function to the upstream Maybe and returns a converted value of type {@code R}.

--- a/src/main/java/io/reactivex/MaybeEmitter.java
+++ b/src/main/java/io/reactivex/MaybeEmitter.java
@@ -97,11 +97,11 @@ public interface MaybeEmitter<T> {
      * <p>
      * Unlike {@link #onError(Throwable)}, the {@code RxJavaPlugins.onError} is not called
      * if the error could not be delivered.
+     * <p>History: 2.1.1 - experimental
      * @param t the throwable error to signal if possible
      * @return true if successful, false if the downstream is not able to accept further
      * events
-     * @since 2.1.1 - experimental
+     * @since 2.2
      */
-    @Experimental
     boolean tryOnError(@NonNull Throwable t);
 }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -4951,14 +4951,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type
      * @param converter the function that receives the current Observable instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
-     * @since 2.1.7 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(@NonNull ObservableConverter<T, ? extends R> converter) {
@@ -6536,13 +6535,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.6 - experimental
      * @param mapper
      *            a function that, when applied to an item emitted by the source ObservableSource, returns a CompletableSource
      * @return a Completable that signals {@code onComplete} when the upstream and all CompletableSources complete
-     * @since 2.1.6 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper) {
@@ -6558,7 +6556,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.6 - experimental
      * @param mapper
      *            a function that, when applied to an item emitted by the source ObservableSource, returns a CompletableSource
      *
@@ -6566,9 +6564,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the number of upstream items expected to be buffered until the current CompletableSource,  mapped from
      *            the current item, completes.
      * @return a Completable that signals {@code onComplete} when the upstream and all CompletableSources complete
-     * @since 2.1.6 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, int capacityHint) {
@@ -6587,16 +6584,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapCompletableDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with the upstream item and should return
      *               a {@code CompletableSource} to become the next source to
      *               be subscribed to
      * @return a new Completable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapCompletable(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper) {
         return concatMapCompletableDelayError(mapper, true, 2);
     }
@@ -6611,6 +6608,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapCompletableDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with the upstream item and should return
      *               a {@code CompletableSource} to become the next source to
      *               be subscribed to
@@ -6621,12 +6619,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                   {@code CompletableSource} terminates and only then is
      *                   it emitted to the downstream.
      * @return a new Completable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapCompletable(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd) {
         return concatMapCompletableDelayError(mapper, tillTheEnd, 2);
     }
@@ -6641,6 +6638,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapCompletableDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with the upstream item and should return
      *               a {@code CompletableSource} to become the next source to
      *               be subscribed to
@@ -6655,12 +6653,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                 The operator replenishes after half of the prefetch amount has been consumed
      *                 and turned into {@code CompletableSource}s.
      * @return a new Completable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapCompletable(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -6734,18 +6731,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code MaybeSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code MaybeSource} to become the next source to
      *               be subscribed to
      * @return a new Observable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapMaybeDelayError(Function)
      * @see #concatMapMaybe(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> concatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         return concatMapMaybe(mapper, 2);
     }
@@ -6760,6 +6757,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code MaybeSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code MaybeSource} to become the next source to
@@ -6769,13 +6767,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                 The operator replenishes after half of the prefetch amount has been consumed
      *                 and turned into {@code MaybeSource}s.
      * @return a new Observable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapMaybe(Function)
      * @see #concatMapMaybeDelayError(Function, boolean, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> concatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -6792,18 +6789,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code MaybeSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code MaybeSource} to become the next source to
      *               be subscribed to
      * @return a new Observable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapMaybe(Function)
      * @see #concatMapMaybeDelayError(Function, boolean)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         return concatMapMaybeDelayError(mapper, true, 2);
     }
@@ -6818,6 +6815,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code MaybeSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code MaybeSource} to become the next source to
@@ -6829,13 +6827,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                   {@code MaybeSource} terminates and only then is
      *                   it emitted to the downstream.
      * @return a new Observable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapMaybe(Function, int)
      * @see #concatMapMaybeDelayError(Function, boolean, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd) {
         return concatMapMaybeDelayError(mapper, tillTheEnd, 2);
     }
@@ -6850,6 +6847,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code MaybeSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code MaybeSource} to become the next source to
@@ -6865,12 +6863,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                 The operator replenishes after half of the prefetch amount has been consumed
      *                 and turned into {@code MaybeSource}s.
      * @return a new Observable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapMaybe(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -6887,18 +6884,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code SingleSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code SingleSource} to become the next source to
      *               be subscribed to
      * @return a new Observable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapSingleDelayError(Function)
      * @see #concatMapSingle(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> concatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return concatMapSingle(mapper, 2);
     }
@@ -6913,6 +6910,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code SingleSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code SingleSource} to become the next source to
@@ -6922,13 +6920,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                 The operator replenishes after half of the prefetch amount has been consumed
      *                 and turned into {@code SingleSource}s.
      * @return a new Observable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapSingle(Function)
      * @see #concatMapSingleDelayError(Function, boolean, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> concatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -6945,18 +6942,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code SingleSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code SingleSource} to become the next source to
      *               be subscribed to
      * @return a new Observable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapSingle(Function)
      * @see #concatMapSingleDelayError(Function, boolean)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return concatMapSingleDelayError(mapper, true, 2);
     }
@@ -6971,6 +6968,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code SingleSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code SingleSource} to become the next source to
@@ -6982,13 +6980,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                   {@code SingleSource} terminates and only then is
      *                   it emitted to the downstream.
      * @return a new Observable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapSingle(Function, int)
      * @see #concatMapSingleDelayError(Function, boolean, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd) {
         return concatMapSingleDelayError(mapper, tillTheEnd, 2);
     }
@@ -7003,6 +7000,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code SingleSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code SingleSource} to become the next source to
@@ -7018,12 +7016,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                 The operator replenishes after half of the prefetch amount has been consumed
      *                 and turned into {@code SingleSource}s.
      * @return a new Observable instance
-     * @since 2.1.11 - experimental
      * @see #concatMapSingle(Function, int)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -7062,13 +7059,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.10 - experimental
      * @param other the SingleSource whose signal should be emitted after this {@code Observable} completes normally.
      * @return the new Observable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Observable<T> concatWith(@NonNull SingleSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableConcatWithSingle<T>(this, other));
@@ -7083,13 +7080,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.10 - experimental
      * @param other the MaybeSource whose signal should be emitted after this Observable completes normally.
      * @return the new Observable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Observable<T> concatWith(@NonNull MaybeSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableConcatWithMaybe<T>(this, other));
@@ -7104,13 +7101,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.10 - experimental
      * @param other the {@code CompletableSource} to subscribe to once the current {@code Observable} completes normally
      * @return the new Observable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Observable<T> concatWith(@NonNull CompletableSource other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableConcatWithCompletable<T>(this, other));
@@ -9604,14 +9601,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.10 - experimental
      * @param other the {@code SingleSource} whose success value to merge with
      * @return the new Observable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Observable<T> mergeWith(@NonNull SingleSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableMergeWithSingle<T>(this, other));
@@ -9629,14 +9625,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.10 - experimental
      * @param other the {@code MaybeSource} which provides a success value to merge with or completes
      * @return the new Observable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Observable<T> mergeWith(@NonNull MaybeSource<? extends T> other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableMergeWithMaybe<T>(this, other));
@@ -9651,14 +9646,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mergeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.10 - experimental
      * @param other the {@code CompletableSource} to await for completion
      * @return the new Observable instance
-     * @since 2.1.10 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Observable<T> mergeWith(@NonNull CompletableSource other) {
         ObjectHelper.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableMergeWithCompletable<T>(this, other));
@@ -12228,16 +12222,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors.
      *  </dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with each upstream item and should return a
      *               {@link CompletableSource} to be subscribed to and awaited for
      *               (non blockingly) for its terminal event
      * @return the new Completable instance
-     * @since 2.1.11 - experimental
      * @see #switchMapCompletableDelayError(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Completable switchMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableSwitchMapCompletable<T>(this, mapper, false));
@@ -12270,16 +12264,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors.
      *  </dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param mapper the function called with each upstream item and should return a
      *               {@link CompletableSource} to be subscribed to and awaited for
      *               (non blockingly) for its terminal event
      * @return the new Completable instance
-     * @since 2.1.11 - experimental
      * @see #switchMapCompletableDelayError(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final Completable switchMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableSwitchMapCompletable<T>(this, mapper, true));
@@ -12305,17 +12299,17 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  {@link io.reactivex.plugins.RxJavaPlugins#onError(Throwable)} as
      *  {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the output value type
      * @param mapper the function called with the current upstream event and should
      *               return a {@code MaybeSource} to replace the current active inner source
      *               and get subscribed to.
      * @return the new Observable instance
-     * @since 2.1.11 - experimental
      * @see #switchMapMaybe(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> switchMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableSwitchMapMaybe<T, R>(this, mapper, false));
@@ -12331,17 +12325,17 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code switchMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.11 - experimental
      * @param <R> the output value type
      * @param mapper the function called with the current upstream event and should
      *               return a {@code MaybeSource} to replace the current active inner source
      *               and get subscribed to.
      * @return the new Observable instance
-     * @since 2.1.11 - experimental
      * @see #switchMapMaybe(Function)
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Observable<R> switchMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableSwitchMapMaybe<T, R>(this, mapper, true));
@@ -12360,16 +12354,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code switchMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.0.8 - experimental
      * @param <R> the element type of the inner SingleSources and the output
      * @param mapper
      *            a function that, when applied to an item emitted by the source ObservableSource, returns a
      *            SingleSource
      * @return an Observable that emits the item emitted by the SingleSource returned from applying {@code func} to the most recently emitted item emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since 2.0.8
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
@@ -12392,16 +12385,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code switchMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.0.8 - experimental
      * @param <R> the element type of the inner SingleSources and the output
      * @param mapper
      *            a function that, when applied to an item emitted by the source ObservableSource, returns a
      *            SingleSource
      * @return an Observable that emits the item emitted by the SingleSource returned from applying {@code func} to the most recently emitted item emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since 2.0.8
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
@@ -13052,15 +13044,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code throttleLatest} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait after an item emission towards the downstream
      *                before trying to emit the latest item from upstream again
      * @param unit    the time unit
      * @return the new Observable instance
-     * @since 2.1.14 - experimental
      * @see #throttleLatest(long, TimeUnit, boolean)
      * @see #throttleLatest(long, TimeUnit, Scheduler)
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Observable<T> throttleLatest(long timeout, TimeUnit unit) {
@@ -13080,6 +13072,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code throttleLatest} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait after an item emission towards the downstream
      *                before trying to emit the latest item from upstream again
      * @param unit    the time unit
@@ -13088,10 +13081,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                 a timeout window active or not. If {@code false}, the very last
      *                 upstream item is ignored and the flow terminates.
      * @return the new Observable instance
-     * @since 2.1.14 - experimental
      * @see #throttleLatest(long, TimeUnit, Scheduler, boolean)
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Observable<T> throttleLatest(long timeout, TimeUnit unit, boolean emitLast) {
@@ -13114,16 +13106,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait after an item emission towards the downstream
      *                before trying to emit the latest item from upstream again
      * @param unit    the time unit
      * @param scheduler the {@link Scheduler} where the timed wait and latest item
      *                  emission will be performed
      * @return the new Observable instance
-     * @since 2.1.14 - experimental
      * @see #throttleLatest(long, TimeUnit, Scheduler, boolean)
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> throttleLatest(long timeout, TimeUnit unit, Scheduler scheduler) {
@@ -13143,6 +13135,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait after an item emission towards the downstream
      *                before trying to emit the latest item from upstream again
      * @param unit    the time unit
@@ -13153,9 +13146,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *                 a timeout window active or not. If {@code false}, the very last
      *                 upstream item is ignored and the flow terminates.
      * @return the new Observable instance
-     * @since 2.1.14 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> throttleLatest(long timeout, TimeUnit unit, Scheduler scheduler, boolean emitLast) {

--- a/src/main/java/io/reactivex/ObservableConverter.java
+++ b/src/main/java/io/reactivex/ObservableConverter.java
@@ -18,12 +18,11 @@ import io.reactivex.annotations.*;
 /**
  * Convenience interface and callback used by the {@link Observable#as} operator to turn an Observable into another
  * value fluently.
- *
+ * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type
  * @param <R> the output type
- * @since 2.1.7 - experimental
+ * @since 2.2
  */
-@Experimental
 public interface ObservableConverter<T, R> {
     /**
      * Applies a function to the upstream Observable and returns a converted value of type {@code R}.

--- a/src/main/java/io/reactivex/ObservableEmitter.java
+++ b/src/main/java/io/reactivex/ObservableEmitter.java
@@ -86,11 +86,11 @@ public interface ObservableEmitter<T> extends Emitter<T> {
      * <p>
      * Unlike {@link #onError(Throwable)}, the {@code RxJavaPlugins.onError} is not called
      * if the error could not be delivered.
+     * <p>History: 2.1.1 - experimental
      * @param t the throwable error to signal if possible
      * @return true if successful, false if the downstream is not able to accept further
      * events
-     * @since 2.1.1 - experimental
+     * @since 2.2
      */
-    @Experimental
     boolean tryOnError(@NonNull Throwable t);
 }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1060,16 +1060,16 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.9 - experimental
      * @param <T> the common and resulting value type
      * @param sources the Iterable sequence of SingleSource sources
      * @return the new Flowable instance
-     * @since 2.1.9 - experimental
      * @see #merge(Iterable)
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public static <T> Flowable<T> mergeDelayError(Iterable<? extends SingleSource<? extends T>> sources) {
         return mergeDelayError(Flowable.fromIterable(sources));
     }
@@ -1083,17 +1083,17 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.9 - experimental
      * @param <T> the common and resulting value type
      * @param sources the Flowable sequence of SingleSource sources
      * @return the new Flowable instance
      * @see #merge(Publisher)
-     * @since 2.1.9 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    @Experimental
     public static <T> Flowable<T> mergeDelayError(Publisher<? extends SingleSource<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, SingleInternalHelper.toFlowable(), true, Integer.MAX_VALUE, Flowable.bufferSize()));
@@ -1114,7 +1114,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.9 - experimental
      * @param <T> the common value type
      * @param source1
      *            a SingleSource to be merged
@@ -1123,13 +1123,12 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #merge(SingleSource, SingleSource)
-     * @since 2.1.9 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
-    @Experimental
     public static <T> Flowable<T> mergeDelayError(
             SingleSource<? extends T> source1, SingleSource<? extends T> source2
      ) {
@@ -1152,7 +1151,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.9 - experimental
      * @param <T> the common value type
      * @param source1
      *            a SingleSource to be merged
@@ -1163,13 +1162,12 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #merge(SingleSource, SingleSource, SingleSource)
-     * @since 2.1.9 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
-    @Experimental
     public static <T> Flowable<T> mergeDelayError(
             SingleSource<? extends T> source1, SingleSource<? extends T> source2,
             SingleSource<? extends T> source3
@@ -1194,7 +1192,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.9 - experimental
      * @param <T> the common value type
      * @param source1
      *            a SingleSource to be merged
@@ -1207,13 +1205,12 @@ public abstract class Single<T> implements SingleSource<T> {
      * @return a Flowable that emits all of the items emitted by the source Singles
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #merge(SingleSource, SingleSource, SingleSource, SingleSource)
-     * @since 2.1.9 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
-    @Experimental
     public static <T> Flowable<T> mergeDelayError(
             SingleSource<? extends T> source1, SingleSource<? extends T> source2,
             SingleSource<? extends T> source3, SingleSource<? extends T> source4
@@ -1925,14 +1922,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type
      * @param converter the function that receives the current Single instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
-     * @since 2.1.7 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> R as(@NonNull SingleConverter<T, ? extends R> converter) {
@@ -2073,14 +2069,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code delay} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
-     *
+     * <p>History: 2.1.5 - experimental
      * @param time the amount of time the success or error signal should be delayed for
      * @param unit the time unit
      * @param delayError if true, both success and error signals are delayed. if false, only success signals are delayed.
      * @return the new Single instance
-     * @since 2.1.5 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Single<T> delay(long time, TimeUnit unit, boolean delayError) {
@@ -2120,7 +2115,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>you specify the {@link Scheduler} where the non-blocking wait and emission happens</dd>
      * </dl>
-     *
+     * <p>History: 2.1.5 - experimental
      * @param time the amount of time the success or error signal should be delayed for
      * @param unit the time unit
      * @param scheduler the target scheduler to use for the non-blocking wait and emission
@@ -2129,9 +2124,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * @throws NullPointerException
      *             if unit is null, or
      *             if scheduler is null
-     * @since 2.1.5 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Single<T> delay(final long time, final TimeUnit unit, final Scheduler scheduler, boolean delayError) {
@@ -3052,11 +3046,11 @@ public abstract class Single<T> implements SingleSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.5 - experimental
      * @return a Single which nulls out references to the upstream producer and downstream SingleObserver if
      * the sequence is terminated or downstream calls dispose()
-     * @since 2.1.5 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> onTerminateDetach() {
@@ -3210,13 +3204,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.8 - experimental
      * @param times the number of times to resubscribe if the current Single fails
      * @param predicate the predicate called with the failure Throwable
      *                  and should return true if a resubscription should happen
      * @return the new Single instance
-     * @since 2.1.8 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> retry(long times, Predicate<? super Throwable> predicate) {
@@ -3798,14 +3792,14 @@ public abstract class Single<T> implements SingleSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code unsubscribeOn} calls dispose() of the upstream on the {@link Scheduler} you specify.</dd>
      * </dl>
+     * <p>History: 2.0.9 - experimental
      * @param scheduler the target scheduler where to execute the cancellation
      * @return the new Single instance
      * @throws NullPointerException if scheduler is null
-     * @since 2.0.9 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    @Experimental
     public final Single<T> unsubscribeOn(final Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new SingleUnsubscribeOn<T>(this, scheduler));

--- a/src/main/java/io/reactivex/SingleConverter.java
+++ b/src/main/java/io/reactivex/SingleConverter.java
@@ -18,12 +18,11 @@ import io.reactivex.annotations.*;
 /**
  * Convenience interface and callback used by the {@link Single#as} operator to turn a Single into another
  * value fluently.
- *
+ * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type
  * @param <R> the output type
- * @since 2.1.7 - experimental
+ * @since 2.2
  */
-@Experimental
 public interface SingleConverter<T, R> {
     /**
      * Applies a function to the upstream Single and returns a converted value of type {@code R}.

--- a/src/main/java/io/reactivex/SingleEmitter.java
+++ b/src/main/java/io/reactivex/SingleEmitter.java
@@ -91,11 +91,11 @@ public interface SingleEmitter<T> {
      * <p>
      * Unlike {@link #onError(Throwable)}, the {@code RxJavaPlugins.onError} is not called
      * if the error could not be delivered.
+     * <p>History: 2.1.1 - experimental
      * @param t the throwable error to signal if possible
      * @return true if successful, false if the downstream is not able to accept further
      * events
-     * @since 2.1.1 - experimental
+     * @since 2.2
      */
-    @Experimental
     boolean tryOnError(@NonNull Throwable t);
 }

--- a/src/main/java/io/reactivex/annotations/SchedulerSupport.java
+++ b/src/main/java/io/reactivex/annotations/SchedulerSupport.java
@@ -63,9 +63,9 @@ public @interface SchedulerSupport {
     /**
      * The operator/class runs on RxJava's {@linkplain Schedulers#single() single scheduler}
      * or takes timing information from it.
-     * @since 2.0.8 - experimental
+     * <p>History: 2.0.8 - experimental
+     * @since 2.2
      */
-    @Experimental
     String SINGLE = "io.reactivex:single";
 
     /**

--- a/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
@@ -19,10 +19,9 @@ import io.reactivex.annotations.*;
  * Represents an exception used to signal to the {@code RxJavaPlugins.onError()} that a
  * callback-based subscribe() method on a base reactive type didn't specify
  * an onError handler.
- * <p>History: 2.0.6 - experimental
- * @since 2.1 - beta
+ * <p>History: 2.0.6 - experimental; 2.1 - beta
+ * @since 2.2
  */
-@Beta
 public final class OnErrorNotImplementedException extends RuntimeException {
 
     private static final long serialVersionUID = -6298857009889503852L;

--- a/src/main/java/io/reactivex/exceptions/ProtocolViolationException.java
+++ b/src/main/java/io/reactivex/exceptions/ProtocolViolationException.java
@@ -13,15 +13,12 @@
 
 package io.reactivex.exceptions;
 
-import io.reactivex.annotations.Beta;
-
 /**
  * Explicitly named exception to indicate a Reactive-Streams
  * protocol violation.
- * <p>History: 2.0.6 - experimental
- * @since 2.1 - beta
+ * <p>History: 2.0.6 - experimental; 2.1 - beta
+ * @since 2.2
  */
-@Beta
 public final class ProtocolViolationException extends IllegalStateException {
 
     private static final long serialVersionUID = 1644750035281290266L;

--- a/src/main/java/io/reactivex/exceptions/UndeliverableException.java
+++ b/src/main/java/io/reactivex/exceptions/UndeliverableException.java
@@ -13,14 +13,11 @@
 
 package io.reactivex.exceptions;
 
-import io.reactivex.annotations.Beta;
-
 /**
  * Wrapper for Throwable errors that are sent to `RxJavaPlugins.onError`.
- * <p>History: 2.0.6 - experimental
- * @since 2.1 - beta
+ * <p>History: 2.0.6 - experimental; 2.1 - beta
+ * @since 2.2
  */
-@Beta
 public final class UndeliverableException extends IllegalStateException {
 
     private static final long serialVersionUID = 1644750035281290266L;

--- a/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
+++ b/src/main/java/io/reactivex/flowables/ConnectableFlowable.java
@@ -102,12 +102,12 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This {@code refCount} overload does not operate on any particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param subscriberCount the number of subscribers required to connect to the upstream
      * @return the new Flowable instance
-     * @since 2.1.14 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     public final Flowable<T> refCount(int subscriberCount) {
@@ -125,14 +125,14 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This {@code refCount} overload operates on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait before disconnecting after all subscribers unsubscribed
      * @param unit the time unit of the timeout
      * @return the new Flowable instance
-     * @since 2.1.14 - experimental
      * @see #refCount(long, TimeUnit, Scheduler)
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     public final Flowable<T> refCount(long timeout, TimeUnit unit) {
@@ -150,14 +150,14 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This {@code refCount} overload operates on the specified {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait before disconnecting after all subscribers unsubscribed
      * @param unit the time unit of the timeout
      * @param scheduler the target scheduler to wait on before disconnecting
      * @return the new Flowable instance
-     * @since 2.1.14 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     public final Flowable<T> refCount(long timeout, TimeUnit unit, Scheduler scheduler) {
@@ -175,15 +175,15 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This {@code refCount} overload operates on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param subscriberCount the number of subscribers required to connect to the upstream
      * @param timeout the time to wait before disconnecting after all subscribers unsubscribed
      * @param unit the time unit of the timeout
      * @return the new Flowable instance
-     * @since 2.1.14 - experimental
      * @see #refCount(int, long, TimeUnit, Scheduler)
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     public final Flowable<T> refCount(int subscriberCount, long timeout, TimeUnit unit) {
@@ -201,15 +201,15 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This {@code refCount} overload operates on the specified {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param subscriberCount the number of subscribers required to connect to the upstream
      * @param timeout the time to wait before disconnecting after all subscribers unsubscribed
      * @param unit the time unit of the timeout
      * @param scheduler the target scheduler to wait on before disconnecting
      * @return the new Flowable instance
-     * @since 2.1.14 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     public final Flowable<T> refCount(int subscriberCount, long timeout, TimeUnit unit, Scheduler scheduler) {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableCache.java
@@ -16,15 +16,13 @@ package io.reactivex.internal.operators.completable;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 
 /**
  * Consume the upstream source exactly once and cache its terminal event.
- * 
- * @since 2.0.4 - experimental
+ * <p>History: 2.0.4 - experimental
+ * @since 2.1
  */
-@Experimental
 public final class CompletableCache extends Completable implements CompletableObserver {
 
     static final InnerCompletableCache[] EMPTY = new InnerCompletableCache[0];

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDetach.java
@@ -14,16 +14,14 @@
 package io.reactivex.internal.operators.completable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
  * Breaks the references between the upstream and downstream when the Completable terminates.
- * 
- * @since 2.1.5 - experimental
+ * <p>History: 2.1.5 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class CompletableDetach extends Completable {
 
     final CompletableSource source;

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDoFinally.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.completable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;
@@ -25,10 +24,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Execute an action after an onError, onComplete or a dispose event.
- *
- * @since 2.0.1 - experimental
+ * <p>History: 2.0.1 - experimental
+ * @since 2.1
  */
-@Experimental
 public final class CompletableDoFinally extends Completable {
 
     final CompletableSource source;

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableTakeUntilCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableTakeUntilCompletable.java
@@ -16,16 +16,15 @@ package io.reactivex.internal.operators.completable;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Terminates the sequence if either the main or the other Completable terminate.
- * @since 2.1.17 - experimental
+ * <p>History: 2.1.17 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class CompletableTakeUntilCompletable extends Completable {
 
     final Completable source;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerPublisher.java
@@ -22,9 +22,10 @@ import io.reactivex.internal.util.ErrorMode;
 
 /**
  * ConcatMapEager which works with an arbitrary Publisher source.
+ * <p>History: 2.0.7 - experimental
  * @param <T> the input value type
  * @param <R> the output type
- * @since 2.0.7 - experimental
+ * @since 2.1
  */
 public final class FlowableConcatMapEagerPublisher<T, R> extends Flowable<R> {
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithCompletable.java
@@ -25,8 +25,9 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 /**
  * Subscribe to a main Flowable first, then when it completes normally, subscribe to a Completable
  * and terminate when it terminates.
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the main source and output type
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class FlowableConcatWithCompletable<T> extends AbstractFlowableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybe.java
@@ -26,8 +26,9 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 /**
  * Subscribe to a main Flowable first, then when it completes normally, subscribe to a Maybe,
  * signal its success value followed by a completion or signal its error or completion signal as is.
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the main source and output type
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class FlowableConcatWithMaybe<T> extends AbstractFlowableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatWithSingle.java
@@ -26,8 +26,9 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 /**
  * Subscribe to a main Flowable first, then when it completes normally, subscribe to a Single,
  * signal its success value followed by a completion or signal its error as is.
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the main source and output type
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class FlowableConcatWithSingle<T> extends AbstractFlowableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
@@ -23,10 +23,10 @@ import io.reactivex.internal.subscribers.*;
 
 /**
  * Calls a consumer after pushing the current item to the downstream.
+ * <p>History: 2.0.1 - experimental
  * @param <T> the value type
- * @since 2.0.1 - experimental
+ * @since 2.1
  */
-@Experimental
 public final class FlowableDoAfterNext<T> extends AbstractFlowableWithUpstream<T, T> {
 
     final Consumer<? super T> onAfterNext;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoFinally.java
@@ -25,11 +25,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Execute an action after an onError, onComplete or a cancel event.
- *
+ * <p>History: 2.0.1 - experimental
  * @param <T> the value type
- * @since 2.0.1 - experimental
+ * @since 2.1
  */
-@Experimental
 public final class FlowableDoFinally<T> extends AbstractFlowableWithUpstream<T, T> {
 
     final Action onFinally;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableLimit.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableLimit.java
@@ -18,17 +18,15 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Limits both the total request amount and items received from the upstream.
- *
+ * <p>History: 2.1.6 - experimental
  * @param <T> the source and output value type
- * @since 2.1.6 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class FlowableLimit<T> extends AbstractFlowableWithUpstream<T, T> {
 
     final long n;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapPublisher.java
@@ -22,10 +22,10 @@ import io.reactivex.internal.operators.flowable.FlowableMap.MapSubscriber;
 
 /**
  * Map working with an arbitrary Publisher source.
- *
+ * <p>History: 2.0.7 - experimental
  * @param <T> the input value type
  * @param <U> the output value type
- * @since 2.0.7 - experimental
+ * @since 2.1
  */
 public final class FlowableMapPublisher<T, U> extends Flowable<U> {
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletable.java
@@ -26,9 +26,9 @@ import io.reactivex.internal.util.*;
 /**
  * Merges a Flowable and a Completable by emitting the items of the Flowable and waiting until
  * both the Flowable and Completable complete normally.
- *
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the Flowable
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class FlowableMergeWithCompletable<T> extends AbstractFlowableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
@@ -29,9 +29,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Merges an Observable and a Maybe by emitting the items of the Observable and the success
  * value of the Maybe and waiting until both the Observable and Maybe terminate normally.
- *
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the Observable
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingle.java
@@ -29,9 +29,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Merges an Observable and a Maybe by emitting the items of the Observable and the success
  * value of the Maybe and waiting until both the Observable and Maybe terminate normally.
- *
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the Observable
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class FlowableMergeWithSingle<T> extends AbstractFlowableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakePublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTakePublisher.java
@@ -20,9 +20,9 @@ import io.reactivex.internal.operators.flowable.FlowableTake.TakeSubscriber;
 
 /**
  * Take with a generic Publisher source.
- *
+ * <p>History: 2.0.7 - experimental
  * @param <T> the value type
- * @since 2.0.7 - experimental
+ * @since 2.1
  */
 public final class FlowableTakePublisher<T> extends Flowable<T> {
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -31,11 +30,10 @@ import io.reactivex.internal.util.BackpressureHelper;
  * it tries to emit the latest item from upstream. If there was no upstream item,
  * in the meantime, the next upstream item is emitted immediately and the
  * timed process repeats.
- *
+ * <p>History: 2.1.14 - experimental
  * @param <T> the upstream and downstream value type
- * @since 2.1.14 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class FlowableThrottleLatest<T> extends AbstractFlowableWithUpstream<T, T> {
 
     final long timeout;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccess.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccess.java
@@ -14,7 +14,6 @@
 package io.reactivex.internal.operators.maybe;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Consumer;
@@ -23,10 +22,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Calls a consumer after pushing the current item to the downstream.
+ * <p>History: 2.0.1 - experimental
  * @param <T> the value type
- * @since 2.0.1 - experimental
+ * @since 2.1
  */
-@Experimental
 public final class MaybeDoAfterSuccess<T> extends AbstractMaybeWithUpstream<T, T> {
 
     final Consumer<? super T> onAfterSuccess;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoFinally.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.maybe;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;
@@ -25,11 +24,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Execute an action after an onSuccess, onError, onComplete or a dispose event.
- *
+ * <p>History: 2.0.1 - experimental
  * @param <T> the value type
- * @since 2.0.1 - experimental
+ * @since 2.1
  */
-@Experimental
 public final class MaybeDoFinally<T> extends AbstractMaybeWithUpstream<T, T> {
 
     final Action onFinally;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapSingleElement.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapSingleElement.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.maybe;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -25,12 +24,11 @@ import io.reactivex.internal.functions.ObjectHelper;
 
 /**
  * Maps the success value of the source MaybeSource into a Single.
+ * <p>History: 2.0.2 - experimental
  * @param <T> the input value type
  * @param <R> the result value type
- * 
- * @since 2.0.2 - experimental
+ * @since 2.1
  */
-@Experimental
 public final class MaybeFlatMapSingleElement<T, R> extends Maybe<R> {
 
     final MaybeSource<T> source;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeToObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeToObservable.java
@@ -14,7 +14,6 @@
 package io.reactivex.internal.operators.maybe;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
@@ -46,12 +45,12 @@ public final class MaybeToObservable<T> extends Observable<T> implements HasUpst
 
     /**
      * Creates a {@link MaybeObserver} wrapper around a {@link Observer}.
+     * <p>History: 2.1.11 - experimental
      * @param <T> the value type
      * @param downstream the downstream {@code Observer} to talk to
      * @return the new MaybeObserver instance
-     * @since 2.1.11 - experimental
+     * @since 2.2
      */
-    @Experimental
     public static <T> MaybeObserver<T> create(Observer<? super T> downstream) {
         return new MaybeToObservableObserver<T>(downstream);
     }

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletable.java
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
@@ -33,10 +32,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Maps the upstream items into {@link CompletableSource}s and subscribes to them one after the
  * other completes or terminates (in error-delaying mode).
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream value type
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class FlowableConcatMapCompletable<T> extends Completable {
 
     final Flowable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybe.java
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
@@ -34,13 +33,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Maps each upstream item into a {@link MaybeSource}, subscribes to them one after the other terminates
  * and relays their success values, optionally delaying any errors till the main and inner sources
  * terminate.
- *
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream element type
  * @param <R> the output element type
- *
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
 
     final Flowable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingle.java
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
@@ -34,13 +33,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Maps each upstream item into a {@link SingleSource}, subscribes to them one after the other terminates
  * and relays their success values, optionally delaying any errors till the main and inner sources
  * terminate.
- *
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream element type
  * @param <R> the output element type
- *
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
 
     final Flowable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletable.java
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -32,11 +31,10 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Maps the upstream values into {@link CompletableSource}s, subscribes to the newer one while
  * disposing the subscription to the previous {@code CompletableSource}, thus keeping at most one
  * active {@code CompletableSource} running.
- *
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream value type
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class FlowableSwitchMapCompletable<T> extends Completable {
 
     final Flowable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybe.java
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -32,12 +31,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Maps the upstream items into {@link MaybeSource}s and switches (subscribes) to the newer ones
  * while disposing the older ones and emits the latest success value if available, optionally delaying
  * errors from the main source or the inner sources.
- *
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream value type
  * @param <R> the downstream value type
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
 
     final Flowable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingle.java
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -32,12 +31,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Maps the upstream items into {@link SingleSource}s and switches (subscribes) to the newer ones
  * while disposing the older ones and emits the latest success value, optionally delaying
  * errors from the main source or the inner sources.
- *
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream value type
  * @param <R> the downstream value type
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
 
     final Flowable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletable.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.mixed;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -30,10 +29,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Maps the upstream items into {@link CompletableSource}s and subscribes to them one after the
  * other completes or terminates (in error-delaying mode).
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream value type
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class ObservableConcatMapCompletable<T> extends Completable {
 
     final Observable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybe.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.mixed;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -31,13 +30,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Maps each upstream item into a {@link MaybeSource}, subscribes to them one after the other terminates
  * and relays their success values, optionally delaying any errors till the main and inner sources
  * terminate.
- *
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream element type
  * @param <R> the output element type
- *
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
 
     final Observable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingle.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.mixed;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -31,13 +30,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Maps each upstream item into a {@link SingleSource}, subscribes to them one after the other terminates
  * and relays their success values, optionally delaying any errors till the main and inner sources
  * terminate.
- *
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream element type
  * @param <R> the output element type
- *
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
 
     final Observable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletable.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.mixed;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -29,11 +28,10 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Maps the upstream values into {@link CompletableSource}s, subscribes to the newer one while
  * disposing the subscription to the previous {@code CompletableSource}, thus keeping at most one
  * active {@code CompletableSource} running.
- *
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream value type
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class ObservableSwitchMapCompletable<T> extends Completable {
 
     final Observable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybe.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.mixed;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -29,12 +28,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Maps the upstream items into {@link MaybeSource}s and switches (subscribes) to the newer ones
  * while disposing the older ones and emits the latest success value if available, optionally delaying
  * errors from the main source or the inner sources.
- *
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream value type
  * @param <R> the downstream value type
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
 
     final Observable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingle.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.mixed;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -29,12 +28,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * Maps the upstream items into {@link SingleSource}s and switches (subscribes) to the newer ones
  * while disposing the older ones and emits the latest success value if available, optionally delaying
  * errors from the main source or the inner sources.
- *
+ * <p>History: 2.1.11 - experimental
  * @param <T> the upstream value type
  * @param <R> the downstream value type
- * @since 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
 
     final Observable<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/ScalarXMapZHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ScalarXMapZHelper.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.mixed;
 import java.util.concurrent.Callable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.EmptyDisposable;
@@ -28,9 +27,9 @@ import io.reactivex.internal.operators.single.SingleToObservable;
  * Utility class to extract a value from a scalar source reactive type,
  * map it to a 0-1 type then subscribe the output type's consumer to it,
  * saving on the overhead of the regular subscription channel.
- * @since 2.1.11 - experimental
+ * <p>History: 2.1.11 - experimental
+ * @since 2.2
  */
-@Experimental
 final class ScalarXMapZHelper {
 
     private ScalarXMapZHelper() {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletable.java
@@ -22,8 +22,9 @@ import io.reactivex.internal.disposables.DisposableHelper;
 /**
  * Subscribe to a main Observable first, then when it completes normally, subscribe to a Single,
  * signal its success value followed by a completion or signal its error as is.
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the main source and output type
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class ObservableConcatWithCompletable<T> extends AbstractObservableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybe.java
@@ -22,8 +22,9 @@ import io.reactivex.internal.disposables.DisposableHelper;
 /**
  * Subscribe to a main Observable first, then when it completes normally, subscribe to a Maybe,
  * signal its success value followed by a completion or signal its error or completion signal as is.
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the main source and output type
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class ObservableConcatWithMaybe<T> extends AbstractObservableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingle.java
@@ -22,8 +22,9 @@ import io.reactivex.internal.disposables.DisposableHelper;
 /**
  * Subscribe to a main Observable first, then when it completes normally, subscribe to a Single,
  * signal its success value followed by a completion or signal its error as is.
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the main source and output type
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class ObservableConcatWithSingle<T> extends AbstractObservableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
@@ -14,17 +14,16 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.observers.BasicFuseableObserver;
 
 /**
  * Calls a consumer after pushing the current item to the downstream.
+ * <p>History: 2.0.1 - experimental
  * @param <T> the value type
- * @since 2.0.1 - experimental
+ * @since 2.1
  */
-@Experimental
 public final class ObservableDoAfterNext<T> extends AbstractObservableWithUpstream<T, T> {
 
     final Consumer<? super T> onAfterNext;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
@@ -14,7 +14,6 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
@@ -26,11 +25,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Execute an action after an onError, onComplete or a dispose event.
- *
+ * <p>History: 2.0.1 - experimental
  * @param <T> the value type
- * @since 2.0.1 - experimental
+ * @since 2.1
  */
-@Experimental
 public final class ObservableDoFinally<T> extends AbstractObservableWithUpstream<T, T> {
 
     final Action onFinally;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletable.java
@@ -23,9 +23,9 @@ import io.reactivex.internal.util.*;
 /**
  * Merges an Observable and a Completable by emitting the items of the Observable and waiting until
  * both the Observable and Completable complete normally.
- *
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the Observable
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class ObservableMergeWithCompletable<T> extends AbstractObservableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybe.java
@@ -26,9 +26,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Merges an Observable and a Maybe by emitting the items of the Observable and the success
  * value of the Maybe and waiting until both the Observable and Maybe terminate normally.
- *
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the Observable
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class ObservableMergeWithMaybe<T> extends AbstractObservableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingle.java
@@ -26,9 +26,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Merges an Observable and a Single by emitting the items of the Observable and the success
  * value of the Single and waiting until both the Observable and Single terminate normally.
- *
+ * <p>History: 2.1.10 - experimental
  * @param <T> the element type of the Observable
- * @since 2.1.10 - experimental
+ * @since 2.2
  */
 public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleLatest.java
@@ -17,7 +17,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
@@ -28,11 +27,10 @@ import io.reactivex.internal.disposables.DisposableHelper;
  * it tries to emit the latest item from upstream. If there was no upstream item,
  * in the meantime, the next upstream item is emitted immediately and the
  * timed process repeats.
- *
+ * <p>History: 2.1.14 - experimental
  * @param <T> the upstream and downstream value type
- * @since 2.1.14 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class ObservableThrottleLatest<T> extends AbstractObservableWithUpstream<T, T> {
 
     final long timeout;

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelDoOnNextTry.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelDoOnNextTry.java
@@ -26,9 +26,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Calls a Consumer for each upstream value passing by
  * and handles any failure with a handler function.
- *
+ * <p>History: 2.0.8 - experimental
  * @param <T> the input value type
- * @since 2.0.8 - experimental
+ * @since 2.2
  */
 public final class ParallelDoOnNextTry<T> extends ParallelFlowable<T> {
 

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelMapTry.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelMapTry.java
@@ -26,10 +26,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Maps each 'rail' of the source ParallelFlowable with a mapper function
  * and handle any failure based on a handler function.
- *
+ * <p>History: 2.0.8 - experimental
  * @param <T> the input value type
  * @param <R> the output value type
- * @since 2.0.8 - experimental
+ * @since 2.2
  */
 public final class ParallelMapTry<T, R> extends ParallelFlowable<R> {
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDetach.java
@@ -14,17 +14,15 @@
 package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
  * Breaks the references between the upstream and downstream when the Maybe terminates.
- *
+ * <p>History: 2.1.5 - experimental
  * @param <T> the value type
- * @since 2.1.5 - experimental
+ * @since 2.2
  */
-@Experimental
 public final class SingleDetach<T> extends Single<T> {
 
     final SingleSource<T> source;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoAfterSuccess.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoAfterSuccess.java
@@ -14,7 +14,6 @@
 package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Consumer;
@@ -23,10 +22,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Calls a consumer after pushing the current item to the downstream.
+ * <p>History: 2.0.1 - experimental
  * @param <T> the value type
- * @since 2.0.1 - experimental
+ * @since 2.1
  */
-@Experimental
 public final class SingleDoAfterSuccess<T> extends Single<T> {
 
     final SingleSource<T> source;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoAfterTerminate.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoAfterTerminate.java
@@ -24,8 +24,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Calls an action after pushing the current item or an error to the downstream.
+ * <p>History: 2.0.6 - experimental
  * @param <T> the value type
- * @since 2.0.6 - experimental
+ * @since 2.1
  */
 public final class SingleDoAfterTerminate<T> extends Single<T> {
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoFinally.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.single;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;
@@ -25,11 +24,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Execute an action after an onSuccess, onError or a dispose event.
- *
+ * <p>History: 2.0.1 - experimental
  * @param <T> the value type
- * @since 2.0.1 - experimental
+ * @since 2.1
  */
-@Experimental
 public final class SingleDoFinally<T> extends Single<T> {
 
     final SingleSource<T> source;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleToObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleToObservable.java
@@ -13,7 +13,6 @@
 package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.observers.DeferredScalarDisposable;
@@ -38,12 +37,12 @@ public final class SingleToObservable<T> extends Observable<T> {
 
     /**
      * Creates a {@link SingleObserver} wrapper around a {@link Observer}.
+     * <p>History: 2.0.1 - experimental
      * @param <T> the value type
      * @param downstream the downstream {@code Observer} to talk to
      * @return the new SingleObserver instance
-     * @since 2.1.11 - experimental
+     * @since 2.2
      */
-    @Experimental
     public static <T> SingleObserver<T> create(Observer<? super T> downstream) {
         return new SingleToObservableObserver<T>(downstream);
     }

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerMultiWorkerSupport.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerMultiWorkerSupport.java
@@ -22,10 +22,9 @@ import io.reactivex.annotations.*;
  * at most the parallelism level of the Scheduler, those
  * {@link io.reactivex.Scheduler.Worker} instances will be running
  * with different backing threads.
- *
- * @since 2.1.8 - experimental
+ * <p>History: 2.1.8 - experimental
+ * @since 2.2
  */
-@Experimental
 public interface SchedulerMultiWorkerSupport {
 
     /**

--- a/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/io/reactivex/internal/schedulers/SchedulerWhen.java
@@ -24,7 +24,6 @@ import io.reactivex.CompletableObserver;
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.reactivex.Scheduler;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
@@ -100,8 +99,9 @@ import io.reactivex.processors.UnicastProcessor;
  *  }));
  * });
  * </pre>
+ * <p>History 2.0.1 - experimental
+ * @since 2.1
  */
-@Experimental
 public class SchedulerWhen extends Scheduler implements Disposable {
     private final Scheduler actualScheduler;
     private final FlowableProcessor<Flowable<Completable>> workerProcessor;

--- a/src/main/java/io/reactivex/observables/ConnectableObservable.java
+++ b/src/main/java/io/reactivex/observables/ConnectableObservable.java
@@ -93,12 +93,12 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This {@code refCount} overload does not operate on any particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param subscriberCount the number of subscribers required to connect to the upstream
      * @return the new Observable instance
-     * @since 2.1.14 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> refCount(int subscriberCount) {
         return refCount(subscriberCount, 0, TimeUnit.NANOSECONDS, Schedulers.trampoline());
@@ -112,14 +112,14 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This {@code refCount} overload operates on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait before disconnecting after all subscribers unsubscribed
      * @param unit the time unit of the timeout
      * @return the new Observable instance
-     * @since 2.1.14 - experimental
      * @see #refCount(long, TimeUnit, Scheduler)
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Observable<T> refCount(long timeout, TimeUnit unit) {
         return refCount(1, timeout, unit, Schedulers.computation());
@@ -133,14 +133,14 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This {@code refCount} overload operates on the specified {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param timeout the time to wait before disconnecting after all subscribers unsubscribed
      * @param unit the time unit of the timeout
      * @param scheduler the target scheduler to wait on before disconnecting
      * @return the new Observable instance
-     * @since 2.1.14 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> refCount(long timeout, TimeUnit unit, Scheduler scheduler) {
         return refCount(1, timeout, unit, scheduler);
@@ -154,15 +154,15 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This {@code refCount} overload operates on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param subscriberCount the number of subscribers required to connect to the upstream
      * @param timeout the time to wait before disconnecting after all subscribers unsubscribed
      * @param unit the time unit of the timeout
      * @return the new Observable instance
-     * @since 2.1.14 - experimental
      * @see #refCount(int, long, TimeUnit, Scheduler)
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Observable<T> refCount(int subscriberCount, long timeout, TimeUnit unit) {
         return refCount(subscriberCount, timeout, unit, Schedulers.computation());
@@ -176,15 +176,15 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This {@code refCount} overload operates on the specified {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.14 - experimental
      * @param subscriberCount the number of subscribers required to connect to the upstream
      * @param timeout the time to wait before disconnecting after all subscribers unsubscribed
      * @param unit the time unit of the timeout
      * @param scheduler the target scheduler to wait on before disconnecting
      * @return the new Observable instance
-     * @since 2.1.14 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> refCount(int subscriberCount, long timeout, TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.verifyPositive(subscriberCount, "subscriberCount");

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -17,7 +17,6 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import io.reactivex.Notification;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Predicate;
@@ -235,7 +234,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that this TestObserver/TestSubscriber received exactly one onComplete event.
-     * @return this;
+     * @return this
      */
     @SuppressWarnings("unchecked")
     public final U assertComplete() {
@@ -251,7 +250,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that this TestObserver/TestSubscriber has not received any onComplete event.
-     * @return this;
+     * @return this
      */
     @SuppressWarnings("unchecked")
     public final U assertNotComplete() {
@@ -267,7 +266,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that this TestObserver/TestSubscriber has not received any onError event.
-     * @return this;
+     * @return this
      */
     @SuppressWarnings("unchecked")
     public final U assertNoErrors() {
@@ -286,7 +285,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * overload to test against the class of an error instead of an instance of an error
      * or {@link #assertError(Predicate)} to test with different condition.
      * @param error the error to check
-     * @return this;
+     * @return this
      * @see #assertError(Class)
      * @see #assertError(Predicate)
      */
@@ -298,7 +297,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * Asserts that this TestObserver/TestSubscriber received exactly one onError event which is an
      * instance of the specified errorClass class.
      * @param errorClass the error class to expect
-     * @return this;
+     * @return this
      */
     @SuppressWarnings({ "unchecked", "rawtypes", "cast" })
     public final U assertError(Class<? extends Throwable> errorClass) {
@@ -347,7 +346,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * Assert that this TestObserver/TestSubscriber received exactly one onNext value which is equal to
      * the given value with respect to Objects.equals.
      * @param value the value to expect
-     * @return this;
+     * @return this
      */
     @SuppressWarnings("unchecked")
     public final U assertValue(T value) {
@@ -433,13 +432,13 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     /**
      * Asserts that this TestObserver/TestSubscriber received an onNext value at the given index
      * which is equal to the given value with respect to null-safe Object.equals.
+     * <p>History: 2.1.3 - experimental
      * @param index the position to assert on
      * @param value the value to expect
      * @return this
-     * @since 2.1.3 - experimental
+     * @since 2.2
      */
     @SuppressWarnings("unchecked")
-    @Experimental
     public final U assertValueAt(int index, T value) {
         int s = values.size();
         if (s == 0) {
@@ -508,7 +507,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     /**
      * Assert that this TestObserver/TestSubscriber received the specified number onNext events.
      * @param count the expected number of onNext events
-     * @return this;
+     * @return this
      */
     @SuppressWarnings("unchecked")
     public final U assertValueCount(int count) {
@@ -521,7 +520,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that this TestObserver/TestSubscriber has not received any onNext events.
-     * @return this;
+     * @return this
      */
     public final U assertNoValues() {
         return assertValueCount(0);
@@ -530,7 +529,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     /**
      * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order.
      * @param values the values expected
-     * @return this;
+     * @return this
      * @see #assertValueSet(Collection)
      */
     @SuppressWarnings("unchecked")
@@ -552,12 +551,12 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order without terminating.
+     * <p>History: 2.1.4 - experimental
      * @param values the values expected
-     * @return this;
-     * @since 2.1.4
+     * @return this
+     * @since 2.2
      */
     @SuppressWarnings("unchecked")
-    @Experimental
     public final U assertValuesOnly(T... values) {
         return assertSubscribed()
                 .assertValues(values)
@@ -571,7 +570,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
      * asynchronous streams.
      *
      * @param expected the collection of values expected in any order
-     * @return this;
+     * @return this
      */
     @SuppressWarnings("unchecked")
     public final U assertValueSet(Collection<? extends T> expected) {
@@ -589,12 +588,11 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that the TestObserver/TestSubscriber received only the specified values in any order without terminating.
+     * <p>History: 2.1.14 - experimental
      * @param expected the collection of values expected in any order
-     * @return this;
-     * @since 2.1.14 - experimental
+     * @return this
+     * @since 2.2
      */
-    @SuppressWarnings("unchecked")
-    @Experimental
     public final U assertValueSetOnly(Collection<? extends T> expected) {
         return assertSubscribed()
                 .assertValueSet(expected)
@@ -605,7 +603,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     /**
      * Assert that the TestObserver/TestSubscriber received only the specified sequence of values in the same order.
      * @param sequence the sequence of expected values in order
-     * @return this;
+     * @return this
      */
     @SuppressWarnings("unchecked")
     public final U assertValueSequence(Iterable<? extends T> sequence) {
@@ -642,12 +640,11 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order without terminating.
+     * <p>History: 2.1.14 - experimental
      * @param sequence the sequence of expected values in order
-     * @return this;
-     * @since 2.1.14 - experimental
+     * @return this
+     * @since 2.2
      */
-    @SuppressWarnings("unchecked")
-    @Experimental
     public final U assertValueSequenceOnly(Iterable<? extends T> sequence) {
         return assertSubscribed()
                 .assertValueSequence(sequence)
@@ -657,7 +654,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that the TestObserver/TestSubscriber terminated (i.e., the terminal latch reached zero).
-     * @return this;
+     * @return this
      */
     @SuppressWarnings("unchecked")
     public final U assertTerminated() {
@@ -681,7 +678,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that the TestObserver/TestSubscriber has not terminated (i.e., the terminal latch is still non-zero).
-     * @return this;
+     * @return this
      */
     @SuppressWarnings("unchecked")
     public final U assertNotTerminated() {
@@ -771,13 +768,13 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that the onSubscribe method was called exactly once.
-     * @return this;
+     * @return this
      */
     public abstract U assertSubscribed();
 
     /**
      * Assert that the onSubscribe method hasn't been called at all.
-     * @return this;
+     * @return this
      */
     public abstract U assertNotSubscribed();
 
@@ -1024,6 +1021,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     }
 
     /**
+     * Returns true if an await timed out.
      * @return true if one of the timeout-based await methods has timed out.
      * <p>History: 2.0.7 - experimental
      * @see #clearTimeout()

--- a/src/main/java/io/reactivex/observers/LambdaConsumerIntrospection.java
+++ b/src/main/java/io/reactivex/observers/LambdaConsumerIntrospection.java
@@ -13,24 +13,21 @@
 
 package io.reactivex.observers;
 
-import io.reactivex.annotations.Experimental;
-
 /**
  * An interface that indicates that the implementing type is composed of individual components and exposes information
  * about their behavior.
  *
  * <p><em>NOTE:</em> This is considered a read-only public API and is not intended to be implemented externally.
- *
- * @since 2.1.4 - experimental
+ * <p>History: 2.1.4 - experimental
+ * @since 2.2
  */
-@Experimental
 public interface LambdaConsumerIntrospection {
 
     /**
+     * Returns true or false if a custom onError consumer has been provided.
      * @return {@code true} if a custom onError consumer implementation was supplied. Returns {@code false} if the
      * implementation is missing an error consumer and thus using a throwing default implementation.
      */
-    @Experimental
     boolean hasCustomOnError();
 
 }

--- a/src/main/java/io/reactivex/parallel/ParallelFailureHandling.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFailureHandling.java
@@ -13,14 +13,13 @@
 
 package io.reactivex.parallel;
 
-import io.reactivex.annotations.Experimental;
 import io.reactivex.functions.BiFunction;
 
 /**
  * Enumerations for handling failure within a parallel operator.
- * @since 2.0.8 - experimental
+ * <p>History: 2.0.8 - experimental
+ * @since 2.2
  */
-@Experimental
 public enum ParallelFailureHandling implements BiFunction<Long, Throwable, ParallelFailureHandling> {
     /**
      * The current rail is stopped and the error is dropped.

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -34,11 +34,10 @@ import org.reactivestreams.*;
  * Use {@code runOn()} to introduce where each 'rail' should run on thread-vise.
  * Use {@code sequential()} to merge the sources back into a single Flowable.
  *
- * <p>History: 2.0.5 - experimental
+ * <p>History: 2.0.5 - experimental; 2.1 - beta
  * @param <T> the value type
- * @since 2.1 - beta
+ * @since 2.2
  */
-@Beta
 public abstract class ParallelFlowable<T> {
 
     /**
@@ -126,14 +125,13 @@ public abstract class ParallelFlowable<T> {
      * Calls the specified converter function during assembly time and returns its resulting value.
      * <p>
      * This allows fluent conversion to any other type.
-     *
+     * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type
      * @param converter the function that receives the current ParallelFlowable instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
-     * @since 2.1.7 - experimental
+     * @since 2.2
      */
-    @Experimental
     @CheckReturnValue
     @NonNull
     public final <R> R as(@NonNull ParallelFlowableConverter<T, R> converter) {
@@ -160,15 +158,15 @@ public abstract class ParallelFlowable<T> {
      * handles errors based on the given {@link ParallelFailureHandling} enumeration value.
      * <p>
      * Note that the same mapper function may be called from multiple threads concurrently.
+     * <p>History: 2.0.8 - experimental
      * @param <R> the output value type
      * @param mapper the mapper function turning Ts into Us.
      * @param errorHandler the enumeration that defines how to handle errors thrown
      *                     from the mapper function
      * @return the new ParallelFlowable instance
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @NonNull
     public final <R> ParallelFlowable<R> map(@NonNull Function<? super T, ? extends R> mapper, @NonNull ParallelFailureHandling errorHandler) {
         ObjectHelper.requireNonNull(mapper, "mapper");
@@ -181,16 +179,16 @@ public abstract class ParallelFlowable<T> {
      * handles errors based on the returned value by the handler function.
      * <p>
      * Note that the same mapper function may be called from multiple threads concurrently.
+     * <p>History: 2.0.8 - experimental
      * @param <R> the output value type
      * @param mapper the mapper function turning Ts into Us.
      * @param errorHandler the function called with the current repeat count and
      *                     failure Throwable and should return one of the {@link ParallelFailureHandling}
      *                     enumeration values to indicate how to proceed.
      * @return the new ParallelFlowable instance
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @NonNull
     public final <R> ParallelFlowable<R> map(@NonNull Function<? super T, ? extends R> mapper, @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
         ObjectHelper.requireNonNull(mapper, "mapper");
@@ -216,14 +214,14 @@ public abstract class ParallelFlowable<T> {
      * handles errors based on the given {@link ParallelFailureHandling} enumeration value.
      * <p>
      * Note that the same predicate may be called from multiple threads concurrently.
+     * <p>History: 2.0.8 - experimental
      * @param predicate the function returning true to keep a value or false to drop a value
      * @param errorHandler the enumeration that defines how to handle errors thrown
      *                     from the predicate
      * @return the new ParallelFlowable instance
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     public final ParallelFlowable<T> filter(@NonNull Predicate<? super T> predicate, @NonNull ParallelFailureHandling errorHandler) {
         ObjectHelper.requireNonNull(predicate, "predicate");
         ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
@@ -236,15 +234,15 @@ public abstract class ParallelFlowable<T> {
      * handles errors based on the returned value by the handler function.
      * <p>
      * Note that the same predicate may be called from multiple threads concurrently.
+     * <p>History: 2.0.8 - experimental
      * @param predicate the function returning true to keep a value or false to drop a value
      * @param errorHandler the function called with the current repeat count and
      *                     failure Throwable and should return one of the {@link ParallelFailureHandling}
      *                     enumeration values to indicate how to proceed.
      * @return the new ParallelFlowable instance
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     public final ParallelFlowable<T> filter(@NonNull Predicate<? super T> predicate, @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
         ObjectHelper.requireNonNull(predicate, "predicate");
         ObjectHelper.requireNonNull(errorHandler, "errorHandler is null");
@@ -401,15 +399,15 @@ public abstract class ParallelFlowable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code sequentialDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.0.7 - experimental
      * @return the new Flowable instance
      * @see ParallelFlowable#sequentialDelayError(int)
      * @see ParallelFlowable#sequential()
-     * @since 2.0.7 - experimental
+     * @since 2.2
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
-    @Experimental
     @NonNull
     public final Flowable<T> sequentialDelayError() {
         return sequentialDelayError(Flowable.bufferSize());
@@ -426,11 +424,12 @@ public abstract class ParallelFlowable<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code sequentialDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.0.7 - experimental
      * @param prefetch the prefetch amount to use for each rail
      * @return the new Flowable instance
      * @see ParallelFlowable#sequential()
      * @see ParallelFlowable#sequentialDelayError()
-     * @since 2.0.7 - experimental
+     * @since 2.2
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -541,15 +540,14 @@ public abstract class ParallelFlowable<T> {
     /**
      * Call the specified consumer with the current element passing through any 'rail' and
      * handles errors based on the given {@link ParallelFailureHandling} enumeration value.
-     *
+     * <p>History: 2.0.8 - experimental
      * @param onNext the callback
      * @param errorHandler the enumeration that defines how to handle errors thrown
      *                     from the onNext consumer
      * @return the new ParallelFlowable instance
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @NonNull
     public final ParallelFlowable<T> doOnNext(@NonNull Consumer<? super T> onNext, @NonNull ParallelFailureHandling errorHandler) {
         ObjectHelper.requireNonNull(onNext, "onNext is null");
@@ -560,16 +558,15 @@ public abstract class ParallelFlowable<T> {
     /**
      * Call the specified consumer with the current element passing through any 'rail' and
      * handles errors based on the returned value by the handler function.
-     *
+     * <p>History: 2.0.8 - experimental
      * @param onNext the callback
      * @param errorHandler the function called with the current repeat count and
      *                     failure Throwable and should return one of the {@link ParallelFailureHandling}
      *                     enumeration values to indicate how to proceed.
      * @return the new ParallelFlowable instance
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @NonNull
     public final ParallelFlowable<T> doOnNext(@NonNull Consumer<? super T> onNext, @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
         ObjectHelper.requireNonNull(onNext, "onNext is null");

--- a/src/main/java/io/reactivex/parallel/ParallelFlowableConverter.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowableConverter.java
@@ -18,12 +18,11 @@ import io.reactivex.annotations.*;
 /**
  * Convenience interface and callback used by the {@link ParallelFlowable#as} operator to turn a ParallelFlowable into
  * another value fluently.
- *
+ * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type
  * @param <R> the output type
- * @since 2.1.7 - experimental
+ * @since 2.2
  */
-@Experimental
 public interface ParallelFlowableConverter<T, R> {
     /**
      * Applies a function to the upstream ParallelFlowable and returns a converted value of type {@code R}.

--- a/src/main/java/io/reactivex/parallel/ParallelTransformer.java
+++ b/src/main/java/io/reactivex/parallel/ParallelTransformer.java
@@ -17,13 +17,11 @@ import io.reactivex.annotations.*;
 
 /**
  * Interface to compose ParallelFlowable.
- *
+ * <p>History: 2.0.8 - experimental
  * @param <Upstream> the upstream value type
  * @param <Downstream> the downstream value type
- * 
- * @since 2.0.8 - experimental
+ * @since 2.2
  */
-@Experimental
 public interface ParallelTransformer<Upstream, Downstream> {
     /**
      * Applies a function to the upstream ParallelFlowable and returns a ParallelFlowable with

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -1104,11 +1104,10 @@ public final class RxJavaPlugins {
 
     /**
      * Sets the specific hook function.
-     * <p>History: 2.0.6 - experimental
+     * <p>History: 2.0.6 - experimental; 2.1 - beta
      * @param handler the hook function to set, null allowed
-     * @since 2.1 - beta
+     * @since 2.2
      */
-    @Beta
     @SuppressWarnings("rawtypes")
     public static void setOnParallelAssembly(@Nullable Function<? super ParallelFlowable, ? extends ParallelFlowable> handler) {
         if (lockdown) {
@@ -1119,11 +1118,10 @@ public final class RxJavaPlugins {
 
     /**
      * Returns the current hook function.
-     * <p>History: 2.0.6 - experimental
+     * <p>History: 2.0.6 - experimental; 2.1 - beta
      * @return the hook function, may be null
-     * @since 2.1 - beta
+     * @since 2.2
      */
-    @Beta
     @SuppressWarnings("rawtypes")
     @Nullable
     public static Function<? super ParallelFlowable, ? extends ParallelFlowable> getOnParallelAssembly() {
@@ -1132,13 +1130,12 @@ public final class RxJavaPlugins {
 
     /**
      * Calls the associated hook function.
-     * <p>History: 2.0.6 - experimental
+     * <p>History: 2.0.6 - experimental; 2.1 - beta
      * @param <T> the value type of the source
      * @param source the hook's input value
      * @return the value returned by the hook
-     * @since 2.1 - beta
+     * @since 2.2
      */
-    @Beta
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
     public static <T> ParallelFlowable<T> onAssembly(@NonNull ParallelFlowable<T> source) {

--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -315,11 +315,11 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      * <p>
      * Calling with null will terminate the PublishProcessor and a NullPointerException
      * is signalled to the Subscribers.
+     * <p>History: 2.0.8 - experimental
      * @param t the item to emit, not null
      * @return true if the item was emitted to all Subscribers
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
-    @Experimental
     public boolean offer(T t) {
         if (t == null) {
             onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));

--- a/src/main/java/io/reactivex/processors/MulticastProcessor.java
+++ b/src/main/java/io/reactivex/processors/MulticastProcessor.java
@@ -123,10 +123,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 
     mp2.test().assertResult(1, 2, 3, 4);
  * </code></pre>
+ * <p>History: 2.1.14 - experimental
  * @param <T> the input and output value type
- * @since 2.1.14 - experimental
+ * @since 2.2
  */
-@Experimental
 @BackpressureSupport(BackpressureKind.FULL)
 @SchedulerSupport(SchedulerSupport.NONE)
 public final class MulticastProcessor<T> extends FlowableProcessor<T> {

--- a/src/main/java/io/reactivex/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/processors/PublishProcessor.java
@@ -280,11 +280,11 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
      * <p>
      * Calling with null will terminate the PublishProcessor and a NullPointerException
      * is signalled to the Subscribers.
+     * <p>History: 2.0.8 - experimental
      * @param t the item to emit, not null
      * @return true if the item was emitted to all Subscribers
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
-    @Experimental
     public boolean offer(T t) {
         if (t == null) {
             onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -433,9 +433,9 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
      * <p>
      * The method must be called sequentially, similar to the standard
      * {@code onXXX} methods.
-     * @since 2.1.11 - experimental
+     * <p>History: 2.1.11 - experimental
+     * @since 2.2
      */
-    @Experimental
     public void cleanupBuffer() {
         buffer.trimHead();
     }

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -16,7 +16,6 @@ package io.reactivex.processors;
 import io.reactivex.annotations.CheckReturnValue;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.annotations.Experimental;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.annotations.NonNull;
 import org.reactivestreams.*;
@@ -198,13 +197,13 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
 
     /**
      * Creates an UnicastProcessor with default internal buffer capacity hint and delay error flag.
+     * <p>History: 2.0.8 - experimental
      * @param <T> the value type
      * @param delayError deliver pending onNext events before onError
      * @return an UnicastProcessor instance
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @NonNull
     public static <T> UnicastProcessor<T> create(boolean delayError) {
         return new UnicastProcessor<T>(bufferSize(), null, delayError);
@@ -235,16 +234,15 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
      *
      * <p>The callback, if not null, is called exactly once and
      * non-overlapped with any active replay.
-     *
+     * <p>History: 2.0.8 - experimental
      * @param <T> the value type
      * @param capacityHint the hint to size the internal unbounded buffer
      * @param onCancelled the non null callback
      * @param delayError deliver pending onNext events before onError
      * @return an UnicastProcessor instance
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @NonNull
     public static <T> UnicastProcessor<T> create(int capacityHint, Runnable onCancelled, boolean delayError) {
         ObjectHelper.requireNonNull(onCancelled, "onTerminate");
@@ -274,10 +272,11 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
     /**
      * Creates an UnicastProcessor with the given capacity hint and callback
      * for when the Processor is terminated normally or its single Subscriber cancels.
+     * <p>History: 2.0.8 - experimental
      * @param capacityHint the capacity hint for the internal, unbounded queue
      * @param onTerminate the callback to run when the Processor is terminated or cancelled, null not allowed
      * @param delayError deliver pending onNext events before onError
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     UnicastProcessor(int capacityHint, Runnable onTerminate, boolean delayError) {
         this.queue = new SpscLinkedArrayQueue<T>(ObjectHelper.verifyPositive(capacityHint, "capacityHint"));

--- a/src/main/java/io/reactivex/schedulers/SchedulerRunnableIntrospection.java
+++ b/src/main/java/io/reactivex/schedulers/SchedulerRunnableIntrospection.java
@@ -24,10 +24,9 @@ import io.reactivex.plugins.RxJavaPlugins;
  * task in a custom {@link RxJavaPlugins#onSchedule(Runnable)} hook set via
  * the {@link RxJavaPlugins#setScheduleHandler(Function)} method multiple times due to internal delegation
  * of the default {@code Scheduler.scheduleDirect} or {@code Scheduler.Worker.schedule} methods.
- *
- * @since 2.1.7 - experimental
+ * <p>History: 2.1.7 - experimental
+ * @since 2.2
  */
-@Experimental
 public interface SchedulerRunnableIntrospection {
 
     /**

--- a/src/main/java/io/reactivex/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/subjects/ReplaySubject.java
@@ -431,9 +431,9 @@ public final class ReplaySubject<T> extends Subject<T> {
      * <p>
      * The method must be called sequentially, similar to the standard
      * {@code onXXX} methods.
-     * @since 2.1.11 - experimental
+     * <p>History: 2.1.11 - experimental
+     * @since 2.2
      */
-    @Experimental
     public void cleanupBuffer() {
         buffer.trimHead();
     }

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.subjects;
 
-import io.reactivex.annotations.Experimental;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.annotations.NonNull;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -221,16 +220,15 @@ public final class UnicastSubject<T> extends Subject<T> {
      *
      * <p>The callback, if not null, is called exactly once and
      * non-overlapped with any active replay.
-     *
+     * <p>History: 2.0.8 - experimental
      * @param <T> the value type
      * @param capacityHint the hint to size the internal unbounded buffer
      * @param onTerminate the callback to run when the Subject is terminated or cancelled, null not allowed
      * @param delayError deliver pending onNext events before onError
      * @return an UnicastSubject instance
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @NonNull
     public static <T> UnicastSubject<T> create(int capacityHint, Runnable onTerminate, boolean delayError) {
         return new UnicastSubject<T>(capacityHint, onTerminate, delayError);
@@ -241,14 +239,13 @@ public final class UnicastSubject<T> extends Subject<T> {
      *
      * <p>The callback, if not null, is called exactly once and
      * non-overlapped with any active replay.
-     *
+     * <p>History: 2.0.8 - experimental
      * @param <T> the value type
      * @param delayError deliver pending onNext events before onError
      * @return an UnicastSubject instance
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     @CheckReturnValue
-    @Experimental
     @NonNull
     public static <T> UnicastSubject<T> create(boolean delayError) {
         return new UnicastSubject<T>(bufferSize(), delayError);
@@ -257,9 +254,10 @@ public final class UnicastSubject<T> extends Subject<T> {
 
     /**
      * Creates an UnicastSubject with the given capacity hint and delay error flag.
+     * <p>History: 2.0.8 - experimental
      * @param capacityHint the capacity hint for the internal, unbounded queue
      * @param delayError deliver pending onNext events before onError
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     UnicastSubject(int capacityHint, boolean delayError) {
         this.queue = new SpscLinkedArrayQueue<T>(ObjectHelper.verifyPositive(capacityHint, "capacityHint"));
@@ -285,10 +283,11 @@ public final class UnicastSubject<T> extends Subject<T> {
     /**
      * Creates an UnicastSubject with the given capacity hint, delay error flag and callback
      * for when the Subject is terminated normally or its single Subscriber cancels.
+     * <p>History: 2.0.8 - experimental
      * @param capacityHint the capacity hint for the internal, unbounded queue
      * @param onTerminate the callback to run when the Subject is terminated or cancelled, null not allowed
      * @param delayError deliver pending onNext events before onError
-     * @since 2.0.8 - experimental
+     * @since 2.2
      */
     UnicastSubject(int capacityHint, Runnable onTerminate, boolean delayError) {
         this.queue = new SpscLinkedArrayQueue<T>(ObjectHelper.verifyPositive(capacityHint, "capacityHint"));


### PR DESCRIPTION
This PR promotes all `@Experimental`/`@Beta` APIs to standard with version number **2.2**.

(In addition, it also fixes remnant markers from earlier promotions in internal files.)

### Operators

- **`Flowable`**: 
  - `as`
  - `blockingSubscribe(..., prefetch)` + 2
  - `concatMapCompletable` + 1
  - `concatMapCompletableDelayError` + 2
  - `concatMapMaybe` + 1
  - `concatMapMaybeDelayError` + 2
  - `concatMapSingle` + 1
  - `concatMapSingleDelayError` + 2
  - `concatWith` + 2
  - `groupBy(..., evictingMapFactory)`
  - `limit`
  - `mergeWith` + 2
  - `parallel` + 2
  - `subscribe(FlowableSubscriber)`
  - `subscribeOn(..., requestOn)`
  - `switchMapCompletable`
  - `switchMapCompletableDelayError`
  - `switchMapMaybe`
  - `switchMapMaybeDelayError`
  - `switchMapSingle`
  - `switchMapSingleDelayError`
  - `throttleLatest` + 3  
- **`Observable`**:
  - `as`
  - `concatMapCompletable` + 1
  - `concatMapCompletableDelayError` + 2
  - `concatMapMaybe` + 1
  - `concatMapMaybeDelayError` + 2
  - `concatMapSingle` + 1
  - `concatMapSingleDelayError` + 2
  - `concatWith` + 2
  - `mergeWith` + 2
  - `switchMapCompletable`
  - `switchMapCompletableDelayError`
  - `switchMapMaybe`
  - `switchMapMaybeDelayError`
  - `switchMapSingle`
  - `switchMapSingleDelayError`
  - `throttleLatest` + 3  
- **`Maybe`**:
  - `mergeDelayError(Publisher, int)`
  - `as`
  - `switchIfEmpty`
- **`Single`**:
  - `mergeDelayError` + 4
  - `as`
  - `delay(..., delayError)` + 1
  - `onTerminateDetach`
  - `retry(long, Predicate)`
  - `unsubscribeOn`
- **`Completable`**: 
  - `fromMaybe`
  - `as`
  - `onTerminateDetach`
  - `retry(long, Predicate)`
  - `takeUntil`
- **`ConnectableFlowable`**:
  - `refCount` + 4
- **`ConnectableObservable`**:
  - `refCount` + 4
- **`ParallelFlowable`**:
  - `as`
  - `map(errorHandling)` + 1
  - `filter(errorHandling)` + 1
  - `doOnNext(errorHandling)` + 1
  - `sequentialDelayError` + 1
- **`TestSubscriber`/`TestObserver`** (**`BaseTestConsumer`**):
  - `assertValueAt`
  - `assertValuesOnly`
  - `assertValueSetOnly`
  - `assertValueSequenceOnly`
- **`RxJavaPlugins`**:
  - `setOnParallelAssembly`
  - `getOnParallelAssembly`
  - `onAssembly(ParallelFlowable)`
- **`Subject`s/`FlowableProcessor`s**:
  - `BehaviorProcessor.offer`
  - `PublishProcessor.offer` 
  - `ReplayProcessor.cleanupBuffer`
  - `ReplaySubject.cleanupBuffer`
  - `UnicastProcessor.create([...], delayError)` + 1
  - `UnicastSubject.create([...], delayError)` + 1

### Interfaces

- `CompletableConverter`
- `CompletableEmitter`
- `FlowableConverter`
- `FlowableEmitter`
- `FlowableSubscriber`
- `MaybeConverter`
- `MaybeEmitter`
- `ObservableConverter`
- `ObservableEmitter`
- `SingleConverter`
- `SingleEmitter`
- `LambdaConsumerIntrospection`
- `ParallelFlowableConverter`
- `ParallelTransformer`
- `SchedulerRunnableIntrospection`

### Enums

- `ParallelFailureHandling`

### Classes

- `OnErrorNotImplementedException`
- `ProtocolViolationException`
- `UndeliverableException`
- `ParallelFlowable`
- `MulticastProcessor`

### Other components

- `SchedulerSupport.SINGLE`
