### PR TITLE
6108 changed README to use Gradle's implementation instead of compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The [1.x version](https://github.com/ReactiveX/RxJava/tree/1.x) is end-of-life a
 The first step is to include RxJava 2 into your project, for example, as a Gradle compile dependency:
 
 ```groovy
-compile "io.reactivex.rxjava2:rxjava:2.x.y"
+implementation "io.reactivex.rxjava2:rxjava:2.x.y"
 ```
 
 (Please replace `x` and `y` with the latest version numbers: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.reactivex.rxjava2/rxjava/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.reactivex.rxjava2/rxjava)


### PR DESCRIPTION
fixes #6108 

Changed `README.md` to reflect Gradle's more recent version of the [library plugin](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation).

I believe that RxJava should be using `implementation`, but I'm not a Gradle expert, feel free to let me know if clients should be using `api`.