### PR TITLE
Encoding Bug

### DIFF
--- a/src/test/java/io/reactivex/JavadocForAnnotations.java
+++ b/src/test/java/io/reactivex/JavadocForAnnotations.java
@@ -51,7 +51,7 @@ public class JavadocForAnnotations {
     public static StringBuilder readFile(File f) throws Exception {
         StringBuilder b = new StringBuilder();
 
-        BufferedReader in = new BufferedReader(new FileReader(f));
+        BufferedReader in = new BufferedReader(new InputStreamReader(f));
         try {
             for (;;) {
                 String line = in.readLine();


### PR DESCRIPTION
Use InputStreamReader to specify encoding otherwise the default encoding will be used leading to strange bugs for some users.