### PR TITLE
Encoding Bug

### DIFF
--- a/src/test/java/io/reactivex/internal/util/ObservableToFlowabeTestSync.java
+++ b/src/test/java/io/reactivex/internal/util/ObservableToFlowabeTestSync.java
@@ -28,7 +28,7 @@ public final class ObservableToFlowabeTestSync {
     static List<String> readAllLines(File f) {
         List<String> result = new ArrayList<String>();
         try {
-            BufferedReader in = new BufferedReader(new FileReader(f));
+            BufferedReader in = new BufferedReader(new InputStreamReader(f));
             try {
                 String line;
 


### PR DESCRIPTION
Use InputStreamReader to specify encoding otherwise the default encoding will be used leading to strange bugs for some users.