### PR TITLE
2.x: Test cleanup

### DIFF
--- a/src/jmh/java/io/reactivex/InputWithIncrementingInteger.java
+++ b/src/jmh/java/io/reactivex/InputWithIncrementingInteger.java
@@ -94,7 +94,7 @@ public abstract class InputWithIncrementingInteger {
     }
 
     public Iterable<Integer> iterable;
-    public Flowable<Integer> observable;
+    public Flowable<Integer> flowable;
     public Flowable<Integer> firehose;
     public Blackhole bh;
 
@@ -104,7 +104,7 @@ public abstract class InputWithIncrementingInteger {
     public void setup(final Blackhole bh) {
         this.bh = bh;
         final int size = getSize();
-        observable = Flowable.range(0, size);
+        flowable = Flowable.range(0, size);
 
         firehose = Flowable.unsafeCreate(new IncrementingPublisher(size));
         iterable = new IncrementingIterable(size);

--- a/src/jmh/java/io/reactivex/OperatorFlatMapPerf.java
+++ b/src/jmh/java/io/reactivex/OperatorFlatMapPerf.java
@@ -42,7 +42,7 @@ public class OperatorFlatMapPerf {
 
     @Benchmark
     public void flatMapIntPassthruSync(Input input) throws InterruptedException {
-        input.observable.flatMap(new Function<Integer, Publisher<Integer>>() {
+        input.flowable.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer v) {
                 return Flowable.just(v);
@@ -53,7 +53,7 @@ public class OperatorFlatMapPerf {
     @Benchmark
     public void flatMapIntPassthruAsync(Input input) throws InterruptedException {
         PerfSubscriber latchedObserver = input.newLatchedObserver();
-        input.observable.flatMap(new Function<Integer, Publisher<Integer>>() {
+        input.flowable.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer i) {
                     return Flowable.just(i).subscribeOn(Schedulers.computation());
@@ -71,7 +71,7 @@ public class OperatorFlatMapPerf {
         Flowable.range(1, 2).flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer i) {
-                    return input.observable;
+                    return input.flowable;
             }
         }).subscribe(input.newSubscriber());
     }

--- a/src/jmh/java/io/reactivex/OperatorMergePerf.java
+++ b/src/jmh/java/io/reactivex/OperatorMergePerf.java
@@ -68,7 +68,7 @@ public class OperatorMergePerf {
 
     @Benchmark
     public void mergeNSyncStreamsOfN(final InputThousand input) throws InterruptedException {
-        Flowable<Flowable<Integer>> os = input.observable.map(new Function<Integer, Flowable<Integer>>() {
+        Flowable<Flowable<Integer>> os = input.flowable.map(new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer i) {
                     return Flowable.range(0, input.size);
@@ -85,7 +85,7 @@ public class OperatorMergePerf {
 
     @Benchmark
     public void mergeNAsyncStreamsOfN(final InputThousand input) throws InterruptedException {
-        Flowable<Flowable<Integer>> os = input.observable.map(new Function<Integer, Flowable<Integer>>() {
+        Flowable<Flowable<Integer>> os = input.flowable.map(new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer i) {
                     return Flowable.range(0, input.size).subscribeOn(Schedulers.computation());

--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -2155,20 +2155,20 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe() {
-        EmptyCompletableObserver s = new EmptyCompletableObserver();
-        subscribe(s);
-        return s;
+        EmptyCompletableObserver observer = new EmptyCompletableObserver();
+        subscribe(observer);
+        return observer;
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
     @Override
-    public final void subscribe(CompletableObserver s) {
-        ObjectHelper.requireNonNull(s, "s is null");
+    public final void subscribe(CompletableObserver observer) {
+        ObjectHelper.requireNonNull(observer, "s is null");
         try {
 
-            s = RxJavaPlugins.onSubscribe(this, s);
+            observer = RxJavaPlugins.onSubscribe(this, observer);
 
-            subscribeActual(s);
+            subscribeActual(observer);
         } catch (NullPointerException ex) { // NOPMD
             throw ex;
         } catch (Throwable ex) {
@@ -2184,9 +2184,9 @@ public abstract class Completable implements CompletableSource {
      * <p>There is no need to call any of the plugin hooks on the current {@code Completable} instance or
      * the {@code CompletableObserver}; all hooks and basic safeguards have been
      * applied by {@link #subscribe(CompletableObserver)} before this method gets called.
-     * @param s the CompletableObserver instance, never null
+     * @param observer the CompletableObserver instance, never null
      */
-    protected abstract void subscribeActual(CompletableObserver s);
+    protected abstract void subscribeActual(CompletableObserver observer);
 
     /**
      * Subscribes a given CompletableObserver (subclass) to this Completable and returns the given
@@ -2240,9 +2240,9 @@ public abstract class Completable implements CompletableSource {
         ObjectHelper.requireNonNull(onError, "onError is null");
         ObjectHelper.requireNonNull(onComplete, "onComplete is null");
 
-        CallbackCompletableObserver s = new CallbackCompletableObserver(onError, onComplete);
-        subscribe(s);
-        return s;
+        CallbackCompletableObserver observer = new CallbackCompletableObserver(onError, onComplete);
+        subscribe(observer);
+        return observer;
     }
 
     /**
@@ -2266,9 +2266,9 @@ public abstract class Completable implements CompletableSource {
     public final Disposable subscribe(final Action onComplete) {
         ObjectHelper.requireNonNull(onComplete, "onComplete is null");
 
-        CallbackCompletableObserver s = new CallbackCompletableObserver(onComplete);
-        subscribe(s);
-        return s;
+        CallbackCompletableObserver observer = new CallbackCompletableObserver(onComplete);
+        subscribe(observer);
+        return observer;
     }
 
     /**

--- a/src/main/java/io/reactivex/FlowableOperator.java
+++ b/src/main/java/io/reactivex/FlowableOperator.java
@@ -25,10 +25,10 @@ import org.reactivestreams.Subscriber;
 public interface FlowableOperator<Downstream, Upstream> {
     /**
      * Applies a function to the child Subscriber and returns a new parent Subscriber.
-     * @param observer the child Subscriber instance
+     * @param subscriber the child Subscriber instance
      * @return the parent Subscriber instance
      * @throws Exception on failure
      */
     @NonNull
-    Subscriber<? super Upstream> apply(@NonNull Subscriber<? super Downstream> observer) throws Exception;
+    Subscriber<? super Upstream> apply(@NonNull Subscriber<? super Downstream> subscriber) throws Exception;
 }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -4982,9 +4982,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingFirst() {
-        BlockingFirstObserver<T> s = new BlockingFirstObserver<T>();
-        subscribe(s);
-        T v = s.blockingGet();
+        BlockingFirstObserver<T> observer = new BlockingFirstObserver<T>();
+        subscribe(observer);
+        T v = observer.blockingGet();
         if (v != null) {
             return v;
         }
@@ -5010,9 +5010,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingFirst(T defaultItem) {
-        BlockingFirstObserver<T> s = new BlockingFirstObserver<T>();
-        subscribe(s);
-        T v = s.blockingGet();
+        BlockingFirstObserver<T> observer = new BlockingFirstObserver<T>();
+        subscribe(observer);
+        T v = observer.blockingGet();
         return v != null ? v : defaultItem;
     }
 
@@ -5119,9 +5119,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingLast() {
-        BlockingLastObserver<T> s = new BlockingLastObserver<T>();
-        subscribe(s);
-        T v = s.blockingGet();
+        BlockingLastObserver<T> observer = new BlockingLastObserver<T>();
+        subscribe(observer);
+        T v = observer.blockingGet();
         if (v != null) {
             return v;
         }
@@ -5151,9 +5151,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingLast(T defaultItem) {
-        BlockingLastObserver<T> s = new BlockingLastObserver<T>();
-        subscribe(s);
-        T v = s.blockingGet();
+        BlockingLastObserver<T> observer = new BlockingLastObserver<T>();
+        subscribe(observer);
+        T v = observer.blockingGet();
         return v != null ? v : defaultItem;
     }
 
@@ -10998,16 +10998,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code safeSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param s the incoming Observer instance
+     * @param observer the incoming Observer instance
      * @throws NullPointerException if s is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void safeSubscribe(Observer<? super T> s) {
-        ObjectHelper.requireNonNull(s, "s is null");
-        if (s instanceof SafeObserver) {
-            subscribe(s);
+    public final void safeSubscribe(Observer<? super T> observer) {
+        ObjectHelper.requireNonNull(observer, "s is null");
+        if (observer instanceof SafeObserver) {
+            subscribe(observer);
         } else {
-            subscribe(new SafeObserver<T>(s));
+            subscribe(new SafeObserver<T>(observer));
         }
     }
 

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -14072,19 +14072,19 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> toFlowable(BackpressureStrategy strategy) {
-        Flowable<T> o = new FlowableFromObservable<T>(this);
+        Flowable<T> f = new FlowableFromObservable<T>(this);
 
         switch (strategy) {
             case DROP:
-                return o.onBackpressureDrop();
+                return f.onBackpressureDrop();
             case LATEST:
-                return o.onBackpressureLatest();
+                return f.onBackpressureLatest();
             case MISSING:
-                return o;
+                return f;
             case ERROR:
-                return RxJavaPlugins.onAssembly(new FlowableOnBackpressureError<T>(o));
+                return RxJavaPlugins.onAssembly(new FlowableOnBackpressureError<T>(f));
             default:
-                return o.onBackpressureBuffer();
+                return f.onBackpressureBuffer();
         }
     }
 

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -3322,9 +3322,9 @@ public abstract class Single<T> implements SingleSource<T> {
     public final Disposable subscribe(final BiConsumer<? super T, ? super Throwable> onCallback) {
         ObjectHelper.requireNonNull(onCallback, "onCallback is null");
 
-        BiConsumerSingleObserver<T> s = new BiConsumerSingleObserver<T>(onCallback);
-        subscribe(s);
-        return s;
+        BiConsumerSingleObserver<T> observer = new BiConsumerSingleObserver<T>(onCallback);
+        subscribe(observer);
+        return observer;
     }
 
     /**
@@ -3376,22 +3376,22 @@ public abstract class Single<T> implements SingleSource<T> {
         ObjectHelper.requireNonNull(onSuccess, "onSuccess is null");
         ObjectHelper.requireNonNull(onError, "onError is null");
 
-        ConsumerSingleObserver<T> s = new ConsumerSingleObserver<T>(onSuccess, onError);
-        subscribe(s);
-        return s;
+        ConsumerSingleObserver<T> observer = new ConsumerSingleObserver<T>(onSuccess, onError);
+        subscribe(observer);
+        return observer;
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
     @Override
-    public final void subscribe(SingleObserver<? super T> subscriber) {
-        ObjectHelper.requireNonNull(subscriber, "subscriber is null");
+    public final void subscribe(SingleObserver<? super T> observer) {
+        ObjectHelper.requireNonNull(observer, "subscriber is null");
 
-        subscriber = RxJavaPlugins.onSubscribe(this, subscriber);
+        observer = RxJavaPlugins.onSubscribe(this, observer);
 
-        ObjectHelper.requireNonNull(subscriber, "subscriber returned by the RxJavaPlugins hook is null");
+        ObjectHelper.requireNonNull(observer, "subscriber returned by the RxJavaPlugins hook is null");
 
         try {
-            subscribeActual(subscriber);
+            subscribeActual(observer);
         } catch (NullPointerException ex) {
             throw ex;
         } catch (Throwable ex) {

--- a/src/main/java/io/reactivex/internal/disposables/EmptyDisposable.java
+++ b/src/main/java/io/reactivex/internal/disposables/EmptyDisposable.java
@@ -48,39 +48,39 @@ public enum EmptyDisposable implements QueueDisposable<Object> {
         return this == INSTANCE;
     }
 
-    public static void complete(Observer<?> s) {
-        s.onSubscribe(INSTANCE);
-        s.onComplete();
+    public static void complete(Observer<?> observer) {
+        observer.onSubscribe(INSTANCE);
+        observer.onComplete();
     }
 
-    public static void complete(MaybeObserver<?> s) {
-        s.onSubscribe(INSTANCE);
-        s.onComplete();
+    public static void complete(MaybeObserver<?> observer) {
+        observer.onSubscribe(INSTANCE);
+        observer.onComplete();
     }
 
-    public static void error(Throwable e, Observer<?> s) {
-        s.onSubscribe(INSTANCE);
-        s.onError(e);
+    public static void error(Throwable e, Observer<?> observer) {
+        observer.onSubscribe(INSTANCE);
+        observer.onError(e);
     }
 
-    public static void complete(CompletableObserver s) {
-        s.onSubscribe(INSTANCE);
-        s.onComplete();
+    public static void complete(CompletableObserver observer) {
+        observer.onSubscribe(INSTANCE);
+        observer.onComplete();
     }
 
-    public static void error(Throwable e, CompletableObserver s) {
-        s.onSubscribe(INSTANCE);
-        s.onError(e);
+    public static void error(Throwable e, CompletableObserver observer) {
+        observer.onSubscribe(INSTANCE);
+        observer.onError(e);
     }
 
-    public static void error(Throwable e, SingleObserver<?> s) {
-        s.onSubscribe(INSTANCE);
-        s.onError(e);
+    public static void error(Throwable e, SingleObserver<?> observer) {
+        observer.onSubscribe(INSTANCE);
+        observer.onError(e);
     }
 
-    public static void error(Throwable e, MaybeObserver<?> s) {
-        s.onSubscribe(INSTANCE);
-        s.onError(e);
+    public static void error(Throwable e, MaybeObserver<?> observer) {
+        observer.onSubscribe(INSTANCE);
+        observer.onError(e);
     }
 
 

--- a/src/main/java/io/reactivex/internal/observers/QueueDrainObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/QueueDrainObserver.java
@@ -62,11 +62,11 @@ public abstract class QueueDrainObserver<T, U, V> extends QueueDrainSubscriberPa
     }
 
     protected final void fastPathEmit(U value, boolean delayError, Disposable dispose) {
-        final Observer<? super V> s = actual;
+        final Observer<? super V> observer = actual;
         final SimplePlainQueue<U> q = queue;
 
         if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
-            accept(s, value);
+            accept(observer, value);
             if (leave(-1) == 0) {
                 return;
             }
@@ -76,7 +76,7 @@ public abstract class QueueDrainObserver<T, U, V> extends QueueDrainSubscriberPa
                 return;
             }
         }
-        QueueDrainHelper.drainLoop(q, s, delayError, dispose, this);
+        QueueDrainHelper.drainLoop(q, observer, delayError, dispose, this);
     }
 
     /**
@@ -86,12 +86,12 @@ public abstract class QueueDrainObserver<T, U, V> extends QueueDrainSubscriberPa
      * @param disposable the resource to dispose if the drain terminates
      */
     protected final void fastPathOrderedEmit(U value, boolean delayError, Disposable disposable) {
-        final Observer<? super V> s = actual;
+        final Observer<? super V> observer = actual;
         final SimplePlainQueue<U> q = queue;
 
         if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
             if (q.isEmpty()) {
-                accept(s, value);
+                accept(observer, value);
                 if (leave(-1) == 0) {
                     return;
                 }
@@ -104,7 +104,7 @@ public abstract class QueueDrainObserver<T, U, V> extends QueueDrainSubscriberPa
                 return;
             }
         }
-        QueueDrainHelper.drainLoop(q, s, delayError, disposable, this);
+        QueueDrainHelper.drainLoop(q, observer, delayError, disposable, this);
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/observers/SubscriberCompletableObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/SubscriberCompletableObserver.java
@@ -24,8 +24,8 @@ public final class SubscriberCompletableObserver<T> implements CompletableObserv
 
     Disposable d;
 
-    public SubscriberCompletableObserver(Subscriber<? super T> observer) {
-        this.subscriber = observer;
+    public SubscriberCompletableObserver(Subscriber<? super T> subscriber) {
+        this.subscriber = subscriber;
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableAmb.java
@@ -31,7 +31,7 @@ public final class CompletableAmb extends Completable {
     }
 
     @Override
-    public void subscribeActual(final CompletableObserver s) {
+    public void subscribeActual(final CompletableObserver observer) {
         CompletableSource[] sources = this.sources;
         int count = 0;
         if (sources == null) {
@@ -39,7 +39,7 @@ public final class CompletableAmb extends Completable {
             try {
                 for (CompletableSource element : sourcesIterable) {
                     if (element == null) {
-                        EmptyDisposable.error(new NullPointerException("One of the sources is null"), s);
+                        EmptyDisposable.error(new NullPointerException("One of the sources is null"), observer);
                         return;
                     }
                     if (count == sources.length) {
@@ -51,7 +51,7 @@ public final class CompletableAmb extends Completable {
                 }
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                EmptyDisposable.error(e, s);
+                EmptyDisposable.error(e, observer);
                 return;
             }
         } else {
@@ -59,11 +59,11 @@ public final class CompletableAmb extends Completable {
         }
 
         final CompositeDisposable set = new CompositeDisposable();
-        s.onSubscribe(set);
+        observer.onSubscribe(set);
 
         final AtomicBoolean once = new AtomicBoolean();
 
-        CompletableObserver inner = new Amb(once, set, s);
+        CompletableObserver inner = new Amb(once, set, observer);
 
         for (int i = 0; i < count; i++) {
             CompletableSource c = sources[i];
@@ -74,7 +74,7 @@ public final class CompletableAmb extends Completable {
                 NullPointerException npe = new NullPointerException("One of the sources is null");
                 if (once.compareAndSet(false, true)) {
                     set.dispose();
-                    s.onError(npe);
+                    observer.onError(npe);
                 } else {
                     RxJavaPlugins.onError(npe);
                 }
@@ -86,26 +86,26 @@ public final class CompletableAmb extends Completable {
         }
 
         if (count == 0) {
-            s.onComplete();
+            observer.onComplete();
         }
     }
 
     static final class Amb implements CompletableObserver {
         private final AtomicBoolean once;
         private final CompositeDisposable set;
-        private final CompletableObserver s;
+        private final CompletableObserver downstream;
 
-        Amb(AtomicBoolean once, CompositeDisposable set, CompletableObserver s) {
+        Amb(AtomicBoolean once, CompositeDisposable set, CompletableObserver observer) {
             this.once = once;
             this.set = set;
-            this.s = s;
+            this.downstream = observer;
         }
 
         @Override
         public void onComplete() {
             if (once.compareAndSet(false, true)) {
                 set.dispose();
-                s.onComplete();
+                downstream.onComplete();
             }
         }
 
@@ -113,7 +113,7 @@ public final class CompletableAmb extends Completable {
         public void onError(Throwable e) {
             if (once.compareAndSet(false, true)) {
                 set.dispose();
-                s.onError(e);
+                downstream.onError(e);
             } else {
                 RxJavaPlugins.onError(e);
             }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableCache.java
@@ -44,9 +44,9 @@ public final class CompletableCache extends Completable implements CompletableOb
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        InnerCompletableCache inner = new InnerCompletableCache(s);
-        s.onSubscribe(inner);
+    protected void subscribeActual(CompletableObserver observer) {
+        InnerCompletableCache inner = new InnerCompletableCache(observer);
+        observer.onSubscribe(inner);
 
         if (add(inner)) {
             if (inner.isDisposed()) {
@@ -59,9 +59,9 @@ public final class CompletableCache extends Completable implements CompletableOb
         } else {
             Throwable ex = error;
             if (ex != null) {
-                s.onError(ex);
+                observer.onError(ex);
             } else {
-                s.onComplete();
+                observer.onComplete();
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcat.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcat.java
@@ -36,8 +36,8 @@ public final class CompletableConcat extends Completable {
     }
 
     @Override
-    public void subscribeActual(CompletableObserver s) {
-        sources.subscribe(new CompletableConcatSubscriber(s, prefetch));
+    public void subscribeActual(CompletableObserver observer) {
+        sources.subscribe(new CompletableConcatSubscriber(observer, prefetch));
     }
 
     static final class CompletableConcatSubscriber

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatArray.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatArray.java
@@ -27,9 +27,9 @@ public final class CompletableConcatArray extends Completable {
     }
 
     @Override
-    public void subscribeActual(CompletableObserver s) {
-        ConcatInnerObserver inner = new ConcatInnerObserver(s, sources);
-        s.onSubscribe(inner.sd);
+    public void subscribeActual(CompletableObserver observer) {
+        ConcatInnerObserver inner = new ConcatInnerObserver(observer, sources);
+        observer.onSubscribe(inner.sd);
         inner.next();
     }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableConcatIterable.java
@@ -30,7 +30,7 @@ public final class CompletableConcatIterable extends Completable {
     }
 
     @Override
-    public void subscribeActual(CompletableObserver s) {
+    public void subscribeActual(CompletableObserver observer) {
 
         Iterator<? extends CompletableSource> it;
 
@@ -38,12 +38,12 @@ public final class CompletableConcatIterable extends Completable {
             it = ObjectHelper.requireNonNull(sources.iterator(), "The iterator returned is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
-            EmptyDisposable.error(e, s);
+            EmptyDisposable.error(e, observer);
             return;
         }
 
-        ConcatInnerObserver inner = new ConcatInnerObserver(s, it);
-        s.onSubscribe(inner.sd);
+        ConcatInnerObserver inner = new ConcatInnerObserver(observer, it);
+        observer.onSubscribe(inner.sd);
         inner.next();
     }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableCreate.java
@@ -31,9 +31,9 @@ public final class CompletableCreate extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        Emitter parent = new Emitter(s);
-        s.onSubscribe(parent);
+    protected void subscribeActual(CompletableObserver observer) {
+        Emitter parent = new Emitter(observer);
+        observer.onSubscribe(parent);
 
         try {
             source.subscribe(parent);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDefer.java
@@ -29,18 +29,18 @@ public final class CompletableDefer extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
+    protected void subscribeActual(CompletableObserver observer) {
         CompletableSource c;
 
         try {
             c = ObjectHelper.requireNonNull(completableSupplier.call(), "The completableSupplier returned a null CompletableSource");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
-            EmptyDisposable.error(e, s);
+            EmptyDisposable.error(e, observer);
             return;
         }
 
-        c.subscribe(s);
+        c.subscribe(observer);
     }
 
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDelay.java
@@ -41,8 +41,8 @@ public final class CompletableDelay extends Completable {
     }
 
     @Override
-    protected void subscribeActual(final CompletableObserver s) {
-        source.subscribe(new Delay(s, delay, unit, scheduler, delayError));
+    protected void subscribeActual(final CompletableObserver observer) {
+        source.subscribe(new Delay(observer, delay, unit, scheduler, delayError));
     }
 
     static final class Delay extends AtomicReference<Disposable>

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDisposeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDisposeOn.java
@@ -30,12 +30,12 @@ public final class CompletableDisposeOn extends Completable {
     }
 
     @Override
-    protected void subscribeActual(final CompletableObserver s) {
-        source.subscribe(new CompletableObserverImplementation(s, scheduler));
+    protected void subscribeActual(final CompletableObserver observer) {
+        source.subscribe(new CompletableObserverImplementation(observer, scheduler));
     }
 
     static final class CompletableObserverImplementation implements CompletableObserver, Disposable, Runnable {
-        final CompletableObserver s;
+        final CompletableObserver downstream;
 
         final Scheduler scheduler;
 
@@ -43,8 +43,8 @@ public final class CompletableDisposeOn extends Completable {
 
         volatile boolean disposed;
 
-        CompletableObserverImplementation(CompletableObserver s, Scheduler scheduler) {
-            this.s = s;
+        CompletableObserverImplementation(CompletableObserver observer, Scheduler scheduler) {
+            this.downstream = observer;
             this.scheduler = scheduler;
         }
 
@@ -53,7 +53,7 @@ public final class CompletableDisposeOn extends Completable {
             if (disposed) {
                 return;
             }
-            s.onComplete();
+            downstream.onComplete();
         }
 
         @Override
@@ -62,7 +62,7 @@ public final class CompletableDisposeOn extends Completable {
                 RxJavaPlugins.onError(e);
                 return;
             }
-            s.onError(e);
+            downstream.onError(e);
         }
 
         @Override
@@ -70,7 +70,7 @@ public final class CompletableDisposeOn extends Completable {
             if (DisposableHelper.validate(this.d, d)) {
                 this.d = d;
 
-                s.onSubscribe(this);
+                downstream.onSubscribe(this);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDoFinally.java
@@ -39,8 +39,8 @@ public final class CompletableDoFinally extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        source.subscribe(new DoFinallyObserver(s, onFinally));
+    protected void subscribeActual(CompletableObserver observer) {
+        source.subscribe(new DoFinallyObserver(observer, onFinally));
     }
 
     static final class DoFinallyObserver extends AtomicInteger implements CompletableObserver, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDoOnEvent.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDoOnEvent.java
@@ -31,8 +31,8 @@ public final class CompletableDoOnEvent extends Completable {
     }
 
     @Override
-    protected void subscribeActual(final CompletableObserver s) {
-        source.subscribe(new DoOnEvent(s));
+    protected void subscribeActual(final CompletableObserver observer) {
+        source.subscribe(new DoOnEvent(observer));
     }
 
     final class DoOnEvent implements CompletableObserver {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableEmpty.java
@@ -23,7 +23,7 @@ public final class CompletableEmpty extends Completable {
     }
 
     @Override
-    public void subscribeActual(CompletableObserver s) {
-        EmptyDisposable.complete(s);
+    public void subscribeActual(CompletableObserver observer) {
+        EmptyDisposable.complete(observer);
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableError.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableError.java
@@ -25,7 +25,7 @@ public final class CompletableError extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        EmptyDisposable.error(error, s);
+    protected void subscribeActual(CompletableObserver observer) {
+        EmptyDisposable.error(error, observer);
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableErrorSupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableErrorSupplier.java
@@ -29,7 +29,7 @@ public final class CompletableErrorSupplier extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
+    protected void subscribeActual(CompletableObserver observer) {
         Throwable error;
 
         try {
@@ -39,7 +39,7 @@ public final class CompletableErrorSupplier extends Completable {
             error = e;
         }
 
-        EmptyDisposable.error(error, s);
+        EmptyDisposable.error(error, observer);
     }
 
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromAction.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromAction.java
@@ -27,20 +27,20 @@ public final class CompletableFromAction extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
+    protected void subscribeActual(CompletableObserver observer) {
         Disposable d = Disposables.empty();
-        s.onSubscribe(d);
+        observer.onSubscribe(d);
         try {
             run.run();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
-                s.onError(e);
+                observer.onError(e);
             }
             return;
         }
         if (!d.isDisposed()) {
-            s.onComplete();
+            observer.onComplete();
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromCallable.java
@@ -28,20 +28,20 @@ public final class CompletableFromCallable extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
+    protected void subscribeActual(CompletableObserver observer) {
         Disposable d = Disposables.empty();
-        s.onSubscribe(d);
+        observer.onSubscribe(d);
         try {
             callable.call();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
-                s.onError(e);
+                observer.onError(e);
             }
             return;
         }
         if (!d.isDisposed()) {
-            s.onComplete();
+            observer.onComplete();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromObservable.java
@@ -25,8 +25,8 @@ public final class CompletableFromObservable<T> extends Completable {
     }
 
     @Override
-    protected void subscribeActual(final CompletableObserver s) {
-        observable.subscribe(new CompletableFromObservableObserver<T>(s));
+    protected void subscribeActual(final CompletableObserver observer) {
+        observable.subscribe(new CompletableFromObservableObserver<T>(observer));
     }
 
     static final class CompletableFromObservableObserver<T> implements Observer<T> {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromRunnable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromRunnable.java
@@ -28,20 +28,20 @@ public final class CompletableFromRunnable extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
+    protected void subscribeActual(CompletableObserver observer) {
         Disposable d = Disposables.empty();
-        s.onSubscribe(d);
+        observer.onSubscribe(d);
         try {
             runnable.run();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
-                s.onError(e);
+                observer.onError(e);
             }
             return;
         }
         if (!d.isDisposed()) {
-            s.onComplete();
+            observer.onComplete();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromSingle.java
@@ -25,8 +25,8 @@ public final class CompletableFromSingle<T> extends Completable {
     }
 
     @Override
-    protected void subscribeActual(final CompletableObserver s) {
-        single.subscribe(new CompletableFromSingleObserver<T>(s));
+    protected void subscribeActual(final CompletableObserver observer) {
+        single.subscribe(new CompletableFromSingleObserver<T>(observer));
     }
 
     static final class CompletableFromSingleObserver<T> implements SingleObserver<T> {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableLift.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableLift.java
@@ -29,11 +29,11 @@ public final class CompletableLift extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
+    protected void subscribeActual(CompletableObserver observer) {
         try {
             // TODO plugin wrapping
 
-            CompletableObserver sw = onLift.apply(s);
+            CompletableObserver sw = onLift.apply(observer);
 
             source.subscribe(sw);
         } catch (NullPointerException ex) { // NOPMD

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMerge.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMerge.java
@@ -36,8 +36,8 @@ public final class CompletableMerge extends Completable {
     }
 
     @Override
-    public void subscribeActual(CompletableObserver s) {
-        CompletableMergeSubscriber parent = new CompletableMergeSubscriber(s, maxConcurrency, delayErrors);
+    public void subscribeActual(CompletableObserver observer) {
+        CompletableMergeSubscriber parent = new CompletableMergeSubscriber(observer, maxConcurrency, delayErrors);
         source.subscribe(parent);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeArray.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeArray.java
@@ -27,12 +27,12 @@ public final class CompletableMergeArray extends Completable {
     }
 
     @Override
-    public void subscribeActual(final CompletableObserver s) {
+    public void subscribeActual(final CompletableObserver observer) {
         final CompositeDisposable set = new CompositeDisposable();
         final AtomicBoolean once = new AtomicBoolean();
 
-        InnerCompletableObserver shared = new InnerCompletableObserver(s, once, set, sources.length + 1);
-        s.onSubscribe(set);
+        InnerCompletableObserver shared = new InnerCompletableObserver(observer, once, set, sources.length + 1);
+        observer.onSubscribe(set);
 
         for (CompletableSource c : sources) {
             if (set.isDisposed()) {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorArray.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorArray.java
@@ -29,13 +29,13 @@ public final class CompletableMergeDelayErrorArray extends Completable {
     }
 
     @Override
-    public void subscribeActual(final CompletableObserver s) {
+    public void subscribeActual(final CompletableObserver observer) {
         final CompositeDisposable set = new CompositeDisposable();
         final AtomicInteger wip = new AtomicInteger(sources.length + 1);
 
         final AtomicThrowable error = new AtomicThrowable();
 
-        s.onSubscribe(set);
+        observer.onSubscribe(set);
 
         for (CompletableSource c : sources) {
             if (set.isDisposed()) {
@@ -49,15 +49,15 @@ public final class CompletableMergeDelayErrorArray extends Completable {
                 continue;
             }
 
-            c.subscribe(new MergeInnerCompletableObserver(s, set, error, wip));
+            c.subscribe(new MergeInnerCompletableObserver(observer, set, error, wip));
         }
 
         if (wip.decrementAndGet() == 0) {
             Throwable ex = error.terminate();
             if (ex == null) {
-                s.onComplete();
+                observer.onComplete();
             } else {
-                s.onError(ex);
+                observer.onError(ex);
             }
         }
     }
@@ -69,9 +69,9 @@ public final class CompletableMergeDelayErrorArray extends Completable {
         final AtomicThrowable error;
         final AtomicInteger wip;
 
-        MergeInnerCompletableObserver(CompletableObserver s, CompositeDisposable set, AtomicThrowable error,
+        MergeInnerCompletableObserver(CompletableObserver observer, CompositeDisposable set, AtomicThrowable error,
                 AtomicInteger wip) {
-            this.actual = s;
+            this.actual = observer;
             this.set = set;
             this.error = error;
             this.wip = wip;

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorIterable.java
@@ -32,10 +32,10 @@ public final class CompletableMergeDelayErrorIterable extends Completable {
     }
 
     @Override
-    public void subscribeActual(final CompletableObserver s) {
+    public void subscribeActual(final CompletableObserver observer) {
         final CompositeDisposable set = new CompositeDisposable();
 
-        s.onSubscribe(set);
+        observer.onSubscribe(set);
 
         Iterator<? extends CompletableSource> iterator;
 
@@ -43,7 +43,7 @@ public final class CompletableMergeDelayErrorIterable extends Completable {
             iterator = ObjectHelper.requireNonNull(sources.iterator(), "The source iterator returned is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
-            s.onError(e);
+            observer.onError(e);
             return;
         }
 
@@ -89,15 +89,15 @@ public final class CompletableMergeDelayErrorIterable extends Completable {
 
             wip.getAndIncrement();
 
-            c.subscribe(new MergeInnerCompletableObserver(s, set, error, wip));
+            c.subscribe(new MergeInnerCompletableObserver(observer, set, error, wip));
         }
 
         if (wip.decrementAndGet() == 0) {
             Throwable ex = error.terminate();
             if (ex == null) {
-                s.onComplete();
+                observer.onComplete();
             } else {
-                s.onError(ex);
+                observer.onError(ex);
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeIterable.java
@@ -30,10 +30,10 @@ public final class CompletableMergeIterable extends Completable {
     }
 
     @Override
-    public void subscribeActual(final CompletableObserver s) {
+    public void subscribeActual(final CompletableObserver observer) {
         final CompositeDisposable set = new CompositeDisposable();
 
-        s.onSubscribe(set);
+        observer.onSubscribe(set);
 
         Iterator<? extends CompletableSource> iterator;
 
@@ -41,13 +41,13 @@ public final class CompletableMergeIterable extends Completable {
             iterator = ObjectHelper.requireNonNull(sources.iterator(), "The source iterator returned is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
-            s.onError(e);
+            observer.onError(e);
             return;
         }
 
         final AtomicInteger wip = new AtomicInteger(1);
 
-        MergeCompletableObserver shared = new MergeCompletableObserver(s, set, wip);
+        MergeCompletableObserver shared = new MergeCompletableObserver(observer, set, wip);
         for (;;) {
             if (set.isDisposed()) {
                 return;

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableNever.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableNever.java
@@ -23,8 +23,8 @@ public final class CompletableNever extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        s.onSubscribe(EmptyDisposable.NEVER);
+    protected void subscribeActual(CompletableObserver observer) {
+        observer.onSubscribe(EmptyDisposable.NEVER);
     }
 
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableObserveOn.java
@@ -30,8 +30,8 @@ public final class CompletableObserveOn extends Completable {
     }
 
     @Override
-    protected void subscribeActual(final CompletableObserver s) {
-        source.subscribe(new ObserveOnCompletableObserver(s, scheduler));
+    protected void subscribeActual(final CompletableObserver observer) {
+        source.subscribe(new ObserveOnCompletableObserver(observer, scheduler));
     }
 
     static final class ObserveOnCompletableObserver

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableOnErrorComplete.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableOnErrorComplete.java
@@ -30,22 +30,22 @@ public final class CompletableOnErrorComplete extends Completable {
     }
 
     @Override
-    protected void subscribeActual(final CompletableObserver s) {
+    protected void subscribeActual(final CompletableObserver observer) {
 
-        source.subscribe(new OnError(s));
+        source.subscribe(new OnError(observer));
     }
 
     final class OnError implements CompletableObserver {
 
-        private final CompletableObserver s;
+        private final CompletableObserver downstream;
 
-        OnError(CompletableObserver s) {
-            this.s = s;
+        OnError(CompletableObserver observer) {
+            this.downstream = observer;
         }
 
         @Override
         public void onComplete() {
-            s.onComplete();
+            downstream.onComplete();
         }
 
         @Override
@@ -56,20 +56,20 @@ public final class CompletableOnErrorComplete extends Completable {
                 b = predicate.test(e);
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-                s.onError(new CompositeException(e, ex));
+                downstream.onError(new CompositeException(e, ex));
                 return;
             }
 
             if (b) {
-                s.onComplete();
+                downstream.onComplete();
             } else {
-                s.onError(e);
+                downstream.onError(e);
             }
         }
 
         @Override
         public void onSubscribe(Disposable d) {
-            s.onSubscribe(d);
+            downstream.onSubscribe(d);
         }
 
     }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
@@ -46,9 +46,9 @@ public final class CompletablePeek extends Completable {
     }
 
     @Override
-    protected void subscribeActual(final CompletableObserver s) {
+    protected void subscribeActual(final CompletableObserver observer) {
 
-        source.subscribe(new CompletableObserverImplementation(s));
+        source.subscribe(new CompletableObserverImplementation(observer));
     }
 
     final class CompletableObserverImplementation implements CompletableObserver, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
@@ -34,26 +34,26 @@ public final class CompletableResumeNext extends Completable {
 
 
     @Override
-    protected void subscribeActual(final CompletableObserver s) {
+    protected void subscribeActual(final CompletableObserver observer) {
 
         final SequentialDisposable sd = new SequentialDisposable();
-        s.onSubscribe(sd);
-        source.subscribe(new ResumeNext(s, sd));
+        observer.onSubscribe(sd);
+        source.subscribe(new ResumeNext(observer, sd));
     }
 
     final class ResumeNext implements CompletableObserver {
 
-        final CompletableObserver s;
+        final CompletableObserver downstream;
         final SequentialDisposable sd;
 
-        ResumeNext(CompletableObserver s, SequentialDisposable sd) {
-            this.s = s;
+        ResumeNext(CompletableObserver observer, SequentialDisposable sd) {
+            this.downstream = observer;
             this.sd = sd;
         }
 
         @Override
         public void onComplete() {
-            s.onComplete();
+            downstream.onComplete();
         }
 
         @Override
@@ -64,14 +64,14 @@ public final class CompletableResumeNext extends Completable {
                 c = errorMapper.apply(e);
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-                s.onError(new CompositeException(ex, e));
+                downstream.onError(new CompositeException(ex, e));
                 return;
             }
 
             if (c == null) {
                 NullPointerException npe = new NullPointerException("The CompletableConsumable returned is null");
                 npe.initCause(e);
-                s.onError(npe);
+                downstream.onError(npe);
                 return;
             }
 
@@ -87,12 +87,12 @@ public final class CompletableResumeNext extends Completable {
 
             @Override
             public void onComplete() {
-                s.onComplete();
+                downstream.onComplete();
             }
 
             @Override
             public void onError(Throwable e) {
-                s.onError(e);
+                downstream.onError(e);
             }
 
             @Override

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableSubscribeOn.java
@@ -30,10 +30,10 @@ public final class CompletableSubscribeOn extends Completable {
     }
 
     @Override
-    protected void subscribeActual(final CompletableObserver s) {
+    protected void subscribeActual(final CompletableObserver observer) {
 
-        final SubscribeOnObserver parent = new SubscribeOnObserver(s, source);
-        s.onSubscribe(parent);
+        final SubscribeOnObserver parent = new SubscribeOnObserver(observer, source);
+        observer.onSubscribe(parent);
 
         Disposable f = scheduler.scheduleDirect(parent);
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableTakeUntilCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableTakeUntilCompletable.java
@@ -38,9 +38,9 @@ public final class CompletableTakeUntilCompletable extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        TakeUntilMainObserver parent = new TakeUntilMainObserver(s);
-        s.onSubscribe(parent);
+    protected void subscribeActual(CompletableObserver observer) {
+        TakeUntilMainObserver parent = new TakeUntilMainObserver(observer);
+        observer.onSubscribe(parent);
 
         other.subscribe(parent.other);
         source.subscribe(parent);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableTimer.java
@@ -36,9 +36,9 @@ public final class CompletableTimer extends Completable {
     }
 
     @Override
-    protected void subscribeActual(final CompletableObserver s) {
-        TimerDisposable parent = new TimerDisposable(s);
-        s.onSubscribe(parent);
+    protected void subscribeActual(final CompletableObserver observer) {
+        TimerDisposable parent = new TimerDisposable(observer);
+        observer.onSubscribe(parent);
         parent.setFuture(scheduler.scheduleDirect(parent, delay, unit));
     }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableToSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableToSingle.java
@@ -34,8 +34,8 @@ public final class CompletableToSingle<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
-        source.subscribe(new ToSingle(s));
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
+        source.subscribe(new ToSingle(observer));
     }
 
     final class ToSingle implements CompletableObserver {

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableNext.java
@@ -48,7 +48,7 @@ public final class BlockingFlowableNext<T> implements Iterable<T> {
     // test needs to access the observer.waiting flag
     static final class NextIterator<T> implements Iterator<T> {
 
-        private final NextSubscriber<T> observer;
+        private final NextSubscriber<T> subscriber;
         private final Publisher<? extends T> items;
         private T next;
         private boolean hasNext = true;
@@ -56,9 +56,9 @@ public final class BlockingFlowableNext<T> implements Iterable<T> {
         private Throwable error;
         private boolean started;
 
-        NextIterator(Publisher<? extends T> items, NextSubscriber<T> observer) {
+        NextIterator(Publisher<? extends T> items, NextSubscriber<T> subscriber) {
             this.items = items;
-            this.observer = observer;
+            this.subscriber = subscriber;
         }
 
         @Override
@@ -82,12 +82,12 @@ public final class BlockingFlowableNext<T> implements Iterable<T> {
                 if (!started) {
                     started = true;
                     // if not started, start now
-                    observer.setWaiting();
+                    subscriber.setWaiting();
                     Flowable.<T>fromPublisher(items)
-                    .materialize().subscribe(observer);
+                    .materialize().subscribe(subscriber);
                 }
 
-                Notification<T> nextNotification = observer.takeNext();
+                Notification<T> nextNotification = subscriber.takeNext();
                 if (nextNotification.isOnNext()) {
                     isNextConsumed = false;
                     next = nextNotification.getValue();
@@ -105,7 +105,7 @@ public final class BlockingFlowableNext<T> implements Iterable<T> {
                 }
                 throw new IllegalStateException("Should not reach here");
             } catch (InterruptedException e) {
-                observer.dispose();
+                subscriber.dispose();
                 error = e;
                 throw ExceptionHelper.wrapOrThrow(e);
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAllSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAllSingle.java
@@ -34,8 +34,8 @@ public final class FlowableAllSingle<T> extends Single<Boolean> implements FuseT
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super Boolean> s) {
-        source.subscribe(new AllSubscriber<T>(s, predicate));
+    protected void subscribeActual(SingleObserver<? super Boolean> observer) {
+        source.subscribe(new AllSubscriber<T>(observer, predicate));
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAnySingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAnySingle.java
@@ -33,8 +33,8 @@ public final class FlowableAnySingle<T> extends Single<Boolean> implements FuseT
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super Boolean> s) {
-        source.subscribe(new AnySubscriber<T>(s, predicate));
+    protected void subscribeActual(SingleObserver<? super Boolean> observer) {
+        source.subscribe(new AnySubscriber<T>(observer, predicate));
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollectSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollectSingle.java
@@ -40,16 +40,16 @@ public final class FlowableCollectSingle<T, U> extends Single<U> implements Fuse
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super U> s) {
+    protected void subscribeActual(SingleObserver<? super U> observer) {
         U u;
         try {
             u = ObjectHelper.requireNonNull(initialSupplier.call(), "The initialSupplier returned a null value");
         } catch (Throwable e) {
-            EmptyDisposable.error(e, s);
+            EmptyDisposable.error(e, observer);
             return;
         }
 
-        source.subscribe(new CollectSubscriber<T, U>(s, u, collector));
+        source.subscribe(new CollectSubscriber<T, U>(observer, u, collector));
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCountSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCountSingle.java
@@ -30,8 +30,8 @@ public final class FlowableCountSingle<T> extends Single<Long> implements FuseTo
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super Long> s) {
-        source.subscribe(new CountSubscriber(s));
+    protected void subscribeActual(SingleObserver<? super Long> observer) {
+        source.subscribe(new CountSubscriber(observer));
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -41,18 +41,18 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
     }
 
     @Override
-    protected void subscribeActual(Subscriber<? super T> observer) {
+    protected void subscribeActual(Subscriber<? super T> subscriber) {
         Collection<? super K> collection;
 
         try {
             collection = ObjectHelper.requireNonNull(collectionSupplier.call(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
-            EmptySubscription.error(ex, observer);
+            EmptySubscription.error(ex, subscriber);
             return;
         }
 
-        source.subscribe(new DistinctSubscriber<T, K>(observer, keySelector, collection));
+        source.subscribe(new DistinctSubscriber<T, K>(subscriber, keySelector, collection));
     }
 
     static final class DistinctSubscriber<T, K> extends BasicFuseableSubscriber<T, T> {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtMaybe.java
@@ -32,8 +32,8 @@ public final class FlowableElementAtMaybe<T> extends Maybe<T> implements FuseToF
     }
 
     @Override
-    protected void subscribeActual(MaybeObserver<? super T> s) {
-        source.subscribe(new ElementAtSubscriber<T>(s, index));
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new ElementAtSubscriber<T>(observer, index));
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtSingle.java
@@ -37,8 +37,8 @@ public final class FlowableElementAtSingle<T> extends Single<T> implements FuseT
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> s) {
-        source.subscribe(new ElementAtSubscriber<T>(s, index, defaultValue));
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        source.subscribe(new ElementAtSubscriber<T>(observer, index, defaultValue));
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletable.java
@@ -50,8 +50,8 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
     }
 
     @Override
-    protected void subscribeActual(Subscriber<? super T> observer) {
-        source.subscribe(new FlatMapCompletableMainSubscriber<T>(observer, mapper, delayErrors, maxConcurrency));
+    protected void subscribeActual(Subscriber<? super T> subscriber) {
+        source.subscribe(new FlatMapCompletableMainSubscriber<T>(subscriber, mapper, delayErrors, maxConcurrency));
     }
 
     static final class FlatMapCompletableMainSubscriber<T> extends BasicIntQueueSubscription<T>
@@ -74,10 +74,10 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
 
         volatile boolean cancelled;
 
-        FlatMapCompletableMainSubscriber(Subscriber<? super T> observer,
+        FlatMapCompletableMainSubscriber(Subscriber<? super T> subscriber,
                 Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors,
                 int maxConcurrency) {
-            this.actual = observer;
+            this.actual = subscriber;
             this.mapper = mapper;
             this.delayErrors = delayErrors;
             this.errors = new AtomicThrowable();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletable.java
@@ -40,9 +40,9 @@ public final class FlowableMergeWithCompletable<T> extends AbstractFlowableWithU
     }
 
     @Override
-    protected void subscribeActual(Subscriber<? super T> observer) {
-        MergeWithSubscriber<T> parent = new MergeWithSubscriber<T>(observer);
-        observer.onSubscribe(parent);
+    protected void subscribeActual(Subscriber<? super T> subscriber) {
+        MergeWithSubscriber<T> parent = new MergeWithSubscriber<T>(subscriber);
+        subscriber.onSubscribe(parent);
         source.subscribe(parent);
         other.subscribe(parent.otherObserver);
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
@@ -43,9 +43,9 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
     }
 
     @Override
-    protected void subscribeActual(Subscriber<? super T> observer) {
-        MergeWithObserver<T> parent = new MergeWithObserver<T>(observer);
-        observer.onSubscribe(parent);
+    protected void subscribeActual(Subscriber<? super T> subscriber) {
+        MergeWithObserver<T> parent = new MergeWithObserver<T>(subscriber);
+        subscriber.onSubscribe(parent);
         source.subscribe(parent);
         other.subscribe(parent.otherObserver);
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingle.java
@@ -43,9 +43,9 @@ public final class FlowableMergeWithSingle<T> extends AbstractFlowableWithUpstre
     }
 
     @Override
-    protected void subscribeActual(Subscriber<? super T> observer) {
-        MergeWithObserver<T> parent = new MergeWithObserver<T>(observer);
-        observer.onSubscribe(parent);
+    protected void subscribeActual(Subscriber<? super T> subscriber) {
+        MergeWithObserver<T> parent = new MergeWithObserver<T>(subscriber);
+        subscriber.onSubscribe(parent);
         source.subscribe(parent);
         other.subscribe(parent.otherObserver);
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -69,8 +69,8 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      * @return the new ConnectableObservable instance
      */
     public static <T> ConnectableFlowable<T> observeOn(final ConnectableFlowable<T> cf, final Scheduler scheduler) {
-        final Flowable<T> observable = cf.observeOn(scheduler);
-        return RxJavaPlugins.onAssembly(new ConnectableFlowableReplay<T>(cf, observable));
+        final Flowable<T> flowable = cf.observeOn(scheduler);
+        return RxJavaPlugins.onAssembly(new ConnectableFlowableReplay<T>(cf, flowable));
     }
 
     /**
@@ -1141,11 +1141,11 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
 
     static final class ConnectableFlowableReplay<T> extends ConnectableFlowable<T> {
         private final ConnectableFlowable<T> cf;
-        private final Flowable<T> observable;
+        private final Flowable<T> flowable;
 
-        ConnectableFlowableReplay(ConnectableFlowable<T> cf, Flowable<T> observable) {
+        ConnectableFlowableReplay(ConnectableFlowable<T> cf, Flowable<T> flowable) {
             this.cf = cf;
-            this.observable = observable;
+            this.flowable = flowable;
         }
 
         @Override
@@ -1155,7 +1155,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
 
         @Override
         protected void subscribeActual(Subscriber<? super T> s) {
-            observable.subscribe(s);
+            flowable.subscribe(s);
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualSingle.java
@@ -42,9 +42,9 @@ public final class FlowableSequenceEqualSingle<T> extends Single<Boolean> implem
     }
 
     @Override
-    public void subscribeActual(SingleObserver<? super Boolean> s) {
-        EqualCoordinator<T> parent = new EqualCoordinator<T>(s, prefetch, comparer);
-        s.onSubscribe(parent);
+    public void subscribeActual(SingleObserver<? super Boolean> observer) {
+        EqualCoordinator<T> parent = new EqualCoordinator<T>(observer, prefetch, comparer);
+        observer.onSubscribe(parent);
         parent.subscribe(first, second);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleMaybe.java
@@ -30,8 +30,8 @@ public final class FlowableSingleMaybe<T> extends Maybe<T> implements FuseToFlow
     }
 
     @Override
-    protected void subscribeActual(MaybeObserver<? super T> s) {
-        source.subscribe(new SingleElementSubscriber<T>(s));
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new SingleElementSubscriber<T>(observer));
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSingleSingle.java
@@ -35,8 +35,8 @@ public final class FlowableSingleSingle<T> extends Single<T> implements FuseToFl
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> s) {
-        source.subscribe(new SingleElementSubscriber<T>(s, defaultValue));
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        source.subscribe(new SingleElementSubscriber<T>(observer, defaultValue));
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableToListSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableToListSingle.java
@@ -45,16 +45,16 @@ public final class FlowableToListSingle<T, U extends Collection<? super T>> exte
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super U> s) {
+    protected void subscribeActual(SingleObserver<? super U> observer) {
         U coll;
         try {
             coll = ObjectHelper.requireNonNull(collectionSupplier.call(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
-            EmptyDisposable.error(e, s);
+            EmptyDisposable.error(e, observer);
             return;
         }
-        source.subscribe(new ToListSubscriber<T, U>(s, coll));
+        source.subscribe(new ToListSubscriber<T, U>(observer, coll));
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeCreate.java
@@ -37,9 +37,9 @@ public final class MaybeCreate<T> extends Maybe<T> {
     }
 
     @Override
-    protected void subscribeActual(MaybeObserver<? super T> s) {
-        Emitter<T> parent = new Emitter<T>(s);
-        s.onSubscribe(parent);
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        Emitter<T> parent = new Emitter<T>(observer);
+        observer.onSubscribe(parent);
 
         try {
             source.subscribe(parent);

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDelayWithCompletable.java
@@ -34,8 +34,8 @@ public final class MaybeDelayWithCompletable<T> extends Maybe<T> {
     }
 
     @Override
-    protected void subscribeActual(MaybeObserver<? super T> subscriber) {
-        other.subscribe(new OtherObserver<T>(subscriber, source));
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        other.subscribe(new OtherObserver<T>(observer, source));
     }
 
     static final class OtherObserver<T>

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccess.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccess.java
@@ -36,8 +36,8 @@ public final class MaybeDoAfterSuccess<T> extends AbstractMaybeWithUpstream<T, T
     }
 
     @Override
-    protected void subscribeActual(MaybeObserver<? super T> s) {
-        source.subscribe(new DoAfterObserver<T>(s, onAfterSuccess));
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new DoAfterObserver<T>(observer, onAfterSuccess));
     }
 
     static final class DoAfterObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDoFinally.java
@@ -38,8 +38,8 @@ public final class MaybeDoFinally<T> extends AbstractMaybeWithUpstream<T, T> {
     }
 
     @Override
-    protected void subscribeActual(MaybeObserver<? super T> s) {
-        source.subscribe(new DoFinallyObserver<T>(s, onFinally));
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new DoFinallyObserver<T>(observer, onFinally));
     }
 
     static final class DoFinallyObserver<T> extends AtomicInteger implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapCompletable.java
@@ -38,9 +38,9 @@ public final class MaybeFlatMapCompletable<T> extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        FlatMapCompletableObserver<T> parent = new FlatMapCompletableObserver<T>(s, mapper);
-        s.onSubscribe(parent);
+    protected void subscribeActual(CompletableObserver observer) {
+        FlatMapCompletableObserver<T> parent = new FlatMapCompletableObserver<T>(observer, mapper);
+        observer.onSubscribe(parent);
         source.subscribe(parent);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservable.java
@@ -43,8 +43,8 @@ public final class MaybeFlatMapIterableObservable<T, R> extends Observable<R> {
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
-        source.subscribe(new FlatMapIterableObserver<T, R>(s, mapper));
+    protected void subscribeActual(Observer<? super R> observer) {
+        source.subscribe(new FlatMapIterableObserver<T, R>(observer, mapper));
     }
 
     static final class FlatMapIterableObserver<T, R>

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeToObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeToObservable.java
@@ -39,8 +39,8 @@ public final class MaybeToObservable<T> extends Observable<T> implements HasUpst
     }
 
     @Override
-    protected void subscribeActual(Observer<? super T> s) {
-        source.subscribe(create(s));
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(create(observer));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservable.java
@@ -39,9 +39,9 @@ public final class CompletableAndThenObservable<R> extends Observable<R> {
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
-        AndThenObservableObserver<R> parent = new AndThenObservableObserver<R>(s, other);
-        s.onSubscribe(parent);
+    protected void subscribeActual(Observer<? super R> observer) {
+        AndThenObservableObserver<R> parent = new AndThenObservableObserver<R>(observer, other);
+        observer.onSubscribe(parent);
         source.subscribe(parent);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletable.java
@@ -57,8 +57,8 @@ public final class FlowableConcatMapCompletable<T> extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        source.subscribe(new ConcatMapCompletableObserver<T>(s, mapper, errorMode, prefetch));
+    protected void subscribeActual(CompletableObserver observer) {
+        source.subscribe(new ConcatMapCompletableObserver<T>(observer, mapper, errorMode, prefetch));
     }
 
     static final class ConcatMapCompletableObserver<T>

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletable.java
@@ -51,8 +51,8 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        source.subscribe(new SwitchMapCompletableObserver<T>(s, mapper, delayErrors));
+    protected void subscribeActual(CompletableObserver observer) {
+        source.subscribe(new SwitchMapCompletableObserver<T>(observer, mapper, delayErrors));
     }
 
     static final class SwitchMapCompletableObserver<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/mixed/MaybeFlatMapObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/MaybeFlatMapObservable.java
@@ -43,9 +43,9 @@ public final class MaybeFlatMapObservable<T, R> extends Observable<R> {
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
-        FlatMapObserver<T, R> parent = new FlatMapObserver<T, R>(s, mapper);
-        s.onSubscribe(parent);
+    protected void subscribeActual(Observer<? super R> observer) {
+        FlatMapObserver<T, R> parent = new FlatMapObserver<T, R>(observer, mapper);
+        observer.onSubscribe(parent);
         source.subscribe(parent);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletable.java
@@ -54,9 +54,9 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        if (!ScalarXMapZHelper.tryAsCompletable(source, mapper, s)) {
-            source.subscribe(new ConcatMapCompletableObserver<T>(s, mapper, errorMode, prefetch));
+    protected void subscribeActual(CompletableObserver observer) {
+        if (!ScalarXMapZHelper.tryAsCompletable(source, mapper, observer)) {
+            source.subscribe(new ConcatMapCompletableObserver<T>(observer, mapper, errorMode, prefetch));
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybe.java
@@ -55,9 +55,9 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
-        if (!ScalarXMapZHelper.tryAsMaybe(source, mapper, s)) {
-            source.subscribe(new ConcatMapMaybeMainObserver<T, R>(s, mapper, prefetch, errorMode));
+    protected void subscribeActual(Observer<? super R> observer) {
+        if (!ScalarXMapZHelper.tryAsMaybe(source, mapper, observer)) {
+            source.subscribe(new ConcatMapMaybeMainObserver<T, R>(observer, mapper, prefetch, errorMode));
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingle.java
@@ -55,9 +55,9 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
-        if (!ScalarXMapZHelper.tryAsSingle(source, mapper, s)) {
-            source.subscribe(new ConcatMapSingleMainObserver<T, R>(s, mapper, prefetch, errorMode));
+    protected void subscribeActual(Observer<? super R> observer) {
+        if (!ScalarXMapZHelper.tryAsSingle(source, mapper, observer)) {
+            source.subscribe(new ConcatMapSingleMainObserver<T, R>(observer, mapper, prefetch, errorMode));
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletable.java
@@ -48,9 +48,9 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        if (!ScalarXMapZHelper.tryAsCompletable(source, mapper, s)) {
-            source.subscribe(new SwitchMapCompletableObserver<T>(s, mapper, delayErrors));
+    protected void subscribeActual(CompletableObserver observer) {
+        if (!ScalarXMapZHelper.tryAsCompletable(source, mapper, observer)) {
+            source.subscribe(new SwitchMapCompletableObserver<T>(observer, mapper, delayErrors));
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybe.java
@@ -50,9 +50,9 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
-        if (!ScalarXMapZHelper.tryAsMaybe(source, mapper, s)) {
-            source.subscribe(new SwitchMapMaybeMainObserver<T, R>(s, mapper, delayErrors));
+    protected void subscribeActual(Observer<? super R> observer) {
+        if (!ScalarXMapZHelper.tryAsMaybe(source, mapper, observer)) {
+            source.subscribe(new SwitchMapMaybeMainObserver<T, R>(observer, mapper, delayErrors));
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingle.java
@@ -50,9 +50,9 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
-        if (!ScalarXMapZHelper.tryAsSingle(source, mapper, s)) {
-            source.subscribe(new SwitchMapSingleMainObserver<T, R>(s, mapper, delayErrors));
+    protected void subscribeActual(Observer<? super R> observer) {
+        if (!ScalarXMapZHelper.tryAsSingle(source, mapper, observer)) {
+            source.subscribe(new SwitchMapSingleMainObserver<T, R>(observer, mapper, delayErrors));
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/SingleFlatMapObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/SingleFlatMapObservable.java
@@ -43,9 +43,9 @@ public final class SingleFlatMapObservable<T, R> extends Observable<R> {
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
-        FlatMapObserver<T, R> parent = new FlatMapObserver<T, R>(s, mapper);
-        s.onSubscribe(parent);
+    protected void subscribeActual(Observer<? super R> observer) {
+        FlatMapObserver<T, R> parent = new FlatMapObserver<T, R>(observer, mapper);
+        observer.onSubscribe(parent);
         source.subscribe(parent);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAmb.java
@@ -32,7 +32,7 @@ public final class ObservableAmb<T> extends Observable<T> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void subscribeActual(Observer<? super T> s) {
+    public void subscribeActual(Observer<? super T> observer) {
         ObservableSource<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
@@ -40,7 +40,7 @@ public final class ObservableAmb<T> extends Observable<T> {
             try {
                 for (ObservableSource<? extends T> p : sourcesIterable) {
                     if (p == null) {
-                        EmptyDisposable.error(new NullPointerException("One of the sources is null"), s);
+                        EmptyDisposable.error(new NullPointerException("One of the sources is null"), observer);
                         return;
                     }
                     if (count == sources.length) {
@@ -52,7 +52,7 @@ public final class ObservableAmb<T> extends Observable<T> {
                 }
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                EmptyDisposable.error(e, s);
+                EmptyDisposable.error(e, observer);
                 return;
             }
         } else {
@@ -60,15 +60,15 @@ public final class ObservableAmb<T> extends Observable<T> {
         }
 
         if (count == 0) {
-            EmptyDisposable.complete(s);
+            EmptyDisposable.complete(observer);
             return;
         } else
         if (count == 1) {
-            sources[0].subscribe(s);
+            sources[0].subscribe(observer);
             return;
         }
 
-        AmbCoordinator<T> ac = new AmbCoordinator<T>(s, count);
+        AmbCoordinator<T> ac = new AmbCoordinator<T>(observer, count);
         ac.subscribe(sources);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
@@ -46,7 +46,7 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void subscribeActual(Observer<? super R> s) {
+    public void subscribeActual(Observer<? super R> observer) {
         ObservableSource<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
@@ -64,11 +64,11 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
         }
 
         if (count == 0) {
-            EmptyDisposable.complete(s);
+            EmptyDisposable.complete(observer);
             return;
         }
 
-        LatestCoordinator<T, R> lc = new LatestCoordinator<T, R>(s, combiner, count, bufferSize, delayError);
+        LatestCoordinator<T, R> lc = new LatestCoordinator<T, R>(observer, combiner, count, bufferSize, delayError);
         lc.subscribe(sources);
     }
 
@@ -136,8 +136,8 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
         }
 
         void cancelSources() {
-            for (CombinerObserver<T, R> s : observers) {
-                s.dispose();
+            for (CombinerObserver<T, R> observer : observers) {
+                observer.dispose();
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
@@ -41,17 +41,17 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
         this.bufferSize = Math.max(8, bufferSize);
     }
     @Override
-    public void subscribeActual(Observer<? super U> s) {
+    public void subscribeActual(Observer<? super U> observer) {
 
-        if (ObservableScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
+        if (ObservableScalarXMap.tryScalarXMapSubscribe(source, observer, mapper)) {
             return;
         }
 
         if (delayErrors == ErrorMode.IMMEDIATE) {
-            SerializedObserver<U> serial = new SerializedObserver<U>(s);
+            SerializedObserver<U> serial = new SerializedObserver<U>(observer);
             source.subscribe(new SourceObserver<T, U>(serial, mapper, bufferSize));
         } else {
-            source.subscribe(new ConcatMapDelayErrorObserver<T, U>(s, mapper, bufferSize, delayErrors == ErrorMode.END));
+            source.subscribe(new ConcatMapDelayErrorObserver<T, U>(observer, mapper, bufferSize, delayErrors == ErrorMode.END));
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDefer.java
@@ -26,16 +26,16 @@ public final class ObservableDefer<T> extends Observable<T> {
         this.supplier = supplier;
     }
     @Override
-    public void subscribeActual(Observer<? super T> s) {
+    public void subscribeActual(Observer<? super T> observer) {
         ObservableSource<? extends T> pub;
         try {
             pub = ObjectHelper.requireNonNull(supplier.call(), "null ObservableSource supplied");
         } catch (Throwable t) {
             Exceptions.throwIfFatal(t);
-            EmptyDisposable.error(t, s);
+            EmptyDisposable.error(t, observer);
             return;
         }
 
-        pub.subscribe(s);
+        pub.subscribe(observer);
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDelay.java
@@ -38,16 +38,16 @@ public final class ObservableDelay<T> extends AbstractObservableWithUpstream<T, 
     @Override
     @SuppressWarnings("unchecked")
     public void subscribeActual(Observer<? super T> t) {
-        Observer<T> s;
+        Observer<T> observer;
         if (delayError) {
-            s = (Observer<T>)t;
+            observer = (Observer<T>)t;
         } else {
-            s = new SerializedObserver<T>(t);
+            observer = new SerializedObserver<T>(t);
         }
 
         Scheduler.Worker w = scheduler.createWorker();
 
-        source.subscribe(new DelayObserver<T>(s, delay, unit, w, delayError));
+        source.subscribe(new DelayObserver<T>(observer, delay, unit, w, delayError));
     }
 
     static final class DelayObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDetach.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDetach.java
@@ -31,8 +31,8 @@ public final class ObservableDetach<T> extends AbstractObservableWithUpstream<T,
     }
 
     @Override
-    protected void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new DetachObserver<T>(s));
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new DetachObserver<T>(observer));
     }
 
     static final class DetachObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
@@ -31,8 +31,8 @@ public final class ObservableDistinctUntilChanged<T, K> extends AbstractObservab
     }
 
     @Override
-    protected void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new DistinctUntilChangedObserver<T, K>(s, keySelector, comparer));
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new DistinctUntilChangedObserver<T, K>(observer, keySelector, comparer));
     }
 
     static final class DistinctUntilChangedObserver<T, K> extends BasicFuseableObserver<T, T> {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
@@ -34,8 +34,8 @@ public final class ObservableDoAfterNext<T> extends AbstractObservableWithUpstre
     }
 
     @Override
-    protected void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new DoAfterObserver<T>(s, onAfterNext));
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new DoAfterObserver<T>(observer, onAfterNext));
     }
 
     static final class DoAfterObserver<T> extends BasicFuseableObserver<T, T> {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
@@ -39,8 +39,8 @@ public final class ObservableDoFinally<T> extends AbstractObservableWithUpstream
     }
 
     @Override
-    protected void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new DoFinallyObserver<T>(s, onFinally));
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new DoFinallyObserver<T>(observer, onFinally));
     }
 
     static final class DoFinallyObserver<T> extends BasicIntQueueDisposable<T> implements Observer<T> {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableError.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableError.java
@@ -26,7 +26,7 @@ public final class ObservableError<T> extends Observable<T> {
         this.errorSupplier = errorSupplier;
     }
     @Override
-    public void subscribeActual(Observer<? super T> s) {
+    public void subscribeActual(Observer<? super T> observer) {
         Throwable error;
         try {
             error = ObjectHelper.requireNonNull(errorSupplier.call(), "Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
@@ -34,6 +34,6 @@ public final class ObservableError<T> extends Observable<T> {
             Exceptions.throwIfFatal(t);
             error = t;
         }
-        EmptyDisposable.error(error, s);
+        EmptyDisposable.error(error, observer);
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
@@ -26,8 +26,8 @@ public final class ObservableFilter<T> extends AbstractObservableWithUpstream<T,
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new FilterObserver<T>(s, predicate));
+    public void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new FilterObserver<T>(observer, predicate));
     }
 
     static final class FilterObserver<T> extends BasicFuseableObserver<T, T> {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
@@ -44,8 +44,8 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
-        source.subscribe(new FlatMapMaybeObserver<T, R>(s, mapper, delayErrors));
+    protected void subscribeActual(Observer<? super R> observer) {
+        source.subscribe(new FlatMapMaybeObserver<T, R>(observer, mapper, delayErrors));
     }
 
     static final class FlatMapMaybeObserver<T, R>

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
@@ -44,8 +44,8 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
-        source.subscribe(new FlatMapSingleObserver<T, R>(s, mapper, delayErrors));
+    protected void subscribeActual(Observer<? super R> observer) {
+        source.subscribe(new FlatMapSingleObserver<T, R>(observer, mapper, delayErrors));
     }
 
     static final class FlatMapSingleObserver<T, R>

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
@@ -24,10 +24,10 @@ public final class ObservableFromArray<T> extends Observable<T> {
         this.array = array;
     }
     @Override
-    public void subscribeActual(Observer<? super T> s) {
-        FromArrayDisposable<T> d = new FromArrayDisposable<T>(s, array);
+    public void subscribeActual(Observer<? super T> observer) {
+        FromArrayDisposable<T> d = new FromArrayDisposable<T>(observer, array);
 
-        s.onSubscribe(d);
+        observer.onSubscribe(d);
 
         if (d.fusionMode) {
             return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromCallable.java
@@ -31,9 +31,9 @@ public final class ObservableFromCallable<T> extends Observable<T> implements Ca
         this.callable = callable;
     }
     @Override
-    public void subscribeActual(Observer<? super T> s) {
-        DeferredScalarDisposable<T> d = new DeferredScalarDisposable<T>(s);
-        s.onSubscribe(d);
+    public void subscribeActual(Observer<? super T> observer) {
+        DeferredScalarDisposable<T> d = new DeferredScalarDisposable<T>(observer);
+        observer.onSubscribe(d);
         if (d.isDisposed()) {
             return;
         }
@@ -43,7 +43,7 @@ public final class ObservableFromCallable<T> extends Observable<T> implements Ca
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
-                s.onError(e);
+                observer.onError(e);
             } else {
                 RxJavaPlugins.onError(e);
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromFuture.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromFuture.java
@@ -32,9 +32,9 @@ public final class ObservableFromFuture<T> extends Observable<T> {
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
-        DeferredScalarDisposable<T> d = new DeferredScalarDisposable<T>(s);
-        s.onSubscribe(d);
+    public void subscribeActual(Observer<? super T> observer) {
+        DeferredScalarDisposable<T> d = new DeferredScalarDisposable<T>(observer);
+        observer.onSubscribe(d);
         if (!d.isDisposed()) {
             T v;
             try {
@@ -42,7 +42,7 @@ public final class ObservableFromFuture<T> extends Observable<T> {
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 if (!d.isDisposed()) {
-                    s.onError(ex);
+                    observer.onError(ex);
                 }
                 return;
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromIterable.java
@@ -29,13 +29,13 @@ public final class ObservableFromIterable<T> extends Observable<T> {
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
+    public void subscribeActual(Observer<? super T> observer) {
         Iterator<? extends T> it;
         try {
             it = source.iterator();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
-            EmptyDisposable.error(e, s);
+            EmptyDisposable.error(e, observer);
             return;
         }
         boolean hasNext;
@@ -43,16 +43,16 @@ public final class ObservableFromIterable<T> extends Observable<T> {
             hasNext = it.hasNext();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
-            EmptyDisposable.error(e, s);
+            EmptyDisposable.error(e, observer);
             return;
         }
         if (!hasNext) {
-            EmptyDisposable.complete(s);
+            EmptyDisposable.complete(observer);
             return;
         }
 
-        FromIterableDisposable<T> d = new FromIterableDisposable<T>(s, it);
-        s.onSubscribe(d);
+        FromIterableDisposable<T> d = new FromIterableDisposable<T>(observer, it);
+        observer.onSubscribe(d);
 
         if (!d.fusionMode) {
             d.run();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
@@ -35,19 +35,19 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
+    public void subscribeActual(Observer<? super T> observer) {
         S state;
 
         try {
             state = stateSupplier.call();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
-            EmptyDisposable.error(e, s);
+            EmptyDisposable.error(e, observer);
             return;
         }
 
-        GeneratorDisposable<T, S> gd = new GeneratorDisposable<T, S>(s, generator, disposeState, state);
-        s.onSubscribe(gd);
+        GeneratorDisposable<T, S> gd = new GeneratorDisposable<T, S>(observer, generator, disposeState, state);
+        observer.onSubscribe(gd);
         gd.run();
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupBy.java
@@ -247,17 +247,17 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
         }
 
         @Override
-        public void subscribe(Observer<? super T> s) {
+        public void subscribe(Observer<? super T> observer) {
             if (once.compareAndSet(false, true)) {
-                s.onSubscribe(this);
-                actual.lazySet(s);
+                observer.onSubscribe(this);
+                actual.lazySet(observer);
                 if (cancelled.get()) {
                     actual.lazySet(null);
                 } else {
                     drain();
                 }
             } else {
-                EmptyDisposable.error(new IllegalStateException("Only one Observer allowed!"), s);
+                EmptyDisposable.error(new IllegalStateException("Only one Observer allowed!"), observer);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGroupJoin.java
@@ -56,12 +56,12 @@ public final class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> ex
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
+    protected void subscribeActual(Observer<? super R> observer) {
 
         GroupJoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R> parent =
-                new GroupJoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R>(s, leftEnd, rightEnd, resultSelector);
+                new GroupJoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R>(observer, leftEnd, rightEnd, resultSelector);
 
-        s.onSubscribe(parent);
+        observer.onSubscribe(parent);
 
         LeftRightObserver left = new LeftRightObserver(parent, true);
         parent.disposables.add(left);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableInterval.java
@@ -36,9 +36,9 @@ public final class ObservableInterval extends Observable<Long> {
     }
 
     @Override
-    public void subscribeActual(Observer<? super Long> s) {
-        IntervalObserver is = new IntervalObserver(s);
-        s.onSubscribe(is);
+    public void subscribeActual(Observer<? super Long> observer) {
+        IntervalObserver is = new IntervalObserver(observer);
+        observer.onSubscribe(is);
 
         Scheduler sch = scheduler;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableIntervalRange.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableIntervalRange.java
@@ -40,9 +40,9 @@ public final class ObservableIntervalRange extends Observable<Long> {
     }
 
     @Override
-    public void subscribeActual(Observer<? super Long> s) {
-        IntervalRangeObserver is = new IntervalRangeObserver(s, start, end);
-        s.onSubscribe(is);
+    public void subscribeActual(Observer<? super Long> observer) {
+        IntervalRangeObserver is = new IntervalRangeObserver(observer, start, end);
+        observer.onSubscribe(is);
 
         Scheduler sch = scheduler;
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableJoin.java
@@ -54,13 +54,13 @@ public final class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
+    protected void subscribeActual(Observer<? super R> observer) {
 
         JoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R> parent =
                 new JoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R>(
-                        s, leftEnd, rightEnd, resultSelector);
+                        observer, leftEnd, rightEnd, resultSelector);
 
-        s.onSubscribe(parent);
+        observer.onSubscribe(parent);
 
         LeftRightObserver left = new LeftRightObserver(parent, true);
         parent.disposables.add(left);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableJust.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableJust.java
@@ -29,9 +29,9 @@ public final class ObservableJust<T> extends Observable<T> implements ScalarCall
     }
 
     @Override
-    protected void subscribeActual(Observer<? super T> s) {
-        ScalarDisposable<T> sd = new ScalarDisposable<T>(s, value);
-        s.onSubscribe(sd);
+    protected void subscribeActual(Observer<? super T> observer) {
+        ScalarDisposable<T> sd = new ScalarDisposable<T>(observer, value);
+        observer.onSubscribe(sd);
         sd.run();
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableLift.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableLift.java
@@ -37,10 +37,10 @@ public final class ObservableLift<R, T> extends AbstractObservableWithUpstream<T
     }
 
     @Override
-    public void subscribeActual(Observer<? super R> s) {
-        Observer<? super T> observer;
+    public void subscribeActual(Observer<? super R> observer) {
+        Observer<? super T> liftedObserver;
         try {
-            observer = ObjectHelper.requireNonNull(operator.apply(s), "Operator " + operator + " returned a null Observer");
+            liftedObserver = ObjectHelper.requireNonNull(operator.apply(observer), "Operator " + operator + " returned a null Observer");
         } catch (NullPointerException e) { // NOPMD
             throw e;
         } catch (Throwable e) {
@@ -54,6 +54,6 @@ public final class ObservableLift<R, T> extends AbstractObservableWithUpstream<T
             throw npe;
         }
 
-        source.subscribe(observer);
+        source.subscribe(liftedObserver);
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
@@ -59,7 +59,7 @@ public final class ObservableRefCount<T> extends Observable<T> {
     }
 
     @Override
-    protected void subscribeActual(Observer<? super T> s) {
+    protected void subscribeActual(Observer<? super T> observer) {
 
         RefConnection conn;
 
@@ -82,7 +82,7 @@ public final class ObservableRefCount<T> extends Observable<T> {
             }
         }
 
-        source.subscribe(new RefCountObserver<T>(s, this, conn));
+        source.subscribe(new RefCountObserver<T>(observer, this, conn));
 
         if (connect) {
             source.connect(conn);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeat.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeat.java
@@ -27,11 +27,11 @@ public final class ObservableRepeat<T> extends AbstractObservableWithUpstream<T,
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
+    public void subscribeActual(Observer<? super T> observer) {
         SequentialDisposable sd = new SequentialDisposable();
-        s.onSubscribe(sd);
+        observer.onSubscribe(sd);
 
-        RepeatObserver<T> rs = new RepeatObserver<T>(s, count != Long.MAX_VALUE ? count - 1 : Long.MAX_VALUE, sd, source);
+        RepeatObserver<T> rs = new RepeatObserver<T>(observer, count != Long.MAX_VALUE ? count - 1 : Long.MAX_VALUE, sd, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeatUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeatUntil.java
@@ -29,11 +29,11 @@ public final class ObservableRepeatUntil<T> extends AbstractObservableWithUpstre
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
+    public void subscribeActual(Observer<? super T> observer) {
         SequentialDisposable sd = new SequentialDisposable();
-        s.onSubscribe(sd);
+        observer.onSubscribe(sd);
 
-        RepeatUntilObserver<T> rs = new RepeatUntilObserver<T>(s, until, sd, source);
+        RepeatUntilObserver<T> rs = new RepeatUntilObserver<T>(observer, until, sd, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryBiPredicate.java
@@ -31,11 +31,11 @@ public final class ObservableRetryBiPredicate<T> extends AbstractObservableWithU
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
+    public void subscribeActual(Observer<? super T> observer) {
         SequentialDisposable sa = new SequentialDisposable();
-        s.onSubscribe(sa);
+        observer.onSubscribe(sa);
 
-        RetryBiObserver<T> rs = new RetryBiObserver<T>(s, predicate, sa, source);
+        RetryBiObserver<T> rs = new RetryBiObserver<T>(observer, predicate, sa, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryPredicate.java
@@ -33,11 +33,11 @@ public final class ObservableRetryPredicate<T> extends AbstractObservableWithUps
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
+    public void subscribeActual(Observer<? super T> observer) {
         SequentialDisposable sa = new SequentialDisposable();
-        s.onSubscribe(sa);
+        observer.onSubscribe(sa);
 
-        RepeatObserver<T> rs = new RepeatObserver<T>(s, count, predicate, sa, source);
+        RepeatObserver<T> rs = new RepeatObserver<T>(observer, count, predicate, sa, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
@@ -136,12 +136,12 @@ public final class ObservableScalarXMap {
 
         @SuppressWarnings("unchecked")
         @Override
-        public void subscribeActual(Observer<? super R> s) {
+        public void subscribeActual(Observer<? super R> observer) {
             ObservableSource<? extends R> other;
             try {
                 other = ObjectHelper.requireNonNull(mapper.apply(value), "The mapper returned a null ObservableSource");
             } catch (Throwable e) {
-                EmptyDisposable.error(e, s);
+                EmptyDisposable.error(e, observer);
                 return;
             }
             if (other instanceof Callable) {
@@ -151,19 +151,19 @@ public final class ObservableScalarXMap {
                     u = ((Callable<R>)other).call();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
-                    EmptyDisposable.error(ex, s);
+                    EmptyDisposable.error(ex, observer);
                     return;
                 }
 
                 if (u == null) {
-                    EmptyDisposable.complete(s);
+                    EmptyDisposable.complete(observer);
                     return;
                 }
-                ScalarDisposable<R> sd = new ScalarDisposable<R>(s, u);
-                s.onSubscribe(sd);
+                ScalarDisposable<R> sd = new ScalarDisposable<R>(observer, u);
+                observer.onSubscribe(sd);
                 sd.run();
             } else {
-                other.subscribe(s);
+                other.subscribe(observer);
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSequenceEqual.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSequenceEqual.java
@@ -37,9 +37,9 @@ public final class ObservableSequenceEqual<T> extends Observable<Boolean> {
     }
 
     @Override
-    public void subscribeActual(Observer<? super Boolean> s) {
-        EqualCoordinator<T> ec = new EqualCoordinator<T>(s, bufferSize, first, second, comparer);
-        s.onSubscribe(ec);
+    public void subscribeActual(Observer<? super Boolean> observer) {
+        EqualCoordinator<T> ec = new EqualCoordinator<T>(observer, bufferSize, first, second, comparer);
+        observer.onSubscribe(ec);
         ec.subscribe();
     }
 
@@ -117,10 +117,10 @@ public final class ObservableSequenceEqual<T> extends Observable<Boolean> {
             int missed = 1;
             EqualObserver<T>[] as = observers;
 
-            final EqualObserver<T> s1 = as[0];
-            final SpscLinkedArrayQueue<T> q1 = s1.queue;
-            final EqualObserver<T> s2 = as[1];
-            final SpscLinkedArrayQueue<T> q2 = s2.queue;
+            final EqualObserver<T> observer1 = as[0];
+            final SpscLinkedArrayQueue<T> q1 = observer1.queue;
+            final EqualObserver<T> observer2 = as[1];
+            final SpscLinkedArrayQueue<T> q2 = observer2.queue;
 
             for (;;) {
 
@@ -131,10 +131,10 @@ public final class ObservableSequenceEqual<T> extends Observable<Boolean> {
                         return;
                     }
 
-                    boolean d1 = s1.done;
+                    boolean d1 = observer1.done;
 
                     if (d1) {
-                        Throwable e = s1.error;
+                        Throwable e = observer1.error;
                         if (e != null) {
                             cancel(q1, q2);
 
@@ -143,9 +143,9 @@ public final class ObservableSequenceEqual<T> extends Observable<Boolean> {
                         }
                     }
 
-                    boolean d2 = s2.done;
+                    boolean d2 = observer2.done;
                     if (d2) {
-                        Throwable e = s2.error;
+                        Throwable e = observer2.error;
                         if (e != null) {
                             cancel(q1, q2);
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualSingle.java
@@ -39,9 +39,9 @@ public final class ObservableSequenceEqualSingle<T> extends Single<Boolean> impl
     }
 
     @Override
-    public void subscribeActual(SingleObserver<? super Boolean> s) {
-        EqualCoordinator<T> ec = new EqualCoordinator<T>(s, bufferSize, first, second, comparer);
-        s.onSubscribe(ec);
+    public void subscribeActual(SingleObserver<? super Boolean> observer) {
+        EqualCoordinator<T> ec = new EqualCoordinator<T>(observer, bufferSize, first, second, comparer);
+        observer.onSubscribe(ec);
         ec.subscribe();
     }
 
@@ -124,10 +124,10 @@ public final class ObservableSequenceEqualSingle<T> extends Single<Boolean> impl
             int missed = 1;
             EqualObserver<T>[] as = observers;
 
-            final EqualObserver<T> s1 = as[0];
-            final SpscLinkedArrayQueue<T> q1 = s1.queue;
-            final EqualObserver<T> s2 = as[1];
-            final SpscLinkedArrayQueue<T> q2 = s2.queue;
+            final EqualObserver<T> observer1 = as[0];
+            final SpscLinkedArrayQueue<T> q1 = observer1.queue;
+            final EqualObserver<T> observer2 = as[1];
+            final SpscLinkedArrayQueue<T> q2 = observer2.queue;
 
             for (;;) {
 
@@ -138,10 +138,10 @@ public final class ObservableSequenceEqualSingle<T> extends Single<Boolean> impl
                         return;
                     }
 
-                    boolean d1 = s1.done;
+                    boolean d1 = observer1.done;
 
                     if (d1) {
-                        Throwable e = s1.error;
+                        Throwable e = observer1.error;
                         if (e != null) {
                             cancel(q1, q2);
 
@@ -150,9 +150,9 @@ public final class ObservableSequenceEqualSingle<T> extends Single<Boolean> impl
                         }
                     }
 
-                    boolean d2 = s2.done;
+                    boolean d2 = observer2.done;
                     if (d2) {
-                        Throwable e = s2.error;
+                        Throwable e = observer2.error;
                         if (e != null) {
                             cancel(q1, q2);
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSkip.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSkip.java
@@ -25,8 +25,8 @@ public final class ObservableSkip<T> extends AbstractObservableWithUpstream<T, T
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new SkipObserver<T>(s, n));
+    public void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new SkipObserver<T>(observer, n));
     }
 
     static final class SkipObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipLast.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipLast.java
@@ -28,8 +28,8 @@ public final class ObservableSkipLast<T> extends AbstractObservableWithUpstream<
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new SkipLastObserver<T>(s, skip));
+    public void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new SkipLastObserver<T>(observer, skip));
     }
 
     static final class SkipLastObserver<T> extends ArrayDeque<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipWhile.java
@@ -27,8 +27,8 @@ public final class ObservableSkipWhile<T> extends AbstractObservableWithUpstream
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new SkipWhileObserver<T>(s, predicate));
+    public void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new SkipWhileObserver<T>(observer, predicate));
     }
 
     static final class SkipWhileObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSubscribeOn.java
@@ -28,10 +28,10 @@ public final class ObservableSubscribeOn<T> extends AbstractObservableWithUpstre
     }
 
     @Override
-    public void subscribeActual(final Observer<? super T> s) {
-        final SubscribeOnObserver<T> parent = new SubscribeOnObserver<T>(s);
+    public void subscribeActual(final Observer<? super T> observer) {
+        final SubscribeOnObserver<T> parent = new SubscribeOnObserver<T>(observer);
 
-        s.onSubscribe(parent);
+        observer.onSubscribe(parent);
 
         parent.setDisposable(scheduler.scheduleDirect(new SubscribeTask(parent)));
     }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastOne.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastOne.java
@@ -23,8 +23,8 @@ public final class ObservableTakeLastOne<T> extends AbstractObservableWithUpstre
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new TakeLastOneObserver<T>(s));
+    public void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new TakeLastOneObserver<T>(observer));
     }
 
     static final class TakeLastOneObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicate.java
@@ -28,8 +28,8 @@ public final class ObservableTakeUntilPredicate<T> extends AbstractObservableWit
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new TakeUntilPredicateObserver<T>(s, predicate));
+    public void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new TakeUntilPredicateObserver<T>(observer, predicate));
     }
 
     static final class TakeUntilPredicateObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableThrottleLatest.java
@@ -52,8 +52,8 @@ public final class ObservableThrottleLatest<T> extends AbstractObservableWithUps
     }
 
     @Override
-    protected void subscribeActual(Observer<? super T> s) {
-        source.subscribe(new ThrottleLatestObserver<T>(s, timeout, unit, scheduler.createWorker(), emitLast));
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new ThrottleLatestObserver<T>(observer, timeout, unit, scheduler.createWorker(), emitLast));
     }
 
     static final class ThrottleLatestObserver<T>

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeout.java
@@ -42,15 +42,15 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
     }
 
     @Override
-    protected void subscribeActual(Observer<? super T> s) {
+    protected void subscribeActual(Observer<? super T> observer) {
         if (other == null) {
-            TimeoutObserver<T> parent = new TimeoutObserver<T>(s, itemTimeoutIndicator);
-            s.onSubscribe(parent);
+            TimeoutObserver<T> parent = new TimeoutObserver<T>(observer, itemTimeoutIndicator);
+            observer.onSubscribe(parent);
             parent.startFirstTimeout(firstTimeoutIndicator);
             source.subscribe(parent);
         } else {
-            TimeoutFallbackObserver<T> parent = new TimeoutFallbackObserver<T>(s, itemTimeoutIndicator, other);
-            s.onSubscribe(parent);
+            TimeoutFallbackObserver<T> parent = new TimeoutFallbackObserver<T>(observer, itemTimeoutIndicator, other);
+            observer.onSubscribe(parent);
             parent.startFirstTimeout(firstTimeoutIndicator);
             source.subscribe(parent);
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
@@ -37,15 +37,15 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
     }
 
     @Override
-    protected void subscribeActual(Observer<? super T> s) {
+    protected void subscribeActual(Observer<? super T> observer) {
         if (other == null) {
-            TimeoutObserver<T> parent = new TimeoutObserver<T>(s, timeout, unit, scheduler.createWorker());
-            s.onSubscribe(parent);
+            TimeoutObserver<T> parent = new TimeoutObserver<T>(observer, timeout, unit, scheduler.createWorker());
+            observer.onSubscribe(parent);
             parent.startTimeout(0L);
             source.subscribe(parent);
         } else {
-            TimeoutFallbackObserver<T> parent = new TimeoutFallbackObserver<T>(s, timeout, unit, scheduler.createWorker(), other);
-            s.onSubscribe(parent);
+            TimeoutFallbackObserver<T> parent = new TimeoutFallbackObserver<T>(observer, timeout, unit, scheduler.createWorker(), other);
+            observer.onSubscribe(parent);
             parent.startTimeout(0L);
             source.subscribe(parent);
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimer.java
@@ -31,9 +31,9 @@ public final class ObservableTimer extends Observable<Long> {
     }
 
     @Override
-    public void subscribeActual(Observer<? super Long> s) {
-        TimerObserver ios = new TimerObserver(s);
-        s.onSubscribe(ios);
+    public void subscribeActual(Observer<? super Long> observer) {
+        TimerObserver ios = new TimerObserver(observer);
+        observer.onSubscribe(ios);
 
         Disposable d = scheduler.scheduleDirect(ios, delay, unit);
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableUsing.java
@@ -41,14 +41,14 @@ public final class ObservableUsing<T, D> extends Observable<T> {
     }
 
     @Override
-    public void subscribeActual(Observer<? super T> s) {
+    public void subscribeActual(Observer<? super T> observer) {
         D resource;
 
         try {
             resource = resourceSupplier.call();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
-            EmptyDisposable.error(e, s);
+            EmptyDisposable.error(e, observer);
             return;
         }
 
@@ -61,14 +61,14 @@ public final class ObservableUsing<T, D> extends Observable<T> {
                 disposer.accept(resource);
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-                EmptyDisposable.error(new CompositeException(e, ex), s);
+                EmptyDisposable.error(new CompositeException(e, ex), observer);
                 return;
             }
-            EmptyDisposable.error(e, s);
+            EmptyDisposable.error(e, observer);
             return;
         }
 
-        UsingObserver<T, D> us = new UsingObserver<T, D>(s, resource, disposer, eager);
+        UsingObserver<T, D> us = new UsingObserver<T, D>(observer, resource, disposer, eager);
 
         source.subscribe(us);
     }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
@@ -59,7 +59,7 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
+    protected void subscribeActual(Observer<? super R> observer) {
         ObservableSource<?>[] others = otherArray;
         int n = 0;
         if (others == null) {
@@ -74,7 +74,7 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
                 }
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-                EmptyDisposable.error(ex, s);
+                EmptyDisposable.error(ex, observer);
                 return;
             }
 
@@ -83,12 +83,12 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
         }
 
         if (n == 0) {
-            new ObservableMap<T, R>(source, new SingletonArrayFunc()).subscribeActual(s);
+            new ObservableMap<T, R>(source, new SingletonArrayFunc()).subscribeActual(observer);
             return;
         }
 
-        WithLatestFromObserver<T, R> parent = new WithLatestFromObserver<T, R>(s, combiner, n);
-        s.onSubscribe(parent);
+        WithLatestFromObserver<T, R> parent = new WithLatestFromObserver<T, R>(observer, combiner, n);
+        observer.onSubscribe(parent);
         parent.subscribe(others, n);
 
         source.subscribe(parent);
@@ -204,8 +204,8 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
         @Override
         public void dispose() {
             DisposableHelper.dispose(d);
-            for (WithLatestInnerObserver s : observers) {
-                s.dispose();
+            for (WithLatestInnerObserver observer : observers) {
+                observer.dispose();
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableZip.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableZip.java
@@ -46,7 +46,7 @@ public final class ObservableZip<T, R> extends Observable<R> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void subscribeActual(Observer<? super R> s) {
+    public void subscribeActual(Observer<? super R> observer) {
         ObservableSource<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
@@ -64,11 +64,11 @@ public final class ObservableZip<T, R> extends Observable<R> {
         }
 
         if (count == 0) {
-            EmptyDisposable.complete(s);
+            EmptyDisposable.complete(observer);
             return;
         }
 
-        ZipCoordinator<T, R> zc = new ZipCoordinator<T, R>(s, zipper, count, delayError);
+        ZipCoordinator<T, R> zc = new ZipCoordinator<T, R>(observer, zipper, count, delayError);
         zc.subscribe(sources, bufferSize);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleCache.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleCache.java
@@ -43,9 +43,9 @@ public final class SingleCache<T> extends Single<T> implements SingleObserver<T>
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
-        CacheDisposable<T> d = new CacheDisposable<T>(s, this);
-        s.onSubscribe(d);
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
+        CacheDisposable<T> d = new CacheDisposable<T>(observer, this);
+        observer.onSubscribe(d);
 
         if (add(d)) {
             if (d.isDisposed()) {
@@ -54,9 +54,9 @@ public final class SingleCache<T> extends Single<T> implements SingleObserver<T>
         } else {
             Throwable ex = error;
             if (ex != null) {
-                s.onError(ex);
+                observer.onError(ex);
             } else {
-                s.onSuccess(value);
+                observer.onSuccess(value);
             }
             return;
         }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleContains.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleContains.java
@@ -33,22 +33,22 @@ public final class SingleContains<T> extends Single<Boolean> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super Boolean> s) {
+    protected void subscribeActual(final SingleObserver<? super Boolean> observer) {
 
-        source.subscribe(new Single(s));
+        source.subscribe(new ContainsSingleObserver(observer));
     }
 
-    final class Single implements SingleObserver<T> {
+    final class ContainsSingleObserver implements SingleObserver<T> {
 
-        private final SingleObserver<? super Boolean> s;
+        private final SingleObserver<? super Boolean> downstream;
 
-        Single(SingleObserver<? super Boolean> s) {
-            this.s = s;
+        ContainsSingleObserver(SingleObserver<? super Boolean> observer) {
+            this.downstream = observer;
         }
 
         @Override
         public void onSubscribe(Disposable d) {
-            s.onSubscribe(d);
+            downstream.onSubscribe(d);
         }
 
         @Override
@@ -59,15 +59,15 @@ public final class SingleContains<T> extends Single<Boolean> {
                 b = comparer.test(v, value);
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-                s.onError(ex);
+                downstream.onError(ex);
                 return;
             }
-            s.onSuccess(b);
+            downstream.onSuccess(b);
         }
 
         @Override
         public void onError(Throwable e) {
-            s.onError(e);
+            downstream.onError(e);
         }
 
     }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleCreate.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleCreate.java
@@ -31,9 +31,9 @@ public final class SingleCreate<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> s) {
-        Emitter<T> parent = new Emitter<T>(s);
-        s.onSubscribe(parent);
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        Emitter<T> parent = new Emitter<T>(observer);
+        observer.onSubscribe(parent);
 
         try {
             source.subscribe(parent);

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDefer.java
@@ -29,18 +29,18 @@ public final class SingleDefer<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> s) {
+    protected void subscribeActual(SingleObserver<? super T> observer) {
         SingleSource<? extends T> next;
 
         try {
             next = ObjectHelper.requireNonNull(singleSupplier.call(), "The singleSupplier returned a null SingleSource");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
-            EmptyDisposable.error(e, s);
+            EmptyDisposable.error(e, observer);
             return;
         }
 
-        next.subscribe(s);
+        next.subscribe(observer);
     }
 
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelay.java
@@ -36,20 +36,20 @@ public final class SingleDelay<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
 
         final SequentialDisposable sd = new SequentialDisposable();
-        s.onSubscribe(sd);
-        source.subscribe(new Delay(sd, s));
+        observer.onSubscribe(sd);
+        source.subscribe(new Delay(sd, observer));
     }
 
     final class Delay implements SingleObserver<T> {
         private final SequentialDisposable sd;
-        final SingleObserver<? super T> s;
+        final SingleObserver<? super T> downstream;
 
-        Delay(SequentialDisposable sd, SingleObserver<? super T> s) {
+        Delay(SequentialDisposable sd, SingleObserver<? super T> observer) {
             this.sd = sd;
-            this.s = s;
+            this.downstream = observer;
         }
 
         @Override
@@ -76,7 +76,7 @@ public final class SingleDelay<T> extends Single<T> {
 
             @Override
             public void run() {
-                s.onSuccess(value);
+                downstream.onSuccess(value);
             }
         }
 
@@ -89,7 +89,7 @@ public final class SingleDelay<T> extends Single<T> {
 
             @Override
             public void run() {
-                s.onError(e);
+                downstream.onError(e);
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithCompletable.java
@@ -32,8 +32,8 @@ public final class SingleDelayWithCompletable<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> subscriber) {
-        other.subscribe(new OtherObserver<T>(subscriber, source));
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        other.subscribe(new OtherObserver<T>(observer, source));
     }
 
     static final class OtherObserver<T>

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithObservable.java
@@ -33,8 +33,8 @@ public final class SingleDelayWithObservable<T, U> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> subscriber) {
-        other.subscribe(new OtherSubscriber<T, U>(subscriber, source));
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        other.subscribe(new OtherSubscriber<T, U>(observer, source));
     }
 
     static final class OtherSubscriber<T, U>

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithPublisher.java
@@ -36,8 +36,8 @@ public final class SingleDelayWithPublisher<T, U> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> subscriber) {
-        other.subscribe(new OtherSubscriber<T, U>(subscriber, source));
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        other.subscribe(new OtherSubscriber<T, U>(observer, source));
     }
 
     static final class OtherSubscriber<T, U>

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDelayWithSingle.java
@@ -32,8 +32,8 @@ public final class SingleDelayWithSingle<T, U> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> subscriber) {
-        other.subscribe(new OtherObserver<T, U>(subscriber, source));
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        other.subscribe(new OtherObserver<T, U>(observer, source));
     }
 
     static final class OtherObserver<T, U>

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoAfterSuccess.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoAfterSuccess.java
@@ -38,8 +38,8 @@ public final class SingleDoAfterSuccess<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> s) {
-        source.subscribe(new DoAfterObserver<T>(s, onAfterSuccess));
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        source.subscribe(new DoAfterObserver<T>(observer, onAfterSuccess));
     }
 
     static final class DoAfterObserver<T> implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoAfterTerminate.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoAfterTerminate.java
@@ -40,8 +40,8 @@ public final class SingleDoAfterTerminate<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> s) {
-        source.subscribe(new DoAfterTerminateObserver<T>(s, onAfterTerminate));
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        source.subscribe(new DoAfterTerminateObserver<T>(observer, onAfterTerminate));
     }
 
     static final class DoAfterTerminateObserver<T> implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoFinally.java
@@ -40,8 +40,8 @@ public final class SingleDoFinally<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> s) {
-        source.subscribe(new DoFinallyObserver<T>(s, onFinally));
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        source.subscribe(new DoFinallyObserver<T>(observer, onFinally));
     }
 
     static final class DoFinallyObserver<T> extends AtomicInteger implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnDispose.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnDispose.java
@@ -33,9 +33,9 @@ public final class SingleDoOnDispose<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
 
-        source.subscribe(new DoOnDisposeObserver<T>(s, onDispose));
+        source.subscribe(new DoOnDisposeObserver<T>(observer, onDispose));
     }
 
     static final class DoOnDisposeObserver<T>

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnError.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnError.java
@@ -30,26 +30,26 @@ public final class SingleDoOnError<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
 
-        source.subscribe(new DoOnError(s));
+        source.subscribe(new DoOnError(observer));
     }
 
     final class DoOnError implements SingleObserver<T> {
-        private final SingleObserver<? super T> s;
+        private final SingleObserver<? super T> downstream;
 
-        DoOnError(SingleObserver<? super T> s) {
-            this.s = s;
+        DoOnError(SingleObserver<? super T> observer) {
+            this.downstream = observer;
         }
 
         @Override
         public void onSubscribe(Disposable d) {
-            s.onSubscribe(d);
+            downstream.onSubscribe(d);
         }
 
         @Override
         public void onSuccess(T value) {
-            s.onSuccess(value);
+            downstream.onSuccess(value);
         }
 
         @Override
@@ -60,7 +60,7 @@ public final class SingleDoOnError<T> extends Single<T> {
                 Exceptions.throwIfFatal(ex);
                 e = new CompositeException(e, ex);
             }
-            s.onError(e);
+            downstream.onError(e);
         }
 
     }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnEvent.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnEvent.java
@@ -32,21 +32,21 @@ public final class SingleDoOnEvent<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
 
-        source.subscribe(new DoOnEvent(s));
+        source.subscribe(new DoOnEvent(observer));
     }
 
     final class DoOnEvent implements SingleObserver<T> {
-        private final SingleObserver<? super T> s;
+        private final SingleObserver<? super T> downstream;
 
-        DoOnEvent(SingleObserver<? super T> s) {
-            this.s = s;
+        DoOnEvent(SingleObserver<? super T> observer) {
+            this.downstream = observer;
         }
 
         @Override
         public void onSubscribe(Disposable d) {
-            s.onSubscribe(d);
+            downstream.onSubscribe(d);
         }
 
         @Override
@@ -55,11 +55,11 @@ public final class SingleDoOnEvent<T> extends Single<T> {
                 onEvent.accept(value, null);
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-                s.onError(ex);
+                downstream.onError(ex);
                 return;
             }
 
-            s.onSuccess(value);
+            downstream.onSuccess(value);
         }
 
         @Override
@@ -70,7 +70,7 @@ public final class SingleDoOnEvent<T> extends Single<T> {
                 Exceptions.throwIfFatal(ex);
                 e = new CompositeException(e, ex);
             }
-            s.onError(e);
+            downstream.onError(e);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSubscribe.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSubscribe.java
@@ -37,8 +37,8 @@ public final class SingleDoOnSubscribe<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
-        source.subscribe(new DoOnSubscribeSingleObserver<T>(s, onSubscribe));
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
+        source.subscribe(new DoOnSubscribeSingleObserver<T>(observer, onSubscribe));
     }
 
     static final class DoOnSubscribeSingleObserver<T> implements SingleObserver<T> {

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSuccess.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDoOnSuccess.java
@@ -30,21 +30,22 @@ public final class SingleDoOnSuccess<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
 
-        source.subscribe(new DoOnSuccess(s));
+        source.subscribe(new DoOnSuccess(observer));
     }
 
     final class DoOnSuccess implements SingleObserver<T> {
-        private final SingleObserver<? super T> s;
 
-        DoOnSuccess(SingleObserver<? super T> s) {
-            this.s = s;
+        final SingleObserver<? super T> downstream;
+
+        DoOnSuccess(SingleObserver<? super T> observer) {
+            this.downstream = observer;
         }
 
         @Override
         public void onSubscribe(Disposable d) {
-            s.onSubscribe(d);
+            downstream.onSubscribe(d);
         }
 
         @Override
@@ -53,15 +54,15 @@ public final class SingleDoOnSuccess<T> extends Single<T> {
                 onSuccess.accept(value);
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-                s.onError(ex);
+                downstream.onError(ex);
                 return;
             }
-            s.onSuccess(value);
+            downstream.onSuccess(value);
         }
 
         @Override
         public void onError(Throwable e) {
-            s.onError(e);
+            downstream.onError(e);
         }
 
     }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleError.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleError.java
@@ -29,7 +29,7 @@ public final class SingleError<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> s) {
+    protected void subscribeActual(SingleObserver<? super T> observer) {
         Throwable error;
 
         try {
@@ -39,7 +39,7 @@ public final class SingleError<T> extends Single<T> {
             error = e;
         }
 
-        EmptyDisposable.error(error, s);
+        EmptyDisposable.error(error, observer);
     }
 
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapCompletable.java
@@ -38,9 +38,9 @@ public final class SingleFlatMapCompletable<T> extends Completable {
     }
 
     @Override
-    protected void subscribeActual(CompletableObserver s) {
-        FlatMapCompletableObserver<T> parent = new FlatMapCompletableObserver<T>(s, mapper);
-        s.onSubscribe(parent);
+    protected void subscribeActual(CompletableObserver observer) {
+        FlatMapCompletableObserver<T> parent = new FlatMapCompletableObserver<T>(observer, mapper);
+        observer.onSubscribe(parent);
         source.subscribe(parent);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservable.java
@@ -43,8 +43,8 @@ public final class SingleFlatMapIterableObservable<T, R> extends Observable<R> {
     }
 
     @Override
-    protected void subscribeActual(Observer<? super R> s) {
-        source.subscribe(new FlatMapIterableObserver<T, R>(s, mapper));
+    protected void subscribeActual(Observer<? super R> observer) {
+        source.subscribe(new FlatMapIterableObserver<T, R>(observer, mapper));
     }
 
     static final class FlatMapIterableObserver<T, R>

--- a/src/main/java/io/reactivex/internal/operators/single/SingleFromPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleFromPublisher.java
@@ -31,8 +31,8 @@ public final class SingleFromPublisher<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
-        publisher.subscribe(new ToSingleObserver<T>(s));
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
+        publisher.subscribe(new ToSingleObserver<T>(observer));
     }
 
     static final class ToSingleObserver<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/single/SingleHide.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleHide.java
@@ -26,8 +26,8 @@ public final class SingleHide<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> subscriber) {
-        source.subscribe(new HideSingleObserver<T>(subscriber));
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        source.subscribe(new HideSingleObserver<T>(observer));
     }
 
     static final class HideSingleObserver<T> implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/internal/operators/single/SingleJust.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleJust.java
@@ -25,9 +25,9 @@ public final class SingleJust<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super T> s) {
-        s.onSubscribe(Disposables.disposed());
-        s.onSuccess(value);
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        observer.onSubscribe(Disposables.disposed());
+        observer.onSuccess(value);
     }
 
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleLift.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleLift.java
@@ -30,14 +30,14 @@ public final class SingleLift<T, R> extends Single<R> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super R> s) {
+    protected void subscribeActual(SingleObserver<? super R> observer) {
         SingleObserver<? super T> sr;
 
         try {
-            sr = ObjectHelper.requireNonNull(onLift.apply(s), "The onLift returned a null SingleObserver");
+            sr = ObjectHelper.requireNonNull(onLift.apply(observer), "The onLift returned a null SingleObserver");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
-            EmptyDisposable.error(ex, s);
+            EmptyDisposable.error(ex, observer);
             return;
         }
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleNever.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleNever.java
@@ -23,8 +23,8 @@ public final class SingleNever extends Single<Object> {
     }
 
     @Override
-    protected void subscribeActual(SingleObserver<? super Object> s) {
-        s.onSubscribe(EmptyDisposable.NEVER);
+    protected void subscribeActual(SingleObserver<? super Object> observer) {
+        observer.onSubscribe(EmptyDisposable.NEVER);
     }
 
 }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleObserveOn.java
@@ -31,8 +31,8 @@ public final class SingleObserveOn<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
-        source.subscribe(new ObserveOnSingleObserver<T>(s, scheduler));
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
+        source.subscribe(new ObserveOnSingleObserver<T>(observer, scheduler));
     }
 
     static final class ObserveOnSingleObserver<T> extends AtomicReference<Disposable>

--- a/src/main/java/io/reactivex/internal/operators/single/SingleOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleOnErrorReturn.java
@@ -35,9 +35,9 @@ public final class SingleOnErrorReturn<T> extends Single<T> {
 
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
 
-        source.subscribe(new OnErrorReturn(s));
+        source.subscribe(new OnErrorReturn(observer));
     }
 
     final class OnErrorReturn implements SingleObserver<T> {

--- a/src/main/java/io/reactivex/internal/operators/single/SingleResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleResumeNext.java
@@ -35,8 +35,8 @@ public final class SingleResumeNext<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
-        source.subscribe(new ResumeMainSingleObserver<T>(s, nextFunction));
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
+        source.subscribe(new ResumeMainSingleObserver<T>(observer, nextFunction));
     }
 
     static final class ResumeMainSingleObserver<T> extends AtomicReference<Disposable>

--- a/src/main/java/io/reactivex/internal/operators/single/SingleSubscribeOn.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleSubscribeOn.java
@@ -30,9 +30,9 @@ public final class SingleSubscribeOn<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
-        final SubscribeOnObserver<T> parent = new SubscribeOnObserver<T>(s, source);
-        s.onSubscribe(parent);
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
+        final SubscribeOnObserver<T> parent = new SubscribeOnObserver<T>(observer, source);
+        observer.onSubscribe(parent);
 
         Disposable f = scheduler.scheduleDirect(parent);
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTimeout.java
@@ -43,10 +43,10 @@ public final class SingleTimeout<T> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
 
-        TimeoutMainObserver<T> parent = new TimeoutMainObserver<T>(s, other);
-        s.onSubscribe(parent);
+        TimeoutMainObserver<T> parent = new TimeoutMainObserver<T>(observer, other);
+        observer.onSubscribe(parent);
 
         DisposableHelper.replace(parent.task, scheduler.scheduleDirect(parent, timeout, unit));
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTimer.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTimer.java
@@ -36,9 +36,9 @@ public final class SingleTimer extends Single<Long> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super Long> s) {
-        TimerDisposable parent = new TimerDisposable(s);
-        s.onSubscribe(parent);
+    protected void subscribeActual(final SingleObserver<? super Long> observer) {
+        TimerDisposable parent = new TimerDisposable(observer);
+        observer.onSubscribe(parent);
         parent.setFuture(scheduler.scheduleDirect(parent, delay, unit));
     }
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleToObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleToObservable.java
@@ -31,8 +31,8 @@ public final class SingleToObservable<T> extends Observable<T> {
     }
 
     @Override
-    public void subscribeActual(final Observer<? super T> s) {
-        source.subscribe(create(s));
+    public void subscribeActual(final Observer<? super T> observer) {
+        source.subscribe(create(observer));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
@@ -42,7 +42,7 @@ public final class SingleUsing<T, U> extends Single<T> {
     }
 
     @Override
-    protected void subscribeActual(final SingleObserver<? super T> s) {
+    protected void subscribeActual(final SingleObserver<? super T> observer) {
 
         final U resource; // NOPMD
 
@@ -50,7 +50,7 @@ public final class SingleUsing<T, U> extends Single<T> {
             resource = resourceSupplier.call();
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
-            EmptyDisposable.error(ex, s);
+            EmptyDisposable.error(ex, observer);
             return;
         }
 
@@ -69,7 +69,7 @@ public final class SingleUsing<T, U> extends Single<T> {
                     ex = new CompositeException(ex, exc);
                 }
             }
-            EmptyDisposable.error(ex, s);
+            EmptyDisposable.error(ex, observer);
             if (!eager) {
                 try {
                     disposer.accept(resource);
@@ -81,7 +81,7 @@ public final class SingleUsing<T, U> extends Single<T> {
             return;
         }
 
-        source.subscribe(new UsingSingleObserver<T, U>(s, resource, eager, disposer));
+        source.subscribe(new UsingSingleObserver<T, U>(observer, resource, eager, disposer));
     }
 
     static final class UsingSingleObserver<T, U> extends

--- a/src/main/java/io/reactivex/internal/util/NotificationLite.java
+++ b/src/main/java/io/reactivex/internal/util/NotificationLite.java
@@ -230,20 +230,20 @@ public enum NotificationLite {
      * <p>Does not check for a subscription notification.
      * @param <T> the expected value type when unwrapped
      * @param o the notification object
-     * @param s the Observer to call methods on
+     * @param observer the Observer to call methods on
      * @return true if the notification was a terminal event (i.e., complete or error)
      */
     @SuppressWarnings("unchecked")
-    public static <T> boolean accept(Object o, Observer<? super T> s) {
+    public static <T> boolean accept(Object o, Observer<? super T> observer) {
         if (o == COMPLETE) {
-            s.onComplete();
+            observer.onComplete();
             return true;
         } else
         if (o instanceof ErrorNotification) {
-            s.onError(((ErrorNotification)o).e);
+            observer.onError(((ErrorNotification)o).e);
             return true;
         }
-        s.onNext((T)o);
+        observer.onNext((T)o);
         return false;
     }
 
@@ -277,25 +277,25 @@ public enum NotificationLite {
      * Calls the appropriate Observer method based on the type of the notification.
      * @param <T> the expected value type when unwrapped
      * @param o the notification object
-     * @param s the subscriber to call methods on
+     * @param observer the subscriber to call methods on
      * @return true if the notification was a terminal event (i.e., complete or error)
      * @see #accept(Object, Observer)
      */
     @SuppressWarnings("unchecked")
-    public static <T> boolean acceptFull(Object o, Observer<? super T> s) {
+    public static <T> boolean acceptFull(Object o, Observer<? super T> observer) {
         if (o == COMPLETE) {
-            s.onComplete();
+            observer.onComplete();
             return true;
         } else
         if (o instanceof ErrorNotification) {
-            s.onError(((ErrorNotification)o).e);
+            observer.onError(((ErrorNotification)o).e);
             return true;
         } else
         if (o instanceof DisposableNotification) {
-            s.onSubscribe(((DisposableNotification)o).d);
+            observer.onSubscribe(((DisposableNotification)o).d);
             return false;
         }
-        s.onNext((T)o);
+        observer.onNext((T)o);
         return false;
     }
 

--- a/src/main/java/io/reactivex/internal/util/QueueDrainHelper.java
+++ b/src/main/java/io/reactivex/internal/util/QueueDrainHelper.java
@@ -158,7 +158,7 @@ public final class QueueDrainHelper {
     }
 
     public static <T, U> boolean checkTerminated(boolean d, boolean empty,
-            Observer<?> s, boolean delayError, SimpleQueue<?> q, Disposable disposable, ObservableQueueDrain<T, U> qd) {
+            Observer<?> observer, boolean delayError, SimpleQueue<?> q, Disposable disposable, ObservableQueueDrain<T, U> qd) {
         if (qd.cancelled()) {
             q.clear();
             disposable.dispose();
@@ -173,9 +173,9 @@ public final class QueueDrainHelper {
                     }
                     Throwable err = qd.error();
                     if (err != null) {
-                        s.onError(err);
+                        observer.onError(err);
                     } else {
-                        s.onComplete();
+                        observer.onComplete();
                     }
                     return true;
                 }
@@ -186,14 +186,14 @@ public final class QueueDrainHelper {
                     if (disposable != null) {
                         disposable.dispose();
                     }
-                    s.onError(err);
+                    observer.onError(err);
                     return true;
                 } else
                 if (empty) {
                     if (disposable != null) {
                         disposable.dispose();
                     }
-                    s.onComplete();
+                    observer.onComplete();
                     return true;
                 }
             }

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -979,17 +979,17 @@ public final class RxJavaPlugins {
      * Calls the associated hook function.
      * @param <T> the value type
      * @param source the hook's input value
-     * @param subscriber the subscriber
+     * @param observer the subscriber
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @NonNull
-    public static <T> MaybeObserver<? super T> onSubscribe(@NonNull Maybe<T> source, @NonNull MaybeObserver<? super T> subscriber) {
+    public static <T> MaybeObserver<? super T> onSubscribe(@NonNull Maybe<T> source, @NonNull MaybeObserver<? super T> observer) {
         BiFunction<? super Maybe, ? super MaybeObserver, ? extends MaybeObserver> f = onMaybeSubscribe;
         if (f != null) {
-            return apply(f, source, subscriber);
+            return apply(f, source, observer);
         }
-        return subscriber;
+        return observer;
     }
 
     /**

--- a/src/main/java/io/reactivex/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/subjects/AsyncSubject.java
@@ -215,9 +215,9 @@ public final class AsyncSubject<T> extends Subject<T> {
     }
 
     @Override
-    protected void subscribeActual(Observer<? super T> s) {
-        AsyncDisposable<T> as = new AsyncDisposable<T>(s, this);
-        s.onSubscribe(as);
+    protected void subscribeActual(Observer<? super T> observer) {
+        AsyncDisposable<T> as = new AsyncDisposable<T>(observer, this);
+        observer.onSubscribe(as);
         if (add(as)) {
             if (as.isDisposed()) {
                 remove(as);
@@ -225,7 +225,7 @@ public final class AsyncSubject<T> extends Subject<T> {
         } else {
             Throwable ex = error;
             if (ex != null) {
-                s.onError(ex);
+                observer.onError(ex);
             } else {
                 T v = value;
                 if (v != null) {

--- a/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
+++ b/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
@@ -188,4 +188,27 @@ public class CheckLocalVariablesInTests {
     public void observableAsC() throws Exception {
         findPattern("Observable<.*>\\s+c\\b");
     }
+
+    @Test
+    public void subscriberAsObserver() throws Exception {
+        findPattern("Subscriber<.*>\\s+observer(0-9)?\\b");
+    }
+
+    @Test
+    public void subscriberAsO() throws Exception {
+        findPattern("Subscriber<.*>\\s+o(0-9)?\\b");
+    }
+
+    public void observerAsSubscriber() throws Exception {
+        findPattern("Observer<.*>\\s+subscriber(0-9)?\\b");
+    }
+
+    public void observerAsS() throws Exception {
+        findPattern("Observer<.*>\\s+s(0-9)?\\b");
+    }
+
+    @Test
+    public void flowableAsObservable() throws Exception {
+        findPattern("Flowable<.*>\\s+observable(0-9)?\\b");
+    }
 }

--- a/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
+++ b/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
@@ -191,24 +191,74 @@ public class CheckLocalVariablesInTests {
 
     @Test
     public void subscriberAsObserver() throws Exception {
-        findPattern("Subscriber<.*>\\s+observer(0-9)?\\b");
+        findPattern("Subscriber<.*>\\s+observer[0-9]?\\b");
     }
 
     @Test
     public void subscriberAsO() throws Exception {
-        findPattern("Subscriber<.*>\\s+o(0-9)?\\b");
+        findPattern("Subscriber<.*>\\s+o[0-9]?\\b");
+    }
+
+    @Test
+    public void singleAsObservable() throws Exception {
+        findPattern("Single<.*>\\s+observable\\b");
+    }
+
+    @Test
+    public void singleAsFlowable() throws Exception {
+        findPattern("Single<.*>\\s+flowable\\b");
     }
 
     public void observerAsSubscriber() throws Exception {
-        findPattern("Observer<.*>\\s+subscriber(0-9)?\\b");
+        findPattern("Observer<.*>\\s+subscriber[0-9]?\\b");
     }
 
     public void observerAsS() throws Exception {
-        findPattern("Observer<.*>\\s+s(0-9)?\\b");
+        findPattern("Observer<.*>\\s+s[0-9]?\\b");
     }
 
     @Test
     public void flowableAsObservable() throws Exception {
-        findPattern("Flowable<.*>\\s+observable(0-9)?\\b");
+        findPattern("Flowable<.*>\\s+observable[0-9]?\\b");
+    }
+
+    @Test
+    public void flowableAsO() throws Exception {
+        findPattern("Flowable<.*>\\s+o[0-9]?\\b");
+    }
+
+    @Test
+    public void flowableNoArgAsO() throws Exception {
+        findPattern("Flowable\\s+o[0-9]?\\b");
+    }
+
+    @Test
+    public void flowableNoArgAsObservable() throws Exception {
+        findPattern("Flowable\\s+observable[0-9]?\\b");
+    }
+
+    @Test
+    public void processorAsSubject() throws Exception {
+        findPattern("Processor<.*>\\s+subject(0-9)?\\b");
+    }
+
+    @Test
+    public void maybeAsObservable() throws Exception {
+        findPattern("Maybe<.*>\\s+observable\\b");
+    }
+
+    @Test
+    public void maybeAsFlowable() throws Exception {
+        findPattern("Maybe<.*>\\s+flowable\\b");
+    }
+
+    @Test
+    public void completableAsObservable() throws Exception {
+        findPattern("Completable\\s+observable\\b");
+    }
+
+    @Test
+    public void completableAsFlowable() throws Exception {
+        findPattern("Completable\\s+flowable\\b");
     }
 }

--- a/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
+++ b/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
@@ -209,15 +209,27 @@ public class CheckLocalVariablesInTests {
         findPattern("Single<.*>\\s+flowable\\b");
     }
 
+    @Test
     public void observerAsSubscriber() throws Exception {
         findPattern("Observer<.*>\\s+subscriber[0-9]?\\b");
     }
 
+    @Test
     public void observerAsS() throws Exception {
         findPattern("Observer<.*>\\s+s[0-9]?\\b");
     }
 
     @Test
+    public void observerNoArgAsSubscriber() throws Exception {
+        findPattern("Observer\\s+subscriber[0-9]?\\b");
+    }
+
+    @Test
+    public void observerNoArgAsS() throws Exception {
+        findPattern("Observer\\s+s[0-9]?\\b");
+    }
+
+@Test
     public void flowableAsObservable() throws Exception {
         findPattern("Flowable<.*>\\s+observable[0-9]?\\b");
     }

--- a/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
+++ b/src/test/java/io/reactivex/CheckLocalVariablesInTests.java
@@ -229,7 +229,7 @@ public class CheckLocalVariablesInTests {
         findPattern("Observer\\s+s[0-9]?\\b");
     }
 
-@Test
+    @Test
     public void flowableAsObservable() throws Exception {
         findPattern("Flowable<.*>\\s+observable[0-9]?\\b");
     }

--- a/src/test/java/io/reactivex/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/ParamValidationCheckerTest.java
@@ -1140,7 +1140,7 @@ public class ParamValidationCheckerTest {
     static final class NeverObservable extends Observable<Object> {
 
         @Override
-        public void subscribeActual(Observer<? super Object> s) {
+        public void subscribeActual(Observer<? super Object> observer) {
             // not invoked, the class is a placeholder default value
         }
 
@@ -1153,7 +1153,7 @@ public class ParamValidationCheckerTest {
     static final class NeverSingle extends Single<Object> {
 
         @Override
-        public void subscribeActual(SingleObserver<? super Object> s) {
+        public void subscribeActual(SingleObserver<? super Object> observer) {
             // not invoked, the class is a placeholder default value
         }
 
@@ -1166,7 +1166,7 @@ public class ParamValidationCheckerTest {
     static final class NeverMaybe extends Maybe<Object> {
 
         @Override
-        public void subscribeActual(MaybeObserver<? super Object> s) {
+        public void subscribeActual(MaybeObserver<? super Object> observer) {
             // not invoked, the class is a placeholder default value
         }
 
@@ -1178,7 +1178,7 @@ public class ParamValidationCheckerTest {
     static final class NeverCompletable extends Completable {
 
         @Override
-        public void subscribeActual(CompletableObserver s) {
+        public void subscribeActual(CompletableObserver observer) {
             // not invoked, the class is a placeholder default value
         }
 

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -1692,15 +1692,15 @@ public enum TestHelper {
 
             Flowable<T> source = new Flowable<T>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super T> observer) {
+                protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
                         BooleanSubscription d1 = new BooleanSubscription();
 
-                        observer.onSubscribe(d1);
+                        subscriber.onSubscribe(d1);
 
                         BooleanSubscription d2 = new BooleanSubscription();
 
-                        observer.onSubscribe(d2);
+                        subscriber.onSubscribe(d2);
 
                         b[0] = d1.isCancelled();
                         b[1] = d2.isCancelled();
@@ -1746,15 +1746,15 @@ public enum TestHelper {
 
             Flowable<T> source = new Flowable<T>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super T> observer) {
+                protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
                         BooleanSubscription d1 = new BooleanSubscription();
 
-                        observer.onSubscribe(d1);
+                        subscriber.onSubscribe(d1);
 
                         BooleanSubscription d2 = new BooleanSubscription();
 
-                        observer.onSubscribe(d2);
+                        subscriber.onSubscribe(d2);
 
                         b[0] = d1.isCancelled();
                         b[1] = d2.isCancelled();
@@ -1800,15 +1800,15 @@ public enum TestHelper {
 
             Flowable<T> source = new Flowable<T>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super T> observer) {
+                protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
                         BooleanSubscription d1 = new BooleanSubscription();
 
-                        observer.onSubscribe(d1);
+                        subscriber.onSubscribe(d1);
 
                         BooleanSubscription d2 = new BooleanSubscription();
 
-                        observer.onSubscribe(d2);
+                        subscriber.onSubscribe(d2);
 
                         b[0] = d1.isCancelled();
                         b[1] = d2.isCancelled();
@@ -1853,15 +1853,15 @@ public enum TestHelper {
 
             Flowable<T> source = new Flowable<T>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super T> observer) {
+                protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
                         BooleanSubscription d1 = new BooleanSubscription();
 
-                        observer.onSubscribe(d1);
+                        subscriber.onSubscribe(d1);
 
                         BooleanSubscription d2 = new BooleanSubscription();
 
-                        observer.onSubscribe(d2);
+                        subscriber.onSubscribe(d2);
 
                         b[0] = d1.isCancelled();
                         b[1] = d2.isCancelled();
@@ -2669,24 +2669,24 @@ public enum TestHelper {
         try {
             Flowable<T> bad = new Flowable<T>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super T> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
+                protected void subscribeActual(Subscriber<? super T> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
 
                     if (goodValue != null) {
-                        observer.onNext(goodValue);
+                        subscriber.onNext(goodValue);
                     }
 
                     if (error) {
-                        observer.onError(new TestException("error"));
+                        subscriber.onError(new TestException("error"));
                     } else {
-                        observer.onComplete();
+                        subscriber.onComplete();
                     }
 
                     if (badValue != null) {
-                        observer.onNext(badValue);
+                        subscriber.onNext(badValue);
                     }
-                    observer.onError(new TestException("second"));
-                    observer.onComplete();
+                    subscriber.onError(new TestException("second"));
+                    subscriber.onComplete();
                 }
             };
 
@@ -2879,8 +2879,8 @@ public enum TestHelper {
     public static <T> Flowable<T> rejectFlowableFusion() {
         return new Flowable<T>() {
             @Override
-            protected void subscribeActual(Subscriber<? super T> observer) {
-                observer.onSubscribe(new QueueSubscription<T>() {
+            protected void subscribeActual(Subscriber<? super T> subscriber) {
+                subscriber.onSubscribe(new QueueSubscription<T>() {
 
                     @Override
                     public int requestFusion(int mode) {

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -556,18 +556,18 @@ public enum TestHelper {
     /**
      * Calls onSubscribe twice and checks if it doesn't affect the first Disposable while
      * reporting it to plugin error handler.
-     * @param subscriber the target
+     * @param observer the target
      */
-    public static void doubleOnSubscribe(Observer<?> subscriber) {
+    public static void doubleOnSubscribe(Observer<?> observer) {
         List<Throwable> errors = trackPluginErrors();
         try {
             Disposable d1 = Disposables.empty();
 
-            subscriber.onSubscribe(d1);
+            observer.onSubscribe(d1);
 
             Disposable d2 = Disposables.empty();
 
-            subscriber.onSubscribe(d2);
+            observer.onSubscribe(d2);
 
             assertFalse(d1.isDisposed());
 
@@ -582,18 +582,18 @@ public enum TestHelper {
     /**
      * Calls onSubscribe twice and checks if it doesn't affect the first Disposable while
      * reporting it to plugin error handler.
-     * @param subscriber the target
+     * @param observer the target
      */
-    public static void doubleOnSubscribe(SingleObserver<?> subscriber) {
+    public static void doubleOnSubscribe(SingleObserver<?> observer) {
         List<Throwable> errors = trackPluginErrors();
         try {
             Disposable d1 = Disposables.empty();
 
-            subscriber.onSubscribe(d1);
+            observer.onSubscribe(d1);
 
             Disposable d2 = Disposables.empty();
 
-            subscriber.onSubscribe(d2);
+            observer.onSubscribe(d2);
 
             assertFalse(d1.isDisposed());
 
@@ -608,18 +608,18 @@ public enum TestHelper {
     /**
      * Calls onSubscribe twice and checks if it doesn't affect the first Disposable while
      * reporting it to plugin error handler.
-     * @param subscriber the target
+     * @param observer the target
      */
-    public static void doubleOnSubscribe(CompletableObserver subscriber) {
+    public static void doubleOnSubscribe(CompletableObserver observer) {
         List<Throwable> errors = trackPluginErrors();
         try {
             Disposable d1 = Disposables.empty();
 
-            subscriber.onSubscribe(d1);
+            observer.onSubscribe(d1);
 
             Disposable d2 = Disposables.empty();
 
-            subscriber.onSubscribe(d2);
+            observer.onSubscribe(d2);
 
             assertFalse(d1.isDisposed());
 
@@ -634,18 +634,18 @@ public enum TestHelper {
     /**
      * Calls onSubscribe twice and checks if it doesn't affect the first Disposable while
      * reporting it to plugin error handler.
-     * @param subscriber the target
+     * @param observer the target
      */
-    public static void doubleOnSubscribe(MaybeObserver<?> subscriber) {
+    public static void doubleOnSubscribe(MaybeObserver<?> observer) {
         List<Throwable> errors = trackPluginErrors();
         try {
             Disposable d1 = Disposables.empty();
 
-            subscriber.onSubscribe(d1);
+            observer.onSubscribe(d1);
 
             Disposable d2 = Disposables.empty();
 
-            subscriber.onSubscribe(d2);
+            observer.onSubscribe(d2);
 
             assertFalse(d1.isDisposed());
 
@@ -3042,8 +3042,8 @@ public enum TestHelper {
         }
 
         @Override
-        protected void subscribeActual(Observer<? super T> s) {
-            source.subscribe(new StripBoundaryObserver<T>(s));
+        protected void subscribeActual(Observer<? super T> observer) {
+            source.subscribe(new StripBoundaryObserver<T>(observer));
         }
 
         static final class StripBoundaryObserver<T> implements Observer<T>, QueueDisposable<T> {

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -2465,8 +2465,8 @@ public class CompletableTest {
         }).retryWhen(new Function<Flowable<? extends Throwable>, Publisher<Object>>() {
             @SuppressWarnings({ "rawtypes", "unchecked" })
             @Override
-            public Publisher<Object> apply(Flowable<? extends Throwable> o) {
-                return (Publisher)o;
+            public Publisher<Object> apply(Flowable<? extends Throwable> f) {
+                return (Publisher)f;
             }
         });
 

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -106,9 +106,9 @@ public class CompletableTest {
 
         public final Completable completable = Completable.unsafeCreate(new CompletableSource() {
             @Override
-            public void subscribe(CompletableObserver s) {
+            public void subscribe(CompletableObserver observer) {
                 getAndIncrement();
-                EmptyDisposable.complete(s);
+                EmptyDisposable.complete(observer);
             }
         });
 
@@ -131,9 +131,9 @@ public class CompletableTest {
 
         public final Completable completable = Completable.unsafeCreate(new CompletableSource() {
             @Override
-            public void subscribe(CompletableObserver s) {
+            public void subscribe(CompletableObserver observer) {
                 getAndIncrement();
-                EmptyDisposable.error(new TestException(), s);
+                EmptyDisposable.error(new TestException(), observer);
             }
         });
 
@@ -379,7 +379,7 @@ public class CompletableTest {
     public void createOnSubscribeThrowsNPE() {
         Completable c = Completable.unsafeCreate(new CompletableSource() {
             @Override
-            public void subscribe(CompletableObserver s) { throw new NullPointerException(); }
+            public void subscribe(CompletableObserver observer) { throw new NullPointerException(); }
         });
 
         c.blockingAwait();
@@ -391,7 +391,7 @@ public class CompletableTest {
         try {
             Completable c = Completable.unsafeCreate(new CompletableSource() {
                 @Override
-                public void subscribe(CompletableObserver s) {
+                public void subscribe(CompletableObserver observer) {
                     throw new TestException();
                 }
             });
@@ -2727,9 +2727,9 @@ public class CompletableTest {
 
         Completable c = Completable.unsafeCreate(new CompletableSource() {
             @Override
-            public void subscribe(CompletableObserver s) {
+            public void subscribe(CompletableObserver observer) {
                 name.set(Thread.currentThread().getName());
-                EmptyDisposable.complete(s);
+                EmptyDisposable.complete(observer);
             }
         }).subscribeOn(Schedulers.computation());
 
@@ -2744,9 +2744,9 @@ public class CompletableTest {
 
         Completable c = Completable.unsafeCreate(new CompletableSource() {
             @Override
-            public void subscribe(CompletableObserver s) {
+            public void subscribe(CompletableObserver observer) {
                 name.set(Thread.currentThread().getName());
-                EmptyDisposable.error(new TestException(), s);
+                EmptyDisposable.error(new TestException(), observer);
             }
         }).subscribeOn(Schedulers.computation());
 
@@ -3762,9 +3762,9 @@ public class CompletableTest {
         Completable.error(e)
             .andThen(new Single<String>() {
                 @Override
-                public void subscribeActual(SingleObserver<? super String> s) {
+                public void subscribeActual(SingleObserver<? super String> observer) {
                     hasRun.set(true);
-                    s.onSuccess("foo");
+                    observer.onSuccess("foo");
                 }
             })
             .toFlowable().subscribe(ts);
@@ -4239,8 +4239,8 @@ public class CompletableTest {
         TestSubscriber<String> ts = new TestSubscriber<String>();
 
         Completable completable = Completable.unsafeCreate(new CompletableSource() {
-            @Override public void subscribe(CompletableObserver s) {
-                s.onComplete();
+            @Override public void subscribe(CompletableObserver observer) {
+                observer.onComplete();
             }
         });
         completable.<String>toFlowable().subscribe(ts);

--- a/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
+++ b/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
@@ -318,13 +318,13 @@ public class ExceptionsTest {
     public void testOnErrorExceptionIsThrownFromSubscribe() {
         Observable.unsafeCreate(new ObservableSource<Integer>() {
                               @Override
-                              public void subscribe(Observer<? super Integer> s1) {
+                              public void subscribe(Observer<? super Integer> observer1) {
                                   Observable.unsafeCreate(new ObservableSource<Integer>() {
                                       @Override
-                                      public void subscribe(Observer<? super Integer> s2) {
+                                      public void subscribe(Observer<? super Integer> observer2) {
                                           throw new IllegalArgumentException("original exception");
                                       }
-                                  }).subscribe(s1);
+                                  }).subscribe(observer1);
                               }
                           }
         ).subscribe(new OnErrorFailedSubscriber());
@@ -335,13 +335,13 @@ public class ExceptionsTest {
     public void testOnErrorExceptionIsThrownFromUnsafeSubscribe() {
         Observable.unsafeCreate(new ObservableSource<Integer>() {
                               @Override
-                              public void subscribe(Observer<? super Integer> s1) {
+                              public void subscribe(Observer<? super Integer> observer1) {
                                   Observable.unsafeCreate(new ObservableSource<Integer>() {
                                       @Override
-                                      public void subscribe(Observer<? super Integer> s2) {
+                                      public void subscribe(Observer<? super Integer> observer2) {
                                           throw new IllegalArgumentException("original exception");
                                       }
-                                  }).subscribe(s1);
+                                  }).subscribe(observer1);
                               }
                           }
         ).subscribe(new OnErrorFailedSubscriber());
@@ -365,13 +365,13 @@ public class ExceptionsTest {
     public void testOnErrorExceptionIsThrownFromSingleSubscribe() {
         Single.unsafeCreate(new SingleSource<Integer>() {
                           @Override
-                          public void subscribe(SingleObserver<? super Integer> s1) {
+                          public void subscribe(SingleObserver<? super Integer> observer1) {
                               Single.unsafeCreate(new SingleSource<Integer>() {
                                   @Override
-                                  public void subscribe(SingleObserver<? super Integer> s2) {
+                                  public void subscribe(SingleObserver<? super Integer> observer2) {
                                       throw new IllegalArgumentException("original exception");
                                   }
-                              }).subscribe(s1);
+                              }).subscribe(observer1);
                           }
                       }
         ).toObservable().subscribe(new OnErrorFailedSubscriber());
@@ -382,10 +382,10 @@ public class ExceptionsTest {
     public void testOnErrorExceptionIsThrownFromSingleUnsafeSubscribe() {
         Single.unsafeCreate(new SingleSource<Integer>() {
                           @Override
-                          public void subscribe(final SingleObserver<? super Integer> s1) {
+                          public void subscribe(final SingleObserver<? super Integer> observer1) {
                               Single.unsafeCreate(new SingleSource<Integer>() {
                                   @Override
-                                  public void subscribe(SingleObserver<? super Integer> s2) {
+                                  public void subscribe(SingleObserver<? super Integer> observer2) {
                                       throw new IllegalArgumentException("original exception");
                                   }
                               }).toFlowable().subscribe(new FlowableSubscriber<Integer>() {
@@ -401,12 +401,12 @@ public class ExceptionsTest {
 
                                   @Override
                                   public void onError(Throwable e) {
-                                      s1.onError(e);
+                                      observer1.onError(e);
                                   }
 
                                   @Override
                                   public void onNext(Integer v) {
-                                      s1.onSuccess(v);
+                                      observer1.onSuccess(v);
                                   }
 
                               });

--- a/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
@@ -31,7 +31,7 @@ public final class FlowableCollectTest {
 
     @Test
     public void testCollectToListFlowable() {
-        Flowable<List<Integer>> o = Flowable.just(1, 2, 3)
+        Flowable<List<Integer>> f = Flowable.just(1, 2, 3)
         .collect(new Callable<List<Integer>>() {
             @Override
             public List<Integer> call() {
@@ -44,7 +44,7 @@ public final class FlowableCollectTest {
             }
         }).toFlowable();
 
-        List<Integer> list =  o.blockingLast();
+        List<Integer> list =  f.blockingLast();
 
         assertEquals(3, list.size());
         assertEquals(1, list.get(0).intValue());
@@ -52,7 +52,7 @@ public final class FlowableCollectTest {
         assertEquals(3, list.get(2).intValue());
 
         // test multiple subscribe
-        List<Integer> list2 =  o.blockingLast();
+        List<Integer> list2 =  f.blockingLast();
 
         assertEquals(3, list2.size());
         assertEquals(1, list2.get(0).intValue());

--- a/src/test/java/io/reactivex/flowable/FlowableConcatTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableConcatTests.java
@@ -26,10 +26,10 @@ public class FlowableConcatTests {
 
     @Test
     public void testConcatSimple() {
-        Flowable<String> o1 = Flowable.just("one", "two");
-        Flowable<String> o2 = Flowable.just("three", "four");
+        Flowable<String> f1 = Flowable.just("one", "two");
+        Flowable<String> f2 = Flowable.just("three", "four");
 
-        List<String> values = Flowable.concat(o1, o2).toList().blockingGet();
+        List<String> values = Flowable.concat(f1, f2).toList().blockingGet();
 
         assertEquals("one", values.get(0));
         assertEquals("two", values.get(1));
@@ -39,11 +39,11 @@ public class FlowableConcatTests {
 
     @Test
     public void testConcatWithFlowableOfFlowable() {
-        Flowable<String> o1 = Flowable.just("one", "two");
-        Flowable<String> o2 = Flowable.just("three", "four");
-        Flowable<String> o3 = Flowable.just("five", "six");
+        Flowable<String> f1 = Flowable.just("one", "two");
+        Flowable<String> f2 = Flowable.just("three", "four");
+        Flowable<String> f3 = Flowable.just("five", "six");
 
-        Flowable<Flowable<String>> os = Flowable.just(o1, o2, o3);
+        Flowable<Flowable<String>> os = Flowable.just(f1, f2, f3);
 
         List<String> values = Flowable.concat(os).toList().blockingGet();
 
@@ -57,12 +57,12 @@ public class FlowableConcatTests {
 
     @Test
     public void testConcatWithIterableOfFlowable() {
-        Flowable<String> o1 = Flowable.just("one", "two");
-        Flowable<String> o2 = Flowable.just("three", "four");
-        Flowable<String> o3 = Flowable.just("five", "six");
+        Flowable<String> f1 = Flowable.just("one", "two");
+        Flowable<String> f2 = Flowable.just("three", "four");
+        Flowable<String> f3 = Flowable.just("five", "six");
 
         @SuppressWarnings("unchecked")
-        Iterable<Flowable<String>> is = Arrays.asList(o1, o2, o3);
+        Iterable<Flowable<String>> is = Arrays.asList(f1, f2, f3);
 
         List<String> values = Flowable.concat(Flowable.fromIterable(is)).toList().blockingGet();
 
@@ -81,10 +81,10 @@ public class FlowableConcatTests {
         Media media = new Media();
         HorrorMovie horrorMovie2 = new HorrorMovie();
 
-        Flowable<Media> o1 = Flowable.<Media> just(horrorMovie1, movie);
-        Flowable<Media> o2 = Flowable.just(media, horrorMovie2);
+        Flowable<Media> f1 = Flowable.<Media> just(horrorMovie1, movie);
+        Flowable<Media> f2 = Flowable.just(media, horrorMovie2);
 
-        Flowable<Flowable<Media>> os = Flowable.just(o1, o2);
+        Flowable<Flowable<Media>> os = Flowable.just(f1, f2);
 
         List<Media> values = Flowable.concat(os).toList().blockingGet();
 
@@ -103,10 +103,10 @@ public class FlowableConcatTests {
         Media media2 = new Media();
         HorrorMovie horrorMovie2 = new HorrorMovie();
 
-        Flowable<Media> o1 = Flowable.just(horrorMovie1, movie, media1);
-        Flowable<Media> o2 = Flowable.just(media2, horrorMovie2);
+        Flowable<Media> f1 = Flowable.just(horrorMovie1, movie, media1);
+        Flowable<Media> f2 = Flowable.just(media2, horrorMovie2);
 
-        Flowable<Flowable<Media>> os = Flowable.just(o1, o2);
+        Flowable<Flowable<Media>> os = Flowable.just(f1, f2);
 
         List<Media> values = Flowable.concat(os).toList().blockingGet();
 
@@ -125,10 +125,10 @@ public class FlowableConcatTests {
         Media media = new Media();
         HorrorMovie horrorMovie2 = new HorrorMovie();
 
-        Flowable<Movie> o1 = Flowable.just(horrorMovie1, movie);
-        Flowable<Media> o2 = Flowable.just(media, horrorMovie2);
+        Flowable<Movie> f1 = Flowable.just(horrorMovie1, movie);
+        Flowable<Media> f2 = Flowable.just(media, horrorMovie2);
 
-        List<Media> values = Flowable.concat(o1, o2).toList().blockingGet();
+        List<Media> values = Flowable.concat(f1, f2).toList().blockingGet();
 
         assertEquals(horrorMovie1, values.get(0));
         assertEquals(movie, values.get(1));
@@ -144,19 +144,19 @@ public class FlowableConcatTests {
         Media media = new Media();
         HorrorMovie horrorMovie2 = new HorrorMovie();
 
-        Flowable<Movie> o1 = Flowable.unsafeCreate(new Publisher<Movie>() {
+        Flowable<Movie> f1 = Flowable.unsafeCreate(new Publisher<Movie>() {
             @Override
-            public void subscribe(Subscriber<? super Movie> o) {
-                    o.onNext(horrorMovie1);
-                    o.onNext(movie);
+            public void subscribe(Subscriber<? super Movie> subscriber) {
+                    subscriber.onNext(horrorMovie1);
+                    subscriber.onNext(movie);
                     //                o.onNext(new Media()); // correctly doesn't compile
-                    o.onComplete();
+                    subscriber.onComplete();
             }
         });
 
-        Flowable<Media> o2 = Flowable.just(media, horrorMovie2);
+        Flowable<Media> f2 = Flowable.just(media, horrorMovie2);
 
-        List<Media> values = Flowable.concat(o1, o2).toList().blockingGet();
+        List<Media> values = Flowable.concat(f1, f2).toList().blockingGet();
 
         assertEquals(horrorMovie1, values.get(0));
         assertEquals(movie, values.get(1));

--- a/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
@@ -147,7 +147,7 @@ public class FlowableConversionTest {
 
     @Test
     public void testConversionBetweenObservableClasses() {
-        final TestObserver<String> subscriber = new TestObserver<String>(new DefaultObserver<String>() {
+        final TestObserver<String> to = new TestObserver<String>(new DefaultObserver<String>() {
 
             @Override
             public void onComplete() {
@@ -196,10 +196,10 @@ public class FlowableConversionTest {
                     return a + n + "\n";
                 }
             })
-            .subscribe(subscriber);
+            .subscribe(to);
 
-        subscriber.assertNoErrors();
-        subscriber.assertComplete();
+        to.assertNoErrors();
+        to.assertComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
@@ -115,16 +115,16 @@ public class FlowableConversionTest {
         public CylonDetectorObservable<R> apply(final Publisher<T> onSubscribe) {
             return CylonDetectorObservable.create(new Publisher<R>() {
                 @Override
-                public void subscribe(Subscriber<? super R> o) {
+                public void subscribe(Subscriber<? super R> subscriber) {
                     try {
-                        Subscriber<? super T> st = operator.apply(o);
+                        Subscriber<? super T> st = operator.apply(subscriber);
                         try {
                             onSubscribe.subscribe(st);
                         } catch (Throwable e) {
                             st.onError(e);
                         }
                     } catch (Throwable e) {
-                        o.onError(e);
+                        subscriber.onError(e);
                     }
 
                 }});

--- a/src/test/java/io/reactivex/flowable/FlowableCovarianceTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableCovarianceTest.java
@@ -56,12 +56,12 @@ public class FlowableCovarianceTest {
         };
 
         // this one would work without the covariance generics
-        Flowable<Media> o = Flowable.just(new Movie(), new TVSeason(), new Album());
-        o.toSortedList(sortFunction);
+        Flowable<Media> f = Flowable.just(new Movie(), new TVSeason(), new Album());
+        f.toSortedList(sortFunction);
 
         // this one would NOT work without the covariance generics
-        Flowable<Movie> o2 = Flowable.just(new Movie(), new ActionMovie(), new HorrorMovie());
-        o2.toSortedList(sortFunction);
+        Flowable<Movie> f2 = Flowable.just(new Movie(), new ActionMovie(), new HorrorMovie());
+        f2.toSortedList(sortFunction);
     }
 
     @Test

--- a/src/test/java/io/reactivex/flowable/FlowableErrorHandlingTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableErrorHandlingTests.java
@@ -35,8 +35,8 @@ public class FlowableErrorHandlingTests {
     public void testOnNextError() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<Throwable>();
-        Flowable<Long> o = Flowable.interval(50, TimeUnit.MILLISECONDS);
-        Subscriber<Long> observer = new DefaultSubscriber<Long>() {
+        Flowable<Long> f = Flowable.interval(50, TimeUnit.MILLISECONDS);
+        Subscriber<Long> subscriber = new DefaultSubscriber<Long>() {
 
             @Override
             public void onComplete() {
@@ -56,7 +56,7 @@ public class FlowableErrorHandlingTests {
                 throw new RuntimeException("forced failure");
             }
         };
-        o.safeSubscribe(observer);
+        f.safeSubscribe(subscriber);
 
         latch.await(2000, TimeUnit.MILLISECONDS);
         assertNotNull(caughtError.get());
@@ -71,8 +71,8 @@ public class FlowableErrorHandlingTests {
     public void testOnNextErrorAcrossThread() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<Throwable>();
-        Flowable<Long> o = Flowable.interval(50, TimeUnit.MILLISECONDS);
-        Subscriber<Long> observer = new DefaultSubscriber<Long>() {
+        Flowable<Long> f = Flowable.interval(50, TimeUnit.MILLISECONDS);
+        Subscriber<Long> subscriber = new DefaultSubscriber<Long>() {
 
             @Override
             public void onComplete() {
@@ -92,8 +92,8 @@ public class FlowableErrorHandlingTests {
                 throw new RuntimeException("forced failure");
             }
         };
-        o.observeOn(Schedulers.newThread())
-        .safeSubscribe(observer);
+        f.observeOn(Schedulers.newThread())
+        .safeSubscribe(subscriber);
 
         latch.await(2000, TimeUnit.MILLISECONDS);
         assertNotNull(caughtError.get());

--- a/src/test/java/io/reactivex/flowable/FlowableMergeTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableMergeTests.java
@@ -38,10 +38,10 @@ public class FlowableMergeTests {
 
     @Test
     public void testMergeCovariance() {
-        Flowable<Media> o1 = Flowable.<Media> just(new HorrorMovie(), new Movie());
-        Flowable<Media> o2 = Flowable.just(new Media(), new HorrorMovie());
+        Flowable<Media> f1 = Flowable.<Media> just(new HorrorMovie(), new Movie());
+        Flowable<Media> f2 = Flowable.just(new Media(), new HorrorMovie());
 
-        Flowable<Flowable<Media>> os = Flowable.just(o1, o2);
+        Flowable<Flowable<Media>> os = Flowable.just(f1, f2);
 
         List<Media> values = Flowable.merge(os).toList().blockingGet();
 
@@ -50,10 +50,10 @@ public class FlowableMergeTests {
 
     @Test
     public void testMergeCovariance2() {
-        Flowable<Media> o1 = Flowable.just(new HorrorMovie(), new Movie(), new Media());
-        Flowable<Media> o2 = Flowable.just(new Media(), new HorrorMovie());
+        Flowable<Media> f1 = Flowable.just(new HorrorMovie(), new Movie(), new Media());
+        Flowable<Media> f2 = Flowable.just(new Media(), new HorrorMovie());
 
-        Flowable<Flowable<Media>> os = Flowable.just(o1, o2);
+        Flowable<Flowable<Media>> os = Flowable.just(f1, f2);
 
         List<Media> values = Flowable.merge(os).toList().blockingGet();
 
@@ -62,10 +62,10 @@ public class FlowableMergeTests {
 
     @Test
     public void testMergeCovariance3() {
-        Flowable<Movie> o1 = Flowable.just(new HorrorMovie(), new Movie());
-        Flowable<Media> o2 = Flowable.just(new Media(), new HorrorMovie());
+        Flowable<Movie> f1 = Flowable.just(new HorrorMovie(), new Movie());
+        Flowable<Media> f2 = Flowable.just(new Media(), new HorrorMovie());
 
-        List<Media> values = Flowable.merge(o1, o2).toList().blockingGet();
+        List<Media> values = Flowable.merge(f1, f2).toList().blockingGet();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);
@@ -76,7 +76,7 @@ public class FlowableMergeTests {
     @Test
     public void testMergeCovariance4() {
 
-        Flowable<Movie> o1 = Flowable.defer(new Callable<Publisher<Movie>>() {
+        Flowable<Movie> f1 = Flowable.defer(new Callable<Publisher<Movie>>() {
             @Override
             public Publisher<Movie> call() {
                 return Flowable.just(
@@ -86,9 +86,9 @@ public class FlowableMergeTests {
             }
         });
 
-        Flowable<Media> o2 = Flowable.just(new Media(), new HorrorMovie());
+        Flowable<Media> f2 = Flowable.just(new Media(), new HorrorMovie());
 
-        List<Media> values = Flowable.merge(o1, o2).toList().blockingGet();
+        List<Media> values = Flowable.merge(f1, f2).toList().blockingGet();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -1805,7 +1805,7 @@ public class FlowableNullTests {
     public void replaySelectorReturnsNull() {
         just1.replay(new Function<Flowable<Integer>, Publisher<Object>>() {
             @Override
-            public Publisher<Object> apply(Flowable<Integer> o) {
+            public Publisher<Object> apply(Flowable<Integer> f) {
                 return null;
             }
         }).blockingSubscribe();
@@ -2738,72 +2738,72 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void asyncSubjectOnNextNull() {
-        FlowableProcessor<Integer> subject = AsyncProcessor.create();
-        subject.onNext(null);
-        subject.blockingSubscribe();
+        FlowableProcessor<Integer> processor = AsyncProcessor.create();
+        processor.onNext(null);
+        processor.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void asyncSubjectOnErrorNull() {
-        FlowableProcessor<Integer> subject = AsyncProcessor.create();
-        subject.onError(null);
-        subject.blockingSubscribe();
+        FlowableProcessor<Integer> processor = AsyncProcessor.create();
+        processor.onError(null);
+        processor.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void behaviorSubjectOnNextNull() {
-        FlowableProcessor<Integer> subject = BehaviorProcessor.create();
-        subject.onNext(null);
-        subject.blockingSubscribe();
+        FlowableProcessor<Integer> processor = BehaviorProcessor.create();
+        processor.onNext(null);
+        processor.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void behaviorSubjectOnErrorNull() {
-        FlowableProcessor<Integer> subject = BehaviorProcessor.create();
-        subject.onError(null);
-        subject.blockingSubscribe();
+        FlowableProcessor<Integer> processor = BehaviorProcessor.create();
+        processor.onError(null);
+        processor.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void publishSubjectOnNextNull() {
-        FlowableProcessor<Integer> subject = PublishProcessor.create();
-        subject.onNext(null);
-        subject.blockingSubscribe();
+        FlowableProcessor<Integer> processor = PublishProcessor.create();
+        processor.onNext(null);
+        processor.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void publishSubjectOnErrorNull() {
-        FlowableProcessor<Integer> subject = PublishProcessor.create();
-        subject.onError(null);
-        subject.blockingSubscribe();
+        FlowableProcessor<Integer> processor = PublishProcessor.create();
+        processor.onError(null);
+        processor.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void replaycSubjectOnNextNull() {
-        FlowableProcessor<Integer> subject = ReplayProcessor.create();
-        subject.onNext(null);
-        subject.blockingSubscribe();
+        FlowableProcessor<Integer> processor = ReplayProcessor.create();
+        processor.onNext(null);
+        processor.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void replaySubjectOnErrorNull() {
-        FlowableProcessor<Integer> subject = ReplayProcessor.create();
-        subject.onError(null);
-        subject.blockingSubscribe();
+        FlowableProcessor<Integer> processor = ReplayProcessor.create();
+        processor.onError(null);
+        processor.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void serializedcSubjectOnNextNull() {
-        FlowableProcessor<Integer> subject = PublishProcessor.<Integer>create().toSerialized();
-        subject.onNext(null);
-        subject.blockingSubscribe();
+        FlowableProcessor<Integer> processor = PublishProcessor.<Integer>create().toSerialized();
+        processor.onNext(null);
+        processor.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void serializedSubjectOnErrorNull() {
-        FlowableProcessor<Integer> subject = PublishProcessor.<Integer>create().toSerialized();
-        subject.onError(null);
-        subject.blockingSubscribe();
+        FlowableProcessor<Integer> processor = PublishProcessor.<Integer>create().toSerialized();
+        processor.onError(null);
+        processor.blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/flowable/FlowableReduceTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableReduceTests.java
@@ -25,8 +25,8 @@ public class FlowableReduceTests {
 
     @Test
     public void reduceIntsFlowable() {
-        Flowable<Integer> o = Flowable.just(1, 2, 3);
-        int value = o.reduce(new BiFunction<Integer, Integer, Integer>() {
+        Flowable<Integer> f = Flowable.just(1, 2, 3);
+        int value = f.reduce(new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2) {
                 return t1 + t2;
@@ -80,8 +80,8 @@ public class FlowableReduceTests {
 
     @Test
     public void reduceInts() {
-        Flowable<Integer> o = Flowable.just(1, 2, 3);
-        int value = o.reduce(new BiFunction<Integer, Integer, Integer>() {
+        Flowable<Integer> f = Flowable.just(1, 2, 3);
+        int value = f.reduce(new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2) {
                 return t1 + t2;

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -27,10 +27,11 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.TestException;
+import io.reactivex.exceptions.*;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.*;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
@@ -99,15 +100,15 @@ public class FlowableTests {
 
         Flowable<String> observable = Flowable.just("one", "two", "three");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -323,7 +324,7 @@ public class FlowableTests {
     @Ignore("Throwing is not allowed from the unsafeCreate?!")
     @Test // FIXME throwing is not allowed from the create?!
     public void testOnSubscribeFails() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         final RuntimeException re = new RuntimeException("bad impl");
         Flowable<String> o = Flowable.unsafeCreate(new Publisher<String>() {
@@ -331,10 +332,11 @@ public class FlowableTests {
             public void subscribe(Subscriber<? super String> s) { throw re; }
         });
 
-        o.subscribe(observer);
-        verify(observer, times(0)).onNext(anyString());
-        verify(observer, times(0)).onComplete();
-        verify(observer, times(1)).onError(re);
+        o.subscribe(subscriber);
+
+        verify(subscriber, times(0)).onNext(anyString());
+        verify(subscriber, times(0)).onComplete();
+        verify(subscriber, times(1)).onError(re);
     }
 
     @Test
@@ -342,13 +344,13 @@ public class FlowableTests {
         Flowable<Integer> obs = Flowable.just(1);
         Flowable<Integer> chained = obs.materialize().dematerialize();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        chained.subscribe(observer);
+        chained.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(1);
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(0)).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(0)).onError(any(Throwable.class));
     }
 
     /**
@@ -770,17 +772,16 @@ public class FlowableTests {
     public void testOfType() {
         Flowable<String> observable = Flowable.just(1, "abc", false, 2L).ofType(String.class);
 
-        Subscriber<Object> observer = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, never()).onNext(1);
-        verify(observer, times(1)).onNext("abc");
-        verify(observer, never()).onNext(false);
-        verify(observer, never()).onNext(2L);
-        verify(observer, never()).onError(
-                any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onNext(1);
+        verify(subscriber, times(1)).onNext("abc");
+        verify(subscriber, never()).onNext(false);
+        verify(subscriber, never()).onNext(2L);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -793,46 +794,43 @@ public class FlowableTests {
         @SuppressWarnings("rawtypes")
         Flowable<List> observable = Flowable.<Object> just(l1, l2, "123").ofType(List.class);
 
-        Subscriber<Object> observer = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(l1);
-        verify(observer, times(1)).onNext(l2);
-        verify(observer, never()).onNext("123");
-        verify(observer, never()).onError(
-                any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(l1);
+        verify(subscriber, times(1)).onNext(l2);
+        verify(subscriber, never()).onNext("123");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testContainsFlowable() {
         Flowable<Boolean> observable = Flowable.just("a", "b", "c").contains("b").toFlowable();
 
-        FlowableSubscriber<Boolean> observer = TestHelper.mockSubscriber();
+        FlowableSubscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onNext(false);
-        verify(observer, never()).onError(
-                any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(true);
+        verify(subscriber, never()).onNext(false);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testContainsWithInexistenceFlowable() {
         Flowable<Boolean> observable = Flowable.just("a", "b").contains("c").toFlowable();
 
-        Subscriber<Object> observer = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(false);
-        verify(observer, never()).onNext(true);
-        verify(observer, never()).onError(
-                any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(false);
+        verify(subscriber, never()).onNext(true);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -840,30 +838,28 @@ public class FlowableTests {
     public void testContainsWithNullFlowable() {
         Flowable<Boolean> observable = Flowable.just("a", "b", null).contains(null).toFlowable();
 
-        Subscriber<Object> observer = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onNext(false);
-        verify(observer, never()).onError(
-                any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(true);
+        verify(subscriber, never()).onNext(false);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testContainsWithEmptyObservableFlowable() {
         Flowable<Boolean> observable = Flowable.<String> empty().contains("a").toFlowable();
 
-        FlowableSubscriber<Object> observer = TestHelper.mockSubscriber();
+        FlowableSubscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(false);
-        verify(observer, never()).onNext(true);
-        verify(observer, never()).onError(
-                any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(false);
+        verify(subscriber, never()).onNext(true);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
 
@@ -928,13 +924,13 @@ public class FlowableTests {
     public void testIgnoreElementsFlowable() {
         Flowable<Integer> observable = Flowable.just(1, 2, 3).ignoreElements().toFlowable();
 
-        Subscriber<Object> observer = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, never()).onNext(any(Integer.class));
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onNext(any(Integer.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -954,16 +950,16 @@ public class FlowableTests {
         TestScheduler scheduler = new TestScheduler();
         Flowable<Integer> observable = Flowable.fromArray(1, 2).subscribeOn(scheduler);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
         scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(1);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -972,18 +968,18 @@ public class FlowableTests {
         TestScheduler scheduler = new TestScheduler();
         Flowable<Integer> observable = Flowable.just(3, 4).startWith(Arrays.asList(1, 2)).subscribeOn(scheduler);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
         scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onNext(3);
-        inOrder.verify(observer, times(1)).onNext(4);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(1);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onNext(3);
+        inOrder.verify(subscriber, times(1)).onNext(4);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -992,18 +988,18 @@ public class FlowableTests {
         TestScheduler scheduler = new TestScheduler();
         Flowable<Integer> observable = Flowable.range(3, 4).subscribeOn(scheduler);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
         scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(3);
-        inOrder.verify(observer, times(1)).onNext(4);
-        inOrder.verify(observer, times(1)).onNext(5);
-        inOrder.verify(observer, times(1)).onNext(6);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(3);
+        inOrder.verify(subscriber, times(1)).onNext(4);
+        inOrder.verify(subscriber, times(1)).onNext(5);
+        inOrder.verify(subscriber, times(1)).onNext(6);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -1075,18 +1071,25 @@ public class FlowableTests {
 
     @Test
     public void testErrorThrownIssue1685() {
-        FlowableProcessor<Object> subject = ReplayProcessor.create();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            FlowableProcessor<Object> subject = ReplayProcessor.create();
 
-        Flowable.error(new RuntimeException("oops"))
-            .materialize()
-            .delay(1, TimeUnit.SECONDS)
-            .dematerialize()
-            .subscribe(subject);
+            Flowable.error(new RuntimeException("oops"))
+                .materialize()
+                .delay(1, TimeUnit.SECONDS)
+                .dematerialize()
+                .subscribe(subject);
 
-        subject.subscribe();
-        subject.materialize().blockingFirst();
+            subject.subscribe();
+            subject.materialize().blockingFirst();
 
-        System.out.println("Done");
+            System.out.println("Done");
+
+            TestHelper.assertError(errors, 0, OnErrorNotImplementedException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -98,11 +98,11 @@ public class FlowableTests {
     @Test
     public void testCreate() {
 
-        Flowable<String> observable = Flowable.just("one", "two", "three");
+        Flowable<String> flowable = Flowable.just("one", "two", "three");
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext("one");
         verify(subscriber, times(1)).onNext("two");
@@ -113,9 +113,9 @@ public class FlowableTests {
 
     @Test
     public void testCountAFewItemsFlowable() {
-        Flowable<String> observable = Flowable.just("a", "b", "c", "d");
+        Flowable<String> flowable = Flowable.just("a", "b", "c", "d");
 
-        observable.count().toFlowable().subscribe(w);
+        flowable.count().toFlowable().subscribe(w);
 
         // we should be called only once
         verify(w).onNext(4L);
@@ -125,8 +125,8 @@ public class FlowableTests {
 
     @Test
     public void testCountZeroItemsFlowable() {
-        Flowable<String> observable = Flowable.empty();
-        observable.count().toFlowable().subscribe(w);
+        Flowable<String> flowable = Flowable.empty();
+        flowable.count().toFlowable().subscribe(w);
         // we should be called only once
         verify(w).onNext(0L);
         verify(w, never()).onError(any(Throwable.class));
@@ -135,14 +135,14 @@ public class FlowableTests {
 
     @Test
     public void testCountErrorFlowable() {
-        Flowable<String> o = Flowable.error(new Callable<Throwable>() {
+        Flowable<String> f = Flowable.error(new Callable<Throwable>() {
             @Override
             public Throwable call() {
                 return new RuntimeException();
             }
         });
 
-        o.count().toFlowable().subscribe(w);
+        f.count().toFlowable().subscribe(w);
         verify(w, never()).onNext(anyInt());
         verify(w, never()).onComplete();
         verify(w, times(1)).onError(any(RuntimeException.class));
@@ -151,9 +151,9 @@ public class FlowableTests {
 
     @Test
     public void testCountAFewItems() {
-        Flowable<String> observable = Flowable.just("a", "b", "c", "d");
+        Flowable<String> flowable = Flowable.just("a", "b", "c", "d");
 
-        observable.count().subscribe(wo);
+        flowable.count().subscribe(wo);
 
         // we should be called only once
         verify(wo).onSuccess(4L);
@@ -162,8 +162,8 @@ public class FlowableTests {
 
     @Test
     public void testCountZeroItems() {
-        Flowable<String> observable = Flowable.empty();
-        observable.count().subscribe(wo);
+        Flowable<String> flowable = Flowable.empty();
+        flowable.count().subscribe(wo);
         // we should be called only once
         verify(wo).onSuccess(0L);
         verify(wo, never()).onError(any(Throwable.class));
@@ -171,22 +171,22 @@ public class FlowableTests {
 
     @Test
     public void testCountError() {
-        Flowable<String> o = Flowable.error(new Callable<Throwable>() {
+        Flowable<String> f = Flowable.error(new Callable<Throwable>() {
             @Override
             public Throwable call() {
                 return new RuntimeException();
             }
         });
 
-        o.count().subscribe(wo);
+        f.count().subscribe(wo);
         verify(wo, never()).onSuccess(anyInt());
         verify(wo, times(1)).onError(any(RuntimeException.class));
     }
 
     @Test
     public void testTakeFirstWithPredicateOfSome() {
-        Flowable<Integer> observable = Flowable.just(1, 3, 5, 4, 6, 3);
-        observable.filter(IS_EVEN).take(1).subscribe(w);
+        Flowable<Integer> flowable = Flowable.just(1, 3, 5, 4, 6, 3);
+        flowable.filter(IS_EVEN).take(1).subscribe(w);
         verify(w, times(1)).onNext(anyInt());
         verify(w).onNext(4);
         verify(w, times(1)).onComplete();
@@ -195,8 +195,8 @@ public class FlowableTests {
 
     @Test
     public void testTakeFirstWithPredicateOfNoneMatchingThePredicate() {
-        Flowable<Integer> observable = Flowable.just(1, 3, 5, 7, 9, 7, 5, 3, 1);
-        observable.filter(IS_EVEN).take(1).subscribe(w);
+        Flowable<Integer> flowable = Flowable.just(1, 3, 5, 7, 9, 7, 5, 3, 1);
+        flowable.filter(IS_EVEN).take(1).subscribe(w);
         verify(w, never()).onNext(anyInt());
         verify(w, times(1)).onComplete();
         verify(w, never()).onError(any(Throwable.class));
@@ -204,8 +204,8 @@ public class FlowableTests {
 
     @Test
     public void testTakeFirstOfSome() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3);
-        observable.take(1).subscribe(w);
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3);
+        flowable.take(1).subscribe(w);
         verify(w, times(1)).onNext(anyInt());
         verify(w).onNext(1);
         verify(w, times(1)).onComplete();
@@ -214,8 +214,8 @@ public class FlowableTests {
 
     @Test
     public void testTakeFirstOfNone() {
-        Flowable<Integer> observable = Flowable.empty();
-        observable.take(1).subscribe(w);
+        Flowable<Integer> flowable = Flowable.empty();
+        flowable.take(1).subscribe(w);
         verify(w, never()).onNext(anyInt());
         verify(w, times(1)).onComplete();
         verify(w, never()).onError(any(Throwable.class));
@@ -223,8 +223,8 @@ public class FlowableTests {
 
     @Test
     public void testFirstOfNoneFlowable() {
-        Flowable<Integer> observable = Flowable.empty();
-        observable.firstElement().toFlowable().subscribe(w);
+        Flowable<Integer> flowable = Flowable.empty();
+        flowable.firstElement().toFlowable().subscribe(w);
         verify(w, never()).onNext(anyInt());
         verify(w).onComplete();
         verify(w, never()).onError(any(Throwable.class));
@@ -232,8 +232,8 @@ public class FlowableTests {
 
     @Test
     public void testFirstWithPredicateOfNoneMatchingThePredicateFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 3, 5, 7, 9, 7, 5, 3, 1);
-        observable.filter(IS_EVEN).firstElement().toFlowable().subscribe(w);
+        Flowable<Integer> flowable = Flowable.just(1, 3, 5, 7, 9, 7, 5, 3, 1);
+        flowable.filter(IS_EVEN).firstElement().toFlowable().subscribe(w);
         verify(w, never()).onNext(anyInt());
         verify(w).onComplete();
         verify(w, never()).onError(any(Throwable.class));
@@ -241,8 +241,8 @@ public class FlowableTests {
 
     @Test
     public void testFirstOfNone() {
-        Flowable<Integer> observable = Flowable.empty();
-        observable.firstElement().subscribe(wm);
+        Flowable<Integer> flowable = Flowable.empty();
+        flowable.firstElement().subscribe(wm);
         verify(wm, never()).onSuccess(anyInt());
         verify(wm).onComplete();
         verify(wm, never()).onError(isA(NoSuchElementException.class));
@@ -250,8 +250,8 @@ public class FlowableTests {
 
     @Test
     public void testFirstWithPredicateOfNoneMatchingThePredicate() {
-        Flowable<Integer> observable = Flowable.just(1, 3, 5, 7, 9, 7, 5, 3, 1);
-        observable.filter(IS_EVEN).firstElement().subscribe(wm);
+        Flowable<Integer> flowable = Flowable.just(1, 3, 5, 7, 9, 7, 5, 3, 1);
+        flowable.filter(IS_EVEN).firstElement().subscribe(wm);
         verify(wm, never()).onSuccess(anyInt());
         verify(wm, times(1)).onComplete();
         verify(wm, never()).onError(isA(NoSuchElementException.class));
@@ -259,8 +259,8 @@ public class FlowableTests {
 
     @Test
     public void testReduce() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3, 4);
-        observable.reduce(new BiFunction<Integer, Integer, Integer>() {
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4);
+        flowable.reduce(new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2) {
                 return t1 + t2;
@@ -275,8 +275,8 @@ public class FlowableTests {
 
     @Test
     public void testReduceWithEmptyObservable() {
-        Flowable<Integer> observable = Flowable.range(1, 0);
-        observable.reduce(new BiFunction<Integer, Integer, Integer>() {
+        Flowable<Integer> flowable = Flowable.range(1, 0);
+        flowable.reduce(new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2) {
                 return t1 + t2;
@@ -294,8 +294,8 @@ public class FlowableTests {
      */
     @Test
     public void testReduceWithEmptyObservableAndSeed() {
-        Flowable<Integer> observable = Flowable.range(1, 0);
-        int value = observable.reduce(1, new BiFunction<Integer, Integer, Integer>() {
+        Flowable<Integer> flowable = Flowable.range(1, 0);
+        int value = flowable.reduce(1, new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2) {
                 return t1 + t2;
@@ -308,8 +308,8 @@ public class FlowableTests {
 
     @Test
     public void testReduceWithInitialValue() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3, 4);
-        observable.reduce(50, new BiFunction<Integer, Integer, Integer>() {
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4);
+        flowable.reduce(50, new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2) {
                 return t1 + t2;
@@ -327,12 +327,12 @@ public class FlowableTests {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         final RuntimeException re = new RuntimeException("bad impl");
-        Flowable<String> o = Flowable.unsafeCreate(new Publisher<String>() {
+        Flowable<String> f = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
             public void subscribe(Subscriber<? super String> s) { throw re; }
         });
 
-        o.subscribe(subscriber);
+        f.subscribe(subscriber);
 
         verify(subscriber, times(0)).onNext(anyString());
         verify(subscriber, times(0)).onComplete();
@@ -496,15 +496,15 @@ public class FlowableTests {
         final AtomicInteger count = new AtomicInteger();
         ConnectableFlowable<String> connectable = Flowable.<String>unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(final Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(final Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 count.incrementAndGet();
                 new Thread(new Runnable() {
                     @Override
                     public void run() {
-                        observer.onNext("first");
-                        observer.onNext("last");
-                        observer.onComplete();
+                        subscriber.onNext("first");
+                        subscriber.onNext("last");
+                        subscriber.onComplete();
                     }
                 }).start();
             }
@@ -532,31 +532,31 @@ public class FlowableTests {
     @Test
     public void testReplay() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        ConnectableFlowable<String> o = Flowable.<String>unsafeCreate(new Publisher<String>() {
+        ConnectableFlowable<String> f = Flowable.<String>unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(final Subscriber<? super String> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(final Subscriber<? super String> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
                     new Thread(new Runnable() {
 
                         @Override
                         public void run() {
                             counter.incrementAndGet();
-                            observer.onNext("one");
-                            observer.onComplete();
+                            subscriber.onNext("one");
+                            subscriber.onComplete();
                         }
                     }).start();
             }
         }).replay();
 
         // we connect immediately and it will emit the value
-        Disposable s = o.connect();
+        Disposable s = f.connect();
         try {
 
             // we then expect the following 2 subscriptions to get that same value
             final CountDownLatch latch = new CountDownLatch(2);
 
             // subscribe once
-            o.subscribe(new Consumer<String>() {
+            f.subscribe(new Consumer<String>() {
                 @Override
                 public void accept(String v) {
                     assertEquals("one", v);
@@ -565,7 +565,7 @@ public class FlowableTests {
             });
 
             // subscribe again
-            o.subscribe(new Consumer<String>() {
+            f.subscribe(new Consumer<String>() {
                 @Override
                 public void accept(String v) {
                     assertEquals("one", v);
@@ -585,16 +585,16 @@ public class FlowableTests {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> o = Flowable.<String>unsafeCreate(new Publisher<String>() {
+        Flowable<String> f = Flowable.<String>unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(final Subscriber<? super String> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(final Subscriber<? super String> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
                     new Thread(new Runnable() {
                         @Override
                         public void run() {
                             counter.incrementAndGet();
-                            observer.onNext("one");
-                            observer.onComplete();
+                            subscriber.onNext("one");
+                            subscriber.onComplete();
                         }
                     }).start();
             }
@@ -604,7 +604,7 @@ public class FlowableTests {
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
             @Override
             public void accept(String v) {
                 assertEquals("one", v);
@@ -613,7 +613,7 @@ public class FlowableTests {
         });
 
         // subscribe again
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
             @Override
             public void accept(String v) {
                 assertEquals("one", v);
@@ -630,16 +630,16 @@ public class FlowableTests {
     @Test
     public void testCacheWithCapacity() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> o = Flowable.<String>unsafeCreate(new Publisher<String>() {
+        Flowable<String> f = Flowable.<String>unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(final Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(final Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 new Thread(new Runnable() {
                     @Override
                     public void run() {
                         counter.incrementAndGet();
-                        observer.onNext("one");
-                        observer.onComplete();
+                        subscriber.onNext("one");
+                        subscriber.onComplete();
                     }
                 }).start();
             }
@@ -649,7 +649,7 @@ public class FlowableTests {
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
             @Override
             public void accept(String v) {
                 assertEquals("one", v);
@@ -658,7 +658,7 @@ public class FlowableTests {
         });
 
         // subscribe again
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
             @Override
             public void accept(String v) {
                 assertEquals("one", v);
@@ -711,13 +711,13 @@ public class FlowableTests {
         final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
         Flowable.unsafeCreate(new Publisher<Object>() {
             @Override
-            public void subscribe(final Subscriber<? super Object> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(final Subscriber<? super Object> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 new Thread(new Runnable() {
                     @Override
                     public void run() {
                         try {
-                            observer.onError(new Error("failure"));
+                            subscriber.onError(new Error("failure"));
                         } catch (Throwable e) {
                             // without an onError handler it has to just throw on whatever thread invokes it
                             exception.set(e);
@@ -770,11 +770,11 @@ public class FlowableTests {
 
     @Test
     public void testOfType() {
-        Flowable<String> observable = Flowable.just(1, "abc", false, 2L).ofType(String.class);
+        Flowable<String> flowable = Flowable.just(1, "abc", false, 2L).ofType(String.class);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, never()).onNext(1);
         verify(subscriber, times(1)).onNext("abc");
@@ -792,11 +792,11 @@ public class FlowableTests {
         l2.add(2);
 
         @SuppressWarnings("rawtypes")
-        Flowable<List> observable = Flowable.<Object> just(l1, l2, "123").ofType(List.class);
+        Flowable<List> flowable = Flowable.<Object> just(l1, l2, "123").ofType(List.class);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(l1);
         verify(subscriber, times(1)).onNext(l2);
@@ -807,11 +807,11 @@ public class FlowableTests {
 
     @Test
     public void testContainsFlowable() {
-        Flowable<Boolean> observable = Flowable.just("a", "b", "c").contains("b").toFlowable();
+        Flowable<Boolean> flowable = Flowable.just("a", "b", "c").contains("b").toFlowable();
 
         FlowableSubscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(true);
         verify(subscriber, never()).onNext(false);
@@ -821,11 +821,11 @@ public class FlowableTests {
 
     @Test
     public void testContainsWithInexistenceFlowable() {
-        Flowable<Boolean> observable = Flowable.just("a", "b").contains("c").toFlowable();
+        Flowable<Boolean> flowable = Flowable.just("a", "b").contains("c").toFlowable();
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(false);
         verify(subscriber, never()).onNext(true);
@@ -836,11 +836,11 @@ public class FlowableTests {
     @Test
     @Ignore("null values are not allowed")
     public void testContainsWithNullFlowable() {
-        Flowable<Boolean> observable = Flowable.just("a", "b", null).contains(null).toFlowable();
+        Flowable<Boolean> flowable = Flowable.just("a", "b", null).contains(null).toFlowable();
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(true);
         verify(subscriber, never()).onNext(false);
@@ -850,11 +850,11 @@ public class FlowableTests {
 
     @Test
     public void testContainsWithEmptyObservableFlowable() {
-        Flowable<Boolean> observable = Flowable.<String> empty().contains("a").toFlowable();
+        Flowable<Boolean> flowable = Flowable.<String> empty().contains("a").toFlowable();
 
         FlowableSubscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(false);
         verify(subscriber, never()).onNext(true);
@@ -865,11 +865,11 @@ public class FlowableTests {
 
     @Test
     public void testContains() {
-        Single<Boolean> observable = Flowable.just("a", "b", "c").contains("b"); // FIXME nulls not allowed, changed to "c"
+        Single<Boolean> single = Flowable.just("a", "b", "c").contains("b"); // FIXME nulls not allowed, changed to "c"
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(true);
         verify(observer, never()).onSuccess(false);
@@ -879,11 +879,11 @@ public class FlowableTests {
 
     @Test
     public void testContainsWithInexistence() {
-        Single<Boolean> observable = Flowable.just("a", "b").contains("c"); // FIXME null values are not allowed, removed
+        Single<Boolean> single = Flowable.just("a", "b").contains("c"); // FIXME null values are not allowed, removed
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(false);
         verify(observer, never()).onSuccess(true);
@@ -894,11 +894,11 @@ public class FlowableTests {
     @Test
     @Ignore("null values are not allowed")
     public void testContainsWithNull() {
-        Single<Boolean> observable = Flowable.just("a", "b", null).contains(null);
+        Single<Boolean> single = Flowable.just("a", "b", null).contains(null);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(true);
         verify(observer, never()).onSuccess(false);
@@ -908,11 +908,11 @@ public class FlowableTests {
 
     @Test
     public void testContainsWithEmptyObservable() {
-        Single<Boolean> observable = Flowable.<String> empty().contains("a");
+        Single<Boolean> single = Flowable.<String> empty().contains("a");
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(false);
         verify(observer, never()).onSuccess(true);
@@ -922,11 +922,11 @@ public class FlowableTests {
 
     @Test
     public void testIgnoreElementsFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3).ignoreElements().toFlowable();
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3).ignoreElements().toFlowable();
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, never()).onNext(any(Integer.class));
         verify(subscriber, never()).onError(any(Throwable.class));
@@ -935,11 +935,11 @@ public class FlowableTests {
 
     @Test
     public void testIgnoreElements() {
-        Completable observable = Flowable.just(1, 2, 3).ignoreElements();
+        Completable completable = Flowable.just(1, 2, 3).ignoreElements();
 
         CompletableObserver observer = TestHelper.mockCompletableObserver();
 
-        observable.subscribe(observer);
+        completable.subscribe(observer);
 
         verify(observer, never()).onError(any(Throwable.class));
         verify(observer, times(1)).onComplete();
@@ -948,11 +948,11 @@ public class FlowableTests {
     @Test
     public void testJustWithScheduler() {
         TestScheduler scheduler = new TestScheduler();
-        Flowable<Integer> observable = Flowable.fromArray(1, 2).subscribeOn(scheduler);
+        Flowable<Integer> flowable = Flowable.fromArray(1, 2).subscribeOn(scheduler);
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
@@ -966,11 +966,11 @@ public class FlowableTests {
     @Test
     public void testStartWithWithScheduler() {
         TestScheduler scheduler = new TestScheduler();
-        Flowable<Integer> observable = Flowable.just(3, 4).startWith(Arrays.asList(1, 2)).subscribeOn(scheduler);
+        Flowable<Integer> flowable = Flowable.just(3, 4).startWith(Arrays.asList(1, 2)).subscribeOn(scheduler);
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
@@ -986,11 +986,11 @@ public class FlowableTests {
     @Test
     public void testRangeWithScheduler() {
         TestScheduler scheduler = new TestScheduler();
-        Flowable<Integer> observable = Flowable.range(3, 4).subscribeOn(scheduler);
+        Flowable<Integer> flowable = Flowable.range(3, 4).subscribeOn(scheduler);
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
@@ -1073,16 +1073,16 @@ public class FlowableTests {
     public void testErrorThrownIssue1685() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            FlowableProcessor<Object> subject = ReplayProcessor.create();
+            FlowableProcessor<Object> processor = ReplayProcessor.create();
 
             Flowable.error(new RuntimeException("oops"))
                 .materialize()
                 .delay(1, TimeUnit.SECONDS)
                 .dematerialize()
-                .subscribe(subject);
+                .subscribe(processor);
 
-            subject.subscribe();
-            subject.materialize().blockingFirst();
+            processor.subscribe();
+            processor.materialize().blockingFirst();
 
             System.out.println("Done");
 

--- a/src/test/java/io/reactivex/flowable/FlowableThrottleLastTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableThrottleLastTests.java
@@ -29,11 +29,11 @@ public class FlowableThrottleLastTests {
 
     @Test
     public void testThrottle() {
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         TestScheduler s = new TestScheduler();
         PublishProcessor<Integer> o = PublishProcessor.create();
-        o.throttleLast(500, TimeUnit.MILLISECONDS, s).subscribe(observer);
+        o.throttleLast(500, TimeUnit.MILLISECONDS, s).subscribe(subscriber);
 
         // send events with simulated time increments
         s.advanceTimeTo(0, TimeUnit.MILLISECONDS);
@@ -51,11 +51,11 @@ public class FlowableThrottleLastTests {
         s.advanceTimeTo(1501, TimeUnit.MILLISECONDS);
         o.onComplete();
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onNext(2);
-        inOrder.verify(observer).onNext(6);
-        inOrder.verify(observer).onNext(7);
-        inOrder.verify(observer).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onNext(6);
+        inOrder.verify(subscriber).onNext(7);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 }

--- a/src/test/java/io/reactivex/flowable/FlowableThrottleWithTimeoutTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableThrottleWithTimeoutTests.java
@@ -29,12 +29,12 @@ public class FlowableThrottleWithTimeoutTests {
 
     @Test
     public void testThrottle() {
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         TestScheduler s = new TestScheduler();
         PublishProcessor<Integer> o = PublishProcessor.create();
         o.throttleWithTimeout(500, TimeUnit.MILLISECONDS, s)
-        .subscribe(observer);
+        .subscribe(subscriber);
 
         // send events with simulated time increments
         s.advanceTimeTo(0, TimeUnit.MILLISECONDS);
@@ -52,11 +52,11 @@ public class FlowableThrottleWithTimeoutTests {
         s.advanceTimeTo(1800, TimeUnit.MILLISECONDS);
         o.onComplete();
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onNext(2);
-        inOrder.verify(observer).onNext(6);
-        inOrder.verify(observer).onNext(7);
-        inOrder.verify(observer).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onNext(6);
+        inOrder.verify(subscriber).onNext(7);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
@@ -196,92 +196,106 @@ public class LambdaObserverTest {
 
     @Test
     public void badSourceOnSubscribe() {
-        Observable<Integer> source = new Observable<Integer>() {
-            @Override
-            public void subscribeActual(Observer<? super Integer> s) {
-                Disposable s1 = Disposables.empty();
-                s.onSubscribe(s1);
-                Disposable s2 = Disposables.empty();
-                s.onSubscribe(s2);
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable<Integer> source = new Observable<Integer>() {
+                @Override
+                public void subscribeActual(Observer<? super Integer> s) {
+                    Disposable s1 = Disposables.empty();
+                    s.onSubscribe(s1);
+                    Disposable s2 = Disposables.empty();
+                    s.onSubscribe(s2);
 
-                assertFalse(s1.isDisposed());
-                assertTrue(s2.isDisposed());
+                    assertFalse(s1.isDisposed());
+                    assertTrue(s2.isDisposed());
 
-                s.onNext(1);
-                s.onComplete();
-            }
-        };
+                    s.onNext(1);
+                    s.onComplete();
+                }
+            };
 
-        final List<Object> received = new ArrayList<Object>();
+            final List<Object> received = new ArrayList<Object>();
 
-        LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                received.add(v);
-            }
-        },
-        new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                received.add(e);
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(100);
-            }
-        }, new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable s) throws Exception {
-            }
-        });
+            LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+                @Override
+                public void accept(Object v) throws Exception {
+                    received.add(v);
+                }
+            },
+            new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable e) throws Exception {
+                    received.add(e);
+                }
+            }, new Action() {
+                @Override
+                public void run() throws Exception {
+                    received.add(100);
+                }
+            }, new Consumer<Disposable>() {
+                @Override
+                public void accept(Disposable s) throws Exception {
+                }
+            });
 
-        source.subscribe(o);
+            source.subscribe(o);
 
-        assertEquals(Arrays.asList(1, 100), received);
+            assertEquals(Arrays.asList(1, 100), received);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
     @Test
     public void badSourceEmitAfterDone() {
-        Observable<Integer> source = new Observable<Integer>() {
-            @Override
-            public void subscribeActual(Observer<? super Integer> s) {
-                s.onSubscribe(Disposables.empty());
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Observable<Integer> source = new Observable<Integer>() {
+                @Override
+                public void subscribeActual(Observer<? super Integer> s) {
+                    s.onSubscribe(Disposables.empty());
 
-                s.onNext(1);
-                s.onComplete();
-                s.onNext(2);
-                s.onError(new TestException());
-                s.onComplete();
-            }
-        };
+                    s.onNext(1);
+                    s.onComplete();
+                    s.onNext(2);
+                    s.onError(new TestException());
+                    s.onComplete();
+                }
+            };
 
-        final List<Object> received = new ArrayList<Object>();
+            final List<Object> received = new ArrayList<Object>();
 
-        LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                received.add(v);
-            }
-        },
-        new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                received.add(e);
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(100);
-            }
-        }, new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable s) throws Exception {
-            }
-        });
+            LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+                @Override
+                public void accept(Object v) throws Exception {
+                    received.add(v);
+                }
+            },
+            new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable e) throws Exception {
+                    received.add(e);
+                }
+            }, new Action() {
+                @Override
+                public void run() throws Exception {
+                    received.add(100);
+                }
+            }, new Consumer<Disposable>() {
+                @Override
+                public void accept(Disposable s) throws Exception {
+                }
+            });
 
-        source.subscribe(o);
+            source.subscribe(o);
 
-        assertEquals(Arrays.asList(1, 100), received);
+            assertEquals(Arrays.asList(1, 100), received);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
@@ -200,17 +200,17 @@ public class LambdaObserverTest {
         try {
             Observable<Integer> source = new Observable<Integer>() {
                 @Override
-                public void subscribeActual(Observer<? super Integer> s) {
+                public void subscribeActual(Observer<? super Integer> observer) {
                     Disposable s1 = Disposables.empty();
-                    s.onSubscribe(s1);
+                    observer.onSubscribe(s1);
                     Disposable s2 = Disposables.empty();
-                    s.onSubscribe(s2);
+                    observer.onSubscribe(s2);
 
                     assertFalse(s1.isDisposed());
                     assertTrue(s2.isDisposed());
 
-                    s.onNext(1);
-                    s.onComplete();
+                    observer.onNext(1);
+                    observer.onComplete();
                 }
             };
 
@@ -253,14 +253,14 @@ public class LambdaObserverTest {
         try {
             Observable<Integer> source = new Observable<Integer>() {
                 @Override
-                public void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
+                public void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
 
-                    s.onNext(1);
-                    s.onComplete();
-                    s.onNext(2);
-                    s.onError(new TestException());
-                    s.onComplete();
+                    observer.onNext(1);
+                    observer.onComplete();
+                    observer.onNext(2);
+                    observer.onError(new TestException());
+                    observer.onComplete();
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
@@ -170,10 +170,10 @@ public class CompletableConcatTest {
 
         Completable.concatArray(new Completable() {
             @Override
-            protected void subscribeActual(CompletableObserver s) {
-                s.onSubscribe(Disposables.empty());
+            protected void subscribeActual(CompletableObserver observer) {
+                observer.onSubscribe(Disposables.empty());
                 to.cancel();
-                s.onComplete();
+                observer.onComplete();
             }
         }, Completable.complete())
         .subscribe(to);
@@ -194,10 +194,10 @@ public class CompletableConcatTest {
 
         Completable.concat(Arrays.asList(new Completable() {
             @Override
-            protected void subscribeActual(CompletableObserver s) {
-                s.onSubscribe(Disposables.empty());
+            protected void subscribeActual(CompletableObserver observer) {
+                observer.onSubscribe(Disposables.empty());
                 to.cancel();
-                s.onComplete();
+                observer.onComplete();
             }
         }, Completable.complete()))
         .subscribe(to);

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableConcatTest.java
@@ -35,21 +35,28 @@ public class CompletableConcatTest {
 
     @Test
     public void overflowReported() {
-        Completable.concat(
-            Flowable.fromPublisher(new Publisher<Completable>() {
-                @Override
-                public void subscribe(Subscriber<? super Completable> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onNext(Completable.never());
-                    s.onNext(Completable.never());
-                    s.onNext(Completable.never());
-                    s.onNext(Completable.never());
-                    s.onComplete();
-                }
-            }), 1
-        )
-        .test()
-        .assertFailure(MissingBackpressureException.class);
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Completable.concat(
+                Flowable.fromPublisher(new Publisher<Completable>() {
+                    @Override
+                    public void subscribe(Subscriber<? super Completable> s) {
+                        s.onSubscribe(new BooleanSubscription());
+                        s.onNext(Completable.never());
+                        s.onNext(Completable.never());
+                        s.onNext(Completable.never());
+                        s.onNext(Completable.never());
+                        s.onComplete();
+                    }
+                }), 1
+            )
+            .test()
+            .assertFailure(MissingBackpressureException.class);
+
+            TestHelper.assertError(errors, 0, MissingBackpressureException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDoOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDoOnTest.java
@@ -85,10 +85,10 @@ public class CompletableDoOnTest {
 
             new Completable() {
                 @Override
-                protected void subscribeActual(CompletableObserver s) {
-                    s.onSubscribe(bs);
-                    s.onError(new TestException("Second"));
-                    s.onComplete();
+                protected void subscribeActual(CompletableObserver observer) {
+                    observer.onSubscribe(bs);
+                    observer.onError(new TestException("Second"));
+                    observer.onComplete();
                 }
             }
             .doOnSubscribe(new Consumer<Disposable>() {

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableLiftTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableLiftTest.java
@@ -13,16 +13,19 @@
 
 package io.reactivex.internal.operators.completable;
 
-import static org.junit.Assert.*;
+import java.util.List;
+
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public class CompletableLiftTest {
 
     @Test
     public void callbackThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Completable.complete()
             .lift(new CompletableOperator() {
@@ -32,8 +35,10 @@ public class CompletableLiftTest {
                 }
             })
             .test();
-        } catch (NullPointerException ex) {
-            assertTrue(ex.toString(), ex.getCause() instanceof TestException);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
@@ -46,9 +46,9 @@ public class CompletableMergeTest {
 
         Completable.mergeArray(new Completable() {
             @Override
-            protected void subscribeActual(CompletableObserver s) {
-                s.onSubscribe(Disposables.empty());
-                s.onComplete();
+            protected void subscribeActual(CompletableObserver observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onComplete();
                 to.cancel();
             }
         }, Completable.complete())
@@ -63,9 +63,9 @@ public class CompletableMergeTest {
 
         Completable.mergeArrayDelayError(new Completable() {
             @Override
-            protected void subscribeActual(CompletableObserver s) {
-                s.onSubscribe(Disposables.empty());
-                s.onComplete();
+            protected void subscribeActual(CompletableObserver observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onComplete();
                 to.cancel();
             }
         }, Completable.complete())
@@ -82,10 +82,10 @@ public class CompletableMergeTest {
 
             Completable.mergeArrayDelayError(Completable.complete(), new Completable() {
                 @Override
-                protected void subscribeActual(CompletableObserver s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onComplete();
-                    co[0] = s;
+                protected void subscribeActual(CompletableObserver observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onComplete();
+                    co[0] = observer;
                 }
             })
             .test()
@@ -408,10 +408,10 @@ public class CompletableMergeTest {
             final CompletableObserver[] o = { null };
             Completable.mergeDelayError(Flowable.just(new Completable() {
                 @Override
-                protected void subscribeActual(CompletableObserver s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onError(new TestException("First"));
-                    o[0] = s;
+                protected void subscribeActual(CompletableObserver observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onError(new TestException("First"));
+                    o[0] = observer;
                 }
             }))
             .test()
@@ -431,13 +431,13 @@ public class CompletableMergeTest {
 
         Completable.mergeDelayError(Flowable.just(new Completable() {
             @Override
-            protected void subscribeActual(CompletableObserver s) {
-                s.onSubscribe(Disposables.empty());
-                assertFalse(((Disposable)s).isDisposed());
+            protected void subscribeActual(CompletableObserver observer) {
+                observer.onSubscribe(Disposables.empty());
+                assertFalse(((Disposable)observer).isDisposed());
 
                 to.dispose();
 
-                assertTrue(((Disposable)s).isDisposed());
+                assertTrue(((Disposable)observer).isDisposed());
             }
         }))
         .subscribe(to);

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableTakeUntilTest.java
@@ -143,9 +143,9 @@ public class CompletableTakeUntilTest {
 
             new Completable() {
                 @Override
-                protected void subscribeActual(CompletableObserver s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onError(new TestException());
+                protected void subscribeActual(CompletableObserver observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onError(new TestException());
                 }
             }.takeUntil(Completable.complete())
             .test()
@@ -165,9 +165,9 @@ public class CompletableTakeUntilTest {
 
             new Completable() {
                 @Override
-                protected void subscribeActual(CompletableObserver s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onComplete();
+                protected void subscribeActual(CompletableObserver observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onComplete();
                 }
             }.takeUntil(Completable.complete())
             .test()
@@ -190,9 +190,9 @@ public class CompletableTakeUntilTest {
             Completable.complete()
             .takeUntil(new Completable() {
                 @Override
-                protected void subscribeActual(CompletableObserver s) {
-                    s.onSubscribe(Disposables.empty());
-                    ref.set(s);
+                protected void subscribeActual(CompletableObserver observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    ref.set(observer);
                 }
             })
             .test()
@@ -217,9 +217,9 @@ public class CompletableTakeUntilTest {
             Completable.complete()
             .takeUntil(new Completable() {
                 @Override
-                protected void subscribeActual(CompletableObserver s) {
-                    s.onSubscribe(Disposables.empty());
-                    ref.set(s);
+                protected void subscribeActual(CompletableObserver observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    ref.set(observer);
                 }
             })
             .test()

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableUnsafeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableUnsafeTest.java
@@ -14,10 +14,14 @@
 package io.reactivex.internal.operators.completable;
 
 import static org.junit.Assert.*;
+
+import java.util.List;
+
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public class CompletableUnsafeTest {
 
@@ -57,6 +61,7 @@ public class CompletableUnsafeTest {
 
     @Test
     public void unsafeCreateThrowsIAE() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Completable.unsafeCreate(new CompletableSource() {
                 @Override
@@ -69,6 +74,10 @@ public class CompletableUnsafeTest {
             if (!(ex.getCause() instanceof IllegalArgumentException)) {
                 fail(ex.toString() + ": should have thrown NPA(IAE)");
             }
+
+            TestHelper.assertError(errors, 0, IllegalArgumentException.class);
+        } finally {
+            RxJavaPlugins.reset();
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableUnsafeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableUnsafeTest.java
@@ -40,9 +40,9 @@ public class CompletableUnsafeTest {
 
         Completable.wrap(new CompletableSource() {
             @Override
-            public void subscribe(CompletableObserver s) {
-                s.onSubscribe(Disposables.empty());
-                s.onComplete();
+            public void subscribe(CompletableObserver observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onComplete();
             }
         })
         .test()
@@ -53,7 +53,7 @@ public class CompletableUnsafeTest {
     public void unsafeCreateThrowsNPE() {
         Completable.unsafeCreate(new CompletableSource() {
             @Override
-            public void subscribe(CompletableObserver s) {
+            public void subscribe(CompletableObserver observer) {
                 throw new NullPointerException();
             }
         }).test();
@@ -65,7 +65,7 @@ public class CompletableUnsafeTest {
         try {
             Completable.unsafeCreate(new CompletableSource() {
                 @Override
-                public void subscribe(CompletableObserver s) {
+                public void subscribe(CompletableObserver observer) {
                     throw new IllegalArgumentException();
                 }
             }).test();

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
@@ -24,6 +24,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
@@ -482,44 +483,49 @@ public class CompletableUsingTest {
 
     @Test
     public void errorDisposeRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+        RxJavaPlugins.setErrorHandler(Functions.emptyConsumer());
+        try {
+            for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            final PublishSubject<Integer> ps = PublishSubject.create();
+                final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Void> to = Completable.using(new Callable<Object>() {
-                @Override
-                public Object call() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, CompletableSource>() {
-                @Override
-                public CompletableSource apply(Object v) throws Exception {
-                    return ps.ignoreElements();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-                }
-            }, true)
-            .test();
+                final TestObserver<Void> to = Completable.using(new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        return 1;
+                    }
+                }, new Function<Object, CompletableSource>() {
+                    @Override
+                    public CompletableSource apply(Object v) throws Exception {
+                        return ps.ignoreElements();
+                    }
+                }, new Consumer<Object>() {
+                    @Override
+                    public void accept(Object d) throws Exception {
+                    }
+                }, true)
+                .test();
 
-            final TestException ex = new TestException();
+                final TestException ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to.cancel();
-                }
-            };
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        to.cancel();
+                    }
+                };
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onError(ex);
-                }
-            };
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        ps.onError(ex);
+                    }
+                };
 
-            TestHelper.race(r1, r2);
+                TestHelper.race(r1, r2);
+            }
+        } finally {
+            RxJavaPlugins.reset();
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
@@ -411,14 +411,14 @@ public class CompletableUsingTest {
                 public CompletableSource apply(Object v) throws Exception {
                     return Completable.wrap(new CompletableSource() {
                         @Override
-                        public void subscribe(CompletableObserver s) {
+                        public void subscribe(CompletableObserver observer) {
                             Disposable d1 = Disposables.empty();
 
-                            s.onSubscribe(d1);
+                            observer.onSubscribe(d1);
 
                             Disposable d2 = Disposables.empty();
 
-                            s.onSubscribe(d2);
+                            observer.onSubscribe(d2);
 
                             assertFalse(d1.isDisposed());
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/AbstractFlowableWithUpstreamTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/AbstractFlowableWithUpstreamTest.java
@@ -26,8 +26,8 @@ public class AbstractFlowableWithUpstreamTest {
     @SuppressWarnings("unchecked")
     @Test
     public void source() {
-        Flowable<Integer> o = Flowable.just(1);
+        Flowable<Integer> f = Flowable.just(1);
 
-        assertSame(o, ((HasUpstreamPublisher<Integer>)o.map(Functions.<Integer>identity())).source());
+        assertSame(f, ((HasUpstreamPublisher<Integer>)f.map(Functions.<Integer>identity())).source());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -241,20 +241,20 @@ public class BlockingFlowableNextTest {
                 final Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() {
 
                     @Override
-                    public void subscribe(final Subscriber<? super Integer> o) {
-                        o.onSubscribe(new BooleanSubscription());
+                    public void subscribe(final Subscriber<? super Integer> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
                         task.replace(Schedulers.single().scheduleDirect(new Runnable() {
 
                             @Override
                             public void run() {
                                 try {
                                     while (running.get() && !task.isDisposed()) {
-                                        o.onNext(count.incrementAndGet());
+                                        subscriber.onNext(count.incrementAndGet());
                                         timeHasPassed.countDown();
                                     }
-                                    o.onComplete();
+                                    subscriber.onComplete();
                                 } catch (Throwable e) {
-                                    o.onError(e);
+                                    subscriber.onError(e);
                                 } finally {
                                     finished.countDown();
                                 }
@@ -308,9 +308,9 @@ public class BlockingFlowableNextTest {
 
     @Test /* (timeout = 8000) */
     public void testSingleSourceManyIterators() throws InterruptedException {
-        Flowable<Long> o = Flowable.interval(250, TimeUnit.MILLISECONDS);
+        Flowable<Long> f = Flowable.interval(250, TimeUnit.MILLISECONDS);
         PublishProcessor<Integer> terminal = PublishProcessor.create();
-        Flowable<Long> source = o.takeUntil(terminal);
+        Flowable<Long> source = f.takeUntil(terminal);
 
         Iterable<Long> iter = source.blockingNext();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
@@ -69,10 +69,10 @@ public class BlockingFlowableToFutureTest {
         Flowable<String> obs = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                observer.onNext("one");
-                observer.onError(new TestException());
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                subscriber.onNext("one");
+                subscriber.onError(new TestException());
             }
         });
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToIteratorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToIteratorTest.java
@@ -51,10 +51,10 @@ public class BlockingFlowableToIteratorTest {
         Flowable<String> obs = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                observer.onNext("one");
-                observer.onError(new TestException());
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                subscriber.onNext("one");
+                subscriber.onError(new TestException());
             }
         });
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
@@ -203,7 +203,7 @@ public class FlowableAllTest {
     public void testAllFlowable() {
         Flowable<String> obs = Flowable.just("one", "two", "six");
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
         obs.all(new Predicate<String>() {
             @Override
@@ -212,19 +212,19 @@ public class FlowableAllTest {
             }
         })
         .toFlowable()
-        .subscribe(observer);
+        .subscribe(subscriber);
 
-        verify(observer).onSubscribe((Subscription)any());
-        verify(observer).onNext(true);
-        verify(observer).onComplete();
-        verifyNoMoreInteractions(observer);
+        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber).onNext(true);
+        verify(subscriber).onComplete();
+        verifyNoMoreInteractions(subscriber);
     }
 
     @Test
     public void testNotAllFlowable() {
         Flowable<String> obs = Flowable.just("one", "two", "three", "six");
 
-        Subscriber <Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber <Boolean> subscriber = TestHelper.mockSubscriber();
 
         obs.all(new Predicate<String>() {
             @Override
@@ -233,19 +233,19 @@ public class FlowableAllTest {
             }
         })
         .toFlowable()
-        .subscribe(observer);
+        .subscribe(subscriber);
 
-        verify(observer).onSubscribe((Subscription)any());
-        verify(observer).onNext(false);
-        verify(observer).onComplete();
-        verifyNoMoreInteractions(observer);
+        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber).onNext(false);
+        verify(subscriber).onComplete();
+        verifyNoMoreInteractions(subscriber);
     }
 
     @Test
     public void testEmptyFlowable() {
         Flowable<String> obs = Flowable.empty();
 
-        Subscriber <Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber <Boolean> subscriber = TestHelper.mockSubscriber();
 
         obs.all(new Predicate<String>() {
             @Override
@@ -254,12 +254,12 @@ public class FlowableAllTest {
             }
         })
         .toFlowable()
-        .subscribe(observer);
+        .subscribe(subscriber);
 
-        verify(observer).onSubscribe((Subscription)any());
-        verify(observer).onNext(true);
-        verify(observer).onComplete();
-        verifyNoMoreInteractions(observer);
+        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber).onNext(true);
+        verify(subscriber).onComplete();
+        verifyNoMoreInteractions(subscriber);
     }
 
     @Test
@@ -267,7 +267,7 @@ public class FlowableAllTest {
         Throwable error = new Throwable();
         Flowable<String> obs = Flowable.error(error);
 
-        Subscriber <Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber <Boolean> subscriber = TestHelper.mockSubscriber();
 
         obs.all(new Predicate<String>() {
             @Override
@@ -276,11 +276,11 @@ public class FlowableAllTest {
             }
         })
         .toFlowable()
-        .subscribe(observer);
+        .subscribe(subscriber);
 
-        verify(observer).onSubscribe((Subscription)any());
-        verify(observer).onError(error);
-        verifyNoMoreInteractions(observer);
+        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber).onError(error);
+        verifyNoMoreInteractions(subscriber);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
@@ -114,8 +114,8 @@ public class FlowableAllTest {
 
     @Test
     public void testFollowingFirst() {
-        Flowable<Integer> o = Flowable.fromArray(1, 3, 5, 6);
-        Single<Boolean> allOdd = o.all(new Predicate<Integer>() {
+        Flowable<Integer> f = Flowable.fromArray(1, 3, 5, 6);
+        Single<Boolean> allOdd = f.all(new Predicate<Integer>() {
             @Override
             public boolean test(Integer i) {
                 return i % 2 == 1;
@@ -285,8 +285,8 @@ public class FlowableAllTest {
 
     @Test
     public void testFollowingFirstFlowable() {
-        Flowable<Integer> o = Flowable.fromArray(1, 3, 5, 6);
-        Flowable<Boolean> allOdd = o.all(new Predicate<Integer>() {
+        Flowable<Integer> f = Flowable.fromArray(1, 3, 5, 6);
+        Flowable<Boolean> allOdd = f.all(new Predicate<Integer>() {
             @Override
             public boolean test(Integer i) {
                 return i % 2 == 1;
@@ -391,13 +391,13 @@ public class FlowableAllTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
 
-                    observer.onNext(1);
-                    observer.onNext(2);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                    subscriber.onNext(1);
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .all(new Predicate<Integer>() {
@@ -422,13 +422,13 @@ public class FlowableAllTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
 
-                    observer.onNext(1);
-                    observer.onNext(2);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                    subscriber.onNext(1);
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .all(new Predicate<Integer>() {
@@ -451,15 +451,15 @@ public class FlowableAllTest {
     public void badSource() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
-            public Object apply(Flowable<Integer> o) throws Exception {
-                return o.all(Functions.alwaysTrue());
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.all(Functions.alwaysTrue());
             }
         }, false, 1, 1, true);
 
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
-            public Object apply(Flowable<Integer> o) throws Exception {
-                return o.all(Functions.alwaysTrue()).toFlowable();
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.all(Functions.alwaysTrue()).toFlowable();
             }
         }, false, 1, 1, true);
     }
@@ -468,14 +468,14 @@ public class FlowableAllTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Boolean>>() {
             @Override
-            public Publisher<Boolean> apply(Flowable<Object> o) throws Exception {
-                return o.all(Functions.alwaysTrue()).toFlowable();
+            public Publisher<Boolean> apply(Flowable<Object> f) throws Exception {
+                return f.all(Functions.alwaysTrue()).toFlowable();
             }
         });
         TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, Single<Boolean>>() {
             @Override
-            public Single<Boolean> apply(Flowable<Object> o) throws Exception {
-                return o.all(Functions.alwaysTrue());
+            public Single<Boolean> apply(Flowable<Object> f) throws Exception {
+                return f.all(Functions.alwaysTrue());
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -105,18 +105,17 @@ public class FlowableAmbTest {
         Flowable<String> o = Flowable.ambArray(flowable1,
                 flowable2, flowable3);
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
-        o.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        o.subscribe(subscriber);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("2");
-        inOrder.verify(observer, times(1)).onNext("22");
-        inOrder.verify(observer, times(1)).onNext("222");
-        inOrder.verify(observer, times(1)).onNext("2222");
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("2");
+        inOrder.verify(subscriber, times(1)).onNext("22");
+        inOrder.verify(subscriber, times(1)).onNext("222");
+        inOrder.verify(subscriber, times(1)).onNext("2222");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -135,18 +134,17 @@ public class FlowableAmbTest {
         Flowable<String> o = Flowable.ambArray(flowable1,
                 flowable2, flowable3);
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
-        o.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        o.subscribe(subscriber);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("2");
-        inOrder.verify(observer, times(1)).onNext("22");
-        inOrder.verify(observer, times(1)).onNext("222");
-        inOrder.verify(observer, times(1)).onNext("2222");
-        inOrder.verify(observer, times(1)).onError(expectedException);
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("2");
+        inOrder.verify(subscriber, times(1)).onNext("22");
+        inOrder.verify(subscriber, times(1)).onNext("222");
+        inOrder.verify(subscriber, times(1)).onNext("2222");
+        inOrder.verify(subscriber, times(1)).onError(expectedException);
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -163,13 +161,12 @@ public class FlowableAmbTest {
         Flowable<String> o = Flowable.ambArray(flowable1,
                 flowable2, flowable3);
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
-        o.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        o.subscribe(subscriber);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -102,11 +102,11 @@ public class FlowableAmbTest {
                 "3", "33", "333", "3333" }, 3000, null);
 
         @SuppressWarnings("unchecked")
-        Flowable<String> o = Flowable.ambArray(flowable1,
+        Flowable<String> f = Flowable.ambArray(flowable1,
                 flowable2, flowable3);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        o.subscribe(subscriber);
+        f.subscribe(subscriber);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);
 
@@ -131,11 +131,11 @@ public class FlowableAmbTest {
                 3000, new IOException("fake exception"));
 
         @SuppressWarnings("unchecked")
-        Flowable<String> o = Flowable.ambArray(flowable1,
+        Flowable<String> f = Flowable.ambArray(flowable1,
                 flowable2, flowable3);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        o.subscribe(subscriber);
+        f.subscribe(subscriber);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);
 
@@ -158,11 +158,11 @@ public class FlowableAmbTest {
                 "3" }, 3000, null);
 
         @SuppressWarnings("unchecked")
-        Flowable<String> o = Flowable.ambArray(flowable1,
+        Flowable<String> f = Flowable.ambArray(flowable1,
                 flowable2, flowable3);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        o.subscribe(subscriber);
+        f.subscribe(subscriber);
 
         scheduler.advanceTimeBy(100000, TimeUnit.MILLISECONDS);
         InOrder inOrder = inOrder(subscriber);
@@ -177,7 +177,7 @@ public class FlowableAmbTest {
         ts.request(3);
         final AtomicLong requested1 = new AtomicLong();
         final AtomicLong requested2 = new AtomicLong();
-        Flowable<Integer> o1 = Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable<Integer> f1 = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -197,7 +197,7 @@ public class FlowableAmbTest {
             }
 
         });
-        Flowable<Integer> o2 = Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable<Integer> f2 = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -217,7 +217,7 @@ public class FlowableAmbTest {
             }
 
         });
-        Flowable.ambArray(o1, o2).subscribe(ts);
+        Flowable.ambArray(f1, f2).subscribe(ts);
         assertEquals(3, requested1.get());
         assertEquals(3, requested2.get());
     }
@@ -249,13 +249,13 @@ public class FlowableAmbTest {
         };
 
         //this aync stream should emit first
-        Flowable<Integer> o1 = Flowable.just(1).doOnSubscribe(incrementer)
+        Flowable<Integer> f1 = Flowable.just(1).doOnSubscribe(incrementer)
                 .delay(100, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.computation());
         //this stream emits second
-        Flowable<Integer> o2 = Flowable.just(1).doOnSubscribe(incrementer)
+        Flowable<Integer> f2 = Flowable.just(1).doOnSubscribe(incrementer)
                 .delay(100, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.computation());
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        Flowable.ambArray(o1, o2).subscribe(ts);
+        Flowable.ambArray(f1, f2).subscribe(ts);
         ts.request(1);
         ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -266,14 +266,14 @@ public class FlowableAmbTest {
     @Test
     public void testSecondaryRequestsPropagatedToChildren() throws InterruptedException {
         //this aync stream should emit first
-        Flowable<Integer> o1 = Flowable.fromArray(1, 2, 3)
+        Flowable<Integer> f1 = Flowable.fromArray(1, 2, 3)
                 .delay(100, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.computation());
         //this stream emits second
-        Flowable<Integer> o2 = Flowable.fromArray(4, 5, 6)
+        Flowable<Integer> f2 = Flowable.fromArray(4, 5, 6)
                 .delay(200, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.computation());
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L);
 
-        Flowable.ambArray(o1, o2).subscribe(ts);
+        Flowable.ambArray(f1, f2).subscribe(ts);
         // before first emission request 20 more
         // this request should suffice to emit all
         ts.request(20);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
@@ -38,7 +38,7 @@ public class FlowableAnyTest {
     @Test
     public void testAnyWithTwoItems() {
         Flowable<Integer> w = Flowable.just(1, 2);
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
@@ -47,7 +47,7 @@ public class FlowableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(false);
         verify(observer, times(1)).onSuccess(true);
@@ -57,11 +57,11 @@ public class FlowableAnyTest {
     @Test
     public void testIsEmptyWithTwoItems() {
         Flowable<Integer> w = Flowable.just(1, 2);
-        Single<Boolean> observable = w.isEmpty();
+        Single<Boolean> single = w.isEmpty();
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(true);
         verify(observer, times(1)).onSuccess(false);
@@ -71,7 +71,7 @@ public class FlowableAnyTest {
     @Test
     public void testAnyWithOneItem() {
         Flowable<Integer> w = Flowable.just(1);
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
@@ -80,7 +80,7 @@ public class FlowableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(false);
         verify(observer, times(1)).onSuccess(true);
@@ -90,11 +90,11 @@ public class FlowableAnyTest {
     @Test
     public void testIsEmptyWithOneItem() {
         Flowable<Integer> w = Flowable.just(1);
-        Single<Boolean> observable = w.isEmpty();
+        Single<Boolean> single = w.isEmpty();
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(true);
         verify(observer, times(1)).onSuccess(false);
@@ -104,7 +104,7 @@ public class FlowableAnyTest {
     @Test
     public void testAnyWithEmpty() {
         Flowable<Integer> w = Flowable.empty();
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
@@ -113,7 +113,7 @@ public class FlowableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(false);
         verify(observer, never()).onSuccess(true);
@@ -123,11 +123,11 @@ public class FlowableAnyTest {
     @Test
     public void testIsEmptyWithEmpty() {
         Flowable<Integer> w = Flowable.empty();
-        Single<Boolean> observable = w.isEmpty();
+        Single<Boolean> single = w.isEmpty();
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(true);
         verify(observer, never()).onSuccess(false);
@@ -137,7 +137,7 @@ public class FlowableAnyTest {
     @Test
     public void testAnyWithPredicate1() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 2;
@@ -146,7 +146,7 @@ public class FlowableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(false);
         verify(observer, times(1)).onSuccess(true);
@@ -156,7 +156,7 @@ public class FlowableAnyTest {
     @Test
     public void testExists1() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 2;
@@ -165,7 +165,7 @@ public class FlowableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(false);
         verify(observer, times(1)).onSuccess(true);
@@ -175,7 +175,7 @@ public class FlowableAnyTest {
     @Test
     public void testAnyWithPredicate2() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 1;
@@ -184,7 +184,7 @@ public class FlowableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(false);
         verify(observer, never()).onSuccess(true);
@@ -195,7 +195,7 @@ public class FlowableAnyTest {
     public void testAnyWithEmptyAndPredicate() {
         // If the source is empty, always output false.
         Flowable<Integer> w = Flowable.empty();
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t) {
                 return true;
@@ -204,7 +204,7 @@ public class FlowableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(false);
         verify(observer, never()).onSuccess(true);
@@ -213,8 +213,8 @@ public class FlowableAnyTest {
 
     @Test
     public void testWithFollowingFirst() {
-        Flowable<Integer> o = Flowable.fromArray(1, 3, 5, 6);
-        Single<Boolean> anyEven = o.any(new Predicate<Integer>() {
+        Flowable<Integer> f = Flowable.fromArray(1, 3, 5, 6);
+        Single<Boolean> anyEven = f.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer i) {
                 return i % 2 == 0;
@@ -293,7 +293,7 @@ public class FlowableAnyTest {
     @Test
     public void testAnyWithTwoItemsFlowable() {
         Flowable<Integer> w = Flowable.just(1, 2);
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
@@ -304,7 +304,7 @@ public class FlowableAnyTest {
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, never()).onNext(false);
         verify(subscriber, times(1)).onNext(true);
@@ -315,11 +315,11 @@ public class FlowableAnyTest {
     @Test
     public void testIsEmptyWithTwoItemsFlowable() {
         Flowable<Integer> w = Flowable.just(1, 2);
-        Flowable<Boolean> observable = w.isEmpty().toFlowable();
+        Flowable<Boolean> flowable = w.isEmpty().toFlowable();
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, never()).onNext(true);
         verify(subscriber, times(1)).onNext(false);
@@ -330,7 +330,7 @@ public class FlowableAnyTest {
     @Test
     public void testAnyWithOneItemFlowable() {
         Flowable<Integer> w = Flowable.just(1);
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
@@ -339,7 +339,7 @@ public class FlowableAnyTest {
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, never()).onNext(false);
         verify(subscriber, times(1)).onNext(true);
@@ -350,11 +350,11 @@ public class FlowableAnyTest {
     @Test
     public void testIsEmptyWithOneItemFlowable() {
         Flowable<Integer> w = Flowable.just(1);
-        Single<Boolean> observable = w.isEmpty();
+        Single<Boolean> single = w.isEmpty();
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(true);
         verify(observer, times(1)).onSuccess(false);
@@ -364,7 +364,7 @@ public class FlowableAnyTest {
     @Test
     public void testAnyWithEmptyFlowable() {
         Flowable<Integer> w = Flowable.empty();
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
@@ -373,7 +373,7 @@ public class FlowableAnyTest {
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(false);
         verify(subscriber, never()).onNext(true);
@@ -384,11 +384,11 @@ public class FlowableAnyTest {
     @Test
     public void testIsEmptyWithEmptyFlowable() {
         Flowable<Integer> w = Flowable.empty();
-        Flowable<Boolean> observable = w.isEmpty().toFlowable();
+        Flowable<Boolean> flowable = w.isEmpty().toFlowable();
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(true);
         verify(subscriber, never()).onNext(false);
@@ -399,7 +399,7 @@ public class FlowableAnyTest {
     @Test
     public void testAnyWithPredicate1Flowable() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 2;
@@ -408,7 +408,7 @@ public class FlowableAnyTest {
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, never()).onNext(false);
         verify(subscriber, times(1)).onNext(true);
@@ -419,7 +419,7 @@ public class FlowableAnyTest {
     @Test
     public void testExists1Flowable() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 2;
@@ -428,7 +428,7 @@ public class FlowableAnyTest {
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, never()).onNext(false);
         verify(subscriber, times(1)).onNext(true);
@@ -439,7 +439,7 @@ public class FlowableAnyTest {
     @Test
     public void testAnyWithPredicate2Flowable() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 1;
@@ -448,7 +448,7 @@ public class FlowableAnyTest {
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(false);
         verify(subscriber, never()).onNext(true);
@@ -460,7 +460,7 @@ public class FlowableAnyTest {
     public void testAnyWithEmptyAndPredicateFlowable() {
         // If the source is empty, always output false.
         Flowable<Integer> w = Flowable.empty();
-        Flowable<Boolean> observable = w.any(new Predicate<Integer>() {
+        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t) {
                 return true;
@@ -469,7 +469,7 @@ public class FlowableAnyTest {
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(false);
         verify(subscriber, never()).onNext(true);
@@ -479,8 +479,8 @@ public class FlowableAnyTest {
 
     @Test
     public void testWithFollowingFirstFlowable() {
-        Flowable<Integer> o = Flowable.fromArray(1, 3, 5, 6);
-        Flowable<Boolean> anyEven = o.any(new Predicate<Integer>() {
+        Flowable<Integer> f = Flowable.fromArray(1, 3, 5, 6);
+        Flowable<Boolean> anyEven = f.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer i) {
                 return i % 2 == 0;
@@ -566,15 +566,15 @@ public class FlowableAnyTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Boolean>>() {
             @Override
-            public Publisher<Boolean> apply(Flowable<Object> o) throws Exception {
-                return o.any(Functions.alwaysTrue()).toFlowable();
+            public Publisher<Boolean> apply(Flowable<Object> f) throws Exception {
+                return f.any(Functions.alwaysTrue()).toFlowable();
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, Single<Boolean>>() {
             @Override
-            public Single<Boolean> apply(Flowable<Object> o) throws Exception {
-                return o.any(Functions.alwaysTrue());
+            public Single<Boolean> apply(Flowable<Object> f) throws Exception {
+                return f.any(Functions.alwaysTrue());
             }
         });
     }
@@ -585,13 +585,13 @@ public class FlowableAnyTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
 
-                    observer.onNext(1);
-                    observer.onNext(2);
-                    observer.onError(new IOException());
-                    observer.onComplete();
+                    subscriber.onNext(1);
+                    subscriber.onNext(2);
+                    subscriber.onError(new IOException());
+                    subscriber.onComplete();
                 }
             }
             .any(new Predicate<Integer>() {
@@ -616,13 +616,13 @@ public class FlowableAnyTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onError(new TestException("First"));
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onError(new TestException("First"));
 
-                    observer.onNext(1);
-                    observer.onError(new TestException("Second"));
-                    observer.onComplete();
+                    subscriber.onNext(1);
+                    subscriber.onError(new TestException("Second"));
+                    subscriber.onComplete();
                 }
             }
             .any(Functions.alwaysTrue())

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
@@ -302,14 +302,14 @@ public class FlowableAnyTest {
         .toFlowable()
         ;
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, never()).onNext(false);
-        verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onNext(false);
+        verify(subscriber, times(1)).onNext(true);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -317,14 +317,14 @@ public class FlowableAnyTest {
         Flowable<Integer> w = Flowable.just(1, 2);
         Flowable<Boolean> observable = w.isEmpty().toFlowable();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, never()).onNext(true);
-        verify(observer, times(1)).onNext(false);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onNext(true);
+        verify(subscriber, times(1)).onNext(false);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -337,14 +337,14 @@ public class FlowableAnyTest {
             }
         }).toFlowable();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, never()).onNext(false);
-        verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onNext(false);
+        verify(subscriber, times(1)).onNext(true);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -371,14 +371,14 @@ public class FlowableAnyTest {
             }
         }).toFlowable();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(false);
-        verify(observer, never()).onNext(true);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(false);
+        verify(subscriber, never()).onNext(true);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -386,14 +386,14 @@ public class FlowableAnyTest {
         Flowable<Integer> w = Flowable.empty();
         Flowable<Boolean> observable = w.isEmpty().toFlowable();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onNext(false);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(true);
+        verify(subscriber, never()).onNext(false);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -406,14 +406,14 @@ public class FlowableAnyTest {
             }
         }).toFlowable();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, never()).onNext(false);
-        verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onNext(false);
+        verify(subscriber, times(1)).onNext(true);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -426,14 +426,14 @@ public class FlowableAnyTest {
             }
         }).toFlowable();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, never()).onNext(false);
-        verify(observer, times(1)).onNext(true);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onNext(false);
+        verify(subscriber, times(1)).onNext(true);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -446,14 +446,14 @@ public class FlowableAnyTest {
             }
         }).toFlowable();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(false);
-        verify(observer, never()).onNext(true);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(false);
+        verify(subscriber, never()).onNext(true);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -467,14 +467,14 @@ public class FlowableAnyTest {
             }
         }).toFlowable();
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(false);
-        verify(observer, never()).onNext(true);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(false);
+        verify(subscriber, never()).onNext(true);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAsObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAsObservableTest.java
@@ -14,15 +14,16 @@
 package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.DefaultSubscriber;
 
 public class FlowableAsObservableTest {
     @Test
@@ -52,14 +53,13 @@ public class FlowableAsObservableTest {
 
         assertFalse(dst instanceof PublishProcessor);
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<Object> o = mock(DefaultSubscriber.class);
+        Subscriber<Integer> o = TestHelper.mockSubscriber();
 
         dst.subscribe(o);
 
         src.onError(new TestException());
 
-        verify(o, never()).onNext(any());
+        verify(o, never()).onNext(Mockito.<Integer>any());
         verify(o, never()).onComplete();
         verify(o).onError(any(TestException.class));
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAsObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAsObservableTest.java
@@ -34,16 +34,16 @@ public class FlowableAsObservableTest {
 
         assertFalse(dst instanceof PublishProcessor);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        dst.subscribe(o);
+        dst.subscribe(subscriber);
 
         src.onNext(1);
         src.onComplete();
 
-        verify(o).onNext(1);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(1);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
     @Test
     public void testHidingError() {
@@ -53,14 +53,14 @@ public class FlowableAsObservableTest {
 
         assertFalse(dst instanceof PublishProcessor);
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        dst.subscribe(o);
+        dst.subscribe(subscriber);
 
         src.onError(new TestException());
 
-        verify(o, never()).onNext(Mockito.<Integer>any());
-        verify(o, never()).onComplete();
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(Mockito.<Integer>any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
@@ -489,9 +489,9 @@ public class FlowableBlockingTest {
 
         new Flowable<Integer>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                s[0] = observer;
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                s[0] = subscriber;
             }
         }.blockingSubscribe(ts);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -42,13 +42,13 @@ import io.reactivex.subscribers.*;
 
 public class FlowableBufferTest {
 
-    private Subscriber<List<String>> observer;
+    private Subscriber<List<String>> subscriber;
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
 
     @Before
     public void before() {
-        observer = TestHelper.mockSubscriber();
+        subscriber = TestHelper.mockSubscriber();
         scheduler = new TestScheduler();
         innerScheduler = scheduler.createWorker();
     }
@@ -58,11 +58,11 @@ public class FlowableBufferTest {
         Flowable<String> source = Flowable.empty();
 
         Flowable<List<String>> buffered = source.buffer(3, 3);
-        buffered.subscribe(observer);
+        buffered.subscribe(subscriber);
 
-        Mockito.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
-        Mockito.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
-        Mockito.verify(observer, Mockito.times(1)).onComplete();
+        Mockito.verify(subscriber, Mockito.never()).onNext(Mockito.<String>anyList());
+        Mockito.verify(subscriber, Mockito.never()).onError(Mockito.any(Throwable.class));
+        Mockito.verify(subscriber, Mockito.times(1)).onComplete();
     }
 
     @Test
@@ -80,15 +80,15 @@ public class FlowableBufferTest {
         });
 
         Flowable<List<String>> buffered = source.buffer(3, 1);
-        buffered.subscribe(observer);
+        buffered.subscribe(subscriber);
 
-        InOrder inOrder = Mockito.inOrder(observer);
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two", "three"));
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("two", "three", "four"));
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("three", "four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
-        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(observer, Mockito.never()).onComplete();
+        InOrder inOrder = Mockito.inOrder(subscriber);
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("one", "two", "three"));
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("two", "three", "four"));
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("three", "four", "five"));
+        inOrder.verify(subscriber, Mockito.never()).onNext(Mockito.<String>anyList());
+        inOrder.verify(subscriber, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(subscriber, Mockito.never()).onComplete();
     }
 
     @Test
@@ -96,14 +96,14 @@ public class FlowableBufferTest {
         Flowable<String> source = Flowable.just("one", "two", "three", "four", "five");
 
         Flowable<List<String>> buffered = source.buffer(3, 3);
-        buffered.subscribe(observer);
+        buffered.subscribe(subscriber);
 
-        InOrder inOrder = Mockito.inOrder(observer);
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two", "three"));
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
-        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(observer, Mockito.times(1)).onComplete();
+        InOrder inOrder = Mockito.inOrder(subscriber);
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("one", "two", "three"));
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("four", "five"));
+        inOrder.verify(subscriber, Mockito.never()).onNext(Mockito.<String>anyList());
+        inOrder.verify(subscriber, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(subscriber, Mockito.times(1)).onComplete();
     }
 
     @Test
@@ -111,14 +111,14 @@ public class FlowableBufferTest {
         Flowable<String> source = Flowable.just("one", "two", "three", "four", "five");
 
         Flowable<List<String>> buffered = source.buffer(2, 3);
-        buffered.subscribe(observer);
+        buffered.subscribe(subscriber);
 
-        InOrder inOrder = Mockito.inOrder(observer);
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two"));
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
-        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(observer, Mockito.times(1)).onComplete();
+        InOrder inOrder = Mockito.inOrder(subscriber);
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("one", "two"));
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("four", "five"));
+        inOrder.verify(subscriber, Mockito.never()).onNext(Mockito.<String>anyList());
+        inOrder.verify(subscriber, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(subscriber, Mockito.times(1)).onComplete();
     }
 
     @Test
@@ -137,20 +137,20 @@ public class FlowableBufferTest {
         });
 
         Flowable<List<String>> buffered = source.buffer(100, TimeUnit.MILLISECONDS, scheduler, 2);
-        buffered.subscribe(observer);
+        buffered.subscribe(subscriber);
 
-        InOrder inOrder = Mockito.inOrder(observer);
+        InOrder inOrder = Mockito.inOrder(subscriber);
         scheduler.advanceTimeTo(100, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two"));
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("one", "two"));
 
         scheduler.advanceTimeTo(200, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("three", "four"));
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("three", "four"));
 
         scheduler.advanceTimeTo(300, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
-        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(observer, Mockito.times(1)).onComplete();
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("five"));
+        inOrder.verify(subscriber, Mockito.never()).onNext(Mockito.<String>anyList());
+        inOrder.verify(subscriber, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(subscriber, Mockito.times(1)).onComplete();
     }
 
     @Test
@@ -174,17 +174,17 @@ public class FlowableBufferTest {
         });
 
         Flowable<List<String>> buffered = source.buffer(100, TimeUnit.MILLISECONDS, scheduler);
-        buffered.subscribe(observer);
+        buffered.subscribe(subscriber);
 
-        InOrder inOrder = Mockito.inOrder(observer);
+        InOrder inOrder = Mockito.inOrder(subscriber);
         scheduler.advanceTimeTo(101, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two", "three"));
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("one", "two", "three"));
 
         scheduler.advanceTimeTo(201, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("four", "five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
-        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(observer, Mockito.times(1)).onComplete();
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("four", "five"));
+        inOrder.verify(subscriber, Mockito.never()).onNext(Mockito.<String>anyList());
+        inOrder.verify(subscriber, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(subscriber, Mockito.times(1)).onComplete();
     }
 
     @Test
@@ -227,29 +227,29 @@ public class FlowableBufferTest {
         };
 
         Flowable<List<String>> buffered = source.buffer(openings, closer);
-        buffered.subscribe(observer);
+        buffered.subscribe(subscriber);
 
-        InOrder inOrder = Mockito.inOrder(observer);
+        InOrder inOrder = Mockito.inOrder(subscriber);
         scheduler.advanceTimeTo(500, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("two", "three"));
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
-        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(observer, Mockito.times(1)).onComplete();
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("two", "three"));
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("five"));
+        inOrder.verify(subscriber, Mockito.never()).onNext(Mockito.<String>anyList());
+        inOrder.verify(subscriber, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(subscriber, Mockito.times(1)).onComplete();
     }
 
     @Test
     public void testFlowableBasedCloser() {
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                push(observer, "one", 10);
-                push(observer, "two", 60);
-                push(observer, "three", 110);
-                push(observer, "four", 160);
-                push(observer, "five", 210);
-                complete(observer, 250);
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                push(subscriber, "one", 10);
+                push(subscriber, "two", 60);
+                push(subscriber, "three", 110);
+                push(subscriber, "four", 160);
+                push(subscriber, "five", 210);
+                complete(subscriber, 250);
             }
         });
 
@@ -258,28 +258,28 @@ public class FlowableBufferTest {
             public Flowable<Object> call() {
                 return Flowable.unsafeCreate(new Publisher<Object>() {
                     @Override
-                    public void subscribe(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        push(observer, new Object(), 100);
-                        push(observer, new Object(), 200);
-                        push(observer, new Object(), 300);
-                        complete(observer, 301);
+                    public void subscribe(Subscriber<? super Object> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        push(subscriber, new Object(), 100);
+                        push(subscriber, new Object(), 200);
+                        push(subscriber, new Object(), 300);
+                        complete(subscriber, 301);
                     }
                 });
             }
         };
 
         Flowable<List<String>> buffered = source.buffer(closer);
-        buffered.subscribe(observer);
+        buffered.subscribe(subscriber);
 
-        InOrder inOrder = Mockito.inOrder(observer);
+        InOrder inOrder = Mockito.inOrder(subscriber);
         scheduler.advanceTimeTo(500, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("one", "two"));
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("three", "four"));
-        inOrder.verify(observer, Mockito.times(1)).onNext(list("five"));
-        inOrder.verify(observer, Mockito.never()).onNext(Mockito.<String>anyList());
-        inOrder.verify(observer, Mockito.never()).onError(Mockito.any(Throwable.class));
-        inOrder.verify(observer, Mockito.times(1)).onComplete();
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("one", "two"));
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("three", "four"));
+        inOrder.verify(subscriber, Mockito.times(1)).onNext(list("five"));
+        inOrder.verify(subscriber, Mockito.never()).onNext(Mockito.<String>anyList());
+        inOrder.verify(subscriber, Mockito.never()).onError(Mockito.any(Throwable.class));
+        inOrder.verify(subscriber, Mockito.times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -69,13 +69,13 @@ public class FlowableBufferTest {
     public void testSkipAndCountOverlappingBuffers() {
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                observer.onNext("one");
-                observer.onNext("two");
-                observer.onNext("three");
-                observer.onNext("four");
-                observer.onNext("five");
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                subscriber.onNext("one");
+                subscriber.onNext("two");
+                subscriber.onNext("three");
+                subscriber.onNext("four");
+                subscriber.onNext("five");
             }
         });
 
@@ -125,14 +125,14 @@ public class FlowableBufferTest {
     public void testTimedAndCount() {
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                push(observer, "one", 10);
-                push(observer, "two", 90);
-                push(observer, "three", 110);
-                push(observer, "four", 190);
-                push(observer, "five", 210);
-                complete(observer, 250);
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                push(subscriber, "one", 10);
+                push(subscriber, "two", 90);
+                push(subscriber, "three", 110);
+                push(subscriber, "four", 190);
+                push(subscriber, "five", 210);
+                complete(subscriber, 250);
             }
         });
 
@@ -157,19 +157,19 @@ public class FlowableBufferTest {
     public void testTimed() {
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                push(observer, "one", 97);
-                push(observer, "two", 98);
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                push(subscriber, "one", 97);
+                push(subscriber, "two", 98);
                 /**
                  * Changed from 100. Because scheduling the cut to 100ms happens before this
                  * Flowable even runs due how lift works, pushing at 100ms would execute after the
                  * buffer cut.
                  */
-                push(observer, "three", 99);
-                push(observer, "four", 101);
-                push(observer, "five", 102);
-                complete(observer, 150);
+                push(subscriber, "three", 99);
+                push(subscriber, "four", 101);
+                push(subscriber, "five", 102);
+                complete(subscriber, 150);
             }
         });
 
@@ -191,24 +191,24 @@ public class FlowableBufferTest {
     public void testFlowableBasedOpenerAndCloser() {
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                push(observer, "one", 10);
-                push(observer, "two", 60);
-                push(observer, "three", 110);
-                push(observer, "four", 160);
-                push(observer, "five", 210);
-                complete(observer, 500);
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                push(subscriber, "one", 10);
+                push(subscriber, "two", 60);
+                push(subscriber, "three", 110);
+                push(subscriber, "four", 160);
+                push(subscriber, "five", 210);
+                complete(subscriber, 500);
             }
         });
 
         Flowable<Object> openings = Flowable.unsafeCreate(new Publisher<Object>() {
             @Override
-            public void subscribe(Subscriber<Object> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                push(observer, new Object(), 50);
-                push(observer, new Object(), 200);
-                complete(observer, 250);
+            public void subscribe(Subscriber<Object> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                push(subscriber, new Object(), 50);
+                push(subscriber, new Object(), 200);
+                complete(subscriber, 250);
             }
         });
 
@@ -217,10 +217,10 @@ public class FlowableBufferTest {
             public Flowable<Object> apply(Object opening) {
                 return Flowable.unsafeCreate(new Publisher<Object>() {
                     @Override
-                    public void subscribe(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        push(observer, new Object(), 100);
-                        complete(observer, 101);
+                    public void subscribe(Subscriber<? super Object> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        push(subscriber, new Object(), 100);
+                        complete(subscriber, 101);
                     }
                 });
             }
@@ -324,20 +324,20 @@ public class FlowableBufferTest {
         return list;
     }
 
-    private <T> void push(final Subscriber<T> observer, final T value, int delay) {
+    private <T> void push(final Subscriber<T> subscriber, final T value, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onNext(value);
+                subscriber.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private void complete(final Subscriber<?> observer, int delay) {
+    private void complete(final Subscriber<?> subscriber, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onComplete();
+                subscriber.onComplete();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
@@ -346,8 +346,8 @@ public class FlowableBufferTest {
     public void testBufferStopsWhenUnsubscribed1() {
         Flowable<Integer> source = Flowable.never();
 
-        Subscriber<List<Integer>> o = TestHelper.mockSubscriber();
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(o, 0L);
+        Subscriber<List<Integer>> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(subscriber, 0L);
 
         source.buffer(100, 200, TimeUnit.MILLISECONDS, scheduler)
         .doOnNext(new Consumer<List<Integer>>() {
@@ -358,11 +358,11 @@ public class FlowableBufferTest {
         })
         .subscribe(ts);
 
-        InOrder inOrder = Mockito.inOrder(o);
+        InOrder inOrder = Mockito.inOrder(subscriber);
 
         scheduler.advanceTimeBy(1001, TimeUnit.MILLISECONDS);
 
-        inOrder.verify(o, times(5)).onNext(Arrays.<Integer> asList());
+        inOrder.verify(subscriber, times(5)).onNext(Arrays.<Integer> asList());
 
         ts.dispose();
 
@@ -376,10 +376,10 @@ public class FlowableBufferTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = Mockito.inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = Mockito.inOrder(subscriber);
 
-        source.buffer(boundary).subscribe(o);
+        source.buffer(boundary).subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -387,23 +387,23 @@ public class FlowableBufferTest {
 
         boundary.onNext(1);
 
-        inOrder.verify(o, times(1)).onNext(Arrays.asList(1, 2, 3));
+        inOrder.verify(subscriber, times(1)).onNext(Arrays.asList(1, 2, 3));
 
         source.onNext(4);
         source.onNext(5);
 
         boundary.onNext(2);
 
-        inOrder.verify(o, times(1)).onNext(Arrays.asList(4, 5));
+        inOrder.verify(subscriber, times(1)).onNext(Arrays.asList(4, 5));
 
         source.onNext(6);
         boundary.onComplete();
 
-        inOrder.verify(o, times(1)).onNext(Arrays.asList(6));
+        inOrder.verify(subscriber, times(1)).onNext(Arrays.asList(6));
 
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -411,18 +411,18 @@ public class FlowableBufferTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = Mockito.inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = Mockito.inOrder(subscriber);
 
-        source.buffer(boundary).subscribe(o);
+        source.buffer(boundary).subscribe(subscriber);
 
         boundary.onComplete();
 
-        inOrder.verify(o, times(1)).onNext(Arrays.asList());
+        inOrder.verify(subscriber, times(1)).onNext(Arrays.asList());
 
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -430,18 +430,18 @@ public class FlowableBufferTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = Mockito.inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = Mockito.inOrder(subscriber);
 
-        source.buffer(boundary).subscribe(o);
+        source.buffer(boundary).subscribe(subscriber);
 
         source.onComplete();
 
-        inOrder.verify(o, times(1)).onNext(Arrays.asList());
+        inOrder.verify(subscriber, times(1)).onNext(Arrays.asList());
 
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -449,19 +449,19 @@ public class FlowableBufferTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = Mockito.inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = Mockito.inOrder(subscriber);
 
-        source.buffer(boundary).subscribe(o);
+        source.buffer(boundary).subscribe(subscriber);
 
         source.onComplete();
         boundary.onComplete();
 
-        inOrder.verify(o, times(1)).onNext(Arrays.asList());
+        inOrder.verify(subscriber, times(1)).onNext(Arrays.asList());
 
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -469,15 +469,15 @@ public class FlowableBufferTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.buffer(boundary).subscribe(o);
+        source.buffer(boundary).subscribe(subscriber);
         source.onNext(1);
         source.onError(new TestException());
 
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onComplete();
-        verify(o, never()).onNext(any());
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -485,16 +485,16 @@ public class FlowableBufferTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.buffer(boundary).subscribe(o);
+        source.buffer(boundary).subscribe(subscriber);
 
         source.onNext(1);
         boundary.onError(new TestException());
 
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onComplete();
-        verify(o, never()).onNext(any());
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
     @Test(timeout = 2000)
     public void bufferWithSizeTake1() {
@@ -502,13 +502,13 @@ public class FlowableBufferTest {
 
         Flowable<List<Integer>> result = source.buffer(2).take(1);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(Arrays.asList(1, 1));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(1, 1));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test(timeout = 2000)
@@ -517,13 +517,13 @@ public class FlowableBufferTest {
 
         Flowable<List<Integer>> result = source.buffer(2, 3).take(1);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(Arrays.asList(1, 1));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(1, 1));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
     @Test(timeout = 2000)
     public void bufferWithTimeTake1() {
@@ -531,15 +531,15 @@ public class FlowableBufferTest {
 
         Flowable<List<Long>> result = source.buffer(100, TimeUnit.MILLISECONDS, scheduler).take(1);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         scheduler.advanceTimeBy(5, TimeUnit.SECONDS);
 
-        verify(o).onNext(Arrays.asList(0L, 1L));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(0L, 1L));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
     @Test(timeout = 2000)
     public void bufferWithTimeSkipTake2() {
@@ -547,18 +547,19 @@ public class FlowableBufferTest {
 
         Flowable<List<Long>> result = source.buffer(100, 60, TimeUnit.MILLISECONDS, scheduler).take(2);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         scheduler.advanceTimeBy(5, TimeUnit.SECONDS);
 
-        inOrder.verify(o).onNext(Arrays.asList(0L, 1L));
-        inOrder.verify(o).onNext(Arrays.asList(1L, 2L));
-        inOrder.verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber).onNext(Arrays.asList(0L, 1L));
+        inOrder.verify(subscriber).onNext(Arrays.asList(1L, 2L));
+        inOrder.verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
+
     @Test(timeout = 2000)
     public void bufferWithBoundaryTake2() {
         Flowable<Long> boundary = Flowable.interval(60, 60, TimeUnit.MILLISECONDS, scheduler);
@@ -566,17 +567,17 @@ public class FlowableBufferTest {
 
         Flowable<List<Long>> result = source.buffer(boundary).take(2);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         scheduler.advanceTimeBy(5, TimeUnit.SECONDS);
 
-        inOrder.verify(o).onNext(Arrays.asList(0L));
-        inOrder.verify(o).onNext(Arrays.asList(1L));
-        inOrder.verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber).onNext(Arrays.asList(0L));
+        inOrder.verify(subscriber).onNext(Arrays.asList(1L));
+        inOrder.verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
     }
 
@@ -594,8 +595,8 @@ public class FlowableBufferTest {
 
         Flowable<List<Long>> result = source.buffer(start, end).take(2);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
         result
         .doOnNext(new Consumer<List<Long>>() {
@@ -604,14 +605,14 @@ public class FlowableBufferTest {
                 System.out.println(pv);
             }
         })
-        .subscribe(o);
+        .subscribe(subscriber);
 
         scheduler.advanceTimeBy(5, TimeUnit.SECONDS);
 
-        inOrder.verify(o).onNext(Arrays.asList(1L, 2L, 3L));
-        inOrder.verify(o).onNext(Arrays.asList(3L, 4L));
-        inOrder.verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber).onNext(Arrays.asList(1L, 2L, 3L));
+        inOrder.verify(subscriber).onNext(Arrays.asList(3L, 4L));
+        inOrder.verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
     @Test
     public void bufferWithSizeThrows() {
@@ -619,22 +620,22 @@ public class FlowableBufferTest {
 
         Flowable<List<Integer>> result = source.buffer(2);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        InOrder inOrder = inOrder(o);
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
         source.onNext(3);
         source.onError(new TestException());
 
-        inOrder.verify(o).onNext(Arrays.asList(1, 2));
-        inOrder.verify(o).onError(any(TestException.class));
+        inOrder.verify(subscriber).onNext(Arrays.asList(1, 2));
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onNext(Arrays.asList(3));
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onNext(Arrays.asList(3));
+        verify(subscriber, never()).onComplete();
 
     }
 
@@ -644,10 +645,10 @@ public class FlowableBufferTest {
 
         Flowable<List<Integer>> result = source.buffer(100, TimeUnit.MILLISECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -656,11 +657,11 @@ public class FlowableBufferTest {
         source.onError(new TestException());
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
-        inOrder.verify(o).onNext(Arrays.asList(1, 2));
-        inOrder.verify(o).onError(any(TestException.class));
+        inOrder.verify(subscriber).onNext(Arrays.asList(1, 2));
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onNext(Arrays.asList(3));
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onNext(Arrays.asList(3));
+        verify(subscriber, never()).onComplete();
 
     }
 
@@ -670,17 +671,17 @@ public class FlowableBufferTest {
 
         Flowable<List<Long>> result = source.buffer(100, TimeUnit.MILLISECONDS, scheduler, 2).take(3);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         scheduler.advanceTimeBy(5, TimeUnit.SECONDS);
 
-        inOrder.verify(o).onNext(Arrays.asList(0L, 1L));
-        inOrder.verify(o).onNext(Arrays.asList(2L));
-        inOrder.verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber).onNext(Arrays.asList(0L, 1L));
+        inOrder.verify(subscriber).onNext(Arrays.asList(2L));
+        inOrder.verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
     @Test
     public void bufferWithStartEndStartThrows() {
@@ -697,18 +698,18 @@ public class FlowableBufferTest {
 
         Flowable<List<Integer>> result = source.buffer(start, end);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         start.onNext(1);
         source.onNext(1);
         source.onNext(2);
         start.onError(new TestException());
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
     }
     @Test
     public void bufferWithStartEndEndFunctionThrows() {
@@ -725,17 +726,17 @@ public class FlowableBufferTest {
 
         Flowable<List<Integer>> result = source.buffer(start, end);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         start.onNext(1);
         source.onNext(1);
         source.onNext(2);
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
     }
     @Test
     public void bufferWithStartEndEndThrows() {
@@ -752,17 +753,17 @@ public class FlowableBufferTest {
 
         Flowable<List<Integer>> result = source.buffer(start, end);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         start.onNext(1);
         source.onNext(1);
         source.onNext(2);
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
     }
 
     @Test
@@ -992,22 +993,22 @@ public class FlowableBufferTest {
     }
     @Test(timeout = 3000)
     public void testBufferWithTimeDoesntUnsubscribeDownstream() throws InterruptedException {
-        final Subscriber<Object> o = TestHelper.mockSubscriber();
+        final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         final CountDownLatch cdl = new CountDownLatch(1);
         ResourceSubscriber<Object> s = new ResourceSubscriber<Object>() {
             @Override
             public void onNext(Object t) {
-                o.onNext(t);
+                subscriber.onNext(t);
             }
             @Override
             public void onError(Throwable e) {
-                o.onError(e);
+                subscriber.onError(e);
                 cdl.countDown();
             }
             @Override
             public void onComplete() {
-                o.onComplete();
+                subscriber.onComplete();
                 cdl.countDown();
             }
         };
@@ -1016,9 +1017,9 @@ public class FlowableBufferTest {
 
         cdl.await();
 
-        verify(o).onNext(Arrays.asList(1));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(1));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         assertFalse(s.isDisposed());
     }
@@ -2480,20 +2481,20 @@ public class FlowableBufferTest {
     public void bufferExactBoundaryBadSource() {
         Flowable<Integer> pp = new Flowable<Integer>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                observer.onComplete();
-                observer.onNext(1);
-                observer.onComplete();
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                subscriber.onComplete();
+                subscriber.onNext(1);
+                subscriber.onComplete();
             }
         };
 
         final AtomicReference<Subscriber<? super Integer>> ref = new AtomicReference<Subscriber<? super Integer>>();
         Flowable<Integer> b = new Flowable<Integer>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                ref.set(observer);
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                ref.set(subscriber);
             }
         };
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -84,19 +84,19 @@ public class FlowableCacheTest {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> o = Flowable.unsafeCreate(new Publisher<String>() {
+        Flowable<String> f = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
-            public void subscribe(final Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(final Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 new Thread(new Runnable() {
 
                     @Override
                     public void run() {
                         counter.incrementAndGet();
                         System.out.println("published observable being executed");
-                        observer.onNext("one");
-                        observer.onComplete();
+                        subscriber.onNext("one");
+                        subscriber.onComplete();
                     }
                 }).start();
             }
@@ -106,7 +106,7 @@ public class FlowableCacheTest {
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
             @Override
             public void accept(String v) {
                     assertEquals("one", v);
@@ -116,7 +116,7 @@ public class FlowableCacheTest {
         });
 
         // subscribe again
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
             @Override
             public void accept(String v) {
                     assertEquals("one", v);
@@ -134,10 +134,10 @@ public class FlowableCacheTest {
     @Test
     public void testUnsubscribeSource() throws Exception {
         Action unsubscribe = mock(Action.class);
-        Flowable<Integer> o = Flowable.just(1).doOnCancel(unsubscribe).cache();
-        o.subscribe();
-        o.subscribe();
-        o.subscribe();
+        Flowable<Integer> f = Flowable.just(1).doOnCancel(unsubscribe).cache();
+        f.subscribe();
+        f.subscribe();
+        f.subscribe();
         verify(unsubscribe, times(1)).run();
     }
 
@@ -305,11 +305,11 @@ public class FlowableCacheTest {
 
     @Test
     public void disposeOnArrival2() {
-        Flowable<Integer> o = PublishProcessor.<Integer>create().cache();
+        Flowable<Integer> f = PublishProcessor.<Integer>create().cache();
 
-        o.test();
+        f.test();
 
-        o.test(0L, true)
+        f.test(0L, true)
         .assertEmpty();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCastTest.java
@@ -29,15 +29,14 @@ public class FlowableCastTest {
         Flowable<?> source = Flowable.just(1, 2);
         Flowable<Integer> observable = source.cast(Integer.class);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(1);
-        verify(observer, times(1)).onNext(1);
-        verify(observer, never()).onError(
-                any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -45,12 +44,11 @@ public class FlowableCastTest {
         Flowable<?> source = Flowable.just(1, 2);
         Flowable<Boolean> observable = source.cast(Boolean.class);
 
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, times(1)).onError(
-                any(ClassCastException.class));
+        verify(subscriber, times(1)).onError(any(ClassCastException.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCastTest.java
@@ -27,11 +27,11 @@ public class FlowableCastTest {
     @Test
     public void testCast() {
         Flowable<?> source = Flowable.just(1, 2);
-        Flowable<Integer> observable = source.cast(Integer.class);
+        Flowable<Integer> flowable = source.cast(Integer.class);
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(1);
         verify(subscriber, times(1)).onNext(1);
@@ -42,11 +42,11 @@ public class FlowableCastTest {
     @Test
     public void testCastWithWrongType() {
         Flowable<?> source = Flowable.just(1, 2);
-        Flowable<Boolean> observable = source.cast(Boolean.class);
+        Flowable<Boolean> flowable = source.cast(Boolean.class);
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onError(any(ClassCastException.class));
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -178,16 +178,16 @@ public class FlowableCombineLatestTest {
         BiFunction<String, Integer, String> combineLatestFunction = getConcatStringIntegerCombineLatestFunction();
 
         /* define an Observer to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<String> w = Flowable.combineLatest(Flowable.just("one", "two"), Flowable.just(2, 3, 4), combineLatestFunction);
-        w.subscribe(observer);
+        w.subscribe(subscriber);
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("two2");
-        verify(observer, times(1)).onNext("two3");
-        verify(observer, times(1)).onNext("two4");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("two2");
+        verify(subscriber, times(1)).onNext("two3");
+        verify(subscriber, times(1)).onNext("two4");
     }
 
     @Test
@@ -195,14 +195,14 @@ public class FlowableCombineLatestTest {
         Function3<String, Integer, int[], String> combineLatestFunction = getConcatStringIntegerIntArrayCombineLatestFunction();
 
         /* define an Observer to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<String> w = Flowable.combineLatest(Flowable.just("one", "two"), Flowable.just(2), Flowable.just(new int[] { 4, 5, 6 }), combineLatestFunction);
-        w.subscribe(observer);
+        w.subscribe(subscriber);
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("two2[4, 5, 6]");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("two2[4, 5, 6]");
     }
 
     @Test
@@ -210,15 +210,15 @@ public class FlowableCombineLatestTest {
         Function3<String, Integer, int[], String> combineLatestFunction = getConcatStringIntegerIntArrayCombineLatestFunction();
 
         /* define an Observer to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<String> w = Flowable.combineLatest(Flowable.just("one"), Flowable.just(2), Flowable.just(new int[] { 4, 5, 6 }, new int[] { 7, 8 }), combineLatestFunction);
-        w.subscribe(observer);
+        w.subscribe(subscriber);
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("one2[4, 5, 6]");
-        verify(observer, times(1)).onNext("one2[7, 8]");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one2[4, 5, 6]");
+        verify(subscriber, times(1)).onNext("one2[7, 8]");
     }
 
     private Function3<String, String, String, String> getConcat3StringsCombineLatestFunction() {
@@ -285,33 +285,33 @@ public class FlowableCombineLatestTest {
 
         Flowable<Integer> source = Flowable.combineLatest(a, b, or);
 
-        Subscriber<Object> observer = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(observer);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.subscribe(observer);
+        source.subscribe(subscriber);
 
         a.onNext(1);
 
-        inOrder.verify(observer, never()).onNext(any());
+        inOrder.verify(subscriber, never()).onNext(any());
 
         a.onNext(2);
 
-        inOrder.verify(observer, never()).onNext(any());
+        inOrder.verify(subscriber, never()).onNext(any());
 
         b.onNext(0x10);
 
-        inOrder.verify(observer, times(1)).onNext(0x12);
+        inOrder.verify(subscriber, times(1)).onNext(0x12);
 
         b.onNext(0x20);
-        inOrder.verify(observer, times(1)).onNext(0x22);
+        inOrder.verify(subscriber, times(1)).onNext(0x22);
 
         b.onComplete();
 
-        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(subscriber, never()).onComplete();
 
         a.onComplete();
 
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
 
         a.onNext(3);
         b.onNext(0x30);
@@ -319,7 +319,7 @@ public class FlowableCombineLatestTest {
         b.onComplete();
 
         inOrder.verifyNoMoreInteractions();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -329,44 +329,44 @@ public class FlowableCombineLatestTest {
 
         Flowable<Integer> source = Flowable.combineLatest(a, b, or);
 
-        Subscriber<Object> observer1 = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
 
-        Subscriber<Object> observer2 = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber2 = TestHelper.mockSubscriber();
 
-        InOrder inOrder1 = inOrder(observer1);
-        InOrder inOrder2 = inOrder(observer2);
+        InOrder inOrder1 = inOrder(subscriber1);
+        InOrder inOrder2 = inOrder(subscriber2);
 
-        source.subscribe(observer1);
-        source.subscribe(observer2);
+        source.subscribe(subscriber1);
+        source.subscribe(subscriber2);
 
         a.onNext(1);
 
-        inOrder1.verify(observer1, never()).onNext(any());
-        inOrder2.verify(observer2, never()).onNext(any());
+        inOrder1.verify(subscriber1, never()).onNext(any());
+        inOrder2.verify(subscriber2, never()).onNext(any());
 
         a.onNext(2);
 
-        inOrder1.verify(observer1, never()).onNext(any());
-        inOrder2.verify(observer2, never()).onNext(any());
+        inOrder1.verify(subscriber1, never()).onNext(any());
+        inOrder2.verify(subscriber2, never()).onNext(any());
 
         b.onNext(0x10);
 
-        inOrder1.verify(observer1, times(1)).onNext(0x12);
-        inOrder2.verify(observer2, times(1)).onNext(0x12);
+        inOrder1.verify(subscriber1, times(1)).onNext(0x12);
+        inOrder2.verify(subscriber2, times(1)).onNext(0x12);
 
         b.onNext(0x20);
-        inOrder1.verify(observer1, times(1)).onNext(0x22);
-        inOrder2.verify(observer2, times(1)).onNext(0x22);
+        inOrder1.verify(subscriber1, times(1)).onNext(0x22);
+        inOrder2.verify(subscriber2, times(1)).onNext(0x22);
 
         b.onComplete();
 
-        inOrder1.verify(observer1, never()).onComplete();
-        inOrder2.verify(observer2, never()).onComplete();
+        inOrder1.verify(subscriber1, never()).onComplete();
+        inOrder2.verify(subscriber2, never()).onComplete();
 
         a.onComplete();
 
-        inOrder1.verify(observer1, times(1)).onComplete();
-        inOrder2.verify(observer2, times(1)).onComplete();
+        inOrder1.verify(subscriber1, times(1)).onComplete();
+        inOrder2.verify(subscriber2, times(1)).onComplete();
 
         a.onNext(3);
         b.onNext(0x30);
@@ -375,8 +375,8 @@ public class FlowableCombineLatestTest {
 
         inOrder1.verifyNoMoreInteractions();
         inOrder2.verifyNoMoreInteractions();
-        verify(observer1, never()).onError(any(Throwable.class));
-        verify(observer2, never()).onError(any(Throwable.class));
+        verify(subscriber1, never()).onError(any(Throwable.class));
+        verify(subscriber2, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -386,19 +386,19 @@ public class FlowableCombineLatestTest {
 
         Flowable<Integer> source = Flowable.combineLatest(a, b, or);
 
-        Subscriber<Object> observer = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(observer);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.subscribe(observer);
+        source.subscribe(subscriber);
 
         b.onNext(0x10);
         b.onNext(0x20);
 
         a.onComplete();
 
-        inOrder.verify(observer, times(1)).onComplete();
-        verify(observer, never()).onNext(any());
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -408,10 +408,10 @@ public class FlowableCombineLatestTest {
 
         Flowable<Integer> source = Flowable.combineLatest(a, b, or);
 
-        Subscriber<Object> observer = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(observer);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.subscribe(observer);
+        source.subscribe(subscriber);
 
         a.onNext(0x1);
         a.onNext(0x2);
@@ -419,9 +419,9 @@ public class FlowableCombineLatestTest {
         b.onComplete();
         a.onComplete();
 
-        inOrder.verify(observer, times(1)).onComplete();
-        verify(observer, never()).onNext(any());
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     public void test0Sources() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -449,13 +449,13 @@ public class FlowableCombineLatestTest {
 
             Flowable<List<Object>> result = Flowable.combineLatest(sources, func);
 
-            Subscriber<List<Object>> o = TestHelper.mockSubscriber();
+            Subscriber<List<Object>> subscriber = TestHelper.mockSubscriber();
 
-            result.subscribe(o);
+            result.subscribe(subscriber);
 
-            verify(o).onNext(values);
-            verify(o).onComplete();
-            verify(o, never()).onError(any(Throwable.class));
+            verify(subscriber).onNext(values);
+            verify(subscriber).onComplete();
+            verify(subscriber, never()).onError(any(Throwable.class));
         }
     }
 
@@ -480,7 +480,7 @@ public class FlowableCombineLatestTest {
 
             Flowable<List<Object>> result = Flowable.combineLatest(sources, func);
 
-            final Subscriber<List<Object>> o = TestHelper.mockSubscriber();
+            final Subscriber<List<Object>> subscriber = TestHelper.mockSubscriber();
 
             final CountDownLatch cdl = new CountDownLatch(1);
 
@@ -488,18 +488,18 @@ public class FlowableCombineLatestTest {
 
                 @Override
                 public void onNext(List<Object> t) {
-                    o.onNext(t);
+                    subscriber.onNext(t);
                 }
 
                 @Override
                 public void onError(Throwable e) {
-                    o.onError(e);
+                    subscriber.onError(e);
                     cdl.countDown();
                 }
 
                 @Override
                 public void onComplete() {
-                    o.onComplete();
+                    subscriber.onComplete();
                     cdl.countDown();
                 }
             };
@@ -508,9 +508,9 @@ public class FlowableCombineLatestTest {
 
             cdl.await();
 
-            verify(o).onNext(values);
-            verify(o).onComplete();
-            verify(o, never()).onError(any(Throwable.class));
+            verify(subscriber).onNext(values);
+            verify(subscriber).onComplete();
+            verify(subscriber, never()).onError(any(Throwable.class));
         }
     }
 
@@ -527,13 +527,13 @@ public class FlowableCombineLatestTest {
                     }
                 });
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(Arrays.asList(1, 2));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(1, 2));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -550,13 +550,13 @@ public class FlowableCombineLatestTest {
                     }
                 });
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(Arrays.asList(1, 2, 3));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(1, 2, 3));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -574,13 +574,13 @@ public class FlowableCombineLatestTest {
                     }
                 });
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(Arrays.asList(1, 2, 3, 4));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(1, 2, 3, 4));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -599,13 +599,13 @@ public class FlowableCombineLatestTest {
                     }
                 });
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(Arrays.asList(1, 2, 3, 4, 5));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(1, 2, 3, 4, 5));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -625,13 +625,13 @@ public class FlowableCombineLatestTest {
                     }
                 });
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(Arrays.asList(1, 2, 3, 4, 5, 6));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(1, 2, 3, 4, 5, 6));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -652,13 +652,13 @@ public class FlowableCombineLatestTest {
                     }
                 });
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -680,13 +680,13 @@ public class FlowableCombineLatestTest {
                     }
                 });
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -709,13 +709,13 @@ public class FlowableCombineLatestTest {
                     }
                 });
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -730,13 +730,13 @@ public class FlowableCombineLatestTest {
 
         });
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onComplete();
-        verify(o, never()).onNext(any());
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
 
     }
 
@@ -808,14 +808,14 @@ public class FlowableCombineLatestTest {
         @SuppressWarnings("unchecked")
         List<Flowable<Integer>> sources = Arrays.asList(Flowable.fromArray(1, 2, 3, 4),
                 Flowable.fromArray(5,6,7,8));
-        Flowable<Integer> o = Flowable.combineLatest(sources,new Function<Object[], Integer>() {
+        Flowable<Integer> f = Flowable.combineLatest(sources,new Function<Object[], Integer>() {
             @Override
             public Integer apply(Object[] args) {
                return (Integer) args[0];
             }});
         //should get at least 4
         final CountDownLatch latch = new CountDownLatch(4);
-        o.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<Integer>() {
+        f.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -588,11 +588,11 @@ public class FlowableConcatMapEagerTest {
 
     @Test
     public void testReentrantWork() {
-        final PublishProcessor<Integer> subject = PublishProcessor.create();
+        final PublishProcessor<Integer> processor = PublishProcessor.create();
 
         final AtomicBoolean once = new AtomicBoolean();
 
-        subject.concatMapEager(new Function<Integer, Flowable<Integer>>() {
+        processor.concatMapEager(new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer t) {
                 return Flowable.just(t);
@@ -602,13 +602,13 @@ public class FlowableConcatMapEagerTest {
             @Override
             public void accept(Integer t) {
                 if (once.compareAndSet(false, true)) {
-                    subject.onNext(2);
+                    processor.onNext(2);
                 }
             }
         })
         .subscribe(ts);
 
-        subject.onNext(1);
+        processor.onNext(1);
 
         ts.assertNoErrors();
         ts.assertNotComplete();
@@ -1051,8 +1051,8 @@ public class FlowableConcatMapEagerTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.concatMapEager(new Function<Object, Flowable<Object>>() {
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.concatMapEager(new Function<Object, Flowable<Object>>() {
                     @Override
                     public Flowable<Object> apply(Object v) throws Exception {
                         return Flowable.just(v);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -41,7 +41,7 @@ public class FlowableConcatTest {
 
     @Test
     public void testConcat() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         final String[] o = { "1", "3", "5", "7" };
         final String[] e = { "2", "4", "6" };
@@ -50,14 +50,14 @@ public class FlowableConcatTest {
         final Flowable<String> even = Flowable.fromArray(e);
 
         Flowable<String> concat = Flowable.concat(odds, even);
-        concat.subscribe(observer);
+        concat.subscribe(subscriber);
 
-        verify(observer, times(7)).onNext(anyString());
+        verify(subscriber, times(7)).onNext(anyString());
     }
 
     @Test
     public void testConcatWithList() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         final String[] o = { "1", "3", "5", "7" };
         final String[] e = { "2", "4", "6" };
@@ -68,14 +68,14 @@ public class FlowableConcatTest {
         list.add(odds);
         list.add(even);
         Flowable<String> concat = Flowable.concat(Flowable.fromIterable(list));
-        concat.subscribe(observer);
+        concat.subscribe(subscriber);
 
-        verify(observer, times(7)).onNext(anyString());
+        verify(subscriber, times(7)).onNext(anyString());
     }
 
     @Test
     public void testConcatObservableOfObservables() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         final String[] o = { "1", "3", "5", "7" };
         final String[] e = { "2", "4", "6" };
@@ -97,9 +97,9 @@ public class FlowableConcatTest {
         });
         Flowable<String> concat = Flowable.concat(observableOfObservables);
 
-        concat.subscribe(observer);
+        concat.subscribe(subscriber);
 
-        verify(observer, times(7)).onNext(anyString());
+        verify(subscriber, times(7)).onNext(anyString());
     }
 
     /**
@@ -107,12 +107,12 @@ public class FlowableConcatTest {
      */
     @Test
     public void testSimpleAsyncConcat() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         TestObservable<String> o1 = new TestObservable<String>("one", "two", "three");
         TestObservable<String> o2 = new TestObservable<String>("four", "five", "six");
 
-        Flowable.concat(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2)).subscribe(observer);
+        Flowable.concat(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2)).subscribe(subscriber);
 
         try {
             // wait for async observables to complete
@@ -122,13 +122,13 @@ public class FlowableConcatTest {
             throw new RuntimeException("failed waiting on threads");
         }
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("one");
-        inOrder.verify(observer, times(1)).onNext("two");
-        inOrder.verify(observer, times(1)).onNext("three");
-        inOrder.verify(observer, times(1)).onNext("four");
-        inOrder.verify(observer, times(1)).onNext("five");
-        inOrder.verify(observer, times(1)).onNext("six");
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        inOrder.verify(subscriber, times(1)).onNext("four");
+        inOrder.verify(subscriber, times(1)).onNext("five");
+        inOrder.verify(subscriber, times(1)).onNext("six");
     }
 
     @Test
@@ -147,7 +147,7 @@ public class FlowableConcatTest {
      */
     @Test
     public void testNestedAsyncConcat() throws InterruptedException {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         final TestObservable<String> o1 = new TestObservable<String>("one", "two", "three");
         final TestObservable<String> o2 = new TestObservable<String>("four", "five", "six");
@@ -215,7 +215,7 @@ public class FlowableConcatTest {
             }
         });
 
-        Flowable.concat(observableOfObservables).subscribe(observer);
+        Flowable.concat(observableOfObservables).subscribe(subscriber);
 
         // wait for parent to start
         parentHasStarted.await();
@@ -230,20 +230,20 @@ public class FlowableConcatTest {
             throw new RuntimeException("failed waiting on threads", e);
         }
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("one");
-        inOrder.verify(observer, times(1)).onNext("two");
-        inOrder.verify(observer, times(1)).onNext("three");
-        inOrder.verify(observer, times(1)).onNext("four");
-        inOrder.verify(observer, times(1)).onNext("five");
-        inOrder.verify(observer, times(1)).onNext("six");
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        inOrder.verify(subscriber, times(1)).onNext("four");
+        inOrder.verify(subscriber, times(1)).onNext("five");
+        inOrder.verify(subscriber, times(1)).onNext("six");
         // we shouldn't have the following 3 yet
-        inOrder.verify(observer, never()).onNext("seven");
-        inOrder.verify(observer, never()).onNext("eight");
-        inOrder.verify(observer, never()).onNext("nine");
+        inOrder.verify(subscriber, never()).onNext("seven");
+        inOrder.verify(subscriber, never()).onNext("eight");
+        inOrder.verify(subscriber, never()).onNext("nine");
         // we should not be completed yet
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         // now allow the third
         allowThird.countDown();
@@ -264,17 +264,17 @@ public class FlowableConcatTest {
             throw new RuntimeException("failed waiting on threads", e);
         }
 
-        inOrder.verify(observer, times(1)).onNext("seven");
-        inOrder.verify(observer, times(1)).onNext("eight");
-        inOrder.verify(observer, times(1)).onNext("nine");
+        inOrder.verify(subscriber, times(1)).onNext("seven");
+        inOrder.verify(subscriber, times(1)).onNext("eight");
+        inOrder.verify(subscriber, times(1)).onNext("nine");
 
-        verify(observer, never()).onError(any(Throwable.class));
-        inOrder.verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testBlockedObservableOfObservables() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         final String[] o = { "1", "3", "5", "7" };
         final String[] e = { "2", "4", "6" };
@@ -285,7 +285,7 @@ public class FlowableConcatTest {
         @SuppressWarnings("unchecked")
         TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(callOnce, okToContinue, odds, even);
         Flowable<String> concatF = Flowable.concat(Flowable.unsafeCreate(observableOfObservables));
-        concatF.subscribe(observer);
+        concatF.subscribe(subscriber);
         try {
             //Block main thread to allow observables to serve up o1.
             callOnce.await();
@@ -294,10 +294,10 @@ public class FlowableConcatTest {
             fail(ex.getMessage());
         }
         // The concated observable should have served up all of the odds.
-        verify(observer, times(1)).onNext("1");
-        verify(observer, times(1)).onNext("3");
-        verify(observer, times(1)).onNext("5");
-        verify(observer, times(1)).onNext("7");
+        verify(subscriber, times(1)).onNext("1");
+        verify(subscriber, times(1)).onNext("3");
+        verify(subscriber, times(1)).onNext("5");
+        verify(subscriber, times(1)).onNext("7");
 
         try {
             // unblock observables so it can serve up o2 and complete
@@ -308,9 +308,9 @@ public class FlowableConcatTest {
             fail(ex.getMessage());
         }
         // The concatenated observable should now have served up all the evens.
-        verify(observer, times(1)).onNext("2");
-        verify(observer, times(1)).onNext("4");
-        verify(observer, times(1)).onNext("6");
+        verify(subscriber, times(1)).onNext("2");
+        verify(subscriber, times(1)).onNext("4");
+        verify(subscriber, times(1)).onNext("6");
     }
 
     @Test
@@ -319,13 +319,13 @@ public class FlowableConcatTest {
         //This observable will send "hello" MAX_VALUE time.
         final TestObservable<String> w2 = new TestObservable<String>("hello", Integer.MAX_VALUE);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         @SuppressWarnings("unchecked")
         TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
         Flowable<String> concatF = Flowable.concat(Flowable.unsafeCreate(observableOfObservables));
 
-        concatF.take(50).subscribe(observer);
+        concatF.take(50).subscribe(subscriber);
 
         //Wait for the thread to start up.
         try {
@@ -335,13 +335,13 @@ public class FlowableConcatTest {
             e.printStackTrace();
         }
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("one");
-        inOrder.verify(observer, times(1)).onNext("two");
-        inOrder.verify(observer, times(1)).onNext("three");
-        inOrder.verify(observer, times(47)).onNext("hello");
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        inOrder.verify(subscriber, times(47)).onNext("hello");
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -353,7 +353,7 @@ public class FlowableConcatTest {
         final TestObservable<String> w1 = new TestObservable<String>(null, okToContinueW1, "one", "two", "three");
         final TestObservable<String> w2 = new TestObservable<String>(null, okToContinueW2, "four", "five", "six");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<Flowable<String>> observableOfObservables = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
 
@@ -368,9 +368,9 @@ public class FlowableConcatTest {
 
         });
         Flowable<String> concat = Flowable.concat(observableOfObservables);
-        concat.subscribe(observer);
+        concat.subscribe(subscriber);
 
-        verify(observer, times(0)).onComplete();
+        verify(subscriber, times(0)).onComplete();
 
         try {
             // release both threads
@@ -383,14 +383,14 @@ public class FlowableConcatTest {
             e.printStackTrace();
         }
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("one");
-        inOrder.verify(observer, times(1)).onNext("two");
-        inOrder.verify(observer, times(1)).onNext("three");
-        inOrder.verify(observer, times(1)).onNext("four");
-        inOrder.verify(observer, times(1)).onNext("five");
-        inOrder.verify(observer, times(1)).onNext("six");
-        verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        inOrder.verify(subscriber, times(1)).onNext("four");
+        inOrder.verify(subscriber, times(1)).onNext("five");
+        inOrder.verify(subscriber, times(1)).onNext("six");
+        verify(subscriber, times(1)).onComplete();
 
     }
 
@@ -404,8 +404,8 @@ public class FlowableConcatTest {
         final TestObservable<String> w1 = new TestObservable<String>("one", "two", "three");
         final TestObservable<String> w2 = new TestObservable<String>(callOnce, okToContinue, "four", "five", "six");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer, 0L);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, 0L);
 
         final Flowable<String> concat = Flowable.concat(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
 
@@ -425,14 +425,14 @@ public class FlowableConcatTest {
             fail(e.getMessage());
         }
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("one");
-        inOrder.verify(observer, times(1)).onNext("two");
-        inOrder.verify(observer, times(1)).onNext("three");
-        inOrder.verify(observer, times(1)).onNext("four");
-        inOrder.verify(observer, never()).onNext("five");
-        inOrder.verify(observer, never()).onNext("six");
-        inOrder.verify(observer, never()).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        inOrder.verify(subscriber, times(1)).onNext("four");
+        inOrder.verify(subscriber, never()).onNext("five");
+        inOrder.verify(subscriber, never()).onNext("six");
+        inOrder.verify(subscriber, never()).onComplete();
 
     }
 
@@ -446,8 +446,8 @@ public class FlowableConcatTest {
         final TestObservable<String> w1 = new TestObservable<String>("one", "two", "three");
         final TestObservable<String> w2 = new TestObservable<String>(callOnce, okToContinue, "four", "five", "six");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer, 0L);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, 0L);
 
         @SuppressWarnings("unchecked")
         TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
@@ -470,15 +470,15 @@ public class FlowableConcatTest {
             fail(e.getMessage());
         }
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("one");
-        inOrder.verify(observer, times(1)).onNext("two");
-        inOrder.verify(observer, times(1)).onNext("three");
-        inOrder.verify(observer, times(1)).onNext("four");
-        inOrder.verify(observer, never()).onNext("five");
-        inOrder.verify(observer, never()).onNext("six");
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        inOrder.verify(subscriber, times(1)).onNext("four");
+        inOrder.verify(subscriber, never()).onNext("five");
+        inOrder.verify(subscriber, never()).onNext("six");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     private static class TestObservable<T> implements Publisher<T> {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCountTest.java
@@ -51,15 +51,15 @@ public class FlowableCountTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Long>>() {
             @Override
-            public Flowable<Long> apply(Flowable<Object> o) throws Exception {
-                return o.count().toFlowable();
+            public Flowable<Long> apply(Flowable<Object> f) throws Exception {
+                return f.count().toFlowable();
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, SingleSource<Long>>() {
             @Override
-            public SingleSource<Long> apply(Flowable<Object> o) throws Exception {
-                return o.count();
+            public SingleSource<Long> apply(Flowable<Object> f) throws Exception {
+                return f.count();
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -223,14 +223,14 @@ public class FlowableCreateTest {
     public void wrap() {
         Flowable.fromPublisher(new Publisher<Integer>() {
             @Override
-            public void subscribe(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                observer.onNext(1);
-                observer.onNext(2);
-                observer.onNext(3);
-                observer.onNext(4);
-                observer.onNext(5);
-                observer.onComplete();
+            public void subscribe(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                subscriber.onNext(1);
+                subscriber.onNext(2);
+                subscriber.onNext(3);
+                subscriber.onNext(4);
+                subscriber.onNext(5);
+                subscriber.onComplete();
             }
         })
         .test()
@@ -241,14 +241,14 @@ public class FlowableCreateTest {
     public void unsafe() {
         Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
-            public void subscribe(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                observer.onNext(1);
-                observer.onNext(2);
-                observer.onNext(3);
-                observer.onNext(4);
-                observer.onNext(5);
-                observer.onComplete();
+            public void subscribe(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                subscriber.onNext(1);
+                subscriber.onNext(2);
+                subscriber.onNext(3);
+                subscriber.onNext(4);
+                subscriber.onNext(5);
+                subscriber.onComplete();
             }
         })
         .test()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -48,137 +48,175 @@ public class FlowableCreateTest {
 
     @Test
     public void basic() {
-        final Disposable d = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d = Disposables.empty();
 
-        Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+            Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    e.setDisposable(d);
 
-                e.onNext(1);
-                e.onNext(2);
-                e.onNext(3);
-                e.onComplete();
-                e.onError(new TestException());
-                e.onNext(4);
-                e.onError(new TestException());
-                e.onComplete();
-            }
-        }, BackpressureStrategy.BUFFER)
-        .test()
-        .assertResult(1, 2, 3);
+                    e.onNext(1);
+                    e.onNext(2);
+                    e.onNext(3);
+                    e.onComplete();
+                    e.onError(new TestException("first"));
+                    e.onNext(4);
+                    e.onError(new TestException("second"));
+                    e.onComplete();
+                }
+            }, BackpressureStrategy.BUFFER)
+            .test()
+            .assertResult(1, 2, 3);
 
-        assertTrue(d.isDisposed());
+            assertTrue(d.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "first");
+            TestHelper.assertUndeliverable(errors, 1, TestException.class, "second");
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void basicWithCancellable() {
-        final Disposable d1 = Disposables.empty();
-        final Disposable d2 = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d1 = Disposables.empty();
+            final Disposable d2 = Disposables.empty();
 
-        Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                e.setDisposable(d1);
-                e.setCancellable(new Cancellable() {
-                    @Override
-                    public void cancel() throws Exception {
-                        d2.dispose();
-                    }
-                });
+            Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    e.setDisposable(d1);
+                    e.setCancellable(new Cancellable() {
+                        @Override
+                        public void cancel() throws Exception {
+                            d2.dispose();
+                        }
+                    });
 
-                e.onNext(1);
-                e.onNext(2);
-                e.onNext(3);
-                e.onComplete();
-                e.onError(new TestException());
-                e.onNext(4);
-                e.onError(new TestException());
-                e.onComplete();
-            }
-        }, BackpressureStrategy.BUFFER)
-        .test()
-        .assertResult(1, 2, 3);
+                    e.onNext(1);
+                    e.onNext(2);
+                    e.onNext(3);
+                    e.onComplete();
+                    e.onError(new TestException("first"));
+                    e.onNext(4);
+                    e.onError(new TestException("second"));
+                    e.onComplete();
+                }
+            }, BackpressureStrategy.BUFFER)
+            .test()
+            .assertResult(1, 2, 3);
 
-        assertTrue(d1.isDisposed());
-        assertTrue(d2.isDisposed());
+            assertTrue(d1.isDisposed());
+            assertTrue(d2.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "first");
+            TestHelper.assertUndeliverable(errors, 1, TestException.class, "second");
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void basicWithError() {
-        final Disposable d = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d = Disposables.empty();
 
-        Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+            Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    e.setDisposable(d);
 
-                e.onNext(1);
-                e.onNext(2);
-                e.onNext(3);
-                e.onError(new TestException());
-                e.onComplete();
-                e.onNext(4);
-                e.onError(new TestException());
-            }
-        }, BackpressureStrategy.BUFFER)
-        .test()
-        .assertFailure(TestException.class, 1, 2, 3);
+                    e.onNext(1);
+                    e.onNext(2);
+                    e.onNext(3);
+                    e.onError(new TestException());
+                    e.onComplete();
+                    e.onNext(4);
+                    e.onError(new TestException("second"));
+                }
+            }, BackpressureStrategy.BUFFER)
+            .test()
+            .assertFailure(TestException.class, 1, 2, 3);
 
-        assertTrue(d.isDisposed());
+            assertTrue(d.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "second");
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void basicSerialized() {
-        final Disposable d = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d = Disposables.empty();
 
-        Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                e = e.serialize();
+            Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    e = e.serialize();
 
-                e.setDisposable(d);
+                    e.setDisposable(d);
 
-                e.onNext(1);
-                e.onNext(2);
-                e.onNext(3);
-                e.onComplete();
-                e.onError(new TestException());
-                e.onNext(4);
-                e.onError(new TestException());
-                e.onComplete();
-            }
-        }, BackpressureStrategy.BUFFER)
-        .test()
-        .assertResult(1, 2, 3);
+                    e.onNext(1);
+                    e.onNext(2);
+                    e.onNext(3);
+                    e.onComplete();
+                    e.onError(new TestException("first"));
+                    e.onNext(4);
+                    e.onError(new TestException("second"));
+                    e.onComplete();
+                }
+            }, BackpressureStrategy.BUFFER)
+            .test()
+            .assertResult(1, 2, 3);
 
-        assertTrue(d.isDisposed());
+            assertTrue(d.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "first");
+            TestHelper.assertUndeliverable(errors, 1, TestException.class, "second");
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void basicWithErrorSerialized() {
-        final Disposable d = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d = Disposables.empty();
 
-        Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                e = e.serialize();
+            Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    e = e.serialize();
 
-                e.setDisposable(d);
+                    e.setDisposable(d);
 
-                e.onNext(1);
-                e.onNext(2);
-                e.onNext(3);
-                e.onError(new TestException());
-                e.onComplete();
-                e.onNext(4);
-                e.onError(new TestException());
-            }
-        }, BackpressureStrategy.BUFFER)
-        .test()
-        .assertFailure(TestException.class, 1, 2, 3);
+                    e.onNext(1);
+                    e.onNext(2);
+                    e.onNext(3);
+                    e.onError(new TestException());
+                    e.onComplete();
+                    e.onNext(4);
+                    e.onError(new TestException("second"));
+                }
+            }, BackpressureStrategy.BUFFER)
+            .test()
+            .assertFailure(TestException.class, 1, 2, 3);
 
-        assertTrue(d.isDisposed());
+            assertTrue(d.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "second");
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
@@ -224,237 +262,308 @@ public class FlowableCreateTest {
 
     @Test
     public void createNullValueBuffer() {
-        final Throwable[] error = { null };
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
 
-        Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
+            final Throwable[] error = { null };
+
+            Flowable.create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
+                    }
                 }
-            }
-        }, BackpressureStrategy.BUFFER)
-        .test()
-        .assertFailure(NullPointerException.class);
+            }, BackpressureStrategy.BUFFER)
+            .test()
+            .assertFailure(NullPointerException.class);
 
-        assertNull(error[0]);
+            assertNull(error[0]);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void createNullValueLatest() {
-        final Throwable[] error = { null };
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Throwable[] error = { null };
 
-        Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
+            Flowable.create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
+                    }
                 }
-            }
-        }, BackpressureStrategy.LATEST)
-        .test()
-        .assertFailure(NullPointerException.class);
+            }, BackpressureStrategy.LATEST)
+            .test()
+            .assertFailure(NullPointerException.class);
 
-        assertNull(error[0]);
+            assertNull(error[0]);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void createNullValueError() {
-        final Throwable[] error = { null };
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Throwable[] error = { null };
 
-        Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
+            Flowable.create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
+                    }
                 }
-            }
-        }, BackpressureStrategy.ERROR)
-        .test()
-        .assertFailure(NullPointerException.class);
+            }, BackpressureStrategy.ERROR)
+            .test()
+            .assertFailure(NullPointerException.class);
 
-        assertNull(error[0]);
+            assertNull(error[0]);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void createNullValueDrop() {
-        final Throwable[] error = { null };
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Throwable[] error = { null };
 
-        Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
+            Flowable.create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
+                    }
                 }
-            }
-        }, BackpressureStrategy.DROP)
-        .test()
-        .assertFailure(NullPointerException.class);
+            }, BackpressureStrategy.DROP)
+            .test()
+            .assertFailure(NullPointerException.class);
 
-        assertNull(error[0]);
+            assertNull(error[0]);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void createNullValueMissing() {
-        final Throwable[] error = { null };
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Throwable[] error = { null };
 
-        Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
+            Flowable.create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
+                    }
                 }
-            }
-        }, BackpressureStrategy.MISSING)
-        .test()
-        .assertFailure(NullPointerException.class);
+            }, BackpressureStrategy.MISSING)
+            .test()
+            .assertFailure(NullPointerException.class);
 
-        assertNull(error[0]);
+            assertNull(error[0]);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void createNullValueBufferSerialized() {
-        final Throwable[] error = { null };
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Throwable[] error = { null };
 
-        Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                e = e.serialize();
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
+            Flowable.create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    e = e.serialize();
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
+                    }
                 }
-            }
-        }, BackpressureStrategy.BUFFER)
-        .test()
-        .assertFailure(NullPointerException.class);
+            }, BackpressureStrategy.BUFFER)
+            .test()
+            .assertFailure(NullPointerException.class);
 
-        assertNull(error[0]);
+            assertNull(error[0]);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void createNullValueLatestSerialized() {
-        final Throwable[] error = { null };
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Throwable[] error = { null };
 
-        Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                e = e.serialize();
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
+            Flowable.create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    e = e.serialize();
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
+                    }
                 }
-            }
-        }, BackpressureStrategy.LATEST)
-        .test()
-        .assertFailure(NullPointerException.class);
+            }, BackpressureStrategy.LATEST)
+            .test()
+            .assertFailure(NullPointerException.class);
 
-        assertNull(error[0]);
+            assertNull(error[0]);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void createNullValueErrorSerialized() {
-        final Throwable[] error = { null };
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Throwable[] error = { null };
 
-        Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                e = e.serialize();
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
+            Flowable.create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    e = e.serialize();
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
+                    }
                 }
-            }
-        }, BackpressureStrategy.ERROR)
-        .test()
-        .assertFailure(NullPointerException.class);
+            }, BackpressureStrategy.ERROR)
+            .test()
+            .assertFailure(NullPointerException.class);
 
-        assertNull(error[0]);
+            assertNull(error[0]);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void createNullValueDropSerialized() {
-        final Throwable[] error = { null };
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Throwable[] error = { null };
 
-        Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                e = e.serialize();
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
+            Flowable.create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    e = e.serialize();
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
+                    }
                 }
-            }
-        }, BackpressureStrategy.DROP)
-        .test()
-        .assertFailure(NullPointerException.class);
+            }, BackpressureStrategy.DROP)
+            .test()
+            .assertFailure(NullPointerException.class);
 
-        assertNull(error[0]);
+            assertNull(error[0]);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void createNullValueMissingSerialized() {
-        final Throwable[] error = { null };
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Throwable[] error = { null };
 
-        Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                e = e.serialize();
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
+            Flowable.create(new FlowableOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                    e = e.serialize();
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
+                    }
                 }
-            }
-        }, BackpressureStrategy.MISSING)
-        .test()
-        .assertFailure(NullPointerException.class);
+            }, BackpressureStrategy.MISSING)
+            .test()
+            .assertFailure(NullPointerException.class);
 
-        assertNull(error[0]);
+            assertNull(error[0]);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
@@ -630,25 +739,32 @@ public class FlowableCreateTest {
     @Test
     public void createNullValue() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            final Throwable[] error = { null };
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
+                Flowable.create(new FlowableOnSubscribe<Integer>() {
+                    @Override
+                    public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                        try {
+                            e.onNext(null);
+                            e.onNext(1);
+                            e.onError(new TestException());
+                            e.onComplete();
+                        } catch (Throwable ex) {
+                            error[0] = ex;
+                        }
                     }
-                }
-            }, m)
-            .test()
-            .assertFailure(NullPointerException.class);
+                }, m)
+                .test()
+                .assertFailure(NullPointerException.class);
 
-            assertNull(error[0]);
+                assertNull(error[0]);
+
+                TestHelper.assertUndeliverable(errors, 0, TestException.class);
+            } finally {
+                RxJavaPlugins.reset();
+            }
         }
     }
 
@@ -736,26 +852,33 @@ public class FlowableCreateTest {
     @Test
     public void createNullValueSerialized() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            final Throwable[] error = { null };
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    e = e.serialize();
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
+                Flowable.create(new FlowableOnSubscribe<Integer>() {
+                    @Override
+                    public void subscribe(FlowableEmitter<Integer> e) throws Exception {
+                        e = e.serialize();
+                        try {
+                            e.onNext(null);
+                            e.onNext(1);
+                            e.onError(new TestException());
+                            e.onComplete();
+                        } catch (Throwable ex) {
+                            error[0] = ex;
+                        }
                     }
-                }
-            }, m)
-            .test()
-            .assertFailure(NullPointerException.class);
+                }, m)
+                .test()
+                .assertFailure(NullPointerException.class);
 
-            assertNull(error[0]);
+                assertNull(error[0]);
+
+                TestHelper.assertUndeliverable(errors, 0, TestException.class);
+            } finally {
+                RxJavaPlugins.reset();
+            }
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
@@ -171,10 +171,10 @@ public class FlowableDebounceTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.debounce(debounceSel).subscribe(o);
+        source.debounce(debounceSel).subscribe(subscriber);
 
         source.onNext(1);
         debouncer.onNext(1);
@@ -188,12 +188,12 @@ public class FlowableDebounceTest {
         source.onNext(5);
         source.onComplete();
 
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(4);
-        inOrder.verify(o).onNext(5);
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(4);
+        inOrder.verify(subscriber).onNext(5);
+        inOrder.verify(subscriber).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -207,15 +207,15 @@ public class FlowableDebounceTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.debounce(debounceSel).subscribe(o);
+        source.debounce(debounceSel).subscribe(subscriber);
 
         source.onNext(1);
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
     }
 
     @Test
@@ -229,32 +229,32 @@ public class FlowableDebounceTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.debounce(debounceSel).subscribe(o);
+        source.debounce(debounceSel).subscribe(subscriber);
 
         source.onNext(1);
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
     }
     @Test
     public void debounceTimedLastIsNotLost() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.debounce(100, TimeUnit.MILLISECONDS, scheduler).subscribe(o);
+        source.debounce(100, TimeUnit.MILLISECONDS, scheduler).subscribe(subscriber);
 
         source.onNext(1);
         source.onComplete();
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        verify(o).onNext(1);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(1);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
     @Test
     public void debounceSelectorLastIsNotLost() {
@@ -269,18 +269,18 @@ public class FlowableDebounceTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.debounce(debounceSel).subscribe(o);
+        source.debounce(debounceSel).subscribe(subscriber);
 
         source.onNext(1);
         source.onComplete();
 
         debouncer.onComplete();
 
-        verify(o).onNext(1);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(1);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -363,8 +363,8 @@ public class FlowableDebounceTest {
     public void badSourceSelector() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
-            public Object apply(Flowable<Integer> o) throws Exception {
-                return o.debounce(new Function<Integer, Flowable<Long>>() {
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.debounce(new Function<Integer, Flowable<Long>>() {
                     @Override
                     public Flowable<Long> apply(Integer v) throws Exception {
                         return Flowable.timer(1, TimeUnit.SECONDS);
@@ -375,11 +375,11 @@ public class FlowableDebounceTest {
 
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
-            public Object apply(final Flowable<Integer> o) throws Exception {
+            public Object apply(final Flowable<Integer> f) throws Exception {
                 return Flowable.just(1).debounce(new Function<Integer, Flowable<Integer>>() {
                     @Override
                     public Flowable<Integer> apply(Integer v) throws Exception {
-                        return o;
+                        return f;
                     }
                 });
             }
@@ -415,8 +415,8 @@ public class FlowableDebounceTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.debounce(Functions.justFunction(Flowable.never()));
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.debounce(Functions.justFunction(Flowable.never()));
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
@@ -27,11 +27,11 @@ public class FlowableDefaultIfEmptyTest {
     @Test
     public void testDefaultIfEmpty() {
         Flowable<Integer> source = Flowable.just(1, 2, 3);
-        Flowable<Integer> observable = source.defaultIfEmpty(10);
+        Flowable<Integer> flowable = source.defaultIfEmpty(10);
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, never()).onNext(10);
         verify(subscriber).onNext(1);
@@ -44,11 +44,11 @@ public class FlowableDefaultIfEmptyTest {
     @Test
     public void testDefaultIfEmptyWithEmpty() {
         Flowable<Integer> source = Flowable.empty();
-        Flowable<Integer> observable = source.defaultIfEmpty(10);
+        Flowable<Integer> flowable = source.defaultIfEmpty(10);
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber).onNext(10);
         verify(subscriber).onComplete();
@@ -58,7 +58,7 @@ public class FlowableDefaultIfEmptyTest {
     @Test
     @Ignore("Subscribers should not throw")
     public void testEmptyButClientThrows() {
-        final Subscriber<Integer> o = TestHelper.mockSubscriber();
+        final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         Flowable.<Integer>empty().defaultIfEmpty(1).subscribe(new DefaultSubscriber<Integer>() {
             @Override
@@ -68,18 +68,18 @@ public class FlowableDefaultIfEmptyTest {
 
             @Override
             public void onError(Throwable e) {
-                o.onError(e);
+                subscriber.onError(e);
             }
 
             @Override
             public void onComplete() {
-                o.onComplete();
+                subscriber.onComplete();
             }
         });
 
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onNext(any(Integer.class));
-        verify(o, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any(Integer.class));
+        verify(subscriber, never()).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
@@ -29,16 +29,16 @@ public class FlowableDefaultIfEmptyTest {
         Flowable<Integer> source = Flowable.just(1, 2, 3);
         Flowable<Integer> observable = source.defaultIfEmpty(10);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, never()).onNext(10);
-        verify(observer).onNext(1);
-        verify(observer).onNext(2);
-        verify(observer).onNext(3);
-        verify(observer).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(10);
+        verify(subscriber).onNext(1);
+        verify(subscriber).onNext(2);
+        verify(subscriber).onNext(3);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -46,13 +46,13 @@ public class FlowableDefaultIfEmptyTest {
         Flowable<Integer> source = Flowable.empty();
         Flowable<Integer> observable = source.defaultIfEmpty(10);
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer).onNext(10);
-        verify(observer).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(10);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDeferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDeferTest.java
@@ -22,7 +22,6 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.subscribers.DefaultSubscriber;
 
 @SuppressWarnings("unchecked")
 public class FlowableDeferTest {
@@ -40,25 +39,25 @@ public class FlowableDeferTest {
 
         verifyZeroInteractions(factory);
 
-        Subscriber<String> firstObserver = TestHelper.mockSubscriber();
-        deferred.subscribe(firstObserver);
+        Subscriber<String> firstSubscriber = TestHelper.mockSubscriber();
+        deferred.subscribe(firstSubscriber);
 
         verify(factory, times(1)).call();
-        verify(firstObserver, times(1)).onNext("one");
-        verify(firstObserver, times(1)).onNext("two");
-        verify(firstObserver, times(0)).onNext("three");
-        verify(firstObserver, times(0)).onNext("four");
-        verify(firstObserver, times(1)).onComplete();
+        verify(firstSubscriber, times(1)).onNext("one");
+        verify(firstSubscriber, times(1)).onNext("two");
+        verify(firstSubscriber, times(0)).onNext("three");
+        verify(firstSubscriber, times(0)).onNext("four");
+        verify(firstSubscriber, times(1)).onComplete();
 
-        Subscriber<String> secondObserver = TestHelper.mockSubscriber();
-        deferred.subscribe(secondObserver);
+        Subscriber<String> secondSubscriber = TestHelper.mockSubscriber();
+        deferred.subscribe(secondSubscriber);
 
         verify(factory, times(2)).call();
-        verify(secondObserver, times(0)).onNext("one");
-        verify(secondObserver, times(0)).onNext("two");
-        verify(secondObserver, times(1)).onNext("three");
-        verify(secondObserver, times(1)).onNext("four");
-        verify(secondObserver, times(1)).onComplete();
+        verify(secondSubscriber, times(0)).onNext("one");
+        verify(secondSubscriber, times(0)).onNext("two");
+        verify(secondSubscriber, times(1)).onNext("three");
+        verify(secondSubscriber, times(1)).onNext("four");
+        verify(secondSubscriber, times(1)).onComplete();
 
     }
 
@@ -70,7 +69,7 @@ public class FlowableDeferTest {
 
         Flowable<String> result = Flowable.defer(factory);
 
-        DefaultSubscriber<String> o = mock(DefaultSubscriber.class);
+        Subscriber<String> o = TestHelper.mockSubscriber();
 
         result.subscribe(o);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDeferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDeferTest.java
@@ -69,12 +69,12 @@ public class FlowableDeferTest {
 
         Flowable<String> result = Flowable.defer(factory);
 
-        Subscriber<String> o = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onNext(any(String.class));
-        verify(o, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any(String.class));
+        verify(subscriber, never()).onComplete();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
@@ -316,8 +316,8 @@ public class FlowableDelaySubscriptionOtherTest {
     public void badSourceOther() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
-            public Object apply(Flowable<Integer> o) throws Exception {
-                return Flowable.just(1).delaySubscription(o);
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return Flowable.just(1).delaySubscription(f);
             }
         }, false, 1, 1, 1);
     }
@@ -327,8 +327,8 @@ public class FlowableDelaySubscriptionOtherTest {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
             for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
-                final TestSubscriber<Boolean> observer = TestSubscriber.create();
-                observer.withTag(s.getClass().getSimpleName());
+                final TestSubscriber<Boolean> ts = TestSubscriber.create();
+                ts.withTag(s.getClass().getSimpleName());
 
                 Flowable.<Boolean>create(new FlowableOnSubscribe<Boolean>() {
                     @Override
@@ -338,10 +338,10 @@ public class FlowableDelaySubscriptionOtherTest {
                     }
                 }, BackpressureStrategy.MISSING)
                 .delaySubscription(100, TimeUnit.MILLISECONDS, s)
-                .subscribe(observer);
+                .subscribe(ts);
 
-                observer.awaitTerminalEvent();
-                observer.assertValue(false);
+                ts.awaitTerminalEvent();
+                ts.assertValue(false);
             }
         } finally {
             exec.shutdown();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
@@ -194,38 +194,38 @@ public class FlowableDelayTest {
     public void testDelaySubscription() {
         Flowable<Integer> result = Flowable.just(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        inOrder.verify(o, never()).onNext(any());
-        inOrder.verify(o, never()).onComplete();
+        inOrder.verify(subscriber, never()).onNext(any());
+        inOrder.verify(subscriber, never()).onComplete();
 
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
-        inOrder.verify(o, times(1)).onNext(1);
-        inOrder.verify(o, times(1)).onNext(2);
-        inOrder.verify(o, times(1)).onNext(3);
-        inOrder.verify(o, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext(1);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onNext(3);
+        inOrder.verify(subscriber, times(1)).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testDelaySubscriptionCancelBeforeTime() {
         Flowable<Integer> result = Flowable.just(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
 
         result.subscribe(ts);
         ts.dispose();
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -245,22 +245,22 @@ public class FlowableDelayTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.delay(delayFunc).subscribe(o);
+        source.delay(delayFunc).subscribe(subscriber);
 
         for (int i = 0; i < n; i++) {
             source.onNext(i);
             delays.get(i).onNext(i);
-            inOrder.verify(o).onNext(i);
+            inOrder.verify(subscriber).onNext(i);
         }
         source.onComplete();
 
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -275,18 +275,18 @@ public class FlowableDelayTest {
                 return delay;
             }
         };
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.delay(delayFunc).subscribe(o);
+        source.delay(delayFunc).subscribe(subscriber);
 
         source.onNext(1);
         delay.onNext(1);
         delay.onNext(2);
 
-        inOrder.verify(o).onNext(1);
+        inOrder.verify(subscriber).onNext(1);
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -301,18 +301,18 @@ public class FlowableDelayTest {
                 return delay;
             }
         };
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.delay(delayFunc).subscribe(o);
+        source.delay(delayFunc).subscribe(subscriber);
         source.onNext(1);
         source.onError(new TestException());
         delay.onNext(1);
 
-        inOrder.verify(o).onError(any(TestException.class));
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -326,16 +326,16 @@ public class FlowableDelayTest {
                 throw new TestException();
             }
         };
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.delay(delayFunc).subscribe(o);
+        source.delay(delayFunc).subscribe(subscriber);
         source.onNext(1);
 
-        inOrder.verify(o).onError(any(TestException.class));
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -350,17 +350,17 @@ public class FlowableDelayTest {
                 return delay;
             }
         };
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.delay(delayFunc).subscribe(o);
+        source.delay(delayFunc).subscribe(subscriber);
         source.onNext(1);
         delay.onError(new TestException());
 
-        inOrder.verify(o).onError(any(TestException.class));
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -375,10 +375,10 @@ public class FlowableDelayTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.delay(delay, delayFunc).subscribe(o);
+        source.delay(delay, delayFunc).subscribe(subscriber);
 
         source.onNext(1);
         delay.onNext(1);
@@ -386,10 +386,10 @@ public class FlowableDelayTest {
         source.onNext(2);
         delay.onNext(2);
 
-        inOrder.verify(o).onNext(2);
+        inOrder.verify(subscriber).onNext(2);
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onError(any(Throwable.class));
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -410,20 +410,20 @@ public class FlowableDelayTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.delay(Flowable.defer(subFunc), delayFunc).subscribe(o);
+        source.delay(Flowable.defer(subFunc), delayFunc).subscribe(subscriber);
 
         source.onNext(1);
         delay.onNext(1);
 
         source.onNext(2);
 
-        inOrder.verify(o).onError(any(TestException.class));
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -444,20 +444,20 @@ public class FlowableDelayTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.delay(Flowable.defer(subFunc), delayFunc).subscribe(o);
+        source.delay(Flowable.defer(subFunc), delayFunc).subscribe(subscriber);
 
         source.onNext(1);
         delay.onError(new TestException());
 
         source.onNext(2);
 
-        inOrder.verify(o).onError(any(TestException.class));
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -471,18 +471,18 @@ public class FlowableDelayTest {
                 return Flowable.empty();
             }
         };
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.delay(delayFunc).subscribe(o);
+        source.delay(delayFunc).subscribe(subscriber);
 
         source.onNext(1);
         source.onComplete();
 
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -504,10 +504,10 @@ public class FlowableDelayTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.delay(Flowable.defer(subFunc), delayFunc).subscribe(o);
+        source.delay(Flowable.defer(subFunc), delayFunc).subscribe(subscriber);
 
         source.onNext(1);
         sdelay.onComplete();
@@ -515,10 +515,10 @@ public class FlowableDelayTest {
         source.onNext(2);
         delay.onNext(2);
 
-        inOrder.verify(o).onNext(2);
+        inOrder.verify(subscriber).onNext(2);
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onError(any(Throwable.class));
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -589,27 +589,27 @@ public class FlowableDelayTest {
             }
         });
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         for (int i = 0; i < n; i++) {
             source.onNext(i);
         }
         source.onComplete();
 
-        inOrder.verify(o, never()).onNext(anyInt());
-        inOrder.verify(o, never()).onComplete();
+        inOrder.verify(subscriber, never()).onNext(anyInt());
+        inOrder.verify(subscriber, never()).onComplete();
 
         for (int i = n - 1; i >= 0; i--) {
             subjects.get(i).onComplete();
-            inOrder.verify(o).onNext(i);
+            inOrder.verify(subscriber).onNext(i);
         }
 
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -624,11 +624,11 @@ public class FlowableDelayTest {
             }
 
         });
-        TestSubscriber<Integer> observer = new TestSubscriber<Integer>();
-        delayed.subscribe(observer);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        delayed.subscribe(ts);
         // all will be delivered after 500ms since range does not delay between them
         scheduler.advanceTimeBy(500L, TimeUnit.MILLISECONDS);
-        observer.assertValues(1, 2, 3, 4, 5);
+        ts.assertValues(1, 2, 3, 4, 5);
     }
 
     @Test
@@ -902,16 +902,16 @@ public class FlowableDelayTest {
     public void testDelaySubscriptionDisposeBeforeTime() {
         Flowable<Integer> result = Flowable.just(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
 
         result.subscribe(ts);
         ts.dispose();
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -947,15 +947,15 @@ public class FlowableDelayTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.delay(1, TimeUnit.SECONDS);
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.delay(1, TimeUnit.SECONDS);
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.delay(Functions.justFunction(Flowable.never()));
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.delay(Functions.justFunction(Flowable.never()));
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
@@ -34,15 +34,15 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 
 public class FlowableDelayTest {
-    private Subscriber<Long> observer;
-    private Subscriber<Long> observer2;
+    private Subscriber<Long> subscriber;
+    private Subscriber<Long> subscriber2;
 
     private TestScheduler scheduler;
 
     @Before
     public void before() {
-        observer = TestHelper.mockSubscriber();
-        observer2 = TestHelper.mockSubscriber();
+        subscriber = TestHelper.mockSubscriber();
+        subscriber2 = TestHelper.mockSubscriber();
 
         scheduler = new TestScheduler();
     }
@@ -51,69 +51,69 @@ public class FlowableDelayTest {
     public void testDelay() {
         Flowable<Long> source = Flowable.interval(1L, TimeUnit.SECONDS, scheduler).take(3);
         Flowable<Long> delayed = source.delay(500L, TimeUnit.MILLISECONDS, scheduler);
-        delayed.subscribe(observer);
+        delayed.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
         scheduler.advanceTimeTo(1499L, TimeUnit.MILLISECONDS);
-        verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(1500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(0L);
-        inOrder.verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext(0L);
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2400L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(1L);
-        inOrder.verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext(1L);
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(3400L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(3500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(2L);
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext(2L);
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testLongDelay() {
         Flowable<Long> source = Flowable.interval(1L, TimeUnit.SECONDS, scheduler).take(3);
         Flowable<Long> delayed = source.delay(5L, TimeUnit.SECONDS, scheduler);
-        delayed.subscribe(observer);
+        delayed.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         scheduler.advanceTimeTo(5999L, TimeUnit.MILLISECONDS);
-        verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(6000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(0L);
+        inOrder.verify(subscriber, times(1)).onNext(0L);
         scheduler.advanceTimeTo(6999L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyLong());
+        inOrder.verify(subscriber, never()).onNext(anyLong());
         scheduler.advanceTimeTo(7000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(1L);
+        inOrder.verify(subscriber, times(1)).onNext(1L);
         scheduler.advanceTimeTo(7999L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyLong());
+        inOrder.verify(subscriber, never()).onNext(anyLong());
         scheduler.advanceTimeTo(8000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(2L);
-        inOrder.verify(observer, times(1)).onComplete();
-        inOrder.verify(observer, never()).onNext(anyLong());
-        inOrder.verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext(2L);
+        inOrder.verify(subscriber, times(1)).onComplete();
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        inOrder.verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -129,65 +129,65 @@ public class FlowableDelayTest {
             }
         });
         Flowable<Long> delayed = source.delay(1L, TimeUnit.SECONDS, scheduler);
-        delayed.subscribe(observer);
+        delayed.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         scheduler.advanceTimeTo(1999L, TimeUnit.MILLISECONDS);
-        verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
-        inOrder.verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
+        inOrder.verify(subscriber, times(1)).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
 
         scheduler.advanceTimeTo(5000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyLong());
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
     public void testDelayWithMultipleSubscriptions() {
         Flowable<Long> source = Flowable.interval(1L, TimeUnit.SECONDS, scheduler).take(3);
         Flowable<Long> delayed = source.delay(500L, TimeUnit.MILLISECONDS, scheduler);
-        delayed.subscribe(observer);
-        delayed.subscribe(observer2);
+        delayed.subscribe(subscriber);
+        delayed.subscribe(subscriber2);
 
-        InOrder inOrder = inOrder(observer);
-        InOrder inOrder2 = inOrder(observer2);
+        InOrder inOrder = inOrder(subscriber);
+        InOrder inOrder2 = inOrder(subscriber2);
 
         scheduler.advanceTimeTo(1499L, TimeUnit.MILLISECONDS);
-        verify(observer, never()).onNext(anyLong());
-        verify(observer2, never()).onNext(anyLong());
+        verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber2, never()).onNext(anyLong());
 
         scheduler.advanceTimeTo(1500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(0L);
-        inOrder2.verify(observer2, times(1)).onNext(0L);
+        inOrder.verify(subscriber, times(1)).onNext(0L);
+        inOrder2.verify(subscriber2, times(1)).onNext(0L);
 
         scheduler.advanceTimeTo(2499L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyLong());
-        inOrder2.verify(observer2, never()).onNext(anyLong());
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        inOrder2.verify(subscriber2, never()).onNext(anyLong());
 
         scheduler.advanceTimeTo(2500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(1L);
-        inOrder2.verify(observer2, times(1)).onNext(1L);
+        inOrder.verify(subscriber, times(1)).onNext(1L);
+        inOrder2.verify(subscriber2, times(1)).onNext(1L);
 
-        verify(observer, never()).onComplete();
-        verify(observer2, never()).onComplete();
+        verify(subscriber, never()).onComplete();
+        verify(subscriber2, never()).onComplete();
 
         scheduler.advanceTimeTo(3500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(2L);
-        inOrder2.verify(observer2, times(1)).onNext(2L);
-        inOrder.verify(observer, never()).onNext(anyLong());
-        inOrder2.verify(observer2, never()).onNext(anyLong());
-        inOrder.verify(observer, times(1)).onComplete();
-        inOrder2.verify(observer2, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext(2L);
+        inOrder2.verify(subscriber2, times(1)).onNext(2L);
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        inOrder2.verify(subscriber2, never()).onNext(anyLong());
+        inOrder.verify(subscriber, times(1)).onComplete();
+        inOrder2.verify(subscriber2, times(1)).onComplete();
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer2, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber2, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -535,40 +535,40 @@ public class FlowableDelayTest {
         };
 
         Flowable<Long> delayed = source.delay(delayFunc);
-        delayed.subscribe(observer);
+        delayed.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
         scheduler.advanceTimeTo(1499L, TimeUnit.MILLISECONDS);
-        verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(1500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(0L);
-        inOrder.verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext(0L);
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2400L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(1L);
-        inOrder.verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext(1L);
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(3400L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(3500L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(2L);
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext(2L);
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
@@ -48,8 +48,8 @@ public class FlowableDematerializeTest {
     @Test
     public void testDematerialize2() {
         Throwable exception = new Throwable("test");
-        Flowable<Integer> observable = Flowable.error(exception);
-        Flowable<Integer> dematerialize = observable.materialize().dematerialize();
+        Flowable<Integer> flowable = Flowable.error(exception);
+        Flowable<Integer> dematerialize = flowable.materialize().dematerialize();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
@@ -63,8 +63,8 @@ public class FlowableDematerializeTest {
     @Test
     public void testDematerialize3() {
         Exception exception = new Exception("test");
-        Flowable<Integer> observable = Flowable.error(exception);
-        Flowable<Integer> dematerialize = observable.materialize().dematerialize();
+        Flowable<Integer> flowable = Flowable.error(exception);
+        Flowable<Integer> dematerialize = flowable.materialize().dematerialize();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
@@ -78,8 +78,8 @@ public class FlowableDematerializeTest {
     @Test
     public void testErrorPassThru() {
         Exception exception = new Exception("test");
-        Flowable<Integer> observable = Flowable.error(exception);
-        Flowable<Integer> dematerialize = observable.dematerialize();
+        Flowable<Integer> flowable = Flowable.error(exception);
+        Flowable<Integer> dematerialize = flowable.dematerialize();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
@@ -92,8 +92,8 @@ public class FlowableDematerializeTest {
 
     @Test
     public void testCompletePassThru() {
-        Flowable<Integer> observable = Flowable.empty();
-        Flowable<Integer> dematerialize = observable.dematerialize();
+        Flowable<Integer> flowable = Flowable.empty();
+        Flowable<Integer> dematerialize = flowable.dematerialize();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
@@ -113,13 +113,13 @@ public class FlowableDematerializeTest {
 
         Flowable<Integer> result = source.materialize().dematerialize();
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(1);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(1);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -128,13 +128,13 @@ public class FlowableDematerializeTest {
 
         Flowable<Integer> result = source.materialize().dematerialize();
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o, never()).onNext(any(Integer.class));
-        verify(o, never()).onComplete();
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any(Integer.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
     }
 
     @Test
@@ -146,8 +146,8 @@ public class FlowableDematerializeTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.dematerialize();
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.dematerialize();
             }
         });
     }
@@ -158,12 +158,12 @@ public class FlowableDematerializeTest {
         try {
             new Flowable<Object>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Object> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onNext(Notification.createOnComplete());
-                    observer.onNext(Notification.createOnNext(1));
-                    observer.onNext(Notification.createOnError(new TestException("First")));
-                    observer.onError(new TestException("Second"));
+                protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onNext(Notification.createOnComplete());
+                    subscriber.onNext(Notification.createOnNext(1));
+                    subscriber.onNext(Notification.createOnError(new TestException("First")));
+                    subscriber.onError(new TestException("Second"));
                 }
             }
             .dematerialize()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
@@ -35,14 +35,14 @@ public class FlowableDematerializeTest {
         Flowable<Notification<Integer>> notifications = Flowable.just(1, 2).materialize();
         Flowable<Integer> dematerialize = notifications.dematerialize();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        dematerialize.subscribe(observer);
+        dematerialize.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(1);
-        verify(observer, times(1)).onNext(2);
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, times(1)).onNext(2);
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -51,13 +51,13 @@ public class FlowableDematerializeTest {
         Flowable<Integer> observable = Flowable.error(exception);
         Flowable<Integer> dematerialize = observable.materialize().dematerialize();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        dematerialize.subscribe(observer);
+        dematerialize.subscribe(subscriber);
 
-        verify(observer, times(1)).onError(exception);
-        verify(observer, times(0)).onComplete();
-        verify(observer, times(0)).onNext(any(Integer.class));
+        verify(subscriber, times(1)).onError(exception);
+        verify(subscriber, times(0)).onComplete();
+        verify(subscriber, times(0)).onNext(any(Integer.class));
     }
 
     @Test
@@ -66,13 +66,13 @@ public class FlowableDematerializeTest {
         Flowable<Integer> observable = Flowable.error(exception);
         Flowable<Integer> dematerialize = observable.materialize().dematerialize();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        dematerialize.subscribe(observer);
+        dematerialize.subscribe(subscriber);
 
-        verify(observer, times(1)).onError(exception);
-        verify(observer, times(0)).onComplete();
-        verify(observer, times(0)).onNext(any(Integer.class));
+        verify(subscriber, times(1)).onError(exception);
+        verify(subscriber, times(0)).onComplete();
+        verify(subscriber, times(0)).onNext(any(Integer.class));
     }
 
     @Test
@@ -81,13 +81,13 @@ public class FlowableDematerializeTest {
         Flowable<Integer> observable = Flowable.error(exception);
         Flowable<Integer> dematerialize = observable.dematerialize();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        dematerialize.subscribe(observer);
+        dematerialize.subscribe(subscriber);
 
-        verify(observer, times(1)).onError(exception);
-        verify(observer, times(0)).onComplete();
-        verify(observer, times(0)).onNext(any(Integer.class));
+        verify(subscriber, times(1)).onError(exception);
+        verify(subscriber, times(0)).onComplete();
+        verify(subscriber, times(0)).onNext(any(Integer.class));
     }
 
     @Test
@@ -95,16 +95,16 @@ public class FlowableDematerializeTest {
         Flowable<Integer> observable = Flowable.empty();
         Flowable<Integer> dematerialize = observable.dematerialize();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(observer);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(subscriber);
         dematerialize.subscribe(ts);
 
         System.out.println(ts.errors());
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(0)).onNext(any(Integer.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(0)).onNext(any(Integer.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
@@ -169,8 +169,8 @@ public class FlowableDetachTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.onTerminateDetach();
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.onTerminateDetach();
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
@@ -232,14 +232,14 @@ public class FlowableDistinctTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
 
-                    observer.onNext(1);
-                    observer.onComplete();
-                    observer.onNext(2);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                    subscriber.onNext(1);
+                    subscriber.onComplete();
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .distinct()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
@@ -37,35 +37,35 @@ import io.reactivex.subscribers.*;
 
 public class FlowableDoOnEachTest {
 
-    Subscriber<String> subscribedObserver;
-    Subscriber<String> sideEffectObserver;
+    Subscriber<String> subscribedSubscriber;
+    Subscriber<String> sideEffectSubscriber;
 
     @Before
     public void before() {
-        subscribedObserver = TestHelper.mockSubscriber();
-        sideEffectObserver = TestHelper.mockSubscriber();
+        subscribedSubscriber = TestHelper.mockSubscriber();
+        sideEffectSubscriber = TestHelper.mockSubscriber();
     }
 
     @Test
     public void testDoOnEach() {
         Flowable<String> base = Flowable.just("a", "b", "c");
-        Flowable<String> doOnEach = base.doOnEach(sideEffectObserver);
+        Flowable<String> doOnEach = base.doOnEach(sideEffectSubscriber);
 
-        doOnEach.subscribe(subscribedObserver);
+        doOnEach.subscribe(subscribedSubscriber);
 
         // ensure the leaf observer is still getting called
-        verify(subscribedObserver, never()).onError(any(Throwable.class));
-        verify(subscribedObserver, times(1)).onNext("a");
-        verify(subscribedObserver, times(1)).onNext("b");
-        verify(subscribedObserver, times(1)).onNext("c");
-        verify(subscribedObserver, times(1)).onComplete();
+        verify(subscribedSubscriber, never()).onError(any(Throwable.class));
+        verify(subscribedSubscriber, times(1)).onNext("a");
+        verify(subscribedSubscriber, times(1)).onNext("b");
+        verify(subscribedSubscriber, times(1)).onNext("c");
+        verify(subscribedSubscriber, times(1)).onComplete();
 
         // ensure our injected observer is getting called
-        verify(sideEffectObserver, never()).onError(any(Throwable.class));
-        verify(sideEffectObserver, times(1)).onNext("a");
-        verify(sideEffectObserver, times(1)).onNext("b");
-        verify(sideEffectObserver, times(1)).onNext("c");
-        verify(sideEffectObserver, times(1)).onComplete();
+        verify(sideEffectSubscriber, never()).onError(any(Throwable.class));
+        verify(sideEffectSubscriber, times(1)).onNext("a");
+        verify(sideEffectSubscriber, times(1)).onNext("b");
+        verify(sideEffectSubscriber, times(1)).onNext("c");
+        verify(sideEffectSubscriber, times(1)).onComplete();
     }
 
     @Test
@@ -81,20 +81,20 @@ public class FlowableDoOnEachTest {
             }
         });
 
-        Flowable<String> doOnEach = errs.doOnEach(sideEffectObserver);
+        Flowable<String> doOnEach = errs.doOnEach(sideEffectSubscriber);
 
-        doOnEach.subscribe(subscribedObserver);
-        verify(subscribedObserver, times(1)).onNext("one");
-        verify(subscribedObserver, never()).onNext("two");
-        verify(subscribedObserver, never()).onNext("three");
-        verify(subscribedObserver, never()).onComplete();
-        verify(subscribedObserver, times(1)).onError(any(Throwable.class));
+        doOnEach.subscribe(subscribedSubscriber);
+        verify(subscribedSubscriber, times(1)).onNext("one");
+        verify(subscribedSubscriber, never()).onNext("two");
+        verify(subscribedSubscriber, never()).onNext("three");
+        verify(subscribedSubscriber, never()).onComplete();
+        verify(subscribedSubscriber, times(1)).onError(any(Throwable.class));
 
-        verify(sideEffectObserver, times(1)).onNext("one");
-        verify(sideEffectObserver, never()).onNext("two");
-        verify(sideEffectObserver, never()).onNext("three");
-        verify(sideEffectObserver, never()).onComplete();
-        verify(sideEffectObserver, times(1)).onError(any(Throwable.class));
+        verify(sideEffectSubscriber, times(1)).onNext("one");
+        verify(sideEffectSubscriber, never()).onNext("two");
+        verify(sideEffectSubscriber, never()).onNext("three");
+        verify(sideEffectSubscriber, never()).onComplete();
+        verify(sideEffectSubscriber, times(1)).onError(any(Throwable.class));
     }
 
     @Test
@@ -109,12 +109,12 @@ public class FlowableDoOnEachTest {
             }
         });
 
-        doOnEach.subscribe(subscribedObserver);
-        verify(subscribedObserver, times(1)).onNext("one");
-        verify(subscribedObserver, times(1)).onNext("two");
-        verify(subscribedObserver, never()).onNext("three");
-        verify(subscribedObserver, never()).onComplete();
-        verify(subscribedObserver, times(1)).onError(any(Throwable.class));
+        doOnEach.subscribe(subscribedSubscriber);
+        verify(subscribedSubscriber, times(1)).onNext("one");
+        verify(subscribedSubscriber, times(1)).onNext("two");
+        verify(subscribedSubscriber, never()).onNext("three");
+        verify(subscribedSubscriber, never()).onComplete();
+        verify(subscribedSubscriber, times(1)).onError(any(Throwable.class));
 
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
@@ -180,7 +180,7 @@ public class FlowableDoOnEachTest {
 //                        public Flowable<?> apply(Integer integer) {
 //                            return Flowable.create(new Publisher<Object>() {
 //                                @Override
-//                                public void subscribe(Subscriber<Object> o) {
+//                                public void subscribe(Subscriber<Object> subscriber) {
 //                                    throw new NullPointerException("Test NPE");
 //                                }
 //                            });
@@ -728,8 +728,8 @@ public class FlowableDoOnEachTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.doOnEach(new TestSubscriber<Object>());
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.doOnEach(new TestSubscriber<Object>());
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
@@ -48,8 +48,8 @@ public class FlowableDoOnLifecycleTest {
 
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
             @Override
-            public Publisher<Object> apply(Flowable<Object> o) throws Exception {
-                return o
+            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
+                return f
                 .doOnLifecycle(new Consumer<Subscription>() {
                     @Override
                     public void accept(Subscription s) throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnSubscribeTest.java
@@ -29,23 +29,23 @@ public class FlowableDoOnSubscribeTest {
     @Test
     public void testDoOnSubscribe() throws Exception {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> o = Flowable.just(1).doOnSubscribe(new Consumer<Subscription>() {
+        Flowable<Integer> f = Flowable.just(1).doOnSubscribe(new Consumer<Subscription>() {
             @Override
             public void accept(Subscription s) {
                     count.incrementAndGet();
             }
         });
 
-        o.subscribe();
-        o.subscribe();
-        o.subscribe();
+        f.subscribe();
+        f.subscribe();
+        f.subscribe();
         assertEquals(3, count.get());
     }
 
     @Test
     public void testDoOnSubscribe2() throws Exception {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> o = Flowable.just(1).doOnSubscribe(new Consumer<Subscription>() {
+        Flowable<Integer> f = Flowable.just(1).doOnSubscribe(new Consumer<Subscription>() {
             @Override
             public void accept(Subscription s) {
                     count.incrementAndGet();
@@ -57,7 +57,7 @@ public class FlowableDoOnSubscribeTest {
             }
         });
 
-        o.subscribe();
+        f.subscribe();
         assertEquals(2, count.get());
     }
 
@@ -67,7 +67,7 @@ public class FlowableDoOnSubscribeTest {
         final AtomicInteger countBefore = new AtomicInteger();
         final AtomicInteger countAfter = new AtomicInteger();
         final AtomicReference<Subscriber<? super Integer>> sref = new AtomicReference<Subscriber<? super Integer>>();
-        Flowable<Integer> o = Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable<Integer> f = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
@@ -89,16 +89,16 @@ public class FlowableDoOnSubscribeTest {
             }
         });
 
-        o.subscribe();
-        o.subscribe();
-        o.subscribe();
+        f.subscribe();
+        f.subscribe();
+        f.subscribe();
         assertEquals(1, countBefore.get());
         assertEquals(1, onSubscribed.get());
         assertEquals(3, countAfter.get());
         sref.get().onComplete();
-        o.subscribe();
-        o.subscribe();
-        o.subscribe();
+        f.subscribe();
+        f.subscribe();
+        f.subscribe();
         assertEquals(2, countBefore.get());
         assertEquals(2, onSubscribed.get());
         assertEquals(6, countAfter.get());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
@@ -191,22 +191,22 @@ public class FlowableElementAtTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
             @Override
-            public Publisher<Object> apply(Flowable<Object> o) throws Exception {
-                return o.elementAt(0).toFlowable();
+            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
+                return f.elementAt(0).toFlowable();
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowableToMaybe(new Function<Flowable<Object>, Maybe<Object>>() {
             @Override
-            public Maybe<Object> apply(Flowable<Object> o) throws Exception {
-                return o.elementAt(0);
+            public Maybe<Object> apply(Flowable<Object> f) throws Exception {
+                return f.elementAt(0);
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, Single<Object>>() {
             @Override
-            public Single<Object> apply(Flowable<Object> o) throws Exception {
-                return o.elementAt(0, 1);
+            public Single<Object> apply(Flowable<Object> f) throws Exception {
+                return f.elementAt(0, 1);
             }
         });
     }
@@ -338,13 +338,13 @@ public class FlowableElementAtTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
 
-                    observer.onNext(1);
-                    observer.onNext(2);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                    subscriber.onNext(1);
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .elementAt(0, 1)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFilterTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFilterTest.java
@@ -66,7 +66,7 @@ public class FlowableFilterTest {
     @Test(timeout = 500)
     public void testWithBackpressure() throws InterruptedException {
         Flowable<String> w = Flowable.just("one", "two", "three");
-        Flowable<String> o = w.filter(new Predicate<String>() {
+        Flowable<String> f = w.filter(new Predicate<String>() {
 
             @Override
             public boolean test(String t1) {
@@ -100,7 +100,7 @@ public class FlowableFilterTest {
         // this means it will only request "one" and "two", expecting to receive them before requesting more
         ts.request(2);
 
-        o.subscribe(ts);
+        f.subscribe(ts);
 
         // this will wait forever unless OperatorTake handles the request(n) on filtered items
         latch.await();
@@ -113,7 +113,7 @@ public class FlowableFilterTest {
     @Test(timeout = 500000)
     public void testWithBackpressure2() throws InterruptedException {
         Flowable<Integer> w = Flowable.range(1, Flowable.bufferSize() * 2);
-        Flowable<Integer> o = w.filter(new Predicate<Integer>() {
+        Flowable<Integer> f = w.filter(new Predicate<Integer>() {
 
             @Override
             public boolean test(Integer t1) {
@@ -146,7 +146,7 @@ public class FlowableFilterTest {
         // this means it will only request 1 item and expect to receive more
         ts.request(1);
 
-        o.subscribe(ts);
+        f.subscribe(ts);
 
         // this will wait forever unless OperatorTake handles the request(n) on filtered items
         latch.await();
@@ -555,8 +555,8 @@ public class FlowableFilterTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.filter(Functions.alwaysTrue());
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.filter(Functions.alwaysTrue());
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFirstTest.java
@@ -94,12 +94,12 @@ public class FlowableFirstTest {
     public void testFirstFlowable() {
         Flowable<Integer> observable = Flowable.just(1, 2, 3).firstElement().toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(1);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -107,12 +107,12 @@ public class FlowableFirstTest {
     public void testFirstWithOneElementFlowable() {
         Flowable<Integer> observable = Flowable.just(1).firstElement().toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(1);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -120,12 +120,12 @@ public class FlowableFirstTest {
     public void testFirstWithEmptyFlowable() {
         Flowable<Integer> observable = Flowable.<Integer> empty().firstElement().toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onComplete();
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onComplete();
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -140,12 +140,12 @@ public class FlowableFirstTest {
                 })
                 .firstElement().toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -160,12 +160,12 @@ public class FlowableFirstTest {
                 })
                 .firstElement().toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -180,12 +180,12 @@ public class FlowableFirstTest {
                 })
                 .firstElement().toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onComplete();
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onComplete();
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -194,12 +194,12 @@ public class FlowableFirstTest {
         Flowable<Integer> observable = Flowable.just(1, 2, 3)
                 .first(4).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(1);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -207,12 +207,12 @@ public class FlowableFirstTest {
     public void testFirstOrDefaultWithOneElementFlowable() {
         Flowable<Integer> observable = Flowable.just(1).first(2).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(1);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -221,12 +221,12 @@ public class FlowableFirstTest {
         Flowable<Integer> observable = Flowable.<Integer> empty()
                 .first(1).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(1);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -241,12 +241,12 @@ public class FlowableFirstTest {
                 })
                 .first(8).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -261,12 +261,12 @@ public class FlowableFirstTest {
                 })
                 .first(4).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -281,12 +281,12 @@ public class FlowableFirstTest {
                 })
                 .first(2).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFirstTest.java
@@ -92,10 +92,10 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3).firstElement().toFlowable();
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3).firstElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(1);
@@ -105,10 +105,10 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstWithOneElementFlowable() {
-        Flowable<Integer> observable = Flowable.just(1).firstElement().toFlowable();
+        Flowable<Integer> flowable = Flowable.just(1).firstElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(1);
@@ -118,10 +118,10 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstWithEmptyFlowable() {
-        Flowable<Integer> observable = Flowable.<Integer> empty().firstElement().toFlowable();
+        Flowable<Integer> flowable = Flowable.<Integer> empty().firstElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber).onComplete();
@@ -131,7 +131,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstWithPredicateFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -141,7 +141,7 @@ public class FlowableFirstTest {
                 .firstElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(2);
@@ -151,7 +151,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstWithPredicateAndOneElementFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2)
+        Flowable<Integer> flowable = Flowable.just(1, 2)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -161,7 +161,7 @@ public class FlowableFirstTest {
                 .firstElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(2);
@@ -171,7 +171,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstWithPredicateAndEmptyFlowable() {
-        Flowable<Integer> observable = Flowable.just(1)
+        Flowable<Integer> flowable = Flowable.just(1)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -181,7 +181,7 @@ public class FlowableFirstTest {
                 .firstElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber).onComplete();
@@ -191,11 +191,11 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefaultFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3)
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3)
                 .first(4).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(1);
@@ -205,10 +205,10 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefaultWithOneElementFlowable() {
-        Flowable<Integer> observable = Flowable.just(1).first(2).toFlowable();
+        Flowable<Integer> flowable = Flowable.just(1).first(2).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(1);
@@ -218,11 +218,11 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefaultWithEmptyFlowable() {
-        Flowable<Integer> observable = Flowable.<Integer> empty()
+        Flowable<Integer> flowable = Flowable.<Integer> empty()
                 .first(1).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(1);
@@ -232,7 +232,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefaultWithPredicateFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -242,7 +242,7 @@ public class FlowableFirstTest {
                 .first(8).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(2);
@@ -252,7 +252,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefaultWithPredicateAndOneElementFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2)
+        Flowable<Integer> flowable = Flowable.just(1, 2)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -262,7 +262,7 @@ public class FlowableFirstTest {
                 .first(4).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(2);
@@ -272,7 +272,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefaultWithPredicateAndEmptyFlowable() {
-        Flowable<Integer> observable = Flowable.just(1)
+        Flowable<Integer> flowable = Flowable.just(1)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -282,7 +282,7 @@ public class FlowableFirstTest {
                 .first(2).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(2);
@@ -332,9 +332,9 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirst() {
-        Maybe<Integer> observable = Flowable.just(1, 2, 3).firstElement();
+        Maybe<Integer> maybe = Flowable.just(1, 2, 3).firstElement();
 
-        observable.subscribe(wm);
+        maybe.subscribe(wm);
 
         InOrder inOrder = inOrder(wm);
         inOrder.verify(wm, times(1)).onSuccess(1);
@@ -343,9 +343,9 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstWithOneElement() {
-        Maybe<Integer> observable = Flowable.just(1).firstElement();
+        Maybe<Integer> maybe = Flowable.just(1).firstElement();
 
-        observable.subscribe(wm);
+        maybe.subscribe(wm);
 
         InOrder inOrder = inOrder(wm);
         inOrder.verify(wm, times(1)).onSuccess(1);
@@ -354,9 +354,9 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstWithEmpty() {
-        Maybe<Integer> observable = Flowable.<Integer> empty().firstElement();
+        Maybe<Integer> maybe = Flowable.<Integer> empty().firstElement();
 
-        observable.subscribe(wm);
+        maybe.subscribe(wm);
 
         InOrder inOrder = inOrder(wm);
         inOrder.verify(wm).onComplete();
@@ -366,7 +366,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstWithPredicate() {
-        Maybe<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
+        Maybe<Integer> maybe = Flowable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -375,7 +375,7 @@ public class FlowableFirstTest {
                 })
                 .firstElement();
 
-        observable.subscribe(wm);
+        maybe.subscribe(wm);
 
         InOrder inOrder = inOrder(wm);
         inOrder.verify(wm, times(1)).onSuccess(2);
@@ -384,7 +384,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstWithPredicateAndOneElement() {
-        Maybe<Integer> observable = Flowable.just(1, 2)
+        Maybe<Integer> maybe = Flowable.just(1, 2)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -393,7 +393,7 @@ public class FlowableFirstTest {
                 })
                 .firstElement();
 
-        observable.subscribe(wm);
+        maybe.subscribe(wm);
 
         InOrder inOrder = inOrder(wm);
         inOrder.verify(wm, times(1)).onSuccess(2);
@@ -402,7 +402,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstWithPredicateAndEmpty() {
-        Maybe<Integer> observable = Flowable.just(1)
+        Maybe<Integer> maybe = Flowable.just(1)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -411,7 +411,7 @@ public class FlowableFirstTest {
                 })
                 .firstElement();
 
-        observable.subscribe(wm);
+        maybe.subscribe(wm);
 
         InOrder inOrder = inOrder(wm);
         inOrder.verify(wm).onComplete();
@@ -421,10 +421,10 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefault() {
-        Single<Integer> observable = Flowable.just(1, 2, 3)
+        Single<Integer> single = Flowable.just(1, 2, 3)
                 .first(4);
 
-        observable.subscribe(wo);
+        single.subscribe(wo);
 
         InOrder inOrder = inOrder(wo);
         inOrder.verify(wo, times(1)).onSuccess(1);
@@ -433,9 +433,9 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefaultWithOneElement() {
-        Single<Integer> observable = Flowable.just(1).first(2);
+        Single<Integer> single = Flowable.just(1).first(2);
 
-        observable.subscribe(wo);
+        single.subscribe(wo);
 
         InOrder inOrder = inOrder(wo);
         inOrder.verify(wo, times(1)).onSuccess(1);
@@ -444,10 +444,10 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefaultWithEmpty() {
-        Single<Integer> observable = Flowable.<Integer> empty()
+        Single<Integer> single = Flowable.<Integer> empty()
                 .first(1);
 
-        observable.subscribe(wo);
+        single.subscribe(wo);
 
         InOrder inOrder = inOrder(wo);
         inOrder.verify(wo, times(1)).onSuccess(1);
@@ -456,7 +456,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefaultWithPredicate() {
-        Single<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
+        Single<Integer> single = Flowable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -465,7 +465,7 @@ public class FlowableFirstTest {
                 })
                 .first(8);
 
-        observable.subscribe(wo);
+        single.subscribe(wo);
 
         InOrder inOrder = inOrder(wo);
         inOrder.verify(wo, times(1)).onSuccess(2);
@@ -474,7 +474,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefaultWithPredicateAndOneElement() {
-        Single<Integer> observable = Flowable.just(1, 2)
+        Single<Integer> single = Flowable.just(1, 2)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -483,7 +483,7 @@ public class FlowableFirstTest {
                 })
                 .first(4);
 
-        observable.subscribe(wo);
+        single.subscribe(wo);
 
         InOrder inOrder = inOrder(wo);
         inOrder.verify(wo, times(1)).onSuccess(2);
@@ -492,7 +492,7 @@ public class FlowableFirstTest {
 
     @Test
     public void testFirstOrDefaultWithPredicateAndEmpty() {
-        Single<Integer> observable = Flowable.just(1)
+        Single<Integer> single = Flowable.just(1)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -501,7 +501,7 @@ public class FlowableFirstTest {
                 })
                 .first(2);
 
-        observable.subscribe(wo);
+        single.subscribe(wo);
 
         InOrder inOrder = inOrder(wo);
         inOrder.verify(wo, times(1)).onSuccess(2);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
@@ -399,8 +399,8 @@ public class FlowableFlatMapCompletableTest {
     public void badSource() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
-            public Object apply(Flowable<Integer> o) throws Exception {
-                return o.flatMapCompletable(new Function<Integer, CompletableSource>() {
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.flatMapCompletable(new Function<Integer, CompletableSource>() {
                     @Override
                     public CompletableSource apply(Integer v) throws Exception {
                         return Completable.complete();
@@ -475,8 +475,8 @@ public class FlowableFlatMapCompletableTest {
     public void badSourceFlowable() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
-            public Object apply(Flowable<Integer> o) throws Exception {
-                return o.flatMapCompletable(new Function<Integer, CompletableSource>() {
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.flatMapCompletable(new Function<Integer, CompletableSource>() {
                     @Override
                     public CompletableSource apply(Integer v) throws Exception {
                         return Completable.complete();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
@@ -455,14 +455,14 @@ public class FlowableFlatMapCompletableTest {
             public CompletableSource apply(Integer v) throws Exception {
                 return new Completable() {
                     @Override
-                    protected void subscribeActual(CompletableObserver s) {
-                        s.onSubscribe(Disposables.empty());
+                    protected void subscribeActual(CompletableObserver observer) {
+                        observer.onSubscribe(Disposables.empty());
 
-                        assertFalse(((Disposable)s).isDisposed());
+                        assertFalse(((Disposable)observer).isDisposed());
 
-                        ((Disposable)s).dispose();
+                        ((Disposable)observer).dispose();
 
-                        assertTrue(((Disposable)s).isDisposed());
+                        assertTrue(((Disposable)observer).isDisposed());
                     }
                 };
             }
@@ -494,14 +494,14 @@ public class FlowableFlatMapCompletableTest {
             public CompletableSource apply(Integer v) throws Exception {
                 return new Completable() {
                     @Override
-                    protected void subscribeActual(CompletableObserver s) {
-                        s.onSubscribe(Disposables.empty());
+                    protected void subscribeActual(CompletableObserver observer) {
+                        observer.onSubscribe(Disposables.empty());
 
-                        assertFalse(((Disposable)s).isDisposed());
+                        assertFalse(((Disposable)observer).isDisposed());
 
-                        ((Disposable)s).dispose();
+                        ((Disposable)observer).dispose();
 
-                        assertTrue(((Disposable)s).isDisposed());
+                        assertTrue(((Disposable)observer).isDisposed());
                     }
                 };
             }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -411,10 +411,10 @@ public class FlowableFlatMapMaybeTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onError(new TestException("First"));
-                    observer.onError(new TestException("Second"));
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onError(new TestException("First"));
+                    subscriber.onError(new TestException("Second"));
                 }
             }
             .flatMapMaybe(Functions.justFunction(Maybe.just(2)))

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -331,10 +331,10 @@ public class FlowableFlatMapSingleTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onError(new TestException("First"));
-                    observer.onError(new TestException("Second"));
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onError(new TestException("First"));
+                    subscriber.onError(new TestException("Second"));
                 }
             }
             .flatMapSingle(Functions.justFunction(Single.just(2)))

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -238,18 +238,25 @@ public class FlowableFlatMapTest {
 
     @Test
     public void testFlatMapTransformsOnNextFuncThrows() {
-        Flowable<Integer> onComplete = Flowable.fromIterable(Arrays.asList(4));
-        Flowable<Integer> onError = Flowable.fromIterable(Arrays.asList(5));
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable<Integer> onComplete = Flowable.fromIterable(Arrays.asList(4));
+            Flowable<Integer> onError = Flowable.fromIterable(Arrays.asList(5));
 
-        Flowable<Integer> source = Flowable.fromIterable(Arrays.asList(10, 20, 30));
+            Flowable<Integer> source = Flowable.fromIterable(Arrays.asList(10, 20, 30));
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+            Subscriber<Object> o = TestHelper.mockSubscriber();
 
-        source.flatMap(funcThrow(1, onError), just(onError), just0(onComplete)).subscribe(o);
+            source.flatMap(funcThrow(1, onError), just(onError), just0(onComplete)).subscribe(o);
 
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+            verify(o).onError(any(TestException.class));
+            verify(o, never()).onNext(any());
+            verify(o, never()).onComplete();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -36,7 +36,7 @@ import io.reactivex.subscribers.TestSubscriber;
 public class FlowableFlatMapTest {
     @Test
     public void testNormal() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         final List<Integer> list = Arrays.asList(1, 2, 3);
 
@@ -56,20 +56,20 @@ public class FlowableFlatMapTest {
 
         List<Integer> source = Arrays.asList(16, 32, 64);
 
-        Flowable.fromIterable(source).flatMapIterable(func, resFunc).subscribe(o);
+        Flowable.fromIterable(source).flatMapIterable(func, resFunc).subscribe(subscriber);
 
         for (Integer s : source) {
             for (Integer v : list) {
-                verify(o).onNext(s | v);
+                verify(subscriber).onNext(s | v);
             }
         }
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testCollectionFunctionThrows() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         Function<Integer, List<Integer>> func = new Function<Integer, List<Integer>>() {
             @Override
@@ -87,16 +87,16 @@ public class FlowableFlatMapTest {
 
         List<Integer> source = Arrays.asList(16, 32, 64);
 
-        Flowable.fromIterable(source).flatMapIterable(func, resFunc).subscribe(o);
+        Flowable.fromIterable(source).flatMapIterable(func, resFunc).subscribe(subscriber);
 
-        verify(o, never()).onComplete();
-        verify(o, never()).onNext(any());
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber).onError(any(TestException.class));
     }
 
     @Test
     public void testResultFunctionThrows() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         final List<Integer> list = Arrays.asList(1, 2, 3);
 
@@ -116,16 +116,16 @@ public class FlowableFlatMapTest {
 
         List<Integer> source = Arrays.asList(16, 32, 64);
 
-        Flowable.fromIterable(source).flatMapIterable(func, resFunc).subscribe(o);
+        Flowable.fromIterable(source).flatMapIterable(func, resFunc).subscribe(subscriber);
 
-        verify(o, never()).onComplete();
-        verify(o, never()).onNext(any());
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber).onError(any(TestException.class));
     }
 
     @Test
     public void testMergeError() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         Function<Integer, Flowable<Integer>> func = new Function<Integer, Flowable<Integer>>() {
             @Override
@@ -143,11 +143,11 @@ public class FlowableFlatMapTest {
 
         List<Integer> source = Arrays.asList(16, 32, 64);
 
-        Flowable.fromIterable(source).flatMap(func, resFunc).subscribe(o);
+        Flowable.fromIterable(source).flatMap(func, resFunc).subscribe(subscriber);
 
-        verify(o, never()).onComplete();
-        verify(o, never()).onNext(any());
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber).onError(any(TestException.class));
     }
 
     <T, R> Function<T, R> just(final R value) {
@@ -178,18 +178,18 @@ public class FlowableFlatMapTest {
 
         Flowable<Integer> source = Flowable.fromIterable(Arrays.asList(10, 20, 30));
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.flatMap(just(onNext), just(onError), just0(onComplete)).subscribe(o);
+        source.flatMap(just(onNext), just(onError), just0(onComplete)).subscribe(subscriber);
 
-        verify(o, times(3)).onNext(1);
-        verify(o, times(3)).onNext(2);
-        verify(o, times(3)).onNext(3);
-        verify(o).onNext(4);
-        verify(o).onComplete();
+        verify(subscriber, times(3)).onNext(1);
+        verify(subscriber, times(3)).onNext(2);
+        verify(subscriber, times(3)).onNext(3);
+        verify(subscriber).onNext(4);
+        verify(subscriber).onComplete();
 
-        verify(o, never()).onNext(5);
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(5);
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -204,18 +204,18 @@ public class FlowableFlatMapTest {
                 );
 
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.flatMap(just(onNext), just(onError), just0(onComplete)).subscribe(o);
+        source.flatMap(just(onNext), just(onError), just0(onComplete)).subscribe(subscriber);
 
-        verify(o, times(3)).onNext(1);
-        verify(o, times(3)).onNext(2);
-        verify(o, times(3)).onNext(3);
-        verify(o).onNext(5);
-        verify(o).onComplete();
-        verify(o, never()).onNext(4);
+        verify(subscriber, times(3)).onNext(1);
+        verify(subscriber, times(3)).onNext(2);
+        verify(subscriber, times(3)).onNext(3);
+        verify(subscriber).onNext(5);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onNext(4);
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     <R> Callable<R> funcThrow0(R r) {
@@ -245,13 +245,13 @@ public class FlowableFlatMapTest {
 
             Flowable<Integer> source = Flowable.fromIterable(Arrays.asList(10, 20, 30));
 
-            Subscriber<Object> o = TestHelper.mockSubscriber();
+            Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-            source.flatMap(funcThrow(1, onError), just(onError), just0(onComplete)).subscribe(o);
+            source.flatMap(funcThrow(1, onError), just(onError), just0(onComplete)).subscribe(subscriber);
 
-            verify(o).onError(any(TestException.class));
-            verify(o, never()).onNext(any());
-            verify(o, never()).onComplete();
+            verify(subscriber).onError(any(TestException.class));
+            verify(subscriber, never()).onNext(any());
+            verify(subscriber, never()).onComplete();
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
@@ -267,13 +267,13 @@ public class FlowableFlatMapTest {
 
         Flowable<Integer> source = Flowable.error(new TestException());
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.flatMap(just(onNext), funcThrow((Throwable) null, onError), just0(onComplete)).subscribe(o);
+        source.flatMap(just(onNext), funcThrow((Throwable) null, onError), just0(onComplete)).subscribe(subscriber);
 
-        verify(o).onError(any(CompositeException.class));
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber).onError(any(CompositeException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -284,13 +284,13 @@ public class FlowableFlatMapTest {
 
         Flowable<Integer> source = Flowable.fromIterable(Arrays.<Integer> asList());
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.flatMap(just(onNext), just(onError), funcThrow0(onComplete)).subscribe(o);
+        source.flatMap(just(onNext), just(onError), funcThrow0(onComplete)).subscribe(subscriber);
 
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -301,13 +301,13 @@ public class FlowableFlatMapTest {
 
         Flowable<Integer> source = Flowable.fromIterable(Arrays.asList(10, 20, 30));
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.flatMap(just(onNext), just(onError), funcThrow0(onComplete)).subscribe(o);
+        source.flatMap(just(onNext), just(onError), funcThrow0(onComplete)).subscribe(subscriber);
 
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     private static <T> Flowable<T> composer(Flowable<T> source, final AtomicInteger subscriptionCount, final int m) {
@@ -418,8 +418,8 @@ public class FlowableFlatMapTest {
 
         Flowable<Integer> source = Flowable.fromIterable(Arrays.asList(10, 20, 30));
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
 
         Function<Integer, Flowable<Integer>> just = just(onNext);
         Function<Throwable, Flowable<Integer>> just2 = just(onError);
@@ -430,14 +430,14 @@ public class FlowableFlatMapTest {
         ts.assertNoErrors();
         ts.assertTerminated();
 
-        verify(o, times(3)).onNext(1);
-        verify(o, times(3)).onNext(2);
-        verify(o, times(3)).onNext(3);
-        verify(o).onNext(4);
-        verify(o).onComplete();
+        verify(subscriber, times(3)).onNext(1);
+        verify(subscriber, times(3)).onNext(2);
+        verify(subscriber, times(3)).onNext(3);
+        verify(subscriber).onNext(4);
+        verify(subscriber).onComplete();
 
-        verify(o, never()).onNext(5);
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(5);
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Ignore("Don't care for any reordering")

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -583,8 +583,8 @@ public class FlowableFlattenIterableTest {
     public void badSource() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
-            public Object apply(Flowable<Integer> o) throws Exception {
-                return o.flatMapIterable(new Function<Object, Iterable<Integer>>() {
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.flatMapIterable(new Function<Object, Iterable<Integer>>() {
                     @Override
                     public Iterable<Integer> apply(Object v) throws Exception {
                         return Arrays.asList(10, 20);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromCallableTest.java
@@ -58,13 +58,13 @@ public class FlowableFromCallableTest {
 
         Flowable<String> fromCallableFlowable = Flowable.fromCallable(func);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        fromCallableFlowable.subscribe(observer);
+        fromCallableFlowable.subscribe(subscriber);
 
-        verify(observer).onNext("test_value");
-        verify(observer).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext("test_value");
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @SuppressWarnings("unchecked")
@@ -77,13 +77,13 @@ public class FlowableFromCallableTest {
 
         Flowable<Object> fromCallableFlowable = Flowable.fromCallable(func);
 
-        Subscriber<Object> observer = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        fromCallableFlowable.subscribe(observer);
+        fromCallableFlowable.subscribe(subscriber);
 
-        verify(observer, never()).onNext(any());
-        verify(observer, never()).onComplete();
-        verify(observer).onError(throwable);
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(throwable);
     }
 
     @SuppressWarnings("unchecked")
@@ -114,9 +114,9 @@ public class FlowableFromCallableTest {
 
         Flowable<String> fromCallableFlowable = Flowable.fromCallable(func);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<String> outer = new TestSubscriber<String>(observer);
+        TestSubscriber<String> outer = new TestSubscriber<String>(subscriber);
 
         fromCallableFlowable
                 .subscribeOn(Schedulers.computation())
@@ -135,8 +135,8 @@ public class FlowableFromCallableTest {
         verify(func).call();
 
         // Observer must not be notified at all
-        verify(observer).onSubscribe(any(Subscription.class));
-        verifyNoMoreInteractions(observer);
+        verify(subscriber).onSubscribe(any(Subscription.class));
+        verifyNoMoreInteractions(subscriber);
     }
 
     @Test
@@ -150,13 +150,13 @@ public class FlowableFromCallableTest {
             }
         });
 
-        Subscriber<Object> observer = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        fromCallableFlowable.subscribe(observer);
+        fromCallableFlowable.subscribe(subscriber);
 
-        verify(observer).onSubscribe(any(Subscription.class));
-        verify(observer).onError(checkedException);
-        verifyNoMoreInteractions(observer);
+        verify(subscriber).onSubscribe(any(Subscription.class));
+        verify(subscriber).onError(checkedException);
+        verifyNoMoreInteractions(subscriber);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
@@ -122,14 +122,14 @@ public class FlowableFromIterableTest {
         for (int i = 1; i <= Flowable.bufferSize() + 1; i++) {
             list.add(i);
         }
-        Flowable<Integer> o = Flowable.fromIterable(list);
+        Flowable<Integer> f = Flowable.fromIterable(list);
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
         ts.assertNoValues();
         ts.request(1);
 
-        o.subscribe(ts);
+        f.subscribe(ts);
 
         ts.assertValue(1);
         ts.request(2);
@@ -142,14 +142,14 @@ public class FlowableFromIterableTest {
 
     @Test
     public void testNoBackpressure() {
-        Flowable<Integer> o = Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5));
+        Flowable<Integer> f = Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5));
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
         ts.assertNoValues();
         ts.request(Long.MAX_VALUE); // infinite
 
-        o.subscribe(ts);
+        f.subscribe(ts);
 
         ts.assertValues(1, 2, 3, 4, 5);
         ts.assertTerminated();
@@ -157,12 +157,12 @@ public class FlowableFromIterableTest {
 
     @Test
     public void testSubscribeMultipleTimes() {
-        Flowable<Integer> o = Flowable.fromIterable(Arrays.asList(1, 2, 3));
+        Flowable<Integer> f = Flowable.fromIterable(Arrays.asList(1, 2, 3));
 
         for (int i = 0; i < 10; i++) {
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-            o.subscribe(ts);
+            f.subscribe(ts);
 
             ts.assertValues(1, 2, 3);
             ts.assertNoErrors();
@@ -172,12 +172,12 @@ public class FlowableFromIterableTest {
 
     @Test
     public void testFromIterableRequestOverflow() throws InterruptedException {
-        Flowable<Integer> o = Flowable.fromIterable(Arrays.asList(1,2,3,4));
+        Flowable<Integer> f = Flowable.fromIterable(Arrays.asList(1,2,3,4));
 
         final int expectedCount = 4;
         final CountDownLatch latch = new CountDownLatch(expectedCount);
 
-        o.subscribeOn(Schedulers.computation())
+        f.subscribeOn(Schedulers.computation())
         .subscribe(new DefaultSubscriber<Integer>() {
 
             @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
@@ -46,15 +46,15 @@ public class FlowableFromIterableTest {
     public void testListIterable() {
         Flowable<String> flowable = Flowable.fromIterable(Arrays.<String> asList("one", "two", "three"));
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        flowable.subscribe(observer);
+        flowable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     /**
@@ -90,30 +90,30 @@ public class FlowableFromIterableTest {
         };
         Flowable<String> flowable = Flowable.fromIterable(it);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        flowable.subscribe(observer);
+        flowable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext("1");
-        verify(observer, times(1)).onNext("2");
-        verify(observer, times(1)).onNext("3");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("1");
+        verify(subscriber, times(1)).onNext("2");
+        verify(subscriber, times(1)).onNext("3");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testObservableFromIterable() {
         Flowable<String> flowable = Flowable.fromIterable(Arrays.<String> asList("one", "two", "three"));
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        flowable.subscribe(observer);
+        flowable.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
@@ -13,12 +13,15 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import java.util.List;
+
 import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Cancellable;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.*;
 
@@ -271,82 +274,116 @@ public class FlowableFromSourceTest {
 
     @Test
     public void unsubscribedNoCancelBuffer() {
-        Flowable.create(sourceNoCancel, BackpressureStrategy.BUFFER).subscribe(ts);
-        ts.cancel();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.create(sourceNoCancel, BackpressureStrategy.BUFFER).subscribe(ts);
+            ts.cancel();
 
-        sourceNoCancel.onNext(1);
-        sourceNoCancel.onNext(2);
-        sourceNoCancel.onError(new TestException());
+            sourceNoCancel.onNext(1);
+            sourceNoCancel.onNext(2);
+            sourceNoCancel.onError(new TestException());
 
-        ts.request(1);
+            ts.request(1);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+            ts.assertNoValues();
+            ts.assertNoErrors();
+            ts.assertNotComplete();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void unsubscribedNoCancelLatest() {
-        Flowable.create(sourceNoCancel, BackpressureStrategy.LATEST).subscribe(ts);
-        ts.cancel();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.create(sourceNoCancel, BackpressureStrategy.LATEST).subscribe(ts);
+            ts.cancel();
 
-        sourceNoCancel.onNext(1);
-        sourceNoCancel.onNext(2);
-        sourceNoCancel.onError(new TestException());
+            sourceNoCancel.onNext(1);
+            sourceNoCancel.onNext(2);
+            sourceNoCancel.onError(new TestException());
 
-        ts.request(1);
+            ts.request(1);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+            ts.assertNoValues();
+            ts.assertNoErrors();
+            ts.assertNotComplete();
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void unsubscribedNoCancelError() {
-        Flowable.create(sourceNoCancel, BackpressureStrategy.ERROR).subscribe(ts);
-        ts.cancel();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.create(sourceNoCancel, BackpressureStrategy.ERROR).subscribe(ts);
+            ts.cancel();
 
-        sourceNoCancel.onNext(1);
-        sourceNoCancel.onNext(2);
-        sourceNoCancel.onError(new TestException());
+            sourceNoCancel.onNext(1);
+            sourceNoCancel.onNext(2);
+            sourceNoCancel.onError(new TestException());
 
-        ts.request(1);
+            ts.request(1);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+            ts.assertNoValues();
+            ts.assertNoErrors();
+            ts.assertNotComplete();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void unsubscribedNoCancelDrop() {
-        Flowable.create(sourceNoCancel, BackpressureStrategy.DROP).subscribe(ts);
-        ts.cancel();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.create(sourceNoCancel, BackpressureStrategy.DROP).subscribe(ts);
+            ts.cancel();
 
-        sourceNoCancel.onNext(1);
-        sourceNoCancel.onNext(2);
-        sourceNoCancel.onError(new TestException());
+            sourceNoCancel.onNext(1);
+            sourceNoCancel.onNext(2);
+            sourceNoCancel.onError(new TestException());
 
-        ts.request(1);
+            ts.request(1);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+            ts.assertNoValues();
+            ts.assertNoErrors();
+            ts.assertNotComplete();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void unsubscribedNoCancelMissing() {
-        Flowable.create(sourceNoCancel, BackpressureStrategy.MISSING).subscribe(ts);
-        ts.cancel();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.create(sourceNoCancel, BackpressureStrategy.MISSING).subscribe(ts);
+            ts.cancel();
 
-        sourceNoCancel.onNext(1);
-        sourceNoCancel.onNext(2);
-        sourceNoCancel.onError(new TestException());
+            sourceNoCancel.onNext(1);
+            sourceNoCancel.onNext(2);
+            sourceNoCancel.onError(new TestException());
 
-        ts.request(1);
+            ts.request(1);
 
-        ts.assertNoValues();
-        ts.assertNoErrors();
-        ts.assertNotComplete();
+            ts.assertNoValues();
+            ts.assertNoErrors();
+            ts.assertNotComplete();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
@@ -659,12 +659,12 @@ public class FlowableFromSourceTest {
 
     static final class PublishAsyncEmitter implements FlowableOnSubscribe<Integer>, FlowableSubscriber<Integer> {
 
-        final PublishProcessor<Integer> subject;
+        final PublishProcessor<Integer> processor;
 
         FlowableEmitter<Integer> current;
 
         PublishAsyncEmitter() {
-            this.subject = PublishProcessor.create();
+            this.processor = PublishProcessor.create();
         }
 
         long requested() {
@@ -695,7 +695,7 @@ public class FlowableFromSourceTest {
 
             };
 
-            subject.subscribe(as);
+            processor.subscribe(as);
 
             t.setCancellable(new Cancellable() {
                 @Override
@@ -712,32 +712,32 @@ public class FlowableFromSourceTest {
 
         @Override
         public void onNext(Integer t) {
-            subject.onNext(t);
+            processor.onNext(t);
         }
 
         @Override
         public void onError(Throwable e) {
-            subject.onError(e);
+            processor.onError(e);
         }
 
         @Override
         public void onComplete() {
-            subject.onComplete();
+            processor.onComplete();
         }
     }
 
     static final class PublishAsyncEmitterNoCancel implements FlowableOnSubscribe<Integer>, FlowableSubscriber<Integer> {
 
-        final PublishProcessor<Integer> subject;
+        final PublishProcessor<Integer> processor;
 
         PublishAsyncEmitterNoCancel() {
-            this.subject = PublishProcessor.create();
+            this.processor = PublishProcessor.create();
         }
 
         @Override
         public void subscribe(final FlowableEmitter<Integer> t) {
 
-            subject.subscribe(new FlowableSubscriber<Integer>() {
+            processor.subscribe(new FlowableSubscriber<Integer>() {
 
                 @Override
                 public void onSubscribe(Subscription s) {
@@ -769,17 +769,17 @@ public class FlowableFromSourceTest {
 
         @Override
         public void onNext(Integer t) {
-            subject.onNext(t);
+            processor.onNext(t);
         }
 
         @Override
         public void onError(Throwable e) {
-            subject.onError(e);
+            processor.onError(e);
         }
 
         @Override
         public void onComplete() {
-            subject.onComplete();
+            processor.onComplete();
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -114,13 +114,13 @@ public class FlowableGroupByTest {
         grouped.flatMap(new Function<GroupedFlowable<Integer, String>, Flowable<String>>() {
 
             @Override
-            public Flowable<String> apply(final GroupedFlowable<Integer, String> o) {
+            public Flowable<String> apply(final GroupedFlowable<Integer, String> f) {
                 groupCounter.incrementAndGet();
-                return o.map(new Function<String, String>() {
+                return f.map(new Function<String, String>() {
 
                     @Override
                     public String apply(String v) {
-                        return "Event => key: " + o.getKey() + " value: " + v;
+                        return "Event => key: " + f.getKey() + " value: " + v;
                     }
                 });
             }
@@ -133,7 +133,8 @@ public class FlowableGroupByTest {
 
             @Override
             public void onError(Throwable e) {
-//                e.printStackTrace();                error.set(e);
+//                e.printStackTrace();
+                error.set(e);
             }
 
             @Override
@@ -151,20 +152,20 @@ public class FlowableGroupByTest {
         assertEquals(error.get().getMessage(), "forced failure");
     }
 
-    private static <K, V> Map<K, Collection<V>> toMap(Flowable<GroupedFlowable<K, V>> observable) {
+    private static <K, V> Map<K, Collection<V>> toMap(Flowable<GroupedFlowable<K, V>> flowable) {
 
         final ConcurrentHashMap<K, Collection<V>> result = new ConcurrentHashMap<K, Collection<V>>();
 
-        observable.blockingForEach(new Consumer<GroupedFlowable<K, V>>() {
+        flowable.blockingForEach(new Consumer<GroupedFlowable<K, V>>() {
 
             @Override
-            public void accept(final GroupedFlowable<K, V> o) {
-                result.put(o.getKey(), new ConcurrentLinkedQueue<V>());
-                o.subscribe(new Consumer<V>() {
+            public void accept(final GroupedFlowable<K, V> f) {
+                result.put(f.getKey(), new ConcurrentLinkedQueue<V>());
+                f.subscribe(new Consumer<V>() {
 
                     @Override
                     public void accept(V v) {
-                        result.get(o.getKey()).add(v);
+                        result.get(f.getKey()).add(v);
                     }
 
                 });
@@ -192,8 +193,8 @@ public class FlowableGroupByTest {
         Flowable<Event> es = Flowable.unsafeCreate(new Publisher<Event>() {
 
             @Override
-            public void subscribe(final Subscriber<? super Event> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(final Subscriber<? super Event> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 System.out.println("*** Subscribing to EventStream ***");
                 subscribeCounter.incrementAndGet();
                 new Thread(new Runnable() {
@@ -204,9 +205,9 @@ public class FlowableGroupByTest {
                             Event e = new Event();
                             e.source = i % groupCount;
                             e.message = "Event-" + i;
-                            observer.onNext(e);
+                            subscriber.onNext(e);
                         }
-                        observer.onComplete();
+                        subscriber.onComplete();
                     }
 
                 }).start();
@@ -999,16 +1000,16 @@ public class FlowableGroupByTest {
         Flowable<GroupedFlowable<Boolean, Long>> stream = source.groupBy(IS_EVEN);
 
         // create two observers
-        Subscriber<GroupedFlowable<Boolean, Long>> o1 = TestHelper.mockSubscriber();
-        Subscriber<GroupedFlowable<Boolean, Long>> o2 = TestHelper.mockSubscriber();
+        Subscriber<GroupedFlowable<Boolean, Long>> f1 = TestHelper.mockSubscriber();
+        Subscriber<GroupedFlowable<Boolean, Long>> f2 = TestHelper.mockSubscriber();
 
         // subscribe with the observers
-        stream.subscribe(o1);
-        stream.subscribe(o2);
+        stream.subscribe(f1);
+        stream.subscribe(f2);
 
         // check that subscriptions were successful
-        verify(o1, never()).onError(Mockito.<Throwable> any());
-        verify(o2, never()).onError(Mockito.<Throwable> any());
+        verify(f1, never()).onError(Mockito.<Throwable> any());
+        verify(f2, never()).onError(Mockito.<Throwable> any());
     }
 
     private static Function<Long, Boolean> IS_EVEN = new Function<Long, Boolean>() {
@@ -1226,13 +1227,13 @@ public class FlowableGroupByTest {
 
         inner.get().subscribe();
 
-        Subscriber<Integer> o2 = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber2 = TestHelper.mockSubscriber();
 
-        inner.get().subscribe(o2);
+        inner.get().subscribe(subscriber2);
 
-        verify(o2, never()).onComplete();
-        verify(o2, never()).onNext(anyInt());
-        verify(o2).onError(any(IllegalStateException.class));
+        verify(subscriber2, never()).onComplete();
+        verify(subscriber2, never()).onNext(anyInt());
+        verify(subscriber2).onError(any(IllegalStateException.class));
     }
 
     @Test
@@ -1384,7 +1385,7 @@ public class FlowableGroupByTest {
     @Test
     public void testGroupByUnsubscribe() {
         final Subscription s = mock(Subscription.class);
-        Flowable<Integer> o = Flowable.unsafeCreate(
+        Flowable<Integer> f = Flowable.unsafeCreate(
                 new Publisher<Integer>() {
                     @Override
                     public void subscribe(Subscriber<? super Integer> subscriber) {
@@ -1394,7 +1395,7 @@ public class FlowableGroupByTest {
         );
         TestSubscriber<Object> ts = new TestSubscriber<Object>();
 
-        o.groupBy(new Function<Integer, Integer>() {
+        f.groupBy(new Function<Integer, Integer>() {
 
             @Override
             public Integer apply(Integer integer) {
@@ -1425,11 +1426,11 @@ public class FlowableGroupByTest {
             }
 
             @Override
-            public void onNext(GroupedFlowable<Integer, Integer> o) {
-                if (o.getKey() == 0) {
-                    o.subscribe(inner1);
+            public void onNext(GroupedFlowable<Integer, Integer> f) {
+                if (f.getKey() == 0) {
+                    f.subscribe(inner1);
                 } else {
-                    o.subscribe(inner2);
+                    f.subscribe(inner2);
                 }
             }
         });

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -102,7 +102,7 @@ public class FlowableGroupByTest {
     @Test
     public void testError() {
         Flowable<String> sourceStrings = Flowable.just("one", "two", "three", "four", "five", "six");
-        Flowable<String> errorSource = Flowable.error(new RuntimeException("forced failure"));
+        Flowable<String> errorSource = Flowable.error(new TestException("forced failure"));
         Flowable<String> source = Flowable.concat(sourceStrings, errorSource);
 
         Flowable<GroupedFlowable<Integer, String>> grouped = source.groupBy(length);
@@ -133,8 +133,7 @@ public class FlowableGroupByTest {
 
             @Override
             public void onError(Throwable e) {
-                e.printStackTrace();
-                error.set(e);
+//                e.printStackTrace();                error.set(e);
             }
 
             @Override
@@ -148,6 +147,8 @@ public class FlowableGroupByTest {
         assertEquals(3, groupCounter.get());
         assertEquals(6, eventCounter.get());
         assertNotNull(error.get());
+        assertTrue("" + error.get(), error.get() instanceof TestException);
+        assertEquals(error.get().getMessage(), "forced failure");
     }
 
     private static <K, V> Map<K, Collection<V>> toMap(Flowable<GroupedFlowable<K, V>> observable) {
@@ -998,10 +999,8 @@ public class FlowableGroupByTest {
         Flowable<GroupedFlowable<Boolean, Long>> stream = source.groupBy(IS_EVEN);
 
         // create two observers
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<GroupedFlowable<Boolean, Long>> o1 = mock(DefaultSubscriber.class);
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<GroupedFlowable<Boolean, Long>> o2 = mock(DefaultSubscriber.class);
+        Subscriber<GroupedFlowable<Boolean, Long>> o1 = TestHelper.mockSubscriber();
+        Subscriber<GroupedFlowable<Boolean, Long>> o2 = TestHelper.mockSubscriber();
 
         // subscribe with the observers
         stream.subscribe(o1);
@@ -1227,8 +1226,7 @@ public class FlowableGroupByTest {
 
         inner.get().subscribe();
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<Integer> o2 = mock(DefaultSubscriber.class);
+        Subscriber<Integer> o2 = TestHelper.mockSubscriber();
 
         inner.get().subscribe(o2);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -36,7 +36,7 @@ import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableGroupJoinTest {
 
-    Subscriber<Object> observer = TestHelper.mockSubscriber();
+    Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
     BiFunction<Integer, Integer, Integer> add = new BiFunction<Integer, Integer, Integer>() {
         @Override
@@ -90,7 +90,7 @@ public class FlowableGroupJoinTest {
                 just(Flowable.never()),
                 just(Flowable.never()), add2));
 
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
         source1.onNext(2);
@@ -103,18 +103,18 @@ public class FlowableGroupJoinTest {
         source1.onComplete();
         source2.onComplete();
 
-        verify(observer, times(1)).onNext(17);
-        verify(observer, times(1)).onNext(18);
-        verify(observer, times(1)).onNext(20);
-        verify(observer, times(1)).onNext(33);
-        verify(observer, times(1)).onNext(34);
-        verify(observer, times(1)).onNext(36);
-        verify(observer, times(1)).onNext(65);
-        verify(observer, times(1)).onNext(66);
-        verify(observer, times(1)).onNext(68);
+        verify(subscriber, times(1)).onNext(17);
+        verify(subscriber, times(1)).onNext(18);
+        verify(subscriber, times(1)).onNext(20);
+        verify(subscriber, times(1)).onNext(33);
+        verify(subscriber, times(1)).onNext(34);
+        verify(subscriber, times(1)).onNext(36);
+        verify(subscriber, times(1)).onNext(65);
+        verify(subscriber, times(1)).onNext(66);
+        verify(subscriber, times(1)).onNext(68);
 
-        verify(observer, times(1)).onComplete(); //Never emitted?
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete(); //Never emitted?
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     class Person {
@@ -184,19 +184,19 @@ public class FlowableGroupJoinTest {
                         }).subscribe(new Consumer<PersonFruit>() {
                             @Override
                             public void accept(PersonFruit t1) {
-                                observer.onNext(Arrays.asList(ppf.person.name, t1.fruit));
+                                subscriber.onNext(Arrays.asList(ppf.person.name, t1.fruit));
                             }
                         });
                     }
 
                     @Override
                     public void onError(Throwable e) {
-                        observer.onError(e);
+                        subscriber.onError(e);
                     }
 
                     @Override
                     public void onComplete() {
-                        observer.onComplete();
+                        subscriber.onComplete();
                     }
 
                     @Override
@@ -207,12 +207,12 @@ public class FlowableGroupJoinTest {
                 }
                 );
 
-        verify(observer, times(1)).onNext(Arrays.asList("Joe", "Strawberry"));
-        verify(observer, times(1)).onNext(Arrays.asList("Joe", "Apple"));
-        verify(observer, times(1)).onNext(Arrays.asList("Charlie", "Peach"));
+        verify(subscriber, times(1)).onNext(Arrays.asList("Joe", "Strawberry"));
+        verify(subscriber, times(1)).onNext(Arrays.asList("Joe", "Apple"));
+        verify(subscriber, times(1)).onNext(Arrays.asList("Charlie", "Peach"));
 
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -224,14 +224,14 @@ public class FlowableGroupJoinTest {
                 just(Flowable.never()),
                 just(Flowable.never()), add2);
 
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source2.onNext(1);
         source1.onError(new RuntimeException("Forced failure"));
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -243,14 +243,14 @@ public class FlowableGroupJoinTest {
                 just(Flowable.never()),
                 just(Flowable.never()), add2);
 
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
         source2.onError(new RuntimeException("Forced failure"));
 
-        verify(observer, times(1)).onNext(any(Flowable.class));
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
+        verify(subscriber, times(1)).onNext(any(Flowable.class));
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -263,13 +263,13 @@ public class FlowableGroupJoinTest {
         Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
                 just(duration1),
                 just(Flowable.never()), add2);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -282,13 +282,13 @@ public class FlowableGroupJoinTest {
         Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
                 just(Flowable.never()),
                 just(duration1), add2);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source2.onNext(1);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -306,13 +306,13 @@ public class FlowableGroupJoinTest {
         Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
                 fail,
                 just(Flowable.never()), add2);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -330,13 +330,13 @@ public class FlowableGroupJoinTest {
         Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
                 just(Flowable.never()),
                 fail, add2);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source2.onNext(1);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -354,14 +354,14 @@ public class FlowableGroupJoinTest {
         Flowable<Integer> m = source1.groupJoin(source2,
                 just(Flowable.never()),
                 just(Flowable.never()), fail);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
         source2.onNext(2);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -478,31 +478,38 @@ public class FlowableGroupJoinTest {
 
     @Test
     public void innerErrorRight() {
-        Flowable.just(1)
-        .groupJoin(
-            Flowable.just(2),
-            new Function<Integer, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Integer left) throws Exception {
-                    return Flowable.never();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable.just(1)
+            .groupJoin(
+                Flowable.just(2),
+                new Function<Integer, Flowable<Object>>() {
+                    @Override
+                    public Flowable<Object> apply(Integer left) throws Exception {
+                        return Flowable.never();
+                    }
+                },
+                new Function<Integer, Flowable<Object>>() {
+                    @Override
+                    public Flowable<Object> apply(Integer right) throws Exception {
+                        return Flowable.error(new TestException());
+                    }
+                },
+                new BiFunction<Integer, Flowable<Integer>, Flowable<Integer>>() {
+                    @Override
+                    public Flowable<Integer> apply(Integer r, Flowable<Integer> l) throws Exception {
+                        return l;
+                    }
                 }
-            },
-            new Function<Integer, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Integer right) throws Exception {
-                    return Flowable.error(new TestException());
-                }
-            },
-            new BiFunction<Integer, Flowable<Integer>, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer r, Flowable<Integer> l) throws Exception {
-                    return l;
-                }
-            }
-        )
-        .flatMap(Functions.<Flowable<Integer>>identity())
-        .test()
-        .assertFailure(TestException.class);
+            )
+            .flatMap(Functions.<Flowable<Integer>>identity())
+            .test()
+            .assertFailure(TestException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -45,20 +45,20 @@ public class FlowableGroupJoinTest {
         }
     };
 
-    <T> Function<Integer, Flowable<T>> just(final Flowable<T> observable) {
+    <T> Function<Integer, Flowable<T>> just(final Flowable<T> flowable) {
         return new Function<Integer, Flowable<T>>() {
             @Override
             public Flowable<T> apply(Integer t1) {
-                return observable;
+                return flowable;
             }
         };
     }
 
-    <T, R> Function<T, Flowable<R>> just2(final Flowable<R> observable) {
+    <T, R> Function<T, Flowable<R>> just2(final Flowable<R> flowable) {
         return new Function<T, Flowable<R>>() {
             @Override
             public Flowable<R> apply(T t1) {
-                return observable;
+                return flowable;
             }
         };
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableHideTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableHideTest.java
@@ -34,16 +34,16 @@ public class FlowableHideTest {
 
         assertFalse(dst instanceof PublishProcessor);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        dst.subscribe(o);
+        dst.subscribe(subscriber);
 
         src.onNext(1);
         src.onComplete();
 
-        verify(o).onNext(1);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(1);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -54,24 +54,24 @@ public class FlowableHideTest {
 
         assertFalse(dst instanceof PublishProcessor);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        dst.subscribe(o);
+        dst.subscribe(subscriber);
 
         src.onError(new TestException());
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
     }
 
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o)
+            public Flowable<Object> apply(Flowable<Object> f)
                     throws Exception {
-                return o.hide();
+                return f.hide();
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -330,17 +330,17 @@ public class FlowableIgnoreElementsTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o)
+            public Flowable<Object> apply(Flowable<Object> f)
                     throws Exception {
-                return o.ignoreElements().toFlowable();
+                return f.ignoreElements().toFlowable();
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowableToCompletable(new Function<Flowable<Object>, Completable>() {
             @Override
-            public Completable apply(Flowable<Object> o)
+            public Completable apply(Flowable<Object> f)
                     throws Exception {
-                return o.ignoreElements();
+                return f.ignoreElements();
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
@@ -34,7 +34,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableJoinTest {
-    Subscriber<Object> observer = TestHelper.mockSubscriber();
+    Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
     BiFunction<Integer, Integer, Integer> add = new BiFunction<Integer, Integer, Integer>() {
         @Override
@@ -66,7 +66,7 @@ public class FlowableJoinTest {
                 just(Flowable.never()),
                 just(Flowable.never()), add);
 
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
         source1.onNext(2);
@@ -79,18 +79,18 @@ public class FlowableJoinTest {
         source1.onComplete();
         source2.onComplete();
 
-        verify(observer, times(1)).onNext(17);
-        verify(observer, times(1)).onNext(18);
-        verify(observer, times(1)).onNext(20);
-        verify(observer, times(1)).onNext(33);
-        verify(observer, times(1)).onNext(34);
-        verify(observer, times(1)).onNext(36);
-        verify(observer, times(1)).onNext(65);
-        verify(observer, times(1)).onNext(66);
-        verify(observer, times(1)).onNext(68);
+        verify(subscriber, times(1)).onNext(17);
+        verify(subscriber, times(1)).onNext(18);
+        verify(subscriber, times(1)).onNext(20);
+        verify(subscriber, times(1)).onNext(33);
+        verify(subscriber, times(1)).onNext(34);
+        verify(subscriber, times(1)).onNext(36);
+        verify(subscriber, times(1)).onNext(65);
+        verify(subscriber, times(1)).onNext(66);
+        verify(subscriber, times(1)).onNext(68);
 
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class FlowableJoinTest {
         Flowable<Integer> m = source1.join(source2,
                 just(duration1),
                 just(Flowable.never()), add);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
         source1.onNext(2);
@@ -117,13 +117,13 @@ public class FlowableJoinTest {
         source1.onComplete();
         source2.onComplete();
 
-        verify(observer, times(1)).onNext(17);
-        verify(observer, times(1)).onNext(18);
-        verify(observer, times(1)).onNext(20);
-        verify(observer, times(1)).onNext(24);
+        verify(subscriber, times(1)).onNext(17);
+        verify(subscriber, times(1)).onNext(18);
+        verify(subscriber, times(1)).onNext(20);
+        verify(subscriber, times(1)).onNext(24);
 
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
     }
 
@@ -136,7 +136,7 @@ public class FlowableJoinTest {
                 just(Flowable.never()),
                 just(Flowable.never()), add);
 
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
         source1.onNext(2);
@@ -148,15 +148,15 @@ public class FlowableJoinTest {
 
         source2.onComplete();
 
-        verify(observer, times(1)).onNext(17);
-        verify(observer, times(1)).onNext(18);
-        verify(observer, times(1)).onNext(33);
-        verify(observer, times(1)).onNext(34);
-        verify(observer, times(1)).onNext(65);
-        verify(observer, times(1)).onNext(66);
+        verify(subscriber, times(1)).onNext(17);
+        verify(subscriber, times(1)).onNext(18);
+        verify(subscriber, times(1)).onNext(33);
+        verify(subscriber, times(1)).onNext(34);
+        verify(subscriber, times(1)).onNext(65);
+        verify(subscriber, times(1)).onNext(66);
 
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -168,14 +168,14 @@ public class FlowableJoinTest {
                 just(Flowable.never()),
                 just(Flowable.never()), add);
 
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source2.onNext(1);
         source1.onError(new RuntimeException("Forced failure"));
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -187,14 +187,14 @@ public class FlowableJoinTest {
                 just(Flowable.never()),
                 just(Flowable.never()), add);
 
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
         source2.onError(new RuntimeException("Forced failure"));
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -207,13 +207,13 @@ public class FlowableJoinTest {
         Flowable<Integer> m = source1.join(source2,
                 just(duration1),
                 just(Flowable.never()), add);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -226,13 +226,13 @@ public class FlowableJoinTest {
         Flowable<Integer> m = source1.join(source2,
                 just(Flowable.never()),
                 just(duration1), add);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source2.onNext(1);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -250,13 +250,13 @@ public class FlowableJoinTest {
         Flowable<Integer> m = source1.join(source2,
                 fail,
                 just(Flowable.never()), add);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -274,13 +274,13 @@ public class FlowableJoinTest {
         Flowable<Integer> m = source1.join(source2,
                 just(Flowable.never()),
                 fail, add);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source2.onNext(1);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -298,14 +298,14 @@ public class FlowableJoinTest {
         Flowable<Integer> m = source1.join(source2,
                 just(Flowable.never()),
                 just(Flowable.never()), fail);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source1.onNext(1);
         source2.onNext(2);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
@@ -43,11 +43,11 @@ public class FlowableJoinTest {
         }
     };
 
-    <T> Function<Integer, Flowable<T>> just(final Flowable<T> observable) {
+    <T> Function<Integer, Flowable<T>> just(final Flowable<T> flowable) {
         return new Function<Integer, Flowable<T>>() {
             @Override
             public Flowable<T> apply(Integer t1) {
-                return observable;
+                return flowable;
             }
         };
     }
@@ -386,10 +386,10 @@ public class FlowableJoinTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onError(new TestException("First"));
-                    observer.onError(new TestException("Second"));
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onError(new TestException("First"));
+                    subscriber.onError(new TestException("Second"));
                 }
             }
             .join(Flowable.just(2),
@@ -422,10 +422,10 @@ public class FlowableJoinTest {
                     Functions.justFunction(Flowable.never()),
                     Functions.justFunction(new Flowable<Integer>() {
                         @Override
-                        protected void subscribeActual(Subscriber<? super Integer> observer) {
-                            o[0] = observer;
-                            observer.onSubscribe(new BooleanSubscription());
-                            observer.onError(new TestException("First"));
+                        protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                            o[0] = subscriber;
+                            subscriber.onSubscribe(new BooleanSubscription());
+                            subscriber.onError(new TestException("First"));
                         }
                     }),
                     new BiFunction<Integer, Integer, Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableLastTest.java
@@ -53,10 +53,10 @@ public class FlowableLastTest {
 
     @Test
     public void testLast() {
-        Maybe<Integer> observable = Flowable.just(1, 2, 3).lastElement();
+        Maybe<Integer> maybe = Flowable.just(1, 2, 3).lastElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(3);
@@ -66,10 +66,10 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithOneElement() {
-        Maybe<Integer> observable = Flowable.just(1).lastElement();
+        Maybe<Integer> maybe = Flowable.just(1).lastElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(1);
@@ -79,10 +79,10 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithEmpty() {
-        Maybe<Integer> observable = Flowable.<Integer> empty().lastElement();
+        Maybe<Integer> maybe = Flowable.<Integer> empty().lastElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer).onComplete();
@@ -92,7 +92,7 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithPredicate() {
-        Maybe<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
+        Maybe<Integer> maybe = Flowable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
 
                     @Override
@@ -103,7 +103,7 @@ public class FlowableLastTest {
                 .lastElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(6);
@@ -113,7 +113,7 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithPredicateAndOneElement() {
-        Maybe<Integer> observable = Flowable.just(1, 2)
+        Maybe<Integer> maybe = Flowable.just(1, 2)
             .filter(
                 new Predicate<Integer>() {
 
@@ -125,7 +125,7 @@ public class FlowableLastTest {
             .lastElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(2);
@@ -135,7 +135,7 @@ public class FlowableLastTest {
 
     @Test
     public void testLastWithPredicateAndEmpty() {
-        Maybe<Integer> observable = Flowable.just(1)
+        Maybe<Integer> maybe = Flowable.just(1)
             .filter(
                 new Predicate<Integer>() {
 
@@ -146,7 +146,7 @@ public class FlowableLastTest {
                 }).lastElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer).onComplete();
@@ -156,11 +156,11 @@ public class FlowableLastTest {
 
     @Test
     public void testLastOrDefault() {
-        Single<Integer> observable = Flowable.just(1, 2, 3)
+        Single<Integer> single = Flowable.just(1, 2, 3)
                 .last(4);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(3);
@@ -170,10 +170,10 @@ public class FlowableLastTest {
 
     @Test
     public void testLastOrDefaultWithOneElement() {
-        Single<Integer> observable = Flowable.just(1).last(2);
+        Single<Integer> single = Flowable.just(1).last(2);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(1);
@@ -183,11 +183,11 @@ public class FlowableLastTest {
 
     @Test
     public void testLastOrDefaultWithEmpty() {
-        Single<Integer> observable = Flowable.<Integer> empty()
+        Single<Integer> single = Flowable.<Integer> empty()
                 .last(1);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(1);
@@ -197,7 +197,7 @@ public class FlowableLastTest {
 
     @Test
     public void testLastOrDefaultWithPredicate() {
-        Single<Integer> observable = Flowable.just(1, 2, 3, 4, 5, 6)
+        Single<Integer> single = Flowable.just(1, 2, 3, 4, 5, 6)
                 .filter(new Predicate<Integer>() {
 
                     @Override
@@ -208,7 +208,7 @@ public class FlowableLastTest {
                 .last(8);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(6);
@@ -218,7 +218,7 @@ public class FlowableLastTest {
 
     @Test
     public void testLastOrDefaultWithPredicateAndOneElement() {
-        Single<Integer> observable = Flowable.just(1, 2)
+        Single<Integer> single = Flowable.just(1, 2)
                 .filter(new Predicate<Integer>() {
 
                     @Override
@@ -229,7 +229,7 @@ public class FlowableLastTest {
                 .last(4);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(2);
@@ -239,7 +239,7 @@ public class FlowableLastTest {
 
     @Test
     public void testLastOrDefaultWithPredicateAndEmpty() {
-        Single<Integer> observable = Flowable.just(1)
+        Single<Integer> single = Flowable.just(1)
                 .filter(
                 new Predicate<Integer>() {
 
@@ -251,7 +251,7 @@ public class FlowableLastTest {
                 .last(2);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(2);
@@ -312,40 +312,40 @@ public class FlowableLastTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowableToMaybe(new Function<Flowable<Object>, MaybeSource<Object>>() {
             @Override
-            public MaybeSource<Object> apply(Flowable<Object> o) throws Exception {
-                return o.lastElement();
+            public MaybeSource<Object> apply(Flowable<Object> f) throws Exception {
+                return f.lastElement();
             }
         });
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.lastElement().toFlowable();
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.lastElement().toFlowable();
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, SingleSource<Object>>() {
             @Override
-            public SingleSource<Object> apply(Flowable<Object> o) throws Exception {
-                return o.lastOrError();
+            public SingleSource<Object> apply(Flowable<Object> f) throws Exception {
+                return f.lastOrError();
             }
         });
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.lastOrError().toFlowable();
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.lastOrError().toFlowable();
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, SingleSource<Object>>() {
             @Override
-            public SingleSource<Object> apply(Flowable<Object> o) throws Exception {
-                return o.last(2);
+            public SingleSource<Object> apply(Flowable<Object> f) throws Exception {
+                return f.last(2);
             }
         });
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.last(2).toFlowable();
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.last(2).toFlowable();
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableLiftTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableLiftTest.java
@@ -33,7 +33,7 @@ public class FlowableLiftTest {
             Flowable.just(1)
             .lift(new FlowableOperator<Object, Integer>() {
                 @Override
-                public Subscriber<? super Integer> apply(Subscriber<? super Object> o) throws Exception {
+                public Subscriber<? super Integer> apply(Subscriber<? super Object> subscriber) throws Exception {
                     throw new TestException();
                 }
             })

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableLiftTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableLiftTest.java
@@ -15,16 +15,20 @@ package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;
 
+import java.util.List;
+
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public class FlowableLiftTest {
 
     @Test
     public void callbackCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.just(1)
             .lift(new FlowableOperator<Object, Integer>() {
@@ -37,6 +41,9 @@ public class FlowableLiftTest {
             fail("Should have thrown");
         } catch (NullPointerException ex) {
             assertTrue(ex.toString(), ex.getCause() instanceof TestException);
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapNotificationTest.java
@@ -153,9 +153,9 @@ public class FlowableMapNotificationTest {
         TestHelper.checkDisposed(new Flowable<Integer>() {
             @SuppressWarnings({ "rawtypes", "unchecked" })
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 MapNotificationSubscriber mn = new MapNotificationSubscriber(
-                        observer,
+                        subscriber,
                         Functions.justFunction(Flowable.just(1)),
                         Functions.justFunction(Flowable.just(2)),
                         Functions.justCallable(Flowable.just(3))
@@ -169,8 +169,8 @@ public class FlowableMapNotificationTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Flowable<Object> o) throws Exception {
-                return o.flatMap(
+            public Flowable<Integer> apply(Flowable<Object> f) throws Exception {
+                return f.flatMap(
                         Functions.justFunction(Flowable.just(1)),
                         Functions.justFunction(Flowable.just(2)),
                         Functions.justCallable(Flowable.just(3))

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
@@ -155,12 +155,14 @@ public class FlowableMapTest {
 
     @Test
     public void testMapWithError() {
+        final List<Throwable> errors = new ArrayList<Throwable>();
+
         Flowable<String> w = Flowable.just("one", "fail", "two", "three", "fail");
         Flowable<String> m = w.map(new Function<String, String>() {
             @Override
             public String apply(String s) {
                 if ("fail".equals(s)) {
-                    throw new RuntimeException("Forced Failure");
+                    throw new TestException("Forced Failure");
                 }
                 return s;
             }
@@ -168,7 +170,7 @@ public class FlowableMapTest {
 
             @Override
             public void accept(Throwable t1) {
-                t1.printStackTrace();
+                errors.add(t1);
             }
 
         });
@@ -178,7 +180,9 @@ public class FlowableMapTest {
         verify(stringSubscriber, never()).onNext("two");
         verify(stringSubscriber, never()).onNext("three");
         verify(stringSubscriber, never()).onComplete();
-        verify(stringSubscriber, times(1)).onError(any(Throwable.class));
+        verify(stringSubscriber, times(1)).onError(any(TestException.class));
+
+        TestHelper.assertError(errors, 0, TestException.class, "Forced Failure");
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
@@ -57,9 +57,9 @@ public class FlowableMapTest {
     public void testMap() {
         Map<String, String> m1 = getMap("One");
         Map<String, String> m2 = getMap("Two");
-        Flowable<Map<String, String>> observable = Flowable.just(m1, m2);
+        Flowable<Map<String, String>> flowable = Flowable.just(m1, m2);
 
-        Flowable<String> m = observable.map(new Function<Map<String, String>, String>() {
+        Flowable<String> m = flowable.map(new Function<Map<String, String>, String>() {
             @Override
             public String apply(Map<String, String> map) {
                 return map.get("firstName");
@@ -120,19 +120,19 @@ public class FlowableMapTest {
     public void testMapMany2() {
         Map<String, String> m1 = getMap("One");
         Map<String, String> m2 = getMap("Two");
-        Flowable<Map<String, String>> observable1 = Flowable.just(m1, m2);
+        Flowable<Map<String, String>> flowable1 = Flowable.just(m1, m2);
 
         Map<String, String> m3 = getMap("Three");
         Map<String, String> m4 = getMap("Four");
-        Flowable<Map<String, String>> observable2 = Flowable.just(m3, m4);
+        Flowable<Map<String, String>> flowable2 = Flowable.just(m3, m4);
 
-        Flowable<Flowable<Map<String, String>>> observable = Flowable.just(observable1, observable2);
+        Flowable<Flowable<Map<String, String>>> f = Flowable.just(flowable1, flowable2);
 
-        Flowable<String> m = observable.flatMap(new Function<Flowable<Map<String, String>>, Flowable<String>>() {
+        Flowable<String> m = f.flatMap(new Function<Flowable<Map<String, String>>, Flowable<String>>() {
 
             @Override
-            public Flowable<String> apply(Flowable<Map<String, String>> o) {
-                return o.map(new Function<Map<String, String>, String>() {
+            public Flowable<String> apply(Flowable<Map<String, String>> f) {
+                return f.map(new Function<Map<String, String>, String>() {
 
                     @Override
                     public String apply(Map<String, String> map) {
@@ -295,11 +295,11 @@ public class FlowableMapTest {
 //        Flowable.OnSubscribe<Object> creator = new Flowable.OnSubscribe<Object>() {
 //
 //            @Override
-//            public void call(Subscriber<? super Object> observer) {
-//                observer.onNext("a");
-//                observer.onNext("b");
-//                observer.onNext("c");
-//                observer.onComplete();
+//            public void call(Subscriber<? super Object> subscriber) {
+//                subscriber.onNext("a");
+//                subscriber.onNext("b");
+//                subscriber.onNext("c");
+//                subscriber.onComplete();
 //            }
 //        };
 //
@@ -634,8 +634,8 @@ public class FlowableMapTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.map(Functions.identity());
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.map(Functions.identity());
             }
         });
     }
@@ -684,8 +684,8 @@ public class FlowableMapTest {
     public void badSource() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
             @Override
-            public Object apply(Flowable<Object> o) throws Exception {
-                return o.map(Functions.identity());
+            public Object apply(Flowable<Object> f) throws Exception {
+                return f.map(Functions.identity());
             }
         }, false, 1, 1, 1);
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
@@ -233,8 +233,8 @@ public class FlowableMaterializeTest {
         volatile Thread t;
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        public void subscribe(final Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -247,14 +247,14 @@ public class FlowableMaterializeTest {
                             } catch (Throwable e) {
 
                             }
-                            observer.onError(new NullPointerException());
+                            subscriber.onError(new NullPointerException());
                             return;
                         } else {
-                            observer.onNext(s);
+                            subscriber.onNext(s);
                         }
                     }
                     System.out.println("subscription complete");
-                    observer.onComplete();
+                    subscriber.onComplete();
                 }
 
             });
@@ -290,8 +290,8 @@ public class FlowableMaterializeTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Notification<Object>>>() {
             @Override
-            public Flowable<Notification<Object>> apply(Flowable<Object> o) throws Exception {
-                return o.materialize();
+            public Flowable<Notification<Object>> apply(Flowable<Object> f) throws Exception {
+                return f.materialize();
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -43,10 +43,10 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed1() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
 
-        Flowable<String> m = Flowable.mergeDelayError(o1, o2);
+        Flowable<String> m = Flowable.mergeDelayError(f1, f2);
         m.subscribe(stringSubscriber);
 
         verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
@@ -64,12 +64,12 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed2() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Flowable<String> o3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight", null));
-        final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> f3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight", null));
+        final Flowable<String> f4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));
 
-        Flowable<String> m = Flowable.mergeDelayError(o1, o2, o3, o4);
+        Flowable<String> m = Flowable.mergeDelayError(f1, f2, f3, f4);
         m.subscribe(stringSubscriber);
 
         verify(stringSubscriber, times(1)).onError(any(CompositeException.class));
@@ -89,12 +89,12 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed3() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("four", "five", "six"));
-        final Flowable<String> o3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight", null));
-        final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("four", "five", "six"));
+        final Flowable<String> f3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight", null));
+        final Flowable<String> f4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));
 
-        Flowable<String> m = Flowable.mergeDelayError(o1, o2, o3, o4);
+        Flowable<String> m = Flowable.mergeDelayError(f1, f2, f3, f4);
         m.subscribe(stringSubscriber);
 
         verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
@@ -112,12 +112,12 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed4() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("four", "five", "six"));
-        final Flowable<String> o3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight"));
-        final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine", null));
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("four", "five", "six"));
+        final Flowable<String> f3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight"));
+        final Flowable<String> f4 = Flowable.unsafeCreate(new TestErrorFlowable("nine", null));
 
-        Flowable<String> m = Flowable.mergeDelayError(o1, o2, o3, o4);
+        Flowable<String> m = Flowable.mergeDelayError(f1, f2, f3, f4);
         m.subscribe(stringSubscriber);
 
         verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
@@ -135,20 +135,20 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testErrorDelayed4WithThreading() {
-        final TestAsyncErrorFlowable o1 = new TestAsyncErrorFlowable("one", "two", "three");
-        final TestAsyncErrorFlowable o2 = new TestAsyncErrorFlowable("four", "five", "six");
-        final TestAsyncErrorFlowable o3 = new TestAsyncErrorFlowable("seven", "eight");
+        final TestAsyncErrorFlowable f1 = new TestAsyncErrorFlowable("one", "two", "three");
+        final TestAsyncErrorFlowable f2 = new TestAsyncErrorFlowable("four", "five", "six");
+        final TestAsyncErrorFlowable f3 = new TestAsyncErrorFlowable("seven", "eight");
         // throw the error at the very end so no onComplete will be called after it
-        final TestAsyncErrorFlowable o4 = new TestAsyncErrorFlowable("nine", null);
+        final TestAsyncErrorFlowable f4 = new TestAsyncErrorFlowable("nine", null);
 
-        Flowable<String> m = Flowable.mergeDelayError(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2), Flowable.unsafeCreate(o3), Flowable.unsafeCreate(o4));
+        Flowable<String> m = Flowable.mergeDelayError(Flowable.unsafeCreate(f1), Flowable.unsafeCreate(f2), Flowable.unsafeCreate(f3), Flowable.unsafeCreate(f4));
         m.subscribe(stringSubscriber);
 
         try {
-            o1.t.join();
-            o2.t.join();
-            o3.t.join();
-            o4.t.join();
+            f1.t.join();
+            f2.t.join();
+            f3.t.join();
+            f4.t.join();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -168,10 +168,10 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testCompositeErrorDelayed1() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", null));
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", null));
 
-        Flowable<String> m = Flowable.mergeDelayError(o1, o2);
+        Flowable<String> m = Flowable.mergeDelayError(f1, f2);
         m.subscribe(stringSubscriber);
 
         verify(stringSubscriber, times(1)).onError(any(Throwable.class));
@@ -188,10 +188,10 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testCompositeErrorDelayed2() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", null));
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", null));
 
-        Flowable<String> m = Flowable.mergeDelayError(o1, o2);
+        Flowable<String> m = Flowable.mergeDelayError(f1, f2);
         CaptureObserver w = new CaptureObserver();
         m.subscribe(w);
 
@@ -218,18 +218,18 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testMergeFlowableOfFlowables() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
         Flowable<Flowable<String>> flowableOfFlowables = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
 
             @Override
-            public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 // simulate what would happen in a Flowable
-                observer.onNext(o1);
-                observer.onNext(o2);
-                observer.onComplete();
+                subscriber.onNext(f1);
+                subscriber.onNext(f2);
+                subscriber.onComplete();
             }
 
         });
@@ -243,10 +243,10 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testMergeArray() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
-        Flowable<String> m = Flowable.mergeDelayError(o1, o2);
+        Flowable<String> m = Flowable.mergeDelayError(f1, f2);
         m.subscribe(stringSubscriber);
 
         verify(stringSubscriber, never()).onError(any(Throwable.class));
@@ -256,11 +256,11 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testMergeList() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
         List<Flowable<String>> listOfFlowables = new ArrayList<Flowable<String>>();
-        listOfFlowables.add(o1);
-        listOfFlowables.add(o2);
+        listOfFlowables.add(f1);
+        listOfFlowables.add(f2);
 
         Flowable<String> m = Flowable.mergeDelayError(Flowable.fromIterable(listOfFlowables));
         m.subscribe(stringSubscriber);
@@ -272,15 +272,15 @@ public class FlowableMergeDelayErrorTest {
 
     @Test
     public void testMergeArrayWithThreading() {
-        final TestASynchronousFlowable o1 = new TestASynchronousFlowable();
-        final TestASynchronousFlowable o2 = new TestASynchronousFlowable();
+        final TestASynchronousFlowable f1 = new TestASynchronousFlowable();
+        final TestASynchronousFlowable f2 = new TestASynchronousFlowable();
 
-        Flowable<String> m = Flowable.mergeDelayError(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2));
+        Flowable<String> m = Flowable.mergeDelayError(Flowable.unsafeCreate(f1), Flowable.unsafeCreate(f2));
         m.subscribe(stringSubscriber);
 
         try {
-            o1.t.join();
-            o2.t.join();
+            f1.t.join();
+            f2.t.join();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -292,10 +292,10 @@ public class FlowableMergeDelayErrorTest {
 
     @Test(timeout = 1000L)
     public void testSynchronousError() {
-        final Flowable<Flowable<String>> o1 = Flowable.error(new RuntimeException("unit test"));
+        final Flowable<Flowable<String>> f1 = Flowable.error(new RuntimeException("unit test"));
 
         final CountDownLatch latch = new CountDownLatch(1);
-        Flowable.mergeDelayError(o1).subscribe(new DefaultSubscriber<String>() {
+        Flowable.mergeDelayError(f1).subscribe(new DefaultSubscriber<String>() {
             @Override
             public void onComplete() {
                 fail("Expected onError path");
@@ -322,10 +322,10 @@ public class FlowableMergeDelayErrorTest {
     private static class TestSynchronousFlowable implements Publisher<String> {
 
         @Override
-        public void subscribe(Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
-            observer.onNext("hello");
-            observer.onComplete();
+        public void subscribe(Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
+            subscriber.onNext("hello");
+            subscriber.onComplete();
         }
     }
 
@@ -333,14 +333,14 @@ public class FlowableMergeDelayErrorTest {
         Thread t;
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        public void subscribe(final Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override
                 public void run() {
-                    observer.onNext("hello");
-                    observer.onComplete();
+                    subscriber.onNext("hello");
+                    subscriber.onComplete();
                 }
 
             });
@@ -357,22 +357,22 @@ public class FlowableMergeDelayErrorTest {
         }
 
         @Override
-        public void subscribe(Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        public void subscribe(Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
             boolean errorThrown = false;
             for (String s : valuesToReturn) {
                 if (s == null) {
                     System.out.println("throwing exception");
-                    observer.onError(new NullPointerException());
+                    subscriber.onError(new NullPointerException());
                     errorThrown = true;
                     // purposefully not returning here so it will continue calling onNext
                     // so that we also test that we handle bad sequences like this
                 } else {
-                    observer.onNext(s);
+                    subscriber.onNext(s);
                 }
             }
             if (!errorThrown) {
-                observer.onComplete();
+                subscriber.onComplete();
             }
         }
     }
@@ -388,8 +388,8 @@ public class FlowableMergeDelayErrorTest {
         Thread t;
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        public void subscribe(final Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -402,14 +402,14 @@ public class FlowableMergeDelayErrorTest {
                             } catch (Throwable e) {
 
                             }
-                            observer.onError(new NullPointerException());
+                            subscriber.onError(new NullPointerException());
                             return;
                         } else {
-                            observer.onNext(s);
+                            subscriber.onNext(s);
                         }
                     }
                     System.out.println("subscription complete");
-                    observer.onComplete();
+                    subscriber.onComplete();
                 }
 
             });
@@ -455,8 +455,8 @@ public class FlowableMergeDelayErrorTest {
 
         Flowable<Integer> result = Flowable.mergeDelayError(source, Flowable.just(2));
 
-        final Subscriber<Integer> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
         result.subscribe(new DefaultSubscriber<Integer>() {
             int calls;
@@ -465,17 +465,17 @@ public class FlowableMergeDelayErrorTest {
                 if (calls++ == 0) {
                     throw new TestException();
                 }
-                o.onNext(t);
+                subscriber.onNext(t);
             }
 
             @Override
             public void onError(Throwable e) {
-                o.onError(e);
+                subscriber.onError(e);
             }
 
             @Override
             public void onComplete() {
-                o.onComplete();
+                subscriber.onComplete();
             }
 
         });
@@ -484,12 +484,12 @@ public class FlowableMergeDelayErrorTest {
          * If the child onNext throws, why would we keep accepting values from
          * other sources?
          */
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o, never()).onNext(0);
-        inOrder.verify(o, never()).onNext(1);
-        inOrder.verify(o, never()).onNext(anyInt());
-        inOrder.verify(o).onError(any(TestException.class));
-        verify(o, never()).onComplete();
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber, never()).onNext(0);
+        inOrder.verify(subscriber, never()).onNext(1);
+        inOrder.verify(subscriber, never()).onNext(anyInt());
+        inOrder.verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -509,14 +509,14 @@ public class FlowableMergeDelayErrorTest {
     @Test
     public void testErrorInParentFlowableDelayed() throws Exception {
         for (int i = 0; i < 50; i++) {
-            final TestASynchronous1sDelayedFlowable o1 = new TestASynchronous1sDelayedFlowable();
-            final TestASynchronous1sDelayedFlowable o2 = new TestASynchronous1sDelayedFlowable();
+            final TestASynchronous1sDelayedFlowable f1 = new TestASynchronous1sDelayedFlowable();
+            final TestASynchronous1sDelayedFlowable f2 = new TestASynchronous1sDelayedFlowable();
             Flowable<Flowable<String>> parentFlowable = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
                 @Override
                 public void subscribe(Subscriber<? super Flowable<String>> op) {
                     op.onSubscribe(new BooleanSubscription());
-                    op.onNext(Flowable.unsafeCreate(o1));
-                    op.onNext(Flowable.unsafeCreate(o2));
+                    op.onNext(Flowable.unsafeCreate(f1));
+                    op.onNext(Flowable.unsafeCreate(f2));
                     op.onError(new NullPointerException("throwing exception in parent"));
                 }
             });
@@ -540,8 +540,8 @@ public class FlowableMergeDelayErrorTest {
         Thread t;
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        public void subscribe(final Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -549,10 +549,10 @@ public class FlowableMergeDelayErrorTest {
                     try {
                         Thread.sleep(100);
                     } catch (InterruptedException e) {
-                        observer.onError(e);
+                        subscriber.onError(e);
                     }
-                    observer.onNext("hello");
-                    observer.onComplete();
+                    subscriber.onNext("hello");
+                    subscriber.onComplete();
                 }
 
             });
@@ -585,11 +585,11 @@ public class FlowableMergeDelayErrorTest {
     // This is pretty much a clone of testMergeList but with the overloaded MergeDelayError for Iterables
     @Test
     public void mergeIterable() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
         List<Flowable<String>> listOfFlowables = new ArrayList<Flowable<String>>();
-        listOfFlowables.add(o1);
-        listOfFlowables.add(o2);
+        listOfFlowables.add(f1);
+        listOfFlowables.add(f2);
 
         Flowable<String> m = Flowable.mergeDelayError(listOfFlowables);
         m.subscribe(stringSubscriber);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -34,11 +34,11 @@ import io.reactivex.subscribers.*;
 
 public class FlowableMergeDelayErrorTest {
 
-    Subscriber<String> stringObserver;
+    Subscriber<String> stringSubscriber;
 
     @Before
     public void before() {
-        stringObserver = TestHelper.mockSubscriber();
+        stringSubscriber = TestHelper.mockSubscriber();
     }
 
     @Test
@@ -47,18 +47,18 @@ public class FlowableMergeDelayErrorTest {
         final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
-        verify(stringObserver, never()).onComplete();
-        verify(stringObserver, times(1)).onNext("one");
-        verify(stringObserver, times(1)).onNext("two");
-        verify(stringObserver, times(1)).onNext("three");
-        verify(stringObserver, times(1)).onNext("four");
-        verify(stringObserver, times(0)).onNext("five");
+        verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
+        verify(stringSubscriber, never()).onComplete();
+        verify(stringSubscriber, times(1)).onNext("one");
+        verify(stringSubscriber, times(1)).onNext("two");
+        verify(stringSubscriber, times(1)).onNext("three");
+        verify(stringSubscriber, times(1)).onNext("four");
+        verify(stringSubscriber, times(0)).onNext("five");
         // despite not expecting it ... we don't do anything to prevent it if the source Flowable keeps sending after onError
         // inner Flowable errors are considered terminal for that source
-//        verify(stringObserver, times(1)).onNext("six");
+//        verify(stringSubscriber, times(1)).onNext("six");
         // inner Flowable errors are considered terminal for that source
     }
 
@@ -70,21 +70,21 @@ public class FlowableMergeDelayErrorTest {
         final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2, o3, o4);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, times(1)).onError(any(CompositeException.class));
-        verify(stringObserver, never()).onComplete();
-        verify(stringObserver, times(1)).onNext("one");
-        verify(stringObserver, times(1)).onNext("two");
-        verify(stringObserver, times(1)).onNext("three");
-        verify(stringObserver, times(1)).onNext("four");
-        verify(stringObserver, times(0)).onNext("five");
+        verify(stringSubscriber, times(1)).onError(any(CompositeException.class));
+        verify(stringSubscriber, never()).onComplete();
+        verify(stringSubscriber, times(1)).onNext("one");
+        verify(stringSubscriber, times(1)).onNext("two");
+        verify(stringSubscriber, times(1)).onNext("three");
+        verify(stringSubscriber, times(1)).onNext("four");
+        verify(stringSubscriber, times(0)).onNext("five");
         // despite not expecting it ... we don't do anything to prevent it if the source Flowable keeps sending after onError
         // inner Flowable errors are considered terminal for that source
-//        verify(stringObserver, times(1)).onNext("six");
-        verify(stringObserver, times(1)).onNext("seven");
-        verify(stringObserver, times(1)).onNext("eight");
-        verify(stringObserver, times(1)).onNext("nine");
+//        verify(stringSubscriber, times(1)).onNext("six");
+        verify(stringSubscriber, times(1)).onNext("seven");
+        verify(stringSubscriber, times(1)).onNext("eight");
+        verify(stringSubscriber, times(1)).onNext("nine");
     }
 
     @Test
@@ -95,19 +95,19 @@ public class FlowableMergeDelayErrorTest {
         final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2, o3, o4);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
-        verify(stringObserver, never()).onComplete();
-        verify(stringObserver, times(1)).onNext("one");
-        verify(stringObserver, times(1)).onNext("two");
-        verify(stringObserver, times(1)).onNext("three");
-        verify(stringObserver, times(1)).onNext("four");
-        verify(stringObserver, times(1)).onNext("five");
-        verify(stringObserver, times(1)).onNext("six");
-        verify(stringObserver, times(1)).onNext("seven");
-        verify(stringObserver, times(1)).onNext("eight");
-        verify(stringObserver, times(1)).onNext("nine");
+        verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
+        verify(stringSubscriber, never()).onComplete();
+        verify(stringSubscriber, times(1)).onNext("one");
+        verify(stringSubscriber, times(1)).onNext("two");
+        verify(stringSubscriber, times(1)).onNext("three");
+        verify(stringSubscriber, times(1)).onNext("four");
+        verify(stringSubscriber, times(1)).onNext("five");
+        verify(stringSubscriber, times(1)).onNext("six");
+        verify(stringSubscriber, times(1)).onNext("seven");
+        verify(stringSubscriber, times(1)).onNext("eight");
+        verify(stringSubscriber, times(1)).onNext("nine");
     }
 
     @Test
@@ -118,19 +118,19 @@ public class FlowableMergeDelayErrorTest {
         final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine", null));
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2, o3, o4);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
-        verify(stringObserver, never()).onComplete();
-        verify(stringObserver, times(1)).onNext("one");
-        verify(stringObserver, times(1)).onNext("two");
-        verify(stringObserver, times(1)).onNext("three");
-        verify(stringObserver, times(1)).onNext("four");
-        verify(stringObserver, times(1)).onNext("five");
-        verify(stringObserver, times(1)).onNext("six");
-        verify(stringObserver, times(1)).onNext("seven");
-        verify(stringObserver, times(1)).onNext("eight");
-        verify(stringObserver, times(1)).onNext("nine");
+        verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
+        verify(stringSubscriber, never()).onComplete();
+        verify(stringSubscriber, times(1)).onNext("one");
+        verify(stringSubscriber, times(1)).onNext("two");
+        verify(stringSubscriber, times(1)).onNext("three");
+        verify(stringSubscriber, times(1)).onNext("four");
+        verify(stringSubscriber, times(1)).onNext("five");
+        verify(stringSubscriber, times(1)).onNext("six");
+        verify(stringSubscriber, times(1)).onNext("seven");
+        verify(stringSubscriber, times(1)).onNext("eight");
+        verify(stringSubscriber, times(1)).onNext("nine");
     }
 
     @Test
@@ -142,7 +142,7 @@ public class FlowableMergeDelayErrorTest {
         final TestAsyncErrorFlowable o4 = new TestAsyncErrorFlowable("nine", null);
 
         Flowable<String> m = Flowable.mergeDelayError(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2), Flowable.unsafeCreate(o3), Flowable.unsafeCreate(o4));
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
         try {
             o1.t.join();
@@ -153,17 +153,17 @@ public class FlowableMergeDelayErrorTest {
             throw new RuntimeException(e);
         }
 
-        verify(stringObserver, times(1)).onNext("one");
-        verify(stringObserver, times(1)).onNext("two");
-        verify(stringObserver, times(1)).onNext("three");
-        verify(stringObserver, times(1)).onNext("four");
-        verify(stringObserver, times(1)).onNext("five");
-        verify(stringObserver, times(1)).onNext("six");
-        verify(stringObserver, times(1)).onNext("seven");
-        verify(stringObserver, times(1)).onNext("eight");
-        verify(stringObserver, times(1)).onNext("nine");
-        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
-        verify(stringObserver, never()).onComplete();
+        verify(stringSubscriber, times(1)).onNext("one");
+        verify(stringSubscriber, times(1)).onNext("two");
+        verify(stringSubscriber, times(1)).onNext("three");
+        verify(stringSubscriber, times(1)).onNext("four");
+        verify(stringSubscriber, times(1)).onNext("five");
+        verify(stringSubscriber, times(1)).onNext("six");
+        verify(stringSubscriber, times(1)).onNext("seven");
+        verify(stringSubscriber, times(1)).onNext("eight");
+        verify(stringSubscriber, times(1)).onNext("nine");
+        verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
+        verify(stringSubscriber, never()).onComplete();
     }
 
     @Test
@@ -172,18 +172,18 @@ public class FlowableMergeDelayErrorTest {
         final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", null));
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, times(1)).onError(any(Throwable.class));
-        verify(stringObserver, never()).onComplete();
-        verify(stringObserver, times(1)).onNext("one");
-        verify(stringObserver, times(1)).onNext("two");
-        verify(stringObserver, times(0)).onNext("three");
-        verify(stringObserver, times(1)).onNext("four");
-        verify(stringObserver, times(0)).onNext("five");
+        verify(stringSubscriber, times(1)).onError(any(Throwable.class));
+        verify(stringSubscriber, never()).onComplete();
+        verify(stringSubscriber, times(1)).onNext("one");
+        verify(stringSubscriber, times(1)).onNext("two");
+        verify(stringSubscriber, times(0)).onNext("three");
+        verify(stringSubscriber, times(1)).onNext("four");
+        verify(stringSubscriber, times(0)).onNext("five");
         // despite not expecting it ... we don't do anything to prevent it if the source Flowable keeps sending after onError
         // inner Flowable errors are considered terminal for that source
-//        verify(stringObserver, times(1)).onNext("six");
+//        verify(stringSubscriber, times(1)).onNext("six");
     }
 
     @Test
@@ -234,11 +234,11 @@ public class FlowableMergeDelayErrorTest {
 
         });
         Flowable<String> m = Flowable.mergeDelayError(flowableOfFlowables);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, never()).onError(any(Throwable.class));
-        verify(stringObserver, times(1)).onComplete();
-        verify(stringObserver, times(2)).onNext("hello");
+        verify(stringSubscriber, never()).onError(any(Throwable.class));
+        verify(stringSubscriber, times(1)).onComplete();
+        verify(stringSubscriber, times(2)).onNext("hello");
     }
 
     @Test
@@ -247,11 +247,11 @@ public class FlowableMergeDelayErrorTest {
         final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
         Flowable<String> m = Flowable.mergeDelayError(o1, o2);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, never()).onError(any(Throwable.class));
-        verify(stringObserver, times(2)).onNext("hello");
-        verify(stringObserver, times(1)).onComplete();
+        verify(stringSubscriber, never()).onError(any(Throwable.class));
+        verify(stringSubscriber, times(2)).onNext("hello");
+        verify(stringSubscriber, times(1)).onComplete();
     }
 
     @Test
@@ -263,11 +263,11 @@ public class FlowableMergeDelayErrorTest {
         listOfFlowables.add(o2);
 
         Flowable<String> m = Flowable.mergeDelayError(Flowable.fromIterable(listOfFlowables));
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, never()).onError(any(Throwable.class));
-        verify(stringObserver, times(1)).onComplete();
-        verify(stringObserver, times(2)).onNext("hello");
+        verify(stringSubscriber, never()).onError(any(Throwable.class));
+        verify(stringSubscriber, times(1)).onComplete();
+        verify(stringSubscriber, times(2)).onNext("hello");
     }
 
     @Test
@@ -276,7 +276,7 @@ public class FlowableMergeDelayErrorTest {
         final TestASynchronousFlowable o2 = new TestASynchronousFlowable();
 
         Flowable<String> m = Flowable.mergeDelayError(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2));
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
         try {
             o1.t.join();
@@ -285,9 +285,9 @@ public class FlowableMergeDelayErrorTest {
             throw new RuntimeException(e);
         }
 
-        verify(stringObserver, never()).onError(any(Throwable.class));
-        verify(stringObserver, times(2)).onNext("hello");
-        verify(stringObserver, times(1)).onComplete();
+        verify(stringSubscriber, never()).onError(any(Throwable.class));
+        verify(stringSubscriber, times(2)).onNext("hello");
+        verify(stringSubscriber, times(1)).onComplete();
     }
 
     @Test(timeout = 1000L)
@@ -521,18 +521,18 @@ public class FlowableMergeDelayErrorTest {
                 }
             });
 
-            Subscriber<String> stringObserver = TestHelper.mockSubscriber();
+            stringSubscriber = TestHelper.mockSubscriber();
 
-            TestSubscriber<String> ts = new TestSubscriber<String>(stringObserver);
+            TestSubscriber<String> ts = new TestSubscriber<String>(stringSubscriber);
             Flowable<String> m = Flowable.mergeDelayError(parentFlowable);
             m.subscribe(ts);
             System.out.println("testErrorInParentFlowableDelayed | " + i);
             ts.awaitTerminalEvent(2000, TimeUnit.MILLISECONDS);
             ts.assertTerminated();
 
-            verify(stringObserver, times(2)).onNext("hello");
-            verify(stringObserver, times(1)).onError(any(NullPointerException.class));
-            verify(stringObserver, never()).onComplete();
+            verify(stringSubscriber, times(2)).onNext("hello");
+            verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
+            verify(stringSubscriber, never()).onComplete();
         }
     }
 
@@ -592,11 +592,11 @@ public class FlowableMergeDelayErrorTest {
         listOfFlowables.add(o2);
 
         Flowable<String> m = Flowable.mergeDelayError(listOfFlowables);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, never()).onError(any(Throwable.class));
-        verify(stringObserver, times(1)).onComplete();
-        verify(stringObserver, times(2)).onNext("hello");
+        verify(stringSubscriber, never()).onError(any(Throwable.class));
+        verify(stringSubscriber, times(1)).onComplete();
+        verify(stringSubscriber, times(2)).onNext("hello");
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
@@ -30,13 +30,6 @@ import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableMergeMaxConcurrentTest {
 
-    Subscriber<String> stringObserver;
-
-    @Before
-    public void before() {
-        stringObserver = TestHelper.mockSubscriber();
-    }
-
     @Test
     public void testWhenMaxConcurrentIsOne() {
         for (int i = 0; i < 100; i++) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -75,18 +75,18 @@ public class FlowableMergeTest {
 
     @Test
     public void testMergeFlowableOfFlowables() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
         Flowable<Flowable<String>> flowableOfFlowables = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
 
             @Override
-            public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 // simulate what would happen in a Flowable
-                observer.onNext(o1);
-                observer.onNext(o2);
-                observer.onComplete();
+                subscriber.onNext(f1);
+                subscriber.onNext(f2);
+                subscriber.onComplete();
             }
 
         });
@@ -100,10 +100,10 @@ public class FlowableMergeTest {
 
     @Test
     public void testMergeArray() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
-        Flowable<String> m = Flowable.merge(o1, o2);
+        Flowable<String> m = Flowable.merge(f1, f2);
         m.subscribe(stringSubscriber);
 
         verify(stringSubscriber, never()).onError(any(Throwable.class));
@@ -113,11 +113,11 @@ public class FlowableMergeTest {
 
     @Test
     public void testMergeList() {
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
         List<Flowable<String>> listOfFlowables = new ArrayList<Flowable<String>>();
-        listOfFlowables.add(o1);
-        listOfFlowables.add(o2);
+        listOfFlowables.add(f1);
+        listOfFlowables.add(f2);
 
         Flowable<String> m = Flowable.merge(listOfFlowables);
         m.subscribe(stringSubscriber);
@@ -136,7 +136,7 @@ public class FlowableMergeTest {
         Flowable<Flowable<Long>> source = Flowable.unsafeCreate(new Publisher<Flowable<Long>>() {
 
             @Override
-            public void subscribe(final Subscriber<? super Flowable<Long>> observer) {
+            public void subscribe(final Subscriber<? super Flowable<Long>> subscriber) {
                 // verbose on purpose so I can track the inside of it
                 final Subscription s = new Subscription() {
 
@@ -152,7 +152,7 @@ public class FlowableMergeTest {
                     }
 
                 };
-                observer.onSubscribe(s);
+                subscriber.onSubscribe(s);
 
                 new Thread(new Runnable() {
 
@@ -160,10 +160,10 @@ public class FlowableMergeTest {
                     public void run() {
 
                         while (!unsubscribed.get()) {
-                            observer.onNext(Flowable.just(1L, 2L));
+                            subscriber.onNext(Flowable.just(1L, 2L));
                         }
                         System.out.println("Done looping after unsubscribe: " + unsubscribed.get());
-                        observer.onComplete();
+                        subscriber.onComplete();
 
                         // mark that the thread is finished
                         latch.countDown();
@@ -197,10 +197,10 @@ public class FlowableMergeTest {
 
     @Test
     public void testMergeArrayWithThreading() {
-        final TestASynchronousFlowable o1 = new TestASynchronousFlowable();
-        final TestASynchronousFlowable o2 = new TestASynchronousFlowable();
+        final TestASynchronousFlowable f1 = new TestASynchronousFlowable();
+        final TestASynchronousFlowable f2 = new TestASynchronousFlowable();
 
-        Flowable<String> m = Flowable.merge(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2));
+        Flowable<String> m = Flowable.merge(Flowable.unsafeCreate(f1), Flowable.unsafeCreate(f2));
         TestSubscriber<String> ts = new TestSubscriber<String>(stringSubscriber);
         m.subscribe(ts);
 
@@ -222,8 +222,8 @@ public class FlowableMergeTest {
 
     @Test
     public void testSynchronizationOfMultipleSequences() throws Throwable {
-        final TestASynchronousFlowable o1 = new TestASynchronousFlowable();
-        final TestASynchronousFlowable o2 = new TestASynchronousFlowable();
+        final TestASynchronousFlowable f1 = new TestASynchronousFlowable();
+        final TestASynchronousFlowable f2 = new TestASynchronousFlowable();
 
         // use this latch to cause onNext to wait until we're ready to let it go
         final CountDownLatch endLatch = new CountDownLatch(1);
@@ -233,7 +233,7 @@ public class FlowableMergeTest {
 
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
 
-        Flowable<String> m = Flowable.merge(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2));
+        Flowable<String> m = Flowable.merge(Flowable.unsafeCreate(f1), Flowable.unsafeCreate(f2));
         m.subscribe(new DefaultSubscriber<String>() {
 
             @Override
@@ -267,8 +267,8 @@ public class FlowableMergeTest {
         });
 
         // wait for both Flowables to send (one should be blocked)
-        o1.onNextBeingSent.await();
-        o2.onNextBeingSent.await();
+        f1.onNextBeingSent.await();
+        f2.onNextBeingSent.await();
 
         // I can't think of a way to know for sure that both threads have or are trying to send onNext
         // since I can't use a CountDownLatch for "after" onNext since I want to catch during it
@@ -295,8 +295,8 @@ public class FlowableMergeTest {
         }
 
         try {
-            o1.t.join();
-            o2.t.join();
+            f1.t.join();
+            f2.t.join();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -311,10 +311,10 @@ public class FlowableMergeTest {
     @Test
     public void testError1() {
         // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six"
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three")); // we expect to lose all of these since o1 is done first and fails
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six"
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three")); // we expect to lose all of these since o1 is done first and fails
 
-        Flowable<String> m = Flowable.merge(o1, o2);
+        Flowable<String> m = Flowable.merge(f1, f2);
         m.subscribe(stringSubscriber);
 
         verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
@@ -333,12 +333,12 @@ public class FlowableMergeTest {
     @Test
     public void testError2() {
         // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
-        final Flowable<String> o1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
-        final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six"
-        final Flowable<String> o3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight", null));// we expect to lose all of these since o2 is done first and fails
-        final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));// we expect to lose all of these since o2 is done first and fails
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six"
+        final Flowable<String> f3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight", null));// we expect to lose all of these since o2 is done first and fails
+        final Flowable<String> f4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));// we expect to lose all of these since o2 is done first and fails
 
-        Flowable<String> m = Flowable.merge(o1, o2, o3, o4);
+        Flowable<String> m = Flowable.merge(f1, f2, f3, f4);
         m.subscribe(stringSubscriber);
 
         verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
@@ -358,7 +358,7 @@ public class FlowableMergeTest {
     @Ignore("Subscribe should not throw")
     public void testThrownErrorHandling() {
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Flowable<String> o1 = Flowable.unsafeCreate(new Publisher<String>() {
+        Flowable<String> f1 = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
             public void subscribe(Subscriber<? super String> s) {
@@ -367,7 +367,7 @@ public class FlowableMergeTest {
 
         });
 
-        Flowable.merge(o1, o1).subscribe(ts);
+        Flowable.merge(f1, f1).subscribe(ts);
         ts.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS);
         ts.assertTerminated();
         System.out.println("Error: " + ts.errors());
@@ -376,10 +376,10 @@ public class FlowableMergeTest {
     private static class TestSynchronousFlowable implements Publisher<String> {
 
         @Override
-        public void subscribe(Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
-            observer.onNext("hello");
-            observer.onComplete();
+        public void subscribe(Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
+            subscriber.onNext("hello");
+            subscriber.onComplete();
         }
     }
 
@@ -388,20 +388,20 @@ public class FlowableMergeTest {
         final CountDownLatch onNextBeingSent = new CountDownLatch(1);
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        public void subscribe(final Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override
                 public void run() {
                     onNextBeingSent.countDown();
                     try {
-                        observer.onNext("hello");
+                        subscriber.onNext("hello");
                         // I can't use a countDownLatch to prove we are actually sending 'onNext'
                         // since it will block if synchronized and I'll deadlock
-                        observer.onComplete();
+                        subscriber.onComplete();
                     } catch (Exception e) {
-                        observer.onError(e);
+                        subscriber.onError(e);
                     }
                 }
 
@@ -419,17 +419,17 @@ public class FlowableMergeTest {
         }
 
         @Override
-        public void subscribe(Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        public void subscribe(Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
             for (String s : valuesToReturn) {
                 if (s == null) {
                     System.out.println("throwing exception");
-                    observer.onError(new NullPointerException());
+                    subscriber.onError(new NullPointerException());
                 } else {
-                    observer.onNext(s);
+                    subscriber.onNext(s);
                 }
             }
-            observer.onComplete();
+            subscriber.onComplete();
         }
     }
 
@@ -437,14 +437,14 @@ public class FlowableMergeTest {
     public void testUnsubscribeAsFlowablesComplete() {
         TestScheduler scheduler1 = new TestScheduler();
         AtomicBoolean os1 = new AtomicBoolean(false);
-        Flowable<Long> o1 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler1, os1);
+        Flowable<Long> f1 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler1, os1);
 
         TestScheduler scheduler2 = new TestScheduler();
         AtomicBoolean os2 = new AtomicBoolean(false);
-        Flowable<Long> o2 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
+        Flowable<Long> f2 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
         TestSubscriber<Long> ts = new TestSubscriber<Long>();
-        Flowable.merge(o1, o2).subscribe(ts);
+        Flowable.merge(f1, f2).subscribe(ts);
 
         // we haven't incremented time so nothing should be received yet
         ts.assertNoValues();
@@ -479,14 +479,14 @@ public class FlowableMergeTest {
         for (int i = 0; i < 10; i++) {
             TestScheduler scheduler1 = new TestScheduler();
             AtomicBoolean os1 = new AtomicBoolean(false);
-            Flowable<Long> o1 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler1, os1);
+            Flowable<Long> f1 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler1, os1);
 
             TestScheduler scheduler2 = new TestScheduler();
             AtomicBoolean os2 = new AtomicBoolean(false);
-            Flowable<Long> o2 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
+            Flowable<Long> f2 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
             TestSubscriber<Long> ts = new TestSubscriber<Long>();
-            Flowable.merge(o1, o2).subscribe(ts);
+            Flowable.merge(f1, f2).subscribe(ts);
 
             // we haven't incremented time so nothing should be received yet
             ts.assertNoValues();
@@ -557,10 +557,10 @@ public class FlowableMergeTest {
 
     @Test//(timeout = 10000)
     public void testConcurrency() {
-        Flowable<Integer> o = Flowable.range(1, 10000).subscribeOn(Schedulers.newThread());
+        Flowable<Integer> f = Flowable.range(1, 10000).subscribeOn(Schedulers.newThread());
 
         for (int i = 0; i < 10; i++) {
-            Flowable<Integer> merge = Flowable.merge(o.onBackpressureBuffer(), o.onBackpressureBuffer(), o.onBackpressureBuffer());
+            Flowable<Integer> merge = Flowable.merge(f.onBackpressureBuffer(), f.onBackpressureBuffer(), f.onBackpressureBuffer());
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
             merge.subscribe(ts);
 
@@ -577,7 +577,7 @@ public class FlowableMergeTest {
     @Test
     public void testConcurrencyWithSleeping() {
 
-        Flowable<Integer> o = Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable<Integer> f = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> s) {
@@ -613,7 +613,7 @@ public class FlowableMergeTest {
         });
 
         for (int i = 0; i < 10; i++) {
-            Flowable<Integer> merge = Flowable.merge(o, o, o);
+            Flowable<Integer> merge = Flowable.merge(f, f, f);
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
             merge.subscribe(ts);
 
@@ -627,7 +627,7 @@ public class FlowableMergeTest {
 
     @Test
     public void testConcurrencyWithBrokenOnCompleteContract() {
-        Flowable<Integer> o = Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable<Integer> f = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> s) {
@@ -660,7 +660,7 @@ public class FlowableMergeTest {
         });
 
         for (int i = 0; i < 10; i++) {
-            Flowable<Integer> merge = Flowable.merge(o.onBackpressureBuffer(), o.onBackpressureBuffer(), o.onBackpressureBuffer());
+            Flowable<Integer> merge = Flowable.merge(f.onBackpressureBuffer(), f.onBackpressureBuffer(), f.onBackpressureBuffer());
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
             merge.subscribe(ts);
 
@@ -676,9 +676,9 @@ public class FlowableMergeTest {
     @Test
     public void testBackpressureUpstream() throws InterruptedException {
         final AtomicInteger generated1 = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteFlowable(generated1).subscribeOn(Schedulers.computation());
+        Flowable<Integer> f1 = createInfiniteFlowable(generated1).subscribeOn(Schedulers.computation());
         final AtomicInteger generated2 = new AtomicInteger();
-        Flowable<Integer> o2 = createInfiniteFlowable(generated2).subscribeOn(Schedulers.computation());
+        Flowable<Integer> f2 = createInfiniteFlowable(generated2).subscribeOn(Schedulers.computation());
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() {
             @Override
@@ -688,7 +688,7 @@ public class FlowableMergeTest {
             }
         };
 
-        Flowable.merge(o1.take(Flowable.bufferSize() * 2), o2.take(Flowable.bufferSize() * 2)).subscribe(testSubscriber);
+        Flowable.merge(f1.take(Flowable.bufferSize() * 2), f2.take(Flowable.bufferSize() * 2)).subscribe(testSubscriber);
         testSubscriber.awaitTerminalEvent();
         if (testSubscriber.errors().size() > 0) {
             testSubscriber.errors().get(0).printStackTrace();
@@ -715,7 +715,7 @@ public class FlowableMergeTest {
     @Test
     public void testBackpressureUpstream2() throws InterruptedException {
         final AtomicInteger generated1 = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteFlowable(generated1).subscribeOn(Schedulers.computation());
+        Flowable<Integer> f1 = createInfiniteFlowable(generated1).subscribeOn(Schedulers.computation());
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() {
             @Override
@@ -724,7 +724,7 @@ public class FlowableMergeTest {
             }
         };
 
-        Flowable.merge(o1.take(Flowable.bufferSize() * 2), Flowable.just(-99)).subscribe(testSubscriber);
+        Flowable.merge(f1.take(Flowable.bufferSize() * 2), Flowable.just(-99)).subscribe(testSubscriber);
         testSubscriber.awaitTerminalEvent();
 
         List<Integer> onNextEvents = testSubscriber.values();
@@ -750,9 +750,9 @@ public class FlowableMergeTest {
     @Test(timeout = 10000)
     public void testBackpressureDownstreamWithConcurrentStreams() throws InterruptedException {
         final AtomicInteger generated1 = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteFlowable(generated1).subscribeOn(Schedulers.computation());
+        Flowable<Integer> f1 = createInfiniteFlowable(generated1).subscribeOn(Schedulers.computation());
         final AtomicInteger generated2 = new AtomicInteger();
-        Flowable<Integer> o2 = createInfiniteFlowable(generated2).subscribeOn(Schedulers.computation());
+        Flowable<Integer> f2 = createInfiniteFlowable(generated2).subscribeOn(Schedulers.computation());
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() {
             @Override
@@ -770,7 +770,7 @@ public class FlowableMergeTest {
             }
         };
 
-        Flowable.merge(o1.take(Flowable.bufferSize() * 2), o2.take(Flowable.bufferSize() * 2)).observeOn(Schedulers.computation()).subscribe(testSubscriber);
+        Flowable.merge(f1.take(Flowable.bufferSize() * 2), f2.take(Flowable.bufferSize() * 2)).observeOn(Schedulers.computation()).subscribe(testSubscriber);
         testSubscriber.awaitTerminalEvent();
         if (testSubscriber.errors().size() > 0) {
             testSubscriber.errors().get(0).printStackTrace();
@@ -787,7 +787,7 @@ public class FlowableMergeTest {
     @Test
     public void testBackpressureBothUpstreamAndDownstreamWithSynchronousScalarFlowables() throws InterruptedException {
         final AtomicInteger generated1 = new AtomicInteger();
-        Flowable<Flowable<Integer>> o1 = createInfiniteFlowable(generated1)
+        Flowable<Flowable<Integer>> f1 = createInfiniteFlowable(generated1)
         .map(new Function<Integer, Flowable<Integer>>() {
 
             @Override
@@ -813,7 +813,7 @@ public class FlowableMergeTest {
             }
         };
 
-        Flowable.merge(o1).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(testSubscriber);
+        Flowable.merge(f1).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(testSubscriber);
         testSubscriber.awaitTerminalEvent();
         if (testSubscriber.errors().size() > 0) {
             testSubscriber.errors().get(0).printStackTrace();
@@ -841,7 +841,7 @@ public class FlowableMergeTest {
     @Test(timeout = 5000)
     public void testBackpressureBothUpstreamAndDownstreamWithRegularFlowables() throws InterruptedException {
         final AtomicInteger generated1 = new AtomicInteger();
-        Flowable<Flowable<Integer>> o1 = createInfiniteFlowable(generated1).map(new Function<Integer, Flowable<Integer>>() {
+        Flowable<Flowable<Integer>> f1 = createInfiniteFlowable(generated1).map(new Function<Integer, Flowable<Integer>>() {
 
             @Override
             public Flowable<Integer> apply(Integer t1) {
@@ -868,7 +868,7 @@ public class FlowableMergeTest {
             }
         };
 
-        Flowable.merge(o1).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(testSubscriber);
+        Flowable.merge(f1).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(testSubscriber);
         testSubscriber.awaitTerminalEvent();
         if (testSubscriber.errors().size() > 0) {
             testSubscriber.errors().get(0).printStackTrace();
@@ -1269,11 +1269,11 @@ public class FlowableMergeTest {
     @Test
     public void testMergeRequestOverflow() throws InterruptedException {
         //do a non-trivial merge so that future optimisations with EMPTY don't invalidate this test
-        Flowable<Integer> o = Flowable.fromIterable(Arrays.asList(1,2))
+        Flowable<Integer> f = Flowable.fromIterable(Arrays.asList(1,2))
                 .mergeWith(Flowable.fromIterable(Arrays.asList(3,4)));
         final int expectedCount = 4;
         final CountDownLatch latch = new CountDownLatch(expectedCount);
-        o.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<Integer>() {
+        f.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -40,13 +40,13 @@ import io.reactivex.subscribers.*;
 
 public class FlowableMergeTest {
 
-    Subscriber<String> stringObserver;
+    Subscriber<String> stringSubscriber;
 
     int count;
 
     @Before
     public void before() {
-        stringObserver = TestHelper.mockSubscriber();
+        stringSubscriber = TestHelper.mockSubscriber();
 
         for (Thread t : Thread.getAllStackTraces().keySet()) {
             if (t.getName().startsWith("RxNewThread")) {
@@ -91,11 +91,11 @@ public class FlowableMergeTest {
 
         });
         Flowable<String> m = Flowable.merge(flowableOfFlowables);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, never()).onError(any(Throwable.class));
-        verify(stringObserver, times(1)).onComplete();
-        verify(stringObserver, times(2)).onNext("hello");
+        verify(stringSubscriber, never()).onError(any(Throwable.class));
+        verify(stringSubscriber, times(1)).onComplete();
+        verify(stringSubscriber, times(2)).onNext("hello");
     }
 
     @Test
@@ -104,11 +104,11 @@ public class FlowableMergeTest {
         final Flowable<String> o2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
         Flowable<String> m = Flowable.merge(o1, o2);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, never()).onError(any(Throwable.class));
-        verify(stringObserver, times(2)).onNext("hello");
-        verify(stringObserver, times(1)).onComplete();
+        verify(stringSubscriber, never()).onError(any(Throwable.class));
+        verify(stringSubscriber, times(2)).onNext("hello");
+        verify(stringSubscriber, times(1)).onComplete();
     }
 
     @Test
@@ -120,11 +120,11 @@ public class FlowableMergeTest {
         listOfFlowables.add(o2);
 
         Flowable<String> m = Flowable.merge(listOfFlowables);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, never()).onError(any(Throwable.class));
-        verify(stringObserver, times(1)).onComplete();
-        verify(stringObserver, times(2)).onNext("hello");
+        verify(stringSubscriber, never()).onError(any(Throwable.class));
+        verify(stringSubscriber, times(1)).onComplete();
+        verify(stringSubscriber, times(2)).onNext("hello");
     }
 
     @Test(timeout = 1000)
@@ -201,15 +201,15 @@ public class FlowableMergeTest {
         final TestASynchronousFlowable o2 = new TestASynchronousFlowable();
 
         Flowable<String> m = Flowable.merge(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2));
-        TestSubscriber<String> ts = new TestSubscriber<String>(stringObserver);
+        TestSubscriber<String> ts = new TestSubscriber<String>(stringSubscriber);
         m.subscribe(ts);
 
         ts.awaitTerminalEvent();
         ts.assertNoErrors();
 
-        verify(stringObserver, never()).onError(any(Throwable.class));
-        verify(stringObserver, times(2)).onNext("hello");
-        verify(stringObserver, times(1)).onComplete();
+        verify(stringSubscriber, never()).onError(any(Throwable.class));
+        verify(stringSubscriber, times(2)).onNext("hello");
+        verify(stringSubscriber, times(1)).onComplete();
     }
 
     @Test
@@ -315,16 +315,16 @@ public class FlowableMergeTest {
         final Flowable<String> o2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three")); // we expect to lose all of these since o1 is done first and fails
 
         Flowable<String> m = Flowable.merge(o1, o2);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
-        verify(stringObserver, never()).onComplete();
-        verify(stringObserver, times(0)).onNext("one");
-        verify(stringObserver, times(0)).onNext("two");
-        verify(stringObserver, times(0)).onNext("three");
-        verify(stringObserver, times(1)).onNext("four");
-        verify(stringObserver, times(0)).onNext("five");
-        verify(stringObserver, times(0)).onNext("six");
+        verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
+        verify(stringSubscriber, never()).onComplete();
+        verify(stringSubscriber, times(0)).onNext("one");
+        verify(stringSubscriber, times(0)).onNext("two");
+        verify(stringSubscriber, times(0)).onNext("three");
+        verify(stringSubscriber, times(1)).onNext("four");
+        verify(stringSubscriber, times(0)).onNext("five");
+        verify(stringSubscriber, times(0)).onNext("six");
     }
 
     /**
@@ -339,19 +339,19 @@ public class FlowableMergeTest {
         final Flowable<String> o4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));// we expect to lose all of these since o2 is done first and fails
 
         Flowable<String> m = Flowable.merge(o1, o2, o3, o4);
-        m.subscribe(stringObserver);
+        m.subscribe(stringSubscriber);
 
-        verify(stringObserver, times(1)).onError(any(NullPointerException.class));
-        verify(stringObserver, never()).onComplete();
-        verify(stringObserver, times(1)).onNext("one");
-        verify(stringObserver, times(1)).onNext("two");
-        verify(stringObserver, times(1)).onNext("three");
-        verify(stringObserver, times(1)).onNext("four");
-        verify(stringObserver, times(0)).onNext("five");
-        verify(stringObserver, times(0)).onNext("six");
-        verify(stringObserver, times(0)).onNext("seven");
-        verify(stringObserver, times(0)).onNext("eight");
-        verify(stringObserver, times(0)).onNext("nine");
+        verify(stringSubscriber, times(1)).onError(any(NullPointerException.class));
+        verify(stringSubscriber, never()).onComplete();
+        verify(stringSubscriber, times(1)).onNext("one");
+        verify(stringSubscriber, times(1)).onNext("two");
+        verify(stringSubscriber, times(1)).onNext("three");
+        verify(stringSubscriber, times(1)).onNext("four");
+        verify(stringSubscriber, times(0)).onNext("five");
+        verify(stringSubscriber, times(0)).onNext("six");
+        verify(stringSubscriber, times(0)).onNext("seven");
+        verify(stringSubscriber, times(0)).onNext("eight");
+        verify(stringSubscriber, times(0)).onNext("nine");
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -46,13 +46,13 @@ public class FlowableObserveOnTest {
      */
     @Test
     public void testObserveOn() {
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        Flowable.just(1, 2, 3).observeOn(ImmediateThinScheduler.INSTANCE).subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        Flowable.just(1, 2, 3).observeOn(ImmediateThinScheduler.INSTANCE).subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(1);
-        verify(observer, times(1)).onNext(2);
-        verify(observer, times(1)).onNext(3);
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, times(1)).onNext(2);
+        verify(subscriber, times(1)).onNext(3);
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -61,10 +61,10 @@ public class FlowableObserveOnTest {
         // FIXME null values not allowed
         Flowable<String> obs = Flowable.just("one", "null", "two", "three", "four");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        InOrder inOrder = inOrder(observer);
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        InOrder inOrder = inOrder(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
 
         obs.observeOn(Schedulers.computation()).subscribe(ts);
 
@@ -76,12 +76,12 @@ public class FlowableObserveOnTest {
             fail("failed with exception");
         }
 
-        inOrder.verify(observer, times(1)).onNext("one");
-        inOrder.verify(observer, times(1)).onNext("null");
-        inOrder.verify(observer, times(1)).onNext("two");
-        inOrder.verify(observer, times(1)).onNext("three");
-        inOrder.verify(observer, times(1)).onNext("four");
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        inOrder.verify(subscriber, times(1)).onNext("null");
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        inOrder.verify(subscriber, times(1)).onNext("four");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -92,7 +92,7 @@ public class FlowableObserveOnTest {
 //        Flowable<String> obs = Flowable.just("one", null, "two", "three", "four");
         Flowable<String> obs = Flowable.just("one", "null", "two", "three", "four");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         final String parentThreadName = Thread.currentThread().getName();
 
         final CountDownLatch completedLatch = new CountDownLatch(1);
@@ -127,15 +127,15 @@ public class FlowableObserveOnTest {
                 completedLatch.countDown();
 
             }
-        }).subscribe(observer);
+        }).subscribe(subscriber);
 
         if (!completedLatch.await(1000, TimeUnit.MILLISECONDS)) {
             fail("timed out waiting");
         }
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(5)).onNext(any(String.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(5)).onNext(any(String.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -366,8 +366,7 @@ public class FlowableObserveOnTest {
 
         Flowable<Integer> source = Flowable.concat(Flowable.<Integer> error(new TestException()), Flowable.just(1));
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<Integer> o = mock(DefaultSubscriber.class);
+        Subscriber<Integer> o = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(o);
 
         source.observeOn(testScheduler).subscribe(o);
@@ -385,8 +384,8 @@ public class FlowableObserveOnTest {
     public void testAfterUnsubscribeCalledThenObserverOnNextNeverCalled() {
         final TestScheduler testScheduler = new TestScheduler();
 
-        final Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(observer);
+        final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(subscriber);
 
         Flowable.just(1, 2, 3)
                 .observeOn(testScheduler)
@@ -395,11 +394,11 @@ public class FlowableObserveOnTest {
         ts.dispose();
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        final InOrder inOrder = inOrder(observer);
+        final InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(observer, never()).onNext(anyInt());
-        inOrder.verify(observer, never()).onError(any(Exception.class));
-        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(subscriber, never()).onNext(anyInt());
+        inOrder.verify(subscriber, never()).onError(any(Exception.class));
+        inOrder.verify(subscriber, never()).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -142,30 +142,30 @@ public class FlowableObserveOnTest {
     public void observeOnTheSameSchedulerTwice() {
         Scheduler scheduler = ImmediateThinScheduler.INSTANCE;
 
-        Flowable<Integer> o = Flowable.just(1, 2, 3);
-        Flowable<Integer> o2 = o.observeOn(scheduler);
+        Flowable<Integer> f = Flowable.just(1, 2, 3);
+        Flowable<Integer> f2 = f.observeOn(scheduler);
 
-        Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-        Subscriber<Object> observer2 = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber2 = TestHelper.mockSubscriber();
 
-        InOrder inOrder1 = inOrder(observer1);
-        InOrder inOrder2 = inOrder(observer2);
+        InOrder inOrder1 = inOrder(subscriber1);
+        InOrder inOrder2 = inOrder(subscriber2);
 
-        o2.subscribe(observer1);
-        o2.subscribe(observer2);
+        f2.subscribe(subscriber1);
+        f2.subscribe(subscriber2);
 
-        inOrder1.verify(observer1, times(1)).onNext(1);
-        inOrder1.verify(observer1, times(1)).onNext(2);
-        inOrder1.verify(observer1, times(1)).onNext(3);
-        inOrder1.verify(observer1, times(1)).onComplete();
-        verify(observer1, never()).onError(any(Throwable.class));
+        inOrder1.verify(subscriber1, times(1)).onNext(1);
+        inOrder1.verify(subscriber1, times(1)).onNext(2);
+        inOrder1.verify(subscriber1, times(1)).onNext(3);
+        inOrder1.verify(subscriber1, times(1)).onComplete();
+        verify(subscriber1, never()).onError(any(Throwable.class));
         inOrder1.verifyNoMoreInteractions();
 
-        inOrder2.verify(observer2, times(1)).onNext(1);
-        inOrder2.verify(observer2, times(1)).onNext(2);
-        inOrder2.verify(observer2, times(1)).onNext(3);
-        inOrder2.verify(observer2, times(1)).onComplete();
-        verify(observer2, never()).onError(any(Throwable.class));
+        inOrder2.verify(subscriber2, times(1)).onNext(1);
+        inOrder2.verify(subscriber2, times(1)).onNext(2);
+        inOrder2.verify(subscriber2, times(1)).onNext(3);
+        inOrder2.verify(subscriber2, times(1)).onComplete();
+        verify(subscriber2, never()).onError(any(Throwable.class));
         inOrder2.verifyNoMoreInteractions();
     }
 
@@ -174,34 +174,34 @@ public class FlowableObserveOnTest {
         TestScheduler scheduler1 = new TestScheduler();
         TestScheduler scheduler2 = new TestScheduler();
 
-        Flowable<Integer> o = Flowable.just(1, 2, 3);
-        Flowable<Integer> o1 = o.observeOn(scheduler1);
-        Flowable<Integer> o2 = o.observeOn(scheduler2);
+        Flowable<Integer> f = Flowable.just(1, 2, 3);
+        Flowable<Integer> f1 = f.observeOn(scheduler1);
+        Flowable<Integer> f2 = f.observeOn(scheduler2);
 
-        Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-        Subscriber<Object> observer2 = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber2 = TestHelper.mockSubscriber();
 
-        InOrder inOrder1 = inOrder(observer1);
-        InOrder inOrder2 = inOrder(observer2);
+        InOrder inOrder1 = inOrder(subscriber1);
+        InOrder inOrder2 = inOrder(subscriber2);
 
-        o1.subscribe(observer1);
-        o2.subscribe(observer2);
+        f1.subscribe(subscriber1);
+        f2.subscribe(subscriber2);
 
         scheduler1.advanceTimeBy(1, TimeUnit.SECONDS);
         scheduler2.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        inOrder1.verify(observer1, times(1)).onNext(1);
-        inOrder1.verify(observer1, times(1)).onNext(2);
-        inOrder1.verify(observer1, times(1)).onNext(3);
-        inOrder1.verify(observer1, times(1)).onComplete();
-        verify(observer1, never()).onError(any(Throwable.class));
+        inOrder1.verify(subscriber1, times(1)).onNext(1);
+        inOrder1.verify(subscriber1, times(1)).onNext(2);
+        inOrder1.verify(subscriber1, times(1)).onNext(3);
+        inOrder1.verify(subscriber1, times(1)).onComplete();
+        verify(subscriber1, never()).onError(any(Throwable.class));
         inOrder1.verifyNoMoreInteractions();
 
-        inOrder2.verify(observer2, times(1)).onNext(1);
-        inOrder2.verify(observer2, times(1)).onNext(2);
-        inOrder2.verify(observer2, times(1)).onNext(3);
-        inOrder2.verify(observer2, times(1)).onComplete();
-        verify(observer2, never()).onError(any(Throwable.class));
+        inOrder2.verify(subscriber2, times(1)).onNext(1);
+        inOrder2.verify(subscriber2, times(1)).onNext(2);
+        inOrder2.verify(subscriber2, times(1)).onNext(3);
+        inOrder2.verify(subscriber2, times(1)).onComplete();
+        verify(subscriber2, never()).onError(any(Throwable.class));
         inOrder2.verifyNoMoreInteractions();
     }
 
@@ -366,18 +366,18 @@ public class FlowableObserveOnTest {
 
         Flowable<Integer> source = Flowable.concat(Flowable.<Integer> error(new TestException()), Flowable.just(1));
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.observeOn(testScheduler).subscribe(o);
+        source.observeOn(testScheduler).subscribe(subscriber);
 
-        inOrder.verify(o, never()).onError(any(TestException.class));
+        inOrder.verify(subscriber, never()).onError(any(TestException.class));
 
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        inOrder.verify(o).onError(any(TestException.class));
-        inOrder.verify(o, never()).onNext(anyInt());
-        inOrder.verify(o, never()).onComplete();
+        inOrder.verify(subscriber).onError(any(TestException.class));
+        inOrder.verify(subscriber, never()).onNext(anyInt());
+        inOrder.verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -537,13 +537,13 @@ public class FlowableObserveOnTest {
         Flowable<Integer> flowable = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
-            public void subscribe(Subscriber<? super Integer> o) {
-                o.onSubscribe(new BooleanSubscription());
+            public void subscribe(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 for (int i = 0; i < Flowable.bufferSize() + 10; i++) {
-                    o.onNext(i);
+                    subscriber.onNext(i);
                 }
                 latch.countDown();
-                o.onComplete();
+                subscriber.onComplete();
             }
 
         });
@@ -600,7 +600,7 @@ public class FlowableObserveOnTest {
     @Test
     public void testOnErrorCutsAheadOfOnNext() {
         for (int i = 0; i < 50; i++) {
-            final PublishProcessor<Long> subject = PublishProcessor.create();
+            final PublishProcessor<Long> processor = PublishProcessor.create();
 
             final AtomicLong counter = new AtomicLong();
             TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultSubscriber<Long>() {
@@ -625,11 +625,11 @@ public class FlowableObserveOnTest {
                 }
 
             });
-            subject.observeOn(Schedulers.computation()).subscribe(ts);
+            processor.observeOn(Schedulers.computation()).subscribe(ts);
 
             // this will blow up with backpressure
             while (counter.get() < 102400) {
-                subject.onNext(counter.get());
+                processor.onNext(counter.get());
                 counter.incrementAndGet();
             }
 
@@ -1150,8 +1150,8 @@ public class FlowableObserveOnTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.observeOn(new TestScheduler());
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.observeOn(new TestScheduler());
             }
         });
     }
@@ -1163,12 +1163,12 @@ public class FlowableObserveOnTest {
             TestScheduler scheduler = new TestScheduler();
             TestSubscriber<Integer> ts = new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onComplete();
-                    observer.onNext(1);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onComplete();
+                    subscriber.onNext(1);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .observeOn(scheduler)
@@ -1343,11 +1343,11 @@ public class FlowableObserveOnTest {
     public void nonFusedPollThrows() {
         new Flowable<Integer>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
 
                 @SuppressWarnings("unchecked")
-                BaseObserveOnSubscriber<Integer> oo = (BaseObserveOnSubscriber<Integer>)observer;
+                BaseObserveOnSubscriber<Integer> oo = (BaseObserveOnSubscriber<Integer>)subscriber;
 
                 oo.sourceMode = QueueFuseable.SYNC;
                 oo.requested.lazySet(1);
@@ -1394,11 +1394,11 @@ public class FlowableObserveOnTest {
     public void conditionalNonFusedPollThrows() {
         new Flowable<Integer>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
 
                 @SuppressWarnings("unchecked")
-                BaseObserveOnSubscriber<Integer> oo = (BaseObserveOnSubscriber<Integer>)observer;
+                BaseObserveOnSubscriber<Integer> oo = (BaseObserveOnSubscriber<Integer>)subscriber;
 
                 oo.sourceMode = QueueFuseable.SYNC;
                 oo.requested.lazySet(1);
@@ -1446,11 +1446,11 @@ public class FlowableObserveOnTest {
     public void asycFusedPollThrows() {
         new Flowable<Integer>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
 
                 @SuppressWarnings("unchecked")
-                BaseObserveOnSubscriber<Integer> oo = (BaseObserveOnSubscriber<Integer>)observer;
+                BaseObserveOnSubscriber<Integer> oo = (BaseObserveOnSubscriber<Integer>)subscriber;
 
                 oo.sourceMode = QueueFuseable.ASYNC;
                 oo.requested.lazySet(1);
@@ -1497,11 +1497,11 @@ public class FlowableObserveOnTest {
     public void conditionalAsyncFusedPollThrows() {
         new Flowable<Integer>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
 
                 @SuppressWarnings("unchecked")
-                BaseObserveOnSubscriber<Integer> oo = (BaseObserveOnSubscriber<Integer>)observer;
+                BaseObserveOnSubscriber<Integer> oo = (BaseObserveOnSubscriber<Integer>)subscriber;
 
                 oo.sourceMode = QueueFuseable.ASYNC;
                 oo.requested.lazySet(1);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
@@ -38,8 +38,8 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
         Flowable<String> observable = w.onErrorResumeNext(resume);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -47,13 +47,13 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
             fail(e.getMessage());
         }
 
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("one");
-        verify(observer, Mockito.never()).onNext("two");
-        verify(observer, Mockito.never()).onNext("three");
-        verify(observer, times(1)).onNext("twoResume");
-        verify(observer, times(1)).onNext("threeResume");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, Mockito.never()).onNext("two");
+        verify(subscriber, Mockito.never()).onNext("three");
+        verify(subscriber, times(1)).onNext("twoResume");
+        verify(subscriber, times(1)).onNext("threeResume");
     }
 
     @Test
@@ -80,9 +80,9 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
 
         Flowable<String> observable = w.onErrorResumeNext(resume);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -90,13 +90,13 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
             fail(e.getMessage());
         }
 
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("one");
-        verify(observer, Mockito.never()).onNext("two");
-        verify(observer, Mockito.never()).onNext("three");
-        verify(observer, times(1)).onNext("twoResume");
-        verify(observer, times(1)).onNext("threeResume");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, Mockito.never()).onNext("two");
+        verify(subscriber, Mockito.never()).onNext("three");
+        verify(subscriber, times(1)).onNext("twoResume");
+        verify(subscriber, times(1)).onNext("threeResume");
     }
 
     @Test
@@ -113,12 +113,12 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
         Flowable<String> resume = Flowable.just("resume");
         Flowable<String> observable = testObservable.onErrorResumeNext(resume);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("resume");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("resume");
     }
 
     @Test
@@ -135,16 +135,15 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
         Flowable<String> resume = Flowable.just("resume");
         Flowable<String> observable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeNext(resume);
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer, Long.MAX_VALUE);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, Long.MAX_VALUE);
         observable.subscribe(ts);
 
         ts.awaitTerminalEvent();
 
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("resume");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("resume");
     }
 
     static final class TestObservable implements Publisher<String> {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
@@ -36,10 +36,10 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
         TestObservable f = new TestObservable(s, "one", "fail", "two", "three");
         Flowable<String> w = Flowable.unsafeCreate(f);
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
-        Flowable<String> observable = w.onErrorResumeNext(resume);
+        Flowable<String> flowable = w.onErrorResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -78,11 +78,11 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
             }
         });
 
-        Flowable<String> observable = w.onErrorResumeNext(resume);
+        Flowable<String> flowable = w.onErrorResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -111,10 +111,10 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
 
         });
         Flowable<String> resume = Flowable.just("resume");
-        Flowable<String> observable = testObservable.onErrorResumeNext(resume);
+        Flowable<String> flowable = testObservable.onErrorResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, Mockito.never()).onError(any(Throwable.class));
         verify(subscriber, times(1)).onComplete();
@@ -133,11 +133,11 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
 
         });
         Flowable<String> resume = Flowable.just("resume");
-        Flowable<String> observable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeNext(resume);
+        Flowable<String> flowable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, Long.MAX_VALUE);
-        observable.subscribe(ts);
+        flowable.subscribe(ts);
 
         ts.awaitTerminalEvent();
 
@@ -158,9 +158,9 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
         }
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
+        public void subscribe(final Subscriber<? super String> subscriber) {
             System.out.println("TestObservable subscribed to ...");
-            observer.onSubscribe(s);
+            subscriber.onSubscribe(s);
             t = new Thread(new Runnable() {
 
                 @Override
@@ -172,13 +172,13 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
                                 throw new RuntimeException("Forced Failure");
                             }
                             System.out.println("TestObservable onNext: " + s);
-                            observer.onNext(s);
+                            subscriber.onNext(s);
                         }
                         System.out.println("TestObservable onComplete");
-                        observer.onComplete();
+                        subscriber.onComplete();
                     } catch (Throwable e) {
                         System.out.println("TestObservable onError: " + e);
-                        observer.onError(e);
+                        subscriber.onError(e);
                     }
                 }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -60,17 +61,17 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
         };
         Flowable<String> observable = w.onErrorResumeNext(resume);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("one");
-        verify(observer, Mockito.never()).onNext("two");
-        verify(observer, Mockito.never()).onNext("three");
-        verify(observer, times(1)).onNext("twoResume");
-        verify(observer, times(1)).onNext("threeResume");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, Mockito.never()).onNext("two");
+        verify(subscriber, Mockito.never()).onNext("three");
+        verify(subscriber, times(1)).onNext("twoResume");
+        verify(subscriber, times(1)).onNext("threeResume");
         assertNotNull(receivedException.get());
     }
 
@@ -90,9 +91,9 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
         };
         Flowable<String> observable = Flowable.unsafeCreate(w).onErrorResumeNext(resume);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
         try {
             w.t.join();
@@ -100,13 +101,13 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
             fail(e.getMessage());
         }
 
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("one");
-        verify(observer, Mockito.never()).onNext("two");
-        verify(observer, Mockito.never()).onNext("three");
-        verify(observer, times(1)).onNext("twoResume");
-        verify(observer, times(1)).onNext("threeResume");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, Mockito.never()).onNext("two");
+        verify(subscriber, Mockito.never()).onNext("three");
+        verify(subscriber, times(1)).onNext("twoResume");
+        verify(subscriber, times(1)).onNext("threeResume");
         assertNotNull(receivedException.get());
     }
 
@@ -127,9 +128,8 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
         };
         Flowable<String> observable = Flowable.unsafeCreate(w).onErrorResumeNext(resume);
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
-        observable.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
         try {
             w.t.join();
@@ -138,11 +138,11 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
         }
 
         // we should get the "one" value before the error
-        verify(observer, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("one");
 
         // we should have received an onError call on the Observer since the resume function threw an exception
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, times(0)).onComplete();
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, times(0)).onComplete();
     }
 
     /**
@@ -260,20 +260,19 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
 
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer, Long.MAX_VALUE);
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, Long.MAX_VALUE);
         observable.subscribe(ts);
         ts.awaitTerminalEvent();
 
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("one");
-        verify(observer, Mockito.never()).onNext("two");
-        verify(observer, Mockito.never()).onNext("three");
-        verify(observer, times(1)).onNext("twoResume");
-        verify(observer, times(1)).onNext("threeResume");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, Mockito.never()).onNext("two");
+        verify(subscriber, Mockito.never()).onNext("three");
+        verify(subscriber, times(1)).onNext("twoResume");
+        verify(subscriber, times(1)).onNext("threeResume");
     }
 
     private static class TestFlowable implements Publisher<String> {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
@@ -41,12 +41,12 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
         Flowable<String> w = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                observer.onNext("one");
-                observer.onError(new Throwable("injected failure"));
-                observer.onNext("two");
-                observer.onNext("three");
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                subscriber.onNext("one");
+                subscriber.onError(new Throwable("injected failure"));
+                subscriber.onNext("two");
+                subscriber.onNext("three");
             }
         });
 
@@ -59,11 +59,11 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
             }
 
         };
-        Flowable<String> observable = w.onErrorResumeNext(resume);
+        Flowable<String> flowable = w.onErrorResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, Mockito.never()).onError(any(Throwable.class));
         verify(subscriber, times(1)).onComplete();
@@ -89,11 +89,11 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
             }
 
         };
-        Flowable<String> observable = Flowable.unsafeCreate(w).onErrorResumeNext(resume);
+        Flowable<String> flowable = Flowable.unsafeCreate(w).onErrorResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         try {
             w.t.join();
@@ -126,10 +126,10 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
             }
 
         };
-        Flowable<String> observable = Flowable.unsafeCreate(w).onErrorResumeNext(resume);
+        Flowable<String> flowable = Flowable.unsafeCreate(w).onErrorResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         try {
             w.t.join();
@@ -251,7 +251,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
             }
         });
 
-        Flowable<String> observable = w.onErrorResumeNext(new Function<Throwable, Flowable<String>>() {
+        Flowable<String> flowable = w.onErrorResumeNext(new Function<Throwable, Flowable<String>>() {
 
             @Override
             public Flowable<String> apply(Throwable t1) {
@@ -263,7 +263,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, Long.MAX_VALUE);
-        observable.subscribe(ts);
+        flowable.subscribe(ts);
         ts.awaitTerminalEvent();
 
         verify(subscriber, Mockito.never()).onError(any(Throwable.class));
@@ -285,9 +285,9 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
         }
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
+        public void subscribe(final Subscriber<? super String> subscriber) {
             System.out.println("TestFlowable subscribed to ...");
-            observer.onSubscribe(new BooleanSubscription());
+            subscriber.onSubscribe(new BooleanSubscription());
             t = new Thread(new Runnable() {
 
                 @Override
@@ -296,11 +296,11 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
                         System.out.println("running TestFlowable thread");
                         for (String s : values) {
                             System.out.println("TestFlowable onNext: " + s);
-                            observer.onNext(s);
+                            subscriber.onNext(s);
                         }
                         throw new RuntimeException("Forced Failure");
                     } catch (Throwable e) {
-                        observer.onError(e);
+                        subscriber.onError(e);
                     }
                 }
 
@@ -381,9 +381,9 @@ public class FlowableOnErrorResumeNextViaFunctionTest {
     public void badOtherSource() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
-            public Object apply(Flowable<Integer> o) throws Exception {
+            public Object apply(Flowable<Integer> f) throws Exception {
                 return Flowable.error(new IOException())
-                        .onErrorResumeNext(Functions.justFunction(o));
+                        .onErrorResumeNext(Functions.justFunction(f));
             }
         }, false, 1, 1, 1);
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
@@ -38,7 +38,7 @@ public class FlowableOnErrorReturnTest {
         Flowable<String> w = Flowable.unsafeCreate(f);
         final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
 
-        Flowable<String> observable = w.onErrorReturn(new Function<Throwable, String>() {
+        Flowable<String> flowable = w.onErrorReturn(new Function<Throwable, String>() {
 
             @Override
             public String apply(Throwable e) {
@@ -49,7 +49,7 @@ public class FlowableOnErrorReturnTest {
         });
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -73,7 +73,7 @@ public class FlowableOnErrorReturnTest {
         Flowable<String> w = Flowable.unsafeCreate(f);
         final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
 
-        Flowable<String> observable = w.onErrorReturn(new Function<Throwable, String>() {
+        Flowable<String> flowable = w.onErrorReturn(new Function<Throwable, String>() {
 
             @Override
             public String apply(Throwable e) {
@@ -84,7 +84,7 @@ public class FlowableOnErrorReturnTest {
         });
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -119,7 +119,7 @@ public class FlowableOnErrorReturnTest {
             }
         });
 
-        Flowable<String> observable = w.onErrorReturn(new Function<Throwable, String>() {
+        Flowable<String> flowable = w.onErrorReturn(new Function<Throwable, String>() {
 
             @Override
             public String apply(Throwable t1) {
@@ -130,7 +130,7 @@ public class FlowableOnErrorReturnTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, Long.MAX_VALUE);
-        observable.subscribe(ts);
+        flowable.subscribe(ts);
         ts.awaitTerminalEvent();
 
         verify(subscriber, Mockito.never()).onError(any(Throwable.class));

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
@@ -48,8 +48,8 @@ public class FlowableOnErrorReturnTest {
 
         });
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -57,10 +57,10 @@ public class FlowableOnErrorReturnTest {
             fail(e.getMessage());
         }
 
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("failure");
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("failure");
+        verify(subscriber, times(1)).onComplete();
         assertNotNull(capturedException.get());
     }
 
@@ -83,9 +83,8 @@ public class FlowableOnErrorReturnTest {
 
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
-        observable.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -94,11 +93,11 @@ public class FlowableOnErrorReturnTest {
         }
 
         // we should get the "one" value before the error
-        verify(observer, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("one");
 
         // we should have received an onError call on the Observer since the resume function threw an exception
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, times(0)).onComplete();
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, times(0)).onComplete();
         assertNotNull(capturedException.get());
     }
 
@@ -129,18 +128,17 @@ public class FlowableOnErrorReturnTest {
 
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<String> observer = mock(DefaultSubscriber.class);
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer, Long.MAX_VALUE);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, Long.MAX_VALUE);
         observable.subscribe(ts);
         ts.awaitTerminalEvent();
 
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("one");
-        verify(observer, Mockito.never()).onNext("two");
-        verify(observer, Mockito.never()).onNext("three");
-        verify(observer, times(1)).onNext("resume");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, Mockito.never()).onNext("two");
+        verify(subscriber, Mockito.never()).onNext("three");
+        verify(subscriber, times(1)).onNext("resume");
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaFlowableTest.java
@@ -38,8 +38,8 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
         Flowable<String> observable = w.onExceptionResumeNext(resume);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -47,15 +47,15 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
             fail(e.getMessage());
         }
 
-        verify(observer).onSubscribe((Subscription)any());
-        verify(observer, times(1)).onNext("one");
-        verify(observer, Mockito.never()).onNext("two");
-        verify(observer, Mockito.never()).onNext("three");
-        verify(observer, times(1)).onNext("twoResume");
-        verify(observer, times(1)).onNext("threeResume");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verifyNoMoreInteractions(observer);
+        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, Mockito.never()).onNext("two");
+        verify(subscriber, Mockito.never()).onNext("three");
+        verify(subscriber, times(1)).onNext("twoResume");
+        verify(subscriber, times(1)).onNext("threeResume");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verifyNoMoreInteractions(subscriber);
     }
 
     @Test
@@ -66,8 +66,8 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
         Flowable<String> observable = w.onExceptionResumeNext(resume);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -75,15 +75,15 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
             fail(e.getMessage());
         }
 
-        verify(observer).onSubscribe((Subscription)any());
-        verify(observer, times(1)).onNext("one");
-        verify(observer, Mockito.never()).onNext("two");
-        verify(observer, Mockito.never()).onNext("three");
-        verify(observer, times(1)).onNext("twoResume");
-        verify(observer, times(1)).onNext("threeResume");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verifyNoMoreInteractions(observer);
+        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, Mockito.never()).onNext("two");
+        verify(subscriber, Mockito.never()).onNext("three");
+        verify(subscriber, times(1)).onNext("twoResume");
+        verify(subscriber, times(1)).onNext("threeResume");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verifyNoMoreInteractions(subscriber);
     }
 
     @Test
@@ -94,8 +94,8 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
         Flowable<String> observable = w.onExceptionResumeNext(resume);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -103,15 +103,15 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
             fail(e.getMessage());
         }
 
-        verify(observer).onSubscribe((Subscription)any());
-        verify(observer, times(1)).onNext("one");
-        verify(observer, never()).onNext("two");
-        verify(observer, never()).onNext("three");
-        verify(observer, never()).onNext("twoResume");
-        verify(observer, never()).onNext("threeResume");
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verifyNoMoreInteractions(observer);
+        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, never()).onNext("two");
+        verify(subscriber, never()).onNext("three");
+        verify(subscriber, never()).onNext("twoResume");
+        verify(subscriber, never()).onNext("threeResume");
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verifyNoMoreInteractions(subscriber);
     }
 
     @Test
@@ -122,8 +122,8 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
         Flowable<String> observable = w.onExceptionResumeNext(resume);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -131,15 +131,15 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
             fail(e.getMessage());
         }
 
-        verify(observer).onSubscribe((Subscription)any());
-        verify(observer, times(1)).onNext("one");
-        verify(observer, never()).onNext("two");
-        verify(observer, never()).onNext("three");
-        verify(observer, never()).onNext("twoResume");
-        verify(observer, never()).onNext("threeResume");
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verifyNoMoreInteractions(observer);
+        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, never()).onNext("two");
+        verify(subscriber, never()).onNext("three");
+        verify(subscriber, never()).onNext("twoResume");
+        verify(subscriber, never()).onNext("threeResume");
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verifyNoMoreInteractions(subscriber);
     }
 
     @Test
@@ -165,8 +165,8 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
 
         Flowable<String> observable = w.onExceptionResumeNext(resume);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
         try {
             // if the thread gets started (which it shouldn't if it's working correctly)
@@ -177,13 +177,13 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
             fail(e.getMessage());
         }
 
-        verify(observer, times(1)).onNext("one");
-        verify(observer, never()).onNext("two");
-        verify(observer, never()).onNext("three");
-        verify(observer, times(1)).onNext("twoResume");
-        verify(observer, times(1)).onNext("threeResume");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, never()).onNext("two");
+        verify(subscriber, never()).onNext("three");
+        verify(subscriber, times(1)).onNext("twoResume");
+        verify(subscriber, times(1)).onNext("threeResume");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaFlowableTest.java
@@ -36,10 +36,10 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
         TestObservable f = new TestObservable("one", "EXCEPTION", "two", "three");
         Flowable<String> w = Flowable.unsafeCreate(f);
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
-        Flowable<String> observable = w.onExceptionResumeNext(resume);
+        Flowable<String> flowable = w.onExceptionResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -64,10 +64,10 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
         TestObservable f = new TestObservable("one", "RUNTIMEEXCEPTION", "two", "three");
         Flowable<String> w = Flowable.unsafeCreate(f);
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
-        Flowable<String> observable = w.onExceptionResumeNext(resume);
+        Flowable<String> flowable = w.onExceptionResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -92,10 +92,10 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
         TestObservable f = new TestObservable("one", "THROWABLE", "two", "three");
         Flowable<String> w = Flowable.unsafeCreate(f);
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
-        Flowable<String> observable = w.onExceptionResumeNext(resume);
+        Flowable<String> flowable = w.onExceptionResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -120,10 +120,10 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
         TestObservable f = new TestObservable("one", "ERROR", "two", "three");
         Flowable<String> w = Flowable.unsafeCreate(f);
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
-        Flowable<String> observable = w.onExceptionResumeNext(resume);
+        Flowable<String> flowable = w.onExceptionResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         try {
             f.t.join();
@@ -163,10 +163,10 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
             }
         });
 
-        Flowable<String> observable = w.onExceptionResumeNext(resume);
+        Flowable<String> flowable = w.onExceptionResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         try {
             // if the thread gets started (which it shouldn't if it's working correctly)
@@ -226,8 +226,8 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
         }
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        public void subscribe(final Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
             System.out.println("TestObservable subscribed to ...");
             t = new Thread(new Runnable() {
 
@@ -246,13 +246,13 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
                                 throw new Throwable("Forced Throwable");
                             }
                             System.out.println("TestObservable onNext: " + s);
-                            observer.onNext(s);
+                            subscriber.onNext(s);
                         }
                         System.out.println("TestObservable onComplete");
-                        observer.onComplete();
+                        subscriber.onComplete();
                     } catch (Throwable e) {
                         System.out.println("TestObservable onError: " + e);
-                        observer.onError(e);
+                        subscriber.onError(e);
                     }
                 }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
@@ -41,8 +41,8 @@ public class FlowablePublishFunctionTest {
 
         Flowable.range(1, 3).publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Flowable<Integer> o) {
-                return Flowable.concat(o.take(5), o.takeLast(5));
+            public Flowable<Integer> apply(Flowable<Integer> f) {
+                return Flowable.concat(f.take(5), f.takeLast(5));
             }
         }).subscribe(ts);
 
@@ -57,8 +57,8 @@ public class FlowablePublishFunctionTest {
 
         Flowable.range(1, 6).publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Flowable<Integer> o) {
-                return Flowable.concat(o.take(5), o.takeLast(5));
+            public Flowable<Integer> apply(Flowable<Integer> f) {
+                return Flowable.concat(f.take(5), f.takeLast(5));
             }
         }).subscribe(ts);
 
@@ -88,8 +88,8 @@ public class FlowablePublishFunctionTest {
 
         pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Flowable<Integer> o) {
-                return Flowable.concat(o.take(5), o.takeLast(5));
+            public Flowable<Integer> apply(Flowable<Integer> f) {
+                return Flowable.concat(f.take(5), f.takeLast(5));
             }
         }).subscribe(ts);
 
@@ -124,8 +124,8 @@ public class FlowablePublishFunctionTest {
 
         pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Flowable<Integer> o) {
-                return o.take(1);
+            public Flowable<Integer> apply(Flowable<Integer> f) {
+                return f.take(1);
             }
         }).subscribe(ts);
 
@@ -155,8 +155,8 @@ public class FlowablePublishFunctionTest {
 
         pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Flowable<Integer> o) {
-                return o.take(1);
+            public Flowable<Integer> apply(Flowable<Integer> f) {
+                return f.take(1);
             }
         }).subscribe(ts);
 
@@ -171,8 +171,8 @@ public class FlowablePublishFunctionTest {
 
         pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Flowable<Integer> o) {
-                return o.take(1);
+            public Flowable<Integer> apply(Flowable<Integer> f) {
+                return f.take(1);
             }
         }).subscribe(ts);
 
@@ -193,8 +193,8 @@ public class FlowablePublishFunctionTest {
 
         pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Flowable<Integer> o) {
-                return o;
+            public Flowable<Integer> apply(Flowable<Integer> f) {
+                return f;
             }
         }).subscribe(ts);
 
@@ -216,8 +216,8 @@ public class FlowablePublishFunctionTest {
 
         pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Flowable<Integer> o) {
-                return o;
+            public Flowable<Integer> apply(Flowable<Integer> f) {
+                return f;
             }
         }).subscribe(ts);
 
@@ -242,8 +242,8 @@ public class FlowablePublishFunctionTest {
 
         new FlowablePublishMulticast<Integer, Integer>(pp, new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Flowable<Integer> o) {
-                return o;
+            public Flowable<Integer> apply(Flowable<Integer> f) {
+                return f;
             }
         }, Flowable.bufferSize(), true).subscribe(ts);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -42,18 +42,18 @@ public class FlowablePublishTest {
     @Test
     public void testPublish() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        ConnectableFlowable<String> o = Flowable.unsafeCreate(new Publisher<String>() {
+        ConnectableFlowable<String> f = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
-            public void subscribe(final Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(final Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 new Thread(new Runnable() {
 
                     @Override
                     public void run() {
                         counter.incrementAndGet();
-                        observer.onNext("one");
-                        observer.onComplete();
+                        subscriber.onNext("one");
+                        subscriber.onComplete();
                     }
                 }).start();
             }
@@ -62,7 +62,7 @@ public class FlowablePublishTest {
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
 
             @Override
             public void accept(String v) {
@@ -72,7 +72,7 @@ public class FlowablePublishTest {
         });
 
         // subscribe again
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
 
             @Override
             public void accept(String v) {
@@ -81,7 +81,7 @@ public class FlowablePublishTest {
             }
         });
 
-        Disposable s = o.connect();
+        Disposable s = f.connect();
         try {
             if (!latch.await(1000, TimeUnit.MILLISECONDS)) {
                 fail("subscriptions did not receive values");
@@ -508,9 +508,9 @@ public class FlowablePublishTest {
 
     @Test
     public void source() {
-        Flowable<Integer> o = Flowable.never();
+        Flowable<Integer> f = Flowable.never();
 
-        assertSame(o, (((HasUpstreamPublisher<?>)o.publish()).source()));
+        assertSame(f, (((HasUpstreamPublisher<?>)f.publish()).source()));
     }
 
     @Test
@@ -651,13 +651,13 @@ public class FlowablePublishTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onNext(1);
-                    observer.onComplete();
-                    observer.onNext(2);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onNext(1);
+                    subscriber.onComplete();
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .publish()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
@@ -33,21 +33,21 @@ public class FlowableRangeLongTest {
 
     @Test
     public void testRangeStartAt2Count3() {
-        Subscriber<Long> observer = TestHelper.mockSubscriber();
+        Subscriber<Long> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.rangeLong(2, 3).subscribe(observer);
+        Flowable.rangeLong(2, 3).subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(2L);
-        verify(observer, times(1)).onNext(3L);
-        verify(observer, times(1)).onNext(4L);
-        verify(observer, never()).onNext(5L);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(2L);
+        verify(subscriber, times(1)).onNext(3L);
+        verify(subscriber, times(1)).onNext(4L);
+        verify(subscriber, never()).onNext(5L);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testRangeUnsubscribe() {
-        Subscriber<Long> observer = TestHelper.mockSubscriber();
+        Subscriber<Long> subscriber = TestHelper.mockSubscriber();
 
         final AtomicInteger count = new AtomicInteger();
 
@@ -57,14 +57,14 @@ public class FlowableRangeLongTest {
                 count.incrementAndGet();
             }
         })
-        .take(3).subscribe(observer);
+        .take(3).subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(1L);
-        verify(observer, times(1)).onNext(2L);
-        verify(observer, times(1)).onNext(3L);
-        verify(observer, never()).onNext(4L);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(1L);
+        verify(subscriber, times(1)).onNext(2L);
+        verify(subscriber, times(1)).onNext(3L);
+        verify(subscriber, never()).onNext(4L);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
         assertEquals(3, count.get());
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
@@ -95,14 +95,14 @@ public class FlowableRangeLongTest {
 
     @Test
     public void testBackpressureViaRequest() {
-        Flowable<Long> o = Flowable.rangeLong(1, Flowable.bufferSize());
+        Flowable<Long> f = Flowable.rangeLong(1, Flowable.bufferSize());
 
         TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
 
         ts.assertNoValues();
         ts.request(1);
 
-        o.subscribe(ts);
+        f.subscribe(ts);
 
         ts.assertValue(1L);
 
@@ -123,14 +123,14 @@ public class FlowableRangeLongTest {
             list.add(i);
         }
 
-        Flowable<Long> o = Flowable.rangeLong(1, list.size());
+        Flowable<Long> f = Flowable.rangeLong(1, list.size());
 
         TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
 
         ts.assertNoValues();
         ts.request(Long.MAX_VALUE); // infinite
 
-        o.subscribe(ts);
+        f.subscribe(ts);
 
         ts.assertValueSequence(list);
         ts.assertTerminated();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
@@ -33,21 +33,21 @@ public class FlowableRangeTest {
 
     @Test
     public void testRangeStartAt2Count3() {
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.range(2, 3).subscribe(observer);
+        Flowable.range(2, 3).subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(2);
-        verify(observer, times(1)).onNext(3);
-        verify(observer, times(1)).onNext(4);
-        verify(observer, never()).onNext(5);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(2);
+        verify(subscriber, times(1)).onNext(3);
+        verify(subscriber, times(1)).onNext(4);
+        verify(subscriber, never()).onNext(5);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testRangeUnsubscribe() {
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         final AtomicInteger count = new AtomicInteger();
 
@@ -57,14 +57,14 @@ public class FlowableRangeTest {
                 count.incrementAndGet();
             }
         })
-        .take(3).subscribe(observer);
+        .take(3).subscribe(subscriber);
 
-        verify(observer, times(1)).onNext(1);
-        verify(observer, times(1)).onNext(2);
-        verify(observer, times(1)).onNext(3);
-        verify(observer, never()).onNext(4);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, times(1)).onNext(2);
+        verify(subscriber, times(1)).onNext(3);
+        verify(subscriber, never()).onNext(4);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
         assertEquals(3, count.get());
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
@@ -95,14 +95,14 @@ public class FlowableRangeTest {
 
     @Test
     public void testBackpressureViaRequest() {
-        Flowable<Integer> o = Flowable.range(1, Flowable.bufferSize());
+        Flowable<Integer> f = Flowable.range(1, Flowable.bufferSize());
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
         ts.assertNoValues();
         ts.request(1);
 
-        o.subscribe(ts);
+        f.subscribe(ts);
 
         ts.assertValue(1);
 
@@ -123,14 +123,14 @@ public class FlowableRangeTest {
             list.add(i);
         }
 
-        Flowable<Integer> o = Flowable.range(1, list.size());
+        Flowable<Integer> f = Flowable.range(1, list.size());
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
 
         ts.assertNoValues();
         ts.request(Long.MAX_VALUE); // infinite
 
-        o.subscribe(ts);
+        f.subscribe(ts);
 
         ts.assertValueSequence(list);
         ts.assertTerminated();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
@@ -34,13 +34,13 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableReduceTest {
-    Subscriber<Object> observer;
+    Subscriber<Object> subscriber;
 
     SingleObserver<Object> singleObserver;
 
     @Before
     public void before() {
-        observer = TestHelper.mockSubscriber();
+        subscriber = TestHelper.mockSubscriber();
         singleObserver = TestHelper.mockSingleObserver();
     }
 
@@ -62,11 +62,11 @@ public class FlowableReduceTest {
                     }
                 });
 
-        result.subscribe(observer);
+        result.subscribe(subscriber);
 
-        verify(observer).onNext(1 + 2 + 3 + 4 + 5);
-        verify(observer).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(1 + 2 + 3 + 4 + 5);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -80,11 +80,11 @@ public class FlowableReduceTest {
                     }
                 });
 
-        result.subscribe(observer);
+        result.subscribe(subscriber);
 
-        verify(observer, never()).onNext(any());
-        verify(observer, never()).onComplete();
-        verify(observer, times(1)).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, times(1)).onError(any(TestException.class));
     }
 
     @Test
@@ -104,11 +104,11 @@ public class FlowableReduceTest {
                     }
                 });
 
-        result.subscribe(observer);
+        result.subscribe(subscriber);
 
-        verify(observer, never()).onNext(any());
-        verify(observer, never()).onComplete();
-        verify(observer, times(1)).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, times(1)).onError(any(TestException.class));
     }
 
     @Test
@@ -125,11 +125,11 @@ public class FlowableReduceTest {
         Flowable<Integer> result = Flowable.just(1, 2, 3, 4, 5)
                 .reduce(0, sum).toFlowable().map(error);
 
-        result.subscribe(observer);
+        result.subscribe(subscriber);
 
-        verify(observer, never()).onNext(any());
-        verify(observer, never()).onComplete();
-        verify(observer, times(1)).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, times(1)).onError(any(TestException.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
@@ -476,9 +476,9 @@ public class FlowableReduceTest {
     public void seedDoubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Integer>, SingleSource<Integer>>() {
             @Override
-            public SingleSource<Integer> apply(Flowable<Integer> o)
+            public SingleSource<Integer> apply(Flowable<Integer> f)
                     throws Exception {
-                return o.reduce(0, new BiFunction<Integer, Integer, Integer>() {
+                return f.reduce(0, new BiFunction<Integer, Integer, Integer>() {
                     @Override
                     public Integer apply(Integer a, Integer b) throws Exception {
                         return a;
@@ -504,12 +504,12 @@ public class FlowableReduceTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onComplete();
-                    observer.onNext(1);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onComplete();
+                    subscriber.onNext(1);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .reduce(0, new BiFunction<Integer, Integer, Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -229,7 +229,7 @@ public class FlowableRefCountTest {
         final CountDownLatch unsubscribeLatch = new CountDownLatch(1);
         final CountDownLatch subscribeLatch = new CountDownLatch(1);
 
-        Flowable<Long> o = synchronousInterval()
+        Flowable<Long> f = synchronousInterval()
                 .doOnSubscribe(new Consumer<Subscription>() {
                     @Override
                     public void accept(Subscription s) {
@@ -248,7 +248,7 @@ public class FlowableRefCountTest {
                 });
 
         TestSubscriber<Long> s = new TestSubscriber<Long>();
-        o.publish().refCount().subscribeOn(Schedulers.newThread()).subscribe(s);
+        f.publish().refCount().subscribeOn(Schedulers.newThread()).subscribe(s);
         System.out.println("send unsubscribe");
         // wait until connected
         subscribeLatch.await();
@@ -275,7 +275,7 @@ public class FlowableRefCountTest {
     @Test
     public void testConnectUnsubscribeRaceCondition() throws InterruptedException {
         final AtomicInteger subUnsubCount = new AtomicInteger();
-        Flowable<Long> o = synchronousInterval()
+        Flowable<Long> f = synchronousInterval()
                 .doOnCancel(new Action() {
                     @Override
                     public void run() {
@@ -294,7 +294,7 @@ public class FlowableRefCountTest {
 
         TestSubscriber<Long> s = new TestSubscriber<Long>();
 
-        o.publish().refCount().subscribeOn(Schedulers.computation()).subscribe(s);
+        f.publish().refCount().subscribeOn(Schedulers.computation()).subscribe(s);
         System.out.println("send unsubscribe");
         // now immediately unsubscribe while subscribeOn is racing to subscribe
         s.dispose();
@@ -347,11 +347,11 @@ public class FlowableRefCountTest {
     public void onlyFirstShouldSubscribeAndLastUnsubscribe() {
         final AtomicInteger subscriptionCount = new AtomicInteger();
         final AtomicInteger unsubscriptionCount = new AtomicInteger();
-        Flowable<Integer> observable = Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable<Integer> flowable = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
-            public void subscribe(Subscriber<? super Integer> observer) {
+            public void subscribe(Subscriber<? super Integer> subscriber) {
                 subscriptionCount.incrementAndGet();
-                observer.onSubscribe(new Subscription() {
+                subscriber.onSubscribe(new Subscription() {
                     @Override
                     public void request(long n) {
 
@@ -364,7 +364,7 @@ public class FlowableRefCountTest {
                 });
             }
         });
-        Flowable<Integer> refCounted = observable.publish().refCount();
+        Flowable<Integer> refCounted = flowable.publish().refCount();
 
         Disposable first = refCounted.subscribe();
         assertEquals(1, subscriptionCount.get());
@@ -465,17 +465,17 @@ public class FlowableRefCountTest {
     public void testAlreadyUnsubscribedClient() {
         Subscriber<Integer> done = CancelledSubscriber.INSTANCE;
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         Flowable<Integer> result = Flowable.just(1).publish().refCount();
 
         result.subscribe(done);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
-        verify(o).onNext(1);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(1);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -484,12 +484,12 @@ public class FlowableRefCountTest {
 
         Subscriber<Integer> done = CancelledSubscriber.INSTANCE;
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
         Flowable<Integer> result = source.publish().refCount();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
 
@@ -498,17 +498,17 @@ public class FlowableRefCountTest {
         source.onNext(2);
         source.onComplete();
 
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testConnectDisconnectConnectAndSubjectState() {
-        Flowable<Integer> o1 = Flowable.just(10);
-        Flowable<Integer> o2 = Flowable.just(20);
-        Flowable<Integer> combined = Flowable.combineLatest(o1, o2, new BiFunction<Integer, Integer, Integer>() {
+        Flowable<Integer> f1 = Flowable.just(10);
+        Flowable<Integer> f2 = Flowable.just(20);
+        Flowable<Integer> combined = Flowable.combineLatest(f1, f2, new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2) {
                 return t1 + t2;
@@ -631,20 +631,20 @@ public class FlowableRefCountTest {
     @Test
     public void noOpConnect() {
         final int[] calls = { 0 };
-        Flowable<Integer> o = new ConnectableFlowable<Integer>() {
+        Flowable<Integer> f = new ConnectableFlowable<Integer>() {
             @Override
             public void connect(Consumer<? super Disposable> connection) {
                 calls[0]++;
             }
 
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
             }
         }.refCount();
 
-        o.test();
-        o.test();
+        f.test();
+        f.test();
 
         assertEquals(1, calls[0]);
     }
@@ -811,7 +811,7 @@ public class FlowableRefCountTest {
         }
 
         @Override
-        protected void subscribeActual(Subscriber<? super Object> observer) {
+        protected void subscribeActual(Subscriber<? super Object> subscriber) {
             throw new TestException("subscribeActual");
         }
     }
@@ -838,8 +838,8 @@ public class FlowableRefCountTest {
         }
 
         @Override
-        protected void subscribeActual(Subscriber<? super Object> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        protected void subscribeActual(Subscriber<? super Object> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
         }
     }
 
@@ -851,8 +851,8 @@ public class FlowableRefCountTest {
         }
 
         @Override
-        protected void subscribeActual(Subscriber<? super Object> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        protected void subscribeActual(Subscriber<? super Object> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
         }
     }
 
@@ -923,9 +923,9 @@ public class FlowableRefCountTest {
         }
 
         @Override
-        protected void subscribeActual(Subscriber<? super Object> observer) {
+        protected void subscribeActual(Subscriber<? super Object> subscriber) {
             if (++count == 1) {
-                observer.onSubscribe(new BooleanSubscription());
+                subscriber.onSubscribe(new BooleanSubscription());
             } else {
                 throw new TestException("subscribeActual");
             }
@@ -938,10 +938,10 @@ public class FlowableRefCountTest {
         try {
             BadFlowableSubscribe2 bf = new BadFlowableSubscribe2();
 
-            Flowable<Object> o = bf.refCount();
-            o.test();
+            Flowable<Object> f = bf.refCount();
+            f.test();
             try {
-                o.test();
+                f.test();
                 fail("Should have thrown");
             } catch (NullPointerException ex) {
                 assertTrue(ex.getCause() instanceof TestException);
@@ -966,9 +966,9 @@ public class FlowableRefCountTest {
         }
 
         @Override
-        protected void subscribeActual(Subscriber<? super Object> observer) {
-            observer.onSubscribe(new BooleanSubscription());
-            observer.onComplete();
+        protected void subscribeActual(Subscriber<? super Object> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
+            subscriber.onComplete();
         }
 
         @Override
@@ -1216,12 +1216,12 @@ public class FlowableRefCountTest {
         }
 
         @Override
-        protected void subscribeActual(Subscriber<? super Object> observer) {
-            observer.onSubscribe(new BooleanSubscription());
-            observer.onSubscribe(new BooleanSubscription());
-            observer.onComplete();
-            observer.onComplete();
-            observer.onError(new TestException());
+        protected void subscribeActual(Subscriber<? super Object> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
+            subscriber.onSubscribe(new BooleanSubscription());
+            subscriber.onComplete();
+            subscriber.onComplete();
+            subscriber.onError(new TestException());
         }
 
         @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
@@ -42,9 +42,9 @@ public class FlowableRepeatTest {
         int value = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
-            public void subscribe(final Subscriber<? super Integer> o) {
-                o.onNext(count.incrementAndGet());
-                o.onComplete();
+            public void subscribe(final Subscriber<? super Integer> subscriber) {
+                subscriber.onNext(count.incrementAndGet());
+                subscriber.onComplete();
             }
         }).repeat().subscribeOn(Schedulers.computation())
         .take(num).blockingLast();
@@ -100,58 +100,58 @@ public class FlowableRepeatTest {
 
     @Test(timeout = 2000)
     public void testRepeatAndTake() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.just(1).repeat().take(10).subscribe(o);
+        Flowable.just(1).repeat().take(10).subscribe(subscriber);
 
-        verify(o, times(10)).onNext(1);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, times(10)).onNext(1);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test(timeout = 2000)
     public void testRepeatLimited() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.just(1).repeat(10).subscribe(o);
+        Flowable.just(1).repeat(10).subscribe(subscriber);
 
-        verify(o, times(10)).onNext(1);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, times(10)).onNext(1);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test(timeout = 2000)
     public void testRepeatError() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.error(new TestException()).repeat(10).subscribe(o);
+        Flowable.error(new TestException()).repeat(10).subscribe(subscriber);
 
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
 
     }
 
     @Test(timeout = 2000)
     public void testRepeatZero() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.just(1).repeat(0).subscribe(o);
+        Flowable.just(1).repeat(0).subscribe(subscriber);
 
-        verify(o).onComplete();
-        verify(o, never()).onNext(any());
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test(timeout = 2000)
     public void testRepeatOne() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.just(1).repeat(1).subscribe(o);
+        Flowable.just(1).repeat(1).subscribe(subscriber);
 
-        verify(o).onComplete();
-        verify(o, times(1)).onNext(any());
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onComplete();
+        verify(subscriber, times(1)).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     /** Issue #2587. */
@@ -216,8 +216,8 @@ public class FlowableRepeatTest {
 
         Flowable.just(1).repeatWhen((Function)new Function<Flowable, Flowable>() {
             @Override
-            public Flowable apply(Flowable o) {
-                return o.take(2);
+            public Flowable apply(Flowable f) {
+                return f.take(2);
             }
         }).subscribe(ts);
 
@@ -235,8 +235,8 @@ public class FlowableRepeatTest {
         Flowable.just(1).subscribeOn(Schedulers.trampoline())
         .repeatWhen((Function)new Function<Flowable, Flowable>() {
             @Override
-            public Flowable apply(Flowable o) {
-                return o.take(2);
+            public Flowable apply(Flowable f) {
+                return f.take(2);
             }
         }).subscribe(ts);
 
@@ -323,7 +323,7 @@ public class FlowableRepeatTest {
 
     @Test
     public void shouldDisposeInnerObservable() {
-      final PublishProcessor<Object> subject = PublishProcessor.create();
+      final PublishProcessor<Object> processor = PublishProcessor.create();
       final Disposable disposable = Flowable.just("Leak")
           .repeatWhen(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
@@ -331,16 +331,16 @@ public class FlowableRepeatTest {
                 return completions.switchMap(new Function<Object, Flowable<Object>>() {
                     @Override
                     public Flowable<Object> apply(Object ignore) throws Exception {
-                        return subject;
+                        return processor;
                     }
                 });
             }
         })
           .subscribe();
 
-      assertTrue(subject.hasSubscribers());
+      assertTrue(processor.hasSubscribers());
       disposable.dispose();
-      assertFalse(subject.hasSubscribers());
+      assertFalse(processor.hasSubscribers());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -50,40 +50,40 @@ public class FlowableReplayTest {
         cf.connect();
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            cf.subscribe(observer1);
+            cf.subscribe(subscriber1);
 
             source.onNext(1);
             source.onNext(2);
             source.onNext(3);
 
-            inOrder.verify(observer1, times(1)).onNext(1);
-            inOrder.verify(observer1, times(1)).onNext(2);
-            inOrder.verify(observer1, times(1)).onNext(3);
+            inOrder.verify(subscriber1, times(1)).onNext(1);
+            inOrder.verify(subscriber1, times(1)).onNext(2);
+            inOrder.verify(subscriber1, times(1)).onNext(3);
 
             source.onNext(4);
             source.onComplete();
-            inOrder.verify(observer1, times(1)).onNext(4);
-            inOrder.verify(observer1, times(1)).onComplete();
+            inOrder.verify(subscriber1, times(1)).onNext(4);
+            inOrder.verify(subscriber1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
 
         }
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            cf.subscribe(observer1);
+            cf.subscribe(subscriber1);
 
-            inOrder.verify(observer1, times(1)).onNext(2);
-            inOrder.verify(observer1, times(1)).onNext(3);
-            inOrder.verify(observer1, times(1)).onNext(4);
-            inOrder.verify(observer1, times(1)).onComplete();
+            inOrder.verify(subscriber1, times(1)).onNext(2);
+            inOrder.verify(subscriber1, times(1)).onNext(3);
+            inOrder.verify(subscriber1, times(1)).onNext(4);
+            inOrder.verify(subscriber1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
         }
     }
 
@@ -95,10 +95,10 @@ public class FlowableReplayTest {
         cf.connect();
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            cf.subscribe(observer1);
+            cf.subscribe(subscriber1);
 
             source.onNext(1);
             scheduler.advanceTimeBy(10, TimeUnit.MILLISECONDS);
@@ -107,33 +107,33 @@ public class FlowableReplayTest {
             source.onNext(3);
             scheduler.advanceTimeBy(10, TimeUnit.MILLISECONDS);
 
-            inOrder.verify(observer1, times(1)).onNext(1);
-            inOrder.verify(observer1, times(1)).onNext(2);
-            inOrder.verify(observer1, times(1)).onNext(3);
+            inOrder.verify(subscriber1, times(1)).onNext(1);
+            inOrder.verify(subscriber1, times(1)).onNext(2);
+            inOrder.verify(subscriber1, times(1)).onNext(3);
 
             source.onNext(4);
             source.onNext(5);
             scheduler.advanceTimeBy(90, TimeUnit.MILLISECONDS);
 
-            inOrder.verify(observer1, times(1)).onNext(4);
+            inOrder.verify(subscriber1, times(1)).onNext(4);
 
-            inOrder.verify(observer1, times(1)).onNext(5);
+            inOrder.verify(subscriber1, times(1)).onNext(5);
 
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
 
         }
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            cf.subscribe(observer1);
+            cf.subscribe(subscriber1);
 
-            inOrder.verify(observer1, times(1)).onNext(4);
-            inOrder.verify(observer1, times(1)).onNext(5);
+            inOrder.verify(subscriber1, times(1)).onNext(4);
+            inOrder.verify(subscriber1, times(1)).onNext(5);
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
         }
     }
 
@@ -147,10 +147,10 @@ public class FlowableReplayTest {
         cf.connect();
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            cf.subscribe(observer1);
+            cf.subscribe(subscriber1);
 
             source.onNext(1);
             scheduler.advanceTimeBy(60, TimeUnit.MILLISECONDS);
@@ -161,25 +161,25 @@ public class FlowableReplayTest {
             source.onComplete();
             scheduler.advanceTimeBy(60, TimeUnit.MILLISECONDS);
 
-            inOrder.verify(observer1, times(1)).onNext(1);
-            inOrder.verify(observer1, times(1)).onNext(2);
-            inOrder.verify(observer1, times(1)).onNext(3);
+            inOrder.verify(subscriber1, times(1)).onNext(1);
+            inOrder.verify(subscriber1, times(1)).onNext(2);
+            inOrder.verify(subscriber1, times(1)).onNext(3);
 
-            inOrder.verify(observer1, times(1)).onComplete();
+            inOrder.verify(subscriber1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
 
         }
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            cf.subscribe(observer1);
-            inOrder.verify(observer1, never()).onNext(3);
+            cf.subscribe(subscriber1);
+            inOrder.verify(subscriber1, never()).onNext(3);
 
-            inOrder.verify(observer1, times(1)).onComplete();
+            inOrder.verify(subscriber1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
         }
     }
 
@@ -208,37 +208,37 @@ public class FlowableReplayTest {
         Flowable<Integer> co = source.replay(selector);
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            co.subscribe(observer1);
+            co.subscribe(subscriber1);
 
             source.onNext(1);
             source.onNext(2);
             source.onNext(3);
 
-            inOrder.verify(observer1, times(1)).onNext(2);
-            inOrder.verify(observer1, times(1)).onNext(4);
-            inOrder.verify(observer1, times(1)).onNext(6);
+            inOrder.verify(subscriber1, times(1)).onNext(2);
+            inOrder.verify(subscriber1, times(1)).onNext(4);
+            inOrder.verify(subscriber1, times(1)).onNext(6);
 
             source.onNext(4);
             source.onComplete();
-            inOrder.verify(observer1, times(1)).onNext(8);
-            inOrder.verify(observer1, times(1)).onComplete();
+            inOrder.verify(subscriber1, times(1)).onNext(8);
+            inOrder.verify(subscriber1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
 
         }
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            co.subscribe(observer1);
+            co.subscribe(subscriber1);
 
-            inOrder.verify(observer1, times(1)).onComplete();
+            inOrder.verify(subscriber1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
 
         }
 
@@ -270,37 +270,37 @@ public class FlowableReplayTest {
         Flowable<Integer> co = source.replay(selector, 3);
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            co.subscribe(observer1);
+            co.subscribe(subscriber1);
 
             source.onNext(1);
             source.onNext(2);
             source.onNext(3);
 
-            inOrder.verify(observer1, times(1)).onNext(2);
-            inOrder.verify(observer1, times(1)).onNext(4);
-            inOrder.verify(observer1, times(1)).onNext(6);
+            inOrder.verify(subscriber1, times(1)).onNext(2);
+            inOrder.verify(subscriber1, times(1)).onNext(4);
+            inOrder.verify(subscriber1, times(1)).onNext(6);
 
             source.onNext(4);
             source.onComplete();
-            inOrder.verify(observer1, times(1)).onNext(8);
-            inOrder.verify(observer1, times(1)).onComplete();
+            inOrder.verify(subscriber1, times(1)).onNext(8);
+            inOrder.verify(subscriber1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
 
         }
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            co.subscribe(observer1);
+            co.subscribe(subscriber1);
 
-            inOrder.verify(observer1, times(1)).onComplete();
+            inOrder.verify(subscriber1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
         }
     }
 
@@ -332,10 +332,10 @@ public class FlowableReplayTest {
         Flowable<Integer> co = source.replay(selector, 100, TimeUnit.MILLISECONDS, scheduler);
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            co.subscribe(observer1);
+            co.subscribe(subscriber1);
 
             source.onNext(1);
             scheduler.advanceTimeBy(60, TimeUnit.MILLISECONDS);
@@ -346,24 +346,24 @@ public class FlowableReplayTest {
             source.onComplete();
             scheduler.advanceTimeBy(60, TimeUnit.MILLISECONDS);
 
-            inOrder.verify(observer1, times(1)).onNext(2);
-            inOrder.verify(observer1, times(1)).onNext(4);
-            inOrder.verify(observer1, times(1)).onNext(6);
+            inOrder.verify(subscriber1, times(1)).onNext(2);
+            inOrder.verify(subscriber1, times(1)).onNext(4);
+            inOrder.verify(subscriber1, times(1)).onNext(6);
 
-            inOrder.verify(observer1, times(1)).onComplete();
+            inOrder.verify(subscriber1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
 
         }
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            co.subscribe(observer1);
+            co.subscribe(subscriber1);
 
-            inOrder.verify(observer1, times(1)).onComplete();
+            inOrder.verify(subscriber1, times(1)).onComplete();
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onError(any(Throwable.class));
+            verify(subscriber1, never()).onError(any(Throwable.class));
         }
     }
 
@@ -375,41 +375,41 @@ public class FlowableReplayTest {
         cf.connect();
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            cf.subscribe(observer1);
+            cf.subscribe(subscriber1);
 
             source.onNext(1);
             source.onNext(2);
             source.onNext(3);
 
-            inOrder.verify(observer1, times(1)).onNext(1);
-            inOrder.verify(observer1, times(1)).onNext(2);
-            inOrder.verify(observer1, times(1)).onNext(3);
+            inOrder.verify(subscriber1, times(1)).onNext(1);
+            inOrder.verify(subscriber1, times(1)).onNext(2);
+            inOrder.verify(subscriber1, times(1)).onNext(3);
 
             source.onNext(4);
             source.onError(new RuntimeException("Forced failure"));
 
-            inOrder.verify(observer1, times(1)).onNext(4);
-            inOrder.verify(observer1, times(1)).onError(any(RuntimeException.class));
+            inOrder.verify(subscriber1, times(1)).onNext(4);
+            inOrder.verify(subscriber1, times(1)).onError(any(RuntimeException.class));
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onComplete();
+            verify(subscriber1, never()).onComplete();
 
         }
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            cf.subscribe(observer1);
+            cf.subscribe(subscriber1);
 
-            inOrder.verify(observer1, times(1)).onNext(2);
-            inOrder.verify(observer1, times(1)).onNext(3);
-            inOrder.verify(observer1, times(1)).onNext(4);
-            inOrder.verify(observer1, times(1)).onError(any(RuntimeException.class));
+            inOrder.verify(subscriber1, times(1)).onNext(2);
+            inOrder.verify(subscriber1, times(1)).onNext(3);
+            inOrder.verify(subscriber1, times(1)).onNext(4);
+            inOrder.verify(subscriber1, times(1)).onError(any(RuntimeException.class));
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onComplete();
+            verify(subscriber1, never()).onComplete();
         }
     }
 
@@ -423,10 +423,10 @@ public class FlowableReplayTest {
         cf.connect();
 
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            cf.subscribe(observer1);
+            cf.subscribe(subscriber1);
 
             source.onNext(1);
             scheduler.advanceTimeBy(60, TimeUnit.MILLISECONDS);
@@ -437,25 +437,25 @@ public class FlowableReplayTest {
             source.onError(new RuntimeException("Forced failure"));
             scheduler.advanceTimeBy(60, TimeUnit.MILLISECONDS);
 
-            inOrder.verify(observer1, times(1)).onNext(1);
-            inOrder.verify(observer1, times(1)).onNext(2);
-            inOrder.verify(observer1, times(1)).onNext(3);
+            inOrder.verify(subscriber1, times(1)).onNext(1);
+            inOrder.verify(subscriber1, times(1)).onNext(2);
+            inOrder.verify(subscriber1, times(1)).onNext(3);
 
-            inOrder.verify(observer1, times(1)).onError(any(RuntimeException.class));
+            inOrder.verify(subscriber1, times(1)).onError(any(RuntimeException.class));
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onComplete();
+            verify(subscriber1, never()).onComplete();
 
         }
         {
-            Subscriber<Object> observer1 = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(observer1);
+            Subscriber<Object> subscriber1 = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber1);
 
-            cf.subscribe(observer1);
-            inOrder.verify(observer1, never()).onNext(3);
+            cf.subscribe(subscriber1);
+            inOrder.verify(subscriber1, never()).onNext(3);
 
-            inOrder.verify(observer1, times(1)).onError(any(RuntimeException.class));
+            inOrder.verify(subscriber1, times(1)).onError(any(RuntimeException.class));
             inOrder.verifyNoMoreInteractions();
-            verify(observer1, never()).onComplete();
+            verify(subscriber1, never()).onComplete();
         }
     }
 
@@ -474,8 +474,8 @@ public class FlowableReplayTest {
         Flowable<Integer> result = source.replay(
         new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Flowable<Integer> o) {
-                return o.take(2);
+            public Flowable<Integer> apply(Flowable<Integer> f) {
+                return f.take(2);
             }
         });
 
@@ -900,19 +900,19 @@ public class FlowableReplayTest {
     @Test
     public void testCache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> o = Flowable.unsafeCreate(new Publisher<String>() {
+        Flowable<String> f = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
-            public void subscribe(final Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(final Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 new Thread(new Runnable() {
 
                     @Override
                     public void run() {
                         counter.incrementAndGet();
                         System.out.println("published observable being executed");
-                        observer.onNext("one");
-                        observer.onComplete();
+                        subscriber.onNext("one");
+                        subscriber.onComplete();
                     }
                 }).start();
             }
@@ -922,7 +922,7 @@ public class FlowableReplayTest {
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
 
             @Override
             public void accept(String v) {
@@ -933,7 +933,7 @@ public class FlowableReplayTest {
         });
 
         // subscribe again
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
 
             @Override
             public void accept(String v) {
@@ -952,10 +952,10 @@ public class FlowableReplayTest {
     @Test
     public void testUnsubscribeSource() throws Exception {
         Action unsubscribe = mock(Action.class);
-        Flowable<Integer> o = Flowable.just(1).doOnCancel(unsubscribe).cache();
-        o.subscribe();
-        o.subscribe();
-        o.subscribe();
+        Flowable<Integer> f = Flowable.just(1).doOnCancel(unsubscribe).cache();
+        f.subscribe();
+        f.subscribe();
+        f.subscribe();
         verify(unsubscribe, times(1)).run();
     }
 
@@ -1425,12 +1425,12 @@ public class FlowableReplayTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onError(new TestException("First"));
-                    observer.onNext(1);
-                    observer.onError(new TestException("Second"));
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onError(new TestException("First"));
+                    subscriber.onNext(1);
+                    subscriber.onError(new TestException("Second"));
+                    subscriber.onComplete();
                 }
             }.replay()
             .autoConnect()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
@@ -111,29 +111,29 @@ public class FlowableRetryTest {
 
     @Test
     public void testRetryIndefinitely() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         int numRetries = 20;
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
-        origin.retry().subscribe(new TestSubscriber<String>(observer));
+        origin.retry().subscribe(new TestSubscriber<String>(subscriber));
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
         // should show 3 attempts
-        inOrder.verify(observer, times(numRetries + 1)).onNext("beginningEveryTime");
+        inOrder.verify(subscriber, times(numRetries + 1)).onNext("beginningEveryTime");
         // should have no errors
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
         // should have a single success
-        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        inOrder.verify(subscriber, times(1)).onNext("onSuccessOnly");
         // should have a single successful onComplete
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testSchedulingNotificationHandler() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         int numRetries = 2;
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
-        TestSubscriber<String> subscriber = new TestSubscriber<String>(observer);
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Flowable<? extends Throwable> t1) {
@@ -151,24 +151,24 @@ public class FlowableRetryTest {
                 e.printStackTrace();
             }
         })
-        .subscribe(subscriber);
+        .subscribe(ts);
 
-        subscriber.awaitTerminalEvent();
-        InOrder inOrder = inOrder(observer);
+        ts.awaitTerminalEvent();
+        InOrder inOrder = inOrder(subscriber);
         // should show 3 attempts
-        inOrder.verify(observer, times(1 + numRetries)).onNext("beginningEveryTime");
+        inOrder.verify(subscriber, times(1 + numRetries)).onNext("beginningEveryTime");
         // should have no errors
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
         // should have a single success
-        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        inOrder.verify(subscriber, times(1)).onNext("onSuccessOnly");
         // should have a single successful onComplete
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testOnNextFromNotificationHandler() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         int numRetries = 2;
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
         origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
@@ -182,58 +182,58 @@ public class FlowableRetryTest {
                     }
                 }).startWith(0).cast(Object.class);
             }
-        }).subscribe(observer);
+        }).subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
         // should show 3 attempts
-        inOrder.verify(observer, times(numRetries + 1)).onNext("beginningEveryTime");
+        inOrder.verify(subscriber, times(numRetries + 1)).onNext("beginningEveryTime");
         // should have no errors
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
         // should have a single success
-        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        inOrder.verify(subscriber, times(1)).onNext("onSuccessOnly");
         // should have a single successful onComplete
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testOnCompletedFromNotificationHandler() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(1));
-        TestSubscriber<String> subscriber = new TestSubscriber<String>(observer);
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Flowable<? extends Throwable> t1) {
                 return Flowable.empty();
             }
-        }).subscribe(subscriber);
+        }).subscribe(ts);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onSubscribe((Subscription)notNull());
-        inOrder.verify(observer, never()).onNext("beginningEveryTime");
-        inOrder.verify(observer, never()).onNext("onSuccessOnly");
-        inOrder.verify(observer, times(1)).onComplete();
-        inOrder.verify(observer, never()).onError(any(Exception.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onSubscribe((Subscription)notNull());
+        inOrder.verify(subscriber, never()).onNext("beginningEveryTime");
+        inOrder.verify(subscriber, never()).onNext("onSuccessOnly");
+        inOrder.verify(subscriber, times(1)).onComplete();
+        inOrder.verify(subscriber, never()).onError(any(Exception.class));
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testOnErrorFromNotificationHandler() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(2));
         origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Flowable<? extends Throwable> t1) {
                 return Flowable.error(new RuntimeException());
             }
-        }).subscribe(observer);
+        }).subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onSubscribe((Subscription)notNull());
-        inOrder.verify(observer, never()).onNext("beginningEveryTime");
-        inOrder.verify(observer, never()).onNext("onSuccessOnly");
-        inOrder.verify(observer, never()).onComplete();
-        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onSubscribe((Subscription)notNull());
+        inOrder.verify(subscriber, never()).onNext("beginningEveryTime");
+        inOrder.verify(subscriber, never()).onNext("onSuccessOnly");
+        inOrder.verify(subscriber, never()).onComplete();
+        inOrder.verify(subscriber, times(1)).onError(any(RuntimeException.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -270,71 +270,71 @@ public class FlowableRetryTest {
 
     @Test
     public void testOriginFails() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(1));
-        origin.subscribe(observer);
+        origin.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("beginningEveryTime");
-        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
-        inOrder.verify(observer, never()).onNext("onSuccessOnly");
-        inOrder.verify(observer, never()).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("beginningEveryTime");
+        inOrder.verify(subscriber, times(1)).onError(any(RuntimeException.class));
+        inOrder.verify(subscriber, never()).onNext("onSuccessOnly");
+        inOrder.verify(subscriber, never()).onComplete();
     }
 
     @Test
     public void testRetryFail() {
         int numRetries = 1;
         int numFailures = 2;
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numFailures));
-        origin.retry(numRetries).subscribe(observer);
+        origin.retry(numRetries).subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
         // should show 2 attempts (first time fail, second time (1st retry) fail)
-        inOrder.verify(observer, times(1 + numRetries)).onNext("beginningEveryTime");
+        inOrder.verify(subscriber, times(1 + numRetries)).onNext("beginningEveryTime");
         // should only retry once, fail again and emit onError
-        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
+        inOrder.verify(subscriber, times(1)).onError(any(RuntimeException.class));
         // no success
-        inOrder.verify(observer, never()).onNext("onSuccessOnly");
-        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(subscriber, never()).onNext("onSuccessOnly");
+        inOrder.verify(subscriber, never()).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testRetrySuccess() {
         int numFailures = 1;
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numFailures));
-        origin.retry(3).subscribe(observer);
+        origin.retry(3).subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
         // should show 3 attempts
-        inOrder.verify(observer, times(1 + numFailures)).onNext("beginningEveryTime");
+        inOrder.verify(subscriber, times(1 + numFailures)).onNext("beginningEveryTime");
         // should have no errors
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
         // should have a single success
-        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        inOrder.verify(subscriber, times(1)).onNext("onSuccessOnly");
         // should have a single successful onComplete
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testInfiniteRetry() {
         int numFailures = 20;
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numFailures));
-        origin.retry().subscribe(observer);
+        origin.retry().subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
         // should show 3 attempts
-        inOrder.verify(observer, times(1 + numFailures)).onNext("beginningEveryTime");
+        inOrder.verify(subscriber, times(1 + numFailures)).onNext("beginningEveryTime");
         // should have no errors
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
         // should have a single success
-        inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+        inOrder.verify(subscriber, times(1)).onNext("onSuccessOnly");
         // should have a single successful onComplete
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -614,7 +614,7 @@ public class FlowableRetryTest {
     }
 
     /** Observer for listener on seperate thread. */
-    static final class AsyncObserver<T> extends DefaultSubscriber<T> {
+    static final class AsyncSubscriber<T> extends DefaultSubscriber<T> {
 
         protected CountDownLatch latch = new CountDownLatch(1);
 
@@ -624,7 +624,7 @@ public class FlowableRetryTest {
          * Wrap existing Observer.
          * @param target the target subscriber
          */
-        AsyncObserver(Subscriber<T> target) {
+        AsyncSubscriber(Subscriber<T> target) {
             this.target = target;
         }
 
@@ -660,23 +660,22 @@ public class FlowableRetryTest {
     @Test(timeout = 10000)
     public void testUnsubscribeAfterError() {
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<Long> observer = mock(DefaultSubscriber.class);
+        Subscriber<Long> subscriber = TestHelper.mockSubscriber();
 
         // Flowable that always fails after 100ms
         SlowFlowable so = new SlowFlowable(100, 0);
         Flowable<Long> o = Flowable.unsafeCreate(so).retry(5);
 
-        AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
+        AsyncSubscriber<Long> async = new AsyncSubscriber<Long>(subscriber);
 
         o.subscribe(async);
 
         async.await();
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
         // Should fail once
-        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
-        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(subscriber, times(1)).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onComplete();
 
         assertEquals("Start 6 threads, retry 5 then fail on 6", 6, so.efforts.get());
         assertEquals("Only 1 active subscription", 1, so.maxActive.get());
@@ -685,23 +684,22 @@ public class FlowableRetryTest {
     @Test//(timeout = 10000)
     public void testTimeoutWithRetry() {
 
-        @SuppressWarnings("unchecked")
-        DefaultSubscriber<Long> observer = mock(DefaultSubscriber.class);
+        Subscriber<Long> subscriber = TestHelper.mockSubscriber();
 
         // Flowable that sends every 100ms (timeout fails instead)
         SlowFlowable so = new SlowFlowable(100, 10);
         Flowable<Long> o = Flowable.unsafeCreate(so).timeout(80, TimeUnit.MILLISECONDS).retry(5);
 
-        AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
+        AsyncSubscriber<Long> async = new AsyncSubscriber<Long>(subscriber);
 
         o.subscribe(async);
 
         async.await();
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
         // Should fail once
-        inOrder.verify(observer, times(1)).onError(any(Throwable.class));
-        inOrder.verify(observer, never()).onComplete();
+        inOrder.verify(subscriber, times(1)).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onComplete();
 
         assertEquals("Start 6 threads, retry 5 then fail on 6", 6, so.efforts.get());
     }
@@ -712,21 +710,21 @@ public class FlowableRetryTest {
         for (int j = 0;j < NUM_LOOPS; j++) {
             final int numRetries = Flowable.bufferSize() * 2;
             for (int i = 0; i < 400; i++) {
-                Subscriber<String> observer = TestHelper.mockSubscriber();
+                Subscriber<String> subscriber = TestHelper.mockSubscriber();
                 Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
-                TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+                TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
                 origin.retry().observeOn(Schedulers.computation()).subscribe(ts);
                 ts.awaitTerminalEvent(5, TimeUnit.SECONDS);
 
-                InOrder inOrder = inOrder(observer);
+                InOrder inOrder = inOrder(subscriber);
                 // should have no errors
-                verify(observer, never()).onError(any(Throwable.class));
+                verify(subscriber, never()).onError(any(Throwable.class));
                 // should show numRetries attempts
-                inOrder.verify(observer, times(numRetries + 1)).onNext("beginningEveryTime");
+                inOrder.verify(subscriber, times(numRetries + 1)).onNext("beginningEveryTime");
                 // should have a single success
-                inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
+                inOrder.verify(subscriber, times(1)).onNext("onSuccessOnly");
                 // should have a single successful onComplete
-                inOrder.verify(observer, times(1)).onComplete();
+                inOrder.verify(subscriber, times(1)).onComplete();
                 inOrder.verifyNoMoreInteractions();
             }
         }
@@ -833,7 +831,7 @@ public class FlowableRetryTest {
     }
     @Test//(timeout = 3000)
     public void testIssue1900() throws InterruptedException {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         final int NUM_MSG = 1034;
         final AtomicInteger count = new AtomicInteger();
 
@@ -858,22 +856,22 @@ public class FlowableRetryTest {
                 return t1.take(1);
             }
         })
-        .subscribe(new TestSubscriber<String>(observer));
+        .subscribe(new TestSubscriber<String>(subscriber));
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
         // should show 3 attempts
-        inOrder.verify(observer, times(NUM_MSG)).onNext(any(java.lang.String.class));
+        inOrder.verify(subscriber, times(NUM_MSG)).onNext(any(java.lang.String.class));
         //        // should have no errors
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
         // should have a single success
         //inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
         // should have a single successful onComplete
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
     @Test//(timeout = 3000)
     public void testIssue1900SourceNotSupportingBackpressure() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         final int NUM_MSG = 1034;
         final AtomicInteger count = new AtomicInteger();
 
@@ -902,17 +900,17 @@ public class FlowableRetryTest {
                 return t1.take(1);
             }
         })
-        .subscribe(new TestSubscriber<String>(observer));
+        .subscribe(new TestSubscriber<String>(subscriber));
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
         // should show 3 attempts
-        inOrder.verify(observer, times(NUM_MSG)).onNext(any(java.lang.String.class));
+        inOrder.verify(subscriber, times(NUM_MSG)).onNext(any(java.lang.String.class));
         //        // should have no errors
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
         // should have a single success
         //inOrder.verify(observer, times(1)).onNext("onSuccessOnly");
         // should have a single successful onComplete
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -59,16 +59,16 @@ public class FlowableRetryWithPredicateTest {
     public void testWithNothingToRetry() {
         Flowable<Integer> source = Flowable.range(0, 3);
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.retry(retryTwice).subscribe(o);
+        source.retry(retryTwice).subscribe(subscriber);
 
-        inOrder.verify(o).onNext(0);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber).onNext(0);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
     @Test
     public void testRetryTwice() {
@@ -90,19 +90,19 @@ public class FlowableRetryWithPredicateTest {
             }
         });
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.retry(retryTwice).subscribe(o);
+        source.retry(retryTwice).subscribe(subscriber);
 
-        inOrder.verify(o).onNext(0);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(0);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o).onNext(3);
-        inOrder.verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber).onNext(0);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(0);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onNext(3);
+        inOrder.verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
     }
     @Test
@@ -117,19 +117,19 @@ public class FlowableRetryWithPredicateTest {
             }
         });
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.retry(retryTwice).subscribe(o);
+        source.retry(retryTwice).subscribe(subscriber);
 
-        inOrder.verify(o).onNext(0);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(0);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(0);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onError(any(TestException.class));
-        verify(o, never()).onComplete();
+        inOrder.verify(subscriber).onNext(0);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(0);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(0);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
 
     }
     @Test
@@ -152,19 +152,19 @@ public class FlowableRetryWithPredicateTest {
             }
         });
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.retry(retryOnTestException).subscribe(o);
+        source.retry(retryOnTestException).subscribe(subscriber);
 
-        inOrder.verify(o).onNext(0);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(0);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o).onNext(3);
-        inOrder.verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber).onNext(0);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(0);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onNext(3);
+        inOrder.verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
     @Test
     public void testRetryOnSpecificExceptionAndNotOther() {
@@ -188,35 +188,35 @@ public class FlowableRetryWithPredicateTest {
             }
         });
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.retry(retryOnTestException).subscribe(o);
+        source.retry(retryOnTestException).subscribe(subscriber);
 
-        inOrder.verify(o).onNext(0);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(0);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o).onNext(3);
-        inOrder.verify(o).onError(te);
-        verify(o, never()).onError(ioe);
-        verify(o, never()).onComplete();
+        inOrder.verify(subscriber).onNext(0);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(0);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onNext(3);
+        inOrder.verify(subscriber).onError(te);
+        verify(subscriber, never()).onError(ioe);
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
     public void testUnsubscribeFromRetry() {
-        PublishProcessor<Integer> subject = PublishProcessor.create();
+        PublishProcessor<Integer> processor = PublishProcessor.create();
         final AtomicInteger count = new AtomicInteger(0);
-        Disposable sub = subject.retry(retryTwice).subscribe(new Consumer<Integer>() {
+        Disposable sub = processor.retry(retryTwice).subscribe(new Consumer<Integer>() {
             @Override
             public void accept(Integer n) {
                 count.incrementAndGet();
             }
         });
-        subject.onNext(1);
+        processor.onNext(1);
         sub.dispose();
-        subject.onNext(2);
+        processor.onNext(2);
         assertEquals(1, count.get());
     }
 
@@ -227,13 +227,13 @@ public class FlowableRetryWithPredicateTest {
 
         // Flowable that always fails after 100ms
         FlowableRetryTest.SlowFlowable so = new FlowableRetryTest.SlowFlowable(100, 0);
-        Flowable<Long> o = Flowable
+        Flowable<Long> f = Flowable
                 .unsafeCreate(so)
                 .retry(retry5);
 
         FlowableRetryTest.AsyncSubscriber<Long> async = new FlowableRetryTest.AsyncSubscriber<Long>(subscriber);
 
-        o.subscribe(async);
+        f.subscribe(async);
 
         async.await();
 
@@ -253,14 +253,14 @@ public class FlowableRetryWithPredicateTest {
 
         // Flowable that sends every 100ms (timeout fails instead)
         FlowableRetryTest.SlowFlowable so = new FlowableRetryTest.SlowFlowable(100, 10);
-        Flowable<Long> o = Flowable
+        Flowable<Long> f = Flowable
                 .unsafeCreate(so)
                 .timeout(80, TimeUnit.MILLISECONDS)
                 .retry(retry5);
 
         FlowableRetryTest.AsyncSubscriber<Long> async = new FlowableRetryTest.AsyncSubscriber<Long>(subscriber);
 
-        o.subscribe(async);
+        f.subscribe(async);
 
         async.await();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
@@ -33,16 +33,16 @@ import io.reactivex.subscribers.TestSubscriber;
 public class FlowableSampleTest {
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
-    private Subscriber<Long> observer;
-    private Subscriber<Object> observer2;
+    private Subscriber<Long> subscriber;
+    private Subscriber<Object> subscriber2;
 
     @Before
     // due to mocking
     public void before() {
         scheduler = new TestScheduler();
         innerScheduler = scheduler.createWorker();
-        observer = TestHelper.mockSubscriber();
-        observer2 = TestHelper.mockSubscriber();
+        subscriber = TestHelper.mockSubscriber();
+        subscriber2 = TestHelper.mockSubscriber();
     }
 
     @Test
@@ -73,38 +73,38 @@ public class FlowableSampleTest {
         });
 
         Flowable<Long> sampled = source.sample(400L, TimeUnit.MILLISECONDS, scheduler);
-        sampled.subscribe(observer);
+        sampled.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         scheduler.advanceTimeTo(800L, TimeUnit.MILLISECONDS);
-        verify(observer, never()).onNext(any(Long.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any(Long.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(1200L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext(1L);
-        verify(observer, never()).onNext(2L);
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext(1L);
+        verify(subscriber, never()).onNext(2L);
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(1600L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(1L);
-        verify(observer, never()).onNext(2L);
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(1L);
+        verify(subscriber, never()).onNext(2L);
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(2000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(1L);
-        inOrder.verify(observer, times(1)).onNext(2L);
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(1L);
+        inOrder.verify(subscriber, times(1)).onNext(2L);
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(3000L, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(1L);
-        inOrder.verify(observer, never()).onNext(2L);
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(1L);
+        inOrder.verify(subscriber, never()).onNext(2L);
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -113,7 +113,7 @@ public class FlowableSampleTest {
         PublishProcessor<Integer> sampler = PublishProcessor.create();
 
         Flowable<Integer> m = source.sample(sampler);
-        m.subscribe(observer2);
+        m.subscribe(subscriber2);
 
         source.onNext(1);
         source.onNext(2);
@@ -124,13 +124,13 @@ public class FlowableSampleTest {
         source.onComplete();
         sampler.onNext(3);
 
-        InOrder inOrder = inOrder(observer2);
-        inOrder.verify(observer2, never()).onNext(1);
-        inOrder.verify(observer2, times(1)).onNext(2);
-        inOrder.verify(observer2, never()).onNext(3);
-        inOrder.verify(observer2, times(1)).onNext(4);
-        inOrder.verify(observer2, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        InOrder inOrder = inOrder(subscriber2);
+        inOrder.verify(subscriber2, never()).onNext(1);
+        inOrder.verify(subscriber2, times(1)).onNext(2);
+        inOrder.verify(subscriber2, never()).onNext(3);
+        inOrder.verify(subscriber2, times(1)).onNext(4);
+        inOrder.verify(subscriber2, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class FlowableSampleTest {
         PublishProcessor<Integer> sampler = PublishProcessor.create();
 
         Flowable<Integer> m = source.sample(sampler);
-        m.subscribe(observer2);
+        m.subscribe(subscriber2);
 
         source.onNext(1);
         source.onNext(2);
@@ -154,13 +154,13 @@ public class FlowableSampleTest {
         source.onComplete();
         sampler.onNext(3);
 
-        InOrder inOrder = inOrder(observer2);
-        inOrder.verify(observer2, never()).onNext(1);
-        inOrder.verify(observer2, times(1)).onNext(2);
-        inOrder.verify(observer2, never()).onNext(3);
-        inOrder.verify(observer2, times(1)).onNext(4);
-        inOrder.verify(observer2, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        InOrder inOrder = inOrder(subscriber2);
+        inOrder.verify(subscriber2, never()).onNext(1);
+        inOrder.verify(subscriber2, times(1)).onNext(2);
+        inOrder.verify(subscriber2, never()).onNext(3);
+        inOrder.verify(subscriber2, times(1)).onNext(4);
+        inOrder.verify(subscriber2, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -169,7 +169,7 @@ public class FlowableSampleTest {
         PublishProcessor<Integer> sampler = PublishProcessor.create();
 
         Flowable<Integer> m = source.sample(sampler);
-        m.subscribe(observer2);
+        m.subscribe(subscriber2);
 
         source.onNext(1);
         source.onNext(2);
@@ -179,12 +179,12 @@ public class FlowableSampleTest {
         source.onNext(3);
         source.onNext(4);
 
-        InOrder inOrder = inOrder(observer2);
-        inOrder.verify(observer2, never()).onNext(1);
-        inOrder.verify(observer2, times(1)).onNext(2);
-        inOrder.verify(observer2, times(1)).onComplete();
-        inOrder.verify(observer2, never()).onNext(any());
-        verify(observer, never()).onError(any(Throwable.class));
+        InOrder inOrder = inOrder(subscriber2);
+        inOrder.verify(subscriber2, never()).onNext(1);
+        inOrder.verify(subscriber2, times(1)).onNext(2);
+        inOrder.verify(subscriber2, times(1)).onComplete();
+        inOrder.verify(subscriber2, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -193,7 +193,7 @@ public class FlowableSampleTest {
         PublishProcessor<Integer> sampler = PublishProcessor.create();
 
         Flowable<Integer> m = source.sample(sampler);
-        m.subscribe(observer2);
+        m.subscribe(subscriber2);
 
         source.onNext(1);
         source.onNext(2);
@@ -203,13 +203,13 @@ public class FlowableSampleTest {
         sampler.onNext(2);
         sampler.onComplete();
 
-        InOrder inOrder = inOrder(observer2);
-        inOrder.verify(observer2, never()).onNext(1);
-        inOrder.verify(observer2, times(1)).onNext(2);
-        inOrder.verify(observer2, never()).onNext(3);
-        inOrder.verify(observer2, times(1)).onComplete();
-        inOrder.verify(observer2, never()).onNext(any());
-        verify(observer, never()).onError(any(Throwable.class));
+        InOrder inOrder = inOrder(subscriber2);
+        inOrder.verify(subscriber2, never()).onNext(1);
+        inOrder.verify(subscriber2, times(1)).onNext(2);
+        inOrder.verify(subscriber2, never()).onNext(3);
+        inOrder.verify(subscriber2, times(1)).onComplete();
+        inOrder.verify(subscriber2, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -218,15 +218,15 @@ public class FlowableSampleTest {
         PublishProcessor<Integer> sampler = PublishProcessor.create();
 
         Flowable<Integer> m = source.sample(sampler);
-        m.subscribe(observer2);
+        m.subscribe(subscriber2);
 
         source.onComplete();
         sampler.onNext(1);
 
-        InOrder inOrder = inOrder(observer2);
-        inOrder.verify(observer2, times(1)).onComplete();
-        verify(observer2, never()).onNext(any());
-        verify(observer, never()).onError(any(Throwable.class));
+        InOrder inOrder = inOrder(subscriber2);
+        inOrder.verify(subscriber2, times(1)).onComplete();
+        verify(subscriber2, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -235,16 +235,16 @@ public class FlowableSampleTest {
         PublishProcessor<Integer> sampler = PublishProcessor.create();
 
         Flowable<Integer> m = source.sample(sampler);
-        m.subscribe(observer2);
+        m.subscribe(subscriber2);
 
         source.onNext(1);
         source.onError(new RuntimeException("Forced failure!"));
         sampler.onNext(1);
 
-        InOrder inOrder = inOrder(observer2);
-        inOrder.verify(observer2, times(1)).onError(any(Throwable.class));
-        verify(observer2, never()).onNext(any());
-        verify(observer, never()).onComplete();
+        InOrder inOrder = inOrder(subscriber2);
+        inOrder.verify(subscriber2, times(1)).onError(any(Throwable.class));
+        verify(subscriber2, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -253,16 +253,16 @@ public class FlowableSampleTest {
         PublishProcessor<Integer> sampler = PublishProcessor.create();
 
         Flowable<Integer> m = source.sample(sampler);
-        m.subscribe(observer2);
+        m.subscribe(subscriber2);
 
         source.onNext(1);
         sampler.onNext(1);
         sampler.onError(new RuntimeException("Forced failure!"));
 
-        InOrder inOrder = inOrder(observer2);
-        inOrder.verify(observer2, times(1)).onNext(1);
-        inOrder.verify(observer2, times(1)).onError(any(RuntimeException.class));
-        verify(observer, never()).onComplete();
+        InOrder inOrder = inOrder(subscriber2);
+        inOrder.verify(subscriber2, times(1)).onNext(1);
+        inOrder.verify(subscriber2, times(1)).onError(any(RuntimeException.class));
+        verify(subscriber, never()).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
@@ -49,24 +49,24 @@ public class FlowableSampleTest {
     public void testSample() {
         Flowable<Long> source = Flowable.unsafeCreate(new Publisher<Long>() {
             @Override
-            public void subscribe(final Subscriber<? super Long> observer1) {
-                observer1.onSubscribe(new BooleanSubscription());
+            public void subscribe(final Subscriber<? super Long> subscriber1) {
+                subscriber1.onSubscribe(new BooleanSubscription());
                 innerScheduler.schedule(new Runnable() {
                     @Override
                     public void run() {
-                        observer1.onNext(1L);
+                        subscriber1.onNext(1L);
                     }
                 }, 1, TimeUnit.SECONDS);
                 innerScheduler.schedule(new Runnable() {
                     @Override
                     public void run() {
-                        observer1.onNext(2L);
+                        subscriber1.onNext(2L);
                     }
                 }, 2, TimeUnit.SECONDS);
                 innerScheduler.schedule(new Runnable() {
                     @Override
                     public void run() {
-                        observer1.onComplete();
+                        subscriber1.onComplete();
                     }
                 }, 3, TimeUnit.SECONDS);
             }
@@ -268,7 +268,7 @@ public class FlowableSampleTest {
     @Test
     public void testSampleUnsubscribe() {
         final Subscription s = mock(Subscription.class);
-        Flowable<Integer> o = Flowable.unsafeCreate(
+        Flowable<Integer> f = Flowable.unsafeCreate(
                 new Publisher<Integer>() {
                     @Override
                     public void subscribe(Subscriber<? super Integer> subscriber) {
@@ -276,7 +276,7 @@ public class FlowableSampleTest {
                     }
                 }
         );
-        o.throttleLast(1, TimeUnit.MILLISECONDS).subscribe().dispose();
+        f.throttleLast(1, TimeUnit.MILLISECONDS).subscribe().dispose();
         verify(s).cancel();
     }
 
@@ -450,9 +450,9 @@ public class FlowableSampleTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o)
+            public Flowable<Object> apply(Flowable<Object> f)
                     throws Exception {
-                return o.sample(1, TimeUnit.SECONDS);
+                return f.sample(1, TimeUnit.SECONDS);
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
@@ -37,7 +37,7 @@ public class FlowableScanTest {
 
     @Test
     public void testScanIntegersWithInitialValue() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<Integer> observable = Flowable.just(1, 2, 3);
 
@@ -49,21 +49,21 @@ public class FlowableScanTest {
             }
 
         });
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onNext("");
-        verify(observer, times(1)).onNext("1");
-        verify(observer, times(1)).onNext("12");
-        verify(observer, times(1)).onNext("123");
-        verify(observer, times(4)).onNext(anyString());
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onNext("");
+        verify(subscriber, times(1)).onNext("1");
+        verify(subscriber, times(1)).onNext("12");
+        verify(subscriber, times(1)).onNext("123");
+        verify(subscriber, times(4)).onNext(anyString());
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testScanIntegersWithoutInitialValue() {
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         Flowable<Integer> observable = Flowable.just(1, 2, 3);
 
@@ -75,21 +75,21 @@ public class FlowableScanTest {
             }
 
         });
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onNext(0);
-        verify(observer, times(1)).onNext(1);
-        verify(observer, times(1)).onNext(3);
-        verify(observer, times(1)).onNext(6);
-        verify(observer, times(3)).onNext(anyInt());
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(0);
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, times(1)).onNext(3);
+        verify(subscriber, times(1)).onNext(6);
+        verify(subscriber, times(3)).onNext(anyInt());
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testScanIntegersWithoutInitialValueAndOnlyOneValue() {
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         Flowable<Integer> observable = Flowable.just(1);
 
@@ -101,14 +101,14 @@ public class FlowableScanTest {
             }
 
         });
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onNext(0);
-        verify(observer, times(1)).onNext(1);
-        verify(observer, times(1)).onNext(anyInt());
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(0);
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, times(1)).onNext(anyInt());
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
@@ -39,9 +39,9 @@ public class FlowableScanTest {
     public void testScanIntegersWithInitialValue() {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable<Integer> observable = Flowable.just(1, 2, 3);
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3);
 
-        Flowable<String> m = observable.scan("", new BiFunction<String, Integer, String>() {
+        Flowable<String> m = flowable.scan("", new BiFunction<String, Integer, String>() {
 
             @Override
             public String apply(String s, Integer n) {
@@ -65,9 +65,9 @@ public class FlowableScanTest {
     public void testScanIntegersWithoutInitialValue() {
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        Flowable<Integer> observable = Flowable.just(1, 2, 3);
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3);
 
-        Flowable<Integer> m = observable.scan(new BiFunction<Integer, Integer, Integer>() {
+        Flowable<Integer> m = flowable.scan(new BiFunction<Integer, Integer, Integer>() {
 
             @Override
             public Integer apply(Integer t1, Integer t2) {
@@ -91,9 +91,9 @@ public class FlowableScanTest {
     public void testScanIntegersWithoutInitialValueAndOnlyOneValue() {
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        Flowable<Integer> observable = Flowable.just(1);
+        Flowable<Integer> flowable = Flowable.just(1);
 
-        Flowable<Integer> m = observable.scan(new BiFunction<Integer, Integer, Integer>() {
+        Flowable<Integer> m = flowable.scan(new BiFunction<Integer, Integer, Integer>() {
 
             @Override
             public Integer apply(Integer t1, Integer t2) {
@@ -283,7 +283,7 @@ public class FlowableScanTest {
      */
     @Test
     public void testSeedFactoryFlowable() {
-        Flowable<List<Integer>> o = Flowable.range(1, 10)
+        Flowable<List<Integer>> f = Flowable.range(1, 10)
                 .collect(new Callable<List<Integer>>() {
 
                     @Override
@@ -300,13 +300,13 @@ public class FlowableScanTest {
 
                 }).toFlowable().takeLast(1);
 
-        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.blockingSingle());
-        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.blockingSingle());
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), f.blockingSingle());
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), f.blockingSingle());
     }
 
     @Test
     public void testScanWithRequestOne() {
-        Flowable<Integer> o = Flowable.just(1, 2).scan(0, new BiFunction<Integer, Integer, Integer>() {
+        Flowable<Integer> f = Flowable.just(1, 2).scan(0, new BiFunction<Integer, Integer, Integer>() {
 
             @Override
             public Integer apply(Integer t1, Integer t2) {
@@ -315,7 +315,7 @@ public class FlowableScanTest {
 
         }).take(1);
         TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
-        o.subscribe(subscriber);
+        f.subscribe(subscriber);
         subscriber.assertValue(0);
         subscriber.assertTerminated();
         subscriber.assertNoErrors();
@@ -324,7 +324,7 @@ public class FlowableScanTest {
     @Test
     public void testScanShouldNotRequestZero() {
         final AtomicReference<Subscription> producer = new AtomicReference<Subscription>();
-        Flowable<Integer> o = Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable<Integer> f = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(final Subscriber<? super Integer> subscriber) {
                 Subscription p = spy(new Subscription() {
@@ -356,7 +356,7 @@ public class FlowableScanTest {
 
         });
 
-        o.subscribe(new TestSubscriber<Integer>(1L) {
+        f.subscribe(new TestSubscriber<Integer>(1L) {
 
             @Override
             public void onNext(Integer integer) {
@@ -427,8 +427,8 @@ public class FlowableScanTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.scan(new BiFunction<Object, Object, Object>() {
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.scan(new BiFunction<Object, Object, Object>() {
                     @Override
                     public Object apply(Object a, Object b) throws Exception {
                         return a;
@@ -439,8 +439,8 @@ public class FlowableScanTest {
 
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.scan(0, new BiFunction<Object, Object, Object>() {
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.scan(0, new BiFunction<Object, Object, Object>() {
                     @Override
                     public Object apply(Object a, Object b) throws Exception {
                         return a;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -37,98 +37,98 @@ public class FlowableSequenceEqualTest {
 
     @Test
     public void test1Flowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.just("one", "two", "three"),
                 Flowable.just("one", "two", "three")).toFlowable();
-        verifyResult(observable, true);
+        verifyResult(flowable, true);
     }
 
     @Test
     public void test2Flowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.just("one", "two", "three"),
                 Flowable.just("one", "two", "three", "four")).toFlowable();
-        verifyResult(observable, false);
+        verifyResult(flowable, false);
     }
 
     @Test
     public void test3Flowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.just("one", "two", "three", "four"),
                 Flowable.just("one", "two", "three")).toFlowable();
-        verifyResult(observable, false);
+        verifyResult(flowable, false);
     }
 
     @Test
     public void testWithError1Flowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.concat(Flowable.just("one"),
                         Flowable.<String> error(new TestException())),
                 Flowable.just("one", "two", "three")).toFlowable();
-        verifyError(observable);
+        verifyError(flowable);
     }
 
     @Test
     public void testWithError2Flowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.just("one", "two", "three"),
                 Flowable.concat(Flowable.just("one"),
                         Flowable.<String> error(new TestException()))).toFlowable();
-        verifyError(observable);
+        verifyError(flowable);
     }
 
     @Test
     public void testWithError3Flowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.concat(Flowable.just("one"),
                         Flowable.<String> error(new TestException())),
                 Flowable.concat(Flowable.just("one"),
                         Flowable.<String> error(new TestException()))).toFlowable();
-        verifyError(observable);
+        verifyError(flowable);
     }
 
     @Test
     public void testWithEmpty1Flowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.<String> empty(),
                 Flowable.just("one", "two", "three")).toFlowable();
-        verifyResult(observable, false);
+        verifyResult(flowable, false);
     }
 
     @Test
     public void testWithEmpty2Flowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.just("one", "two", "three"),
                 Flowable.<String> empty()).toFlowable();
-        verifyResult(observable, false);
+        verifyResult(flowable, false);
     }
 
     @Test
     public void testWithEmpty3Flowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.<String> empty(), Flowable.<String> empty()).toFlowable();
-        verifyResult(observable, true);
+        verifyResult(flowable, true);
     }
 
     @Test
     @Ignore("Null values not allowed")
     public void testWithNull1Flowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.just((String) null), Flowable.just("one")).toFlowable();
-        verifyResult(observable, false);
+        verifyResult(flowable, false);
     }
 
     @Test
     @Ignore("Null values not allowed")
     public void testWithNull2Flowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.just((String) null), Flowable.just((String) null)).toFlowable();
-        verifyResult(observable, true);
+        verifyResult(flowable, true);
     }
 
     @Test
     public void testWithEqualityErrorFlowable() {
-        Flowable<Boolean> observable = Flowable.sequenceEqual(
+        Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.just("one"), Flowable.just("one"),
                 new BiPredicate<String, String>() {
                     @Override
@@ -136,103 +136,103 @@ public class FlowableSequenceEqualTest {
                         throw new TestException();
                     }
                 }).toFlowable();
-        verifyError(observable);
+        verifyError(flowable);
     }
 
     @Test
     public void test1() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.just("one", "two", "three"),
                 Flowable.just("one", "two", "three"));
-        verifyResult(observable, true);
+        verifyResult(single, true);
     }
 
     @Test
     public void test2() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.just("one", "two", "three"),
                 Flowable.just("one", "two", "three", "four"));
-        verifyResult(observable, false);
+        verifyResult(single, false);
     }
 
     @Test
     public void test3() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.just("one", "two", "three", "four"),
                 Flowable.just("one", "two", "three"));
-        verifyResult(observable, false);
+        verifyResult(single, false);
     }
 
     @Test
     public void testWithError1() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.concat(Flowable.just("one"),
                         Flowable.<String> error(new TestException())),
                 Flowable.just("one", "two", "three"));
-        verifyError(observable);
+        verifyError(single);
     }
 
     @Test
     public void testWithError2() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.just("one", "two", "three"),
                 Flowable.concat(Flowable.just("one"),
                         Flowable.<String> error(new TestException())));
-        verifyError(observable);
+        verifyError(single);
     }
 
     @Test
     public void testWithError3() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.concat(Flowable.just("one"),
                         Flowable.<String> error(new TestException())),
                 Flowable.concat(Flowable.just("one"),
                         Flowable.<String> error(new TestException())));
-        verifyError(observable);
+        verifyError(single);
     }
 
     @Test
     public void testWithEmpty1() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.<String> empty(),
                 Flowable.just("one", "two", "three"));
-        verifyResult(observable, false);
+        verifyResult(single, false);
     }
 
     @Test
     public void testWithEmpty2() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.just("one", "two", "three"),
                 Flowable.<String> empty());
-        verifyResult(observable, false);
+        verifyResult(single, false);
     }
 
     @Test
     public void testWithEmpty3() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.<String> empty(), Flowable.<String> empty());
-        verifyResult(observable, true);
+        verifyResult(single, true);
     }
 
     @Test
     @Ignore("Null values not allowed")
     public void testWithNull1() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.just((String) null), Flowable.just("one"));
-        verifyResult(observable, false);
+        verifyResult(single, false);
     }
 
     @Test
     @Ignore("Null values not allowed")
     public void testWithNull2() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.just((String) null), Flowable.just((String) null));
-        verifyResult(observable, true);
+        verifyResult(single, true);
     }
 
     @Test
     public void testWithEqualityError() {
-        Single<Boolean> observable = Flowable.sequenceEqual(
+        Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.just("one"), Flowable.just("one"),
                 new BiPredicate<String, String>() {
                     @Override
@@ -240,13 +240,13 @@ public class FlowableSequenceEqualTest {
                         throw new TestException();
                     }
                 });
-        verifyError(observable);
+        verifyError(single);
     }
 
-    private void verifyResult(Flowable<Boolean> observable, boolean result) {
+    private void verifyResult(Flowable<Boolean> flowable, boolean result) {
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(result);
@@ -254,28 +254,28 @@ public class FlowableSequenceEqualTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    private void verifyResult(Single<Boolean> observable, boolean result) {
+    private void verifyResult(Single<Boolean> single, boolean result) {
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(result);
         inOrder.verifyNoMoreInteractions();
     }
 
-    private void verifyError(Flowable<Boolean> observable) {
+    private void verifyError(Flowable<Boolean> flowable) {
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onError(isA(TestException.class));
         inOrder.verifyNoMoreInteractions();
     }
 
-    private void verifyError(Single<Boolean> observable) {
+    private void verifyError(Single<Boolean> single) {
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onError(isA(TestException.class));

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -244,13 +244,13 @@ public class FlowableSequenceEqualTest {
     }
 
     private void verifyResult(Flowable<Boolean> observable, boolean result) {
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(result);
-        inOrder.verify(observer).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(result);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -265,11 +265,11 @@ public class FlowableSequenceEqualTest {
     }
 
     private void verifyError(Flowable<Boolean> observable) {
-        Subscriber<Boolean> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(isA(TestException.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onError(isA(TestException.class));
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
@@ -144,18 +144,18 @@ public class FlowableSerializeTest {
      */
     static class OnNextThread implements Runnable {
 
-        private final DefaultSubscriber<String> observer;
+        private final DefaultSubscriber<String> subscriber;
         private final int numStringsToSend;
 
-        OnNextThread(DefaultSubscriber<String> observer, int numStringsToSend) {
-            this.observer = observer;
+        OnNextThread(DefaultSubscriber<String> subscriber, int numStringsToSend) {
+            this.subscriber = subscriber;
             this.numStringsToSend = numStringsToSend;
         }
 
         @Override
         public void run() {
             for (int i = 0; i < numStringsToSend; i++) {
-                observer.onNext("aString");
+                subscriber.onNext("aString");
             }
         }
     }
@@ -165,12 +165,12 @@ public class FlowableSerializeTest {
      */
     static class CompletionThread implements Runnable {
 
-        private final DefaultSubscriber<String> observer;
+        private final DefaultSubscriber<String> subscriber;
         private final TestConcurrencyobserverEvent event;
         private final Future<?>[] waitOnThese;
 
-        CompletionThread(DefaultSubscriber<String> observer, TestConcurrencyobserverEvent event, Future<?>... waitOnThese) {
-            this.observer = observer;
+        CompletionThread(DefaultSubscriber<String> subscriber, TestConcurrencyobserverEvent event, Future<?>... waitOnThese) {
+            this.subscriber = subscriber;
             this.event = event;
             this.waitOnThese = waitOnThese;
         }
@@ -190,9 +190,9 @@ public class FlowableSerializeTest {
 
             /* send the event */
             if (event == TestConcurrencyobserverEvent.onError) {
-                observer.onError(new RuntimeException("mocked exception"));
+                subscriber.onError(new RuntimeException("mocked exception"));
             } else if (event == TestConcurrencyobserverEvent.onComplete) {
-                observer.onComplete();
+                subscriber.onComplete();
 
             } else {
                 throw new IllegalArgumentException("Expecting either onError or onComplete");
@@ -218,8 +218,8 @@ public class FlowableSerializeTest {
         }
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        public void subscribe(final Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
             System.out.println("TestSingleThreadedObservable subscribed to ...");
             t = new Thread(new Runnable() {
 
@@ -229,9 +229,9 @@ public class FlowableSerializeTest {
                         System.out.println("running TestSingleThreadedObservable thread");
                         for (String s : values) {
                             System.out.println("TestSingleThreadedObservable onNext: " + s);
-                            observer.onNext(s);
+                            subscriber.onNext(s);
                         }
-                        observer.onComplete();
+                        subscriber.onComplete();
                     } catch (Throwable e) {
                         throw new RuntimeException(e);
                     }
@@ -269,8 +269,8 @@ public class FlowableSerializeTest {
         }
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        public void subscribe(final Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
             System.out.println("TestMultiThreadedObservable subscribed to ...");
             final NullPointerException npe = new NullPointerException();
             t = new Thread(new Runnable() {
@@ -299,7 +299,7 @@ public class FlowableSerializeTest {
                                             }
                                             System.out.println("TestMultiThreadedObservable onNext: " + s);
                                         }
-                                        observer.onNext(s);
+                                        subscriber.onNext(s);
                                         // capture 'maxThreads'
                                         int concurrentThreads = threadsRunning.get();
                                         int maxThreads = maxConcurrentThreads.get();
@@ -307,7 +307,7 @@ public class FlowableSerializeTest {
                                             maxConcurrentThreads.compareAndSet(maxThreads, concurrentThreads);
                                         }
                                     } catch (Throwable e) {
-                                        observer.onError(e);
+                                        subscriber.onError(e);
                                     } finally {
                                         threadsRunning.decrementAndGet();
                                     }
@@ -327,7 +327,7 @@ public class FlowableSerializeTest {
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }
-                    observer.onComplete();
+                    subscriber.onComplete();
                 }
             });
             System.out.println("starting TestMultiThreadedObservable thread");

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
@@ -28,11 +28,11 @@ import io.reactivex.subscribers.DefaultSubscriber;
 
 public class FlowableSerializeTest {
 
-    Subscriber<String> observer;
+    Subscriber<String> subscriber;
 
     @Before
     public void before() {
-        observer = TestHelper.mockSubscriber();
+        subscriber = TestHelper.mockSubscriber();
     }
 
     @Test
@@ -40,14 +40,14 @@ public class FlowableSerializeTest {
         TestSingleThreadedObservable onSubscribe = new TestSingleThreadedObservable("one", "two", "three");
         Flowable<String> w = Flowable.unsafeCreate(onSubscribe);
 
-        w.serialize().subscribe(observer);
+        w.serialize().subscribe(subscriber);
         onSubscribe.waitToFinish();
 
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
         // non-deterministic because unsubscribe happens after 'waitToFinish' releases
         // so commenting out for now as this is not a critical thing to test here
         //            verify(s, times(1)).unsubscribe();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
@@ -34,10 +34,10 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleFlowable() {
-        Flowable<Integer> observable = Flowable.just(1).singleElement().toFlowable();
+        Flowable<Integer> flowable = Flowable.just(1).singleElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(1);
@@ -47,10 +47,10 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleWithTooManyElementsFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2).singleElement().toFlowable();
+        Flowable<Integer> flowable = Flowable.just(1, 2).singleElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onError(
@@ -60,10 +60,10 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleWithEmptyFlowable() {
-        Flowable<Integer> observable = Flowable.<Integer> empty().singleElement().toFlowable();
+        Flowable<Integer> flowable = Flowable.<Integer> empty().singleElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber).onComplete();
@@ -195,7 +195,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleWithPredicateFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2)
+        Flowable<Integer> flowable = Flowable.just(1, 2)
                 .filter(
                 new Predicate<Integer>() {
 
@@ -207,7 +207,7 @@ public class FlowableSingleTest {
                 .singleElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(2);
@@ -217,7 +217,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleWithPredicateAndTooManyElementsFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3, 4)
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4)
                 .filter(
                 new Predicate<Integer>() {
 
@@ -229,7 +229,7 @@ public class FlowableSingleTest {
                 .singleElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onError(
@@ -239,7 +239,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleWithPredicateAndEmptyFlowable() {
-        Flowable<Integer> observable = Flowable.just(1)
+        Flowable<Integer> flowable = Flowable.just(1)
                 .filter(
                 new Predicate<Integer>() {
 
@@ -250,7 +250,7 @@ public class FlowableSingleTest {
                 })
                 .singleElement().toFlowable();
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber).onComplete();
@@ -260,10 +260,10 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefaultFlowable() {
-        Flowable<Integer> observable = Flowable.just(1).single(2).toFlowable();
+        Flowable<Integer> flowable = Flowable.just(1).single(2).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(1);
@@ -273,10 +273,10 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefaultWithTooManyElementsFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2).single(3).toFlowable();
+        Flowable<Integer> flowable = Flowable.just(1, 2).single(3).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onError(
@@ -286,11 +286,11 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefaultWithEmptyFlowable() {
-        Flowable<Integer> observable = Flowable.<Integer> empty()
+        Flowable<Integer> flowable = Flowable.<Integer> empty()
                 .single(1).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(1);
@@ -300,7 +300,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefaultWithPredicateFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2)
+        Flowable<Integer> flowable = Flowable.just(1, 2)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -310,7 +310,7 @@ public class FlowableSingleTest {
                 .single(4).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(2);
@@ -320,7 +320,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefaultWithPredicateAndTooManyElementsFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2, 3, 4)
+        Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -330,7 +330,7 @@ public class FlowableSingleTest {
                 .single(6).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onError(
@@ -340,7 +340,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefaultWithPredicateAndEmptyFlowable() {
-        Flowable<Integer> observable = Flowable.just(1)
+        Flowable<Integer> flowable = Flowable.just(1)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -350,7 +350,7 @@ public class FlowableSingleTest {
                 .single(2).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext(2);
@@ -360,7 +360,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleWithBackpressureFlowable() {
-        Flowable<Integer> observable = Flowable.just(1, 2).singleElement().toFlowable();
+        Flowable<Integer> flowable = Flowable.just(1, 2).singleElement().toFlowable();
 
         Subscriber<Integer> subscriber = spy(new DefaultSubscriber<Integer>() {
 
@@ -384,7 +384,7 @@ public class FlowableSingleTest {
                 request(1);
             }
         });
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onError(isA(IllegalArgumentException.class));
@@ -393,10 +393,10 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingle() {
-        Maybe<Integer> observable = Flowable.just(1).singleElement();
+        Maybe<Integer> maybe = Flowable.just(1).singleElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(1);
@@ -405,10 +405,10 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleWithTooManyElements() {
-        Maybe<Integer> observable = Flowable.just(1, 2).singleElement();
+        Maybe<Integer> maybe = Flowable.just(1, 2).singleElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onError(
@@ -418,10 +418,10 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleWithEmpty() {
-        Maybe<Integer> observable = Flowable.<Integer> empty().singleElement();
+        Maybe<Integer> maybe = Flowable.<Integer> empty().singleElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer).onComplete();
@@ -476,7 +476,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleWithPredicate() {
-        Maybe<Integer> observable = Flowable.just(1, 2)
+        Maybe<Integer> maybe = Flowable.just(1, 2)
                 .filter(
                 new Predicate<Integer>() {
 
@@ -488,7 +488,7 @@ public class FlowableSingleTest {
                 .singleElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(2);
@@ -497,7 +497,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleWithPredicateAndTooManyElements() {
-        Maybe<Integer> observable = Flowable.just(1, 2, 3, 4)
+        Maybe<Integer> maybe = Flowable.just(1, 2, 3, 4)
                 .filter(
                 new Predicate<Integer>() {
 
@@ -509,7 +509,7 @@ public class FlowableSingleTest {
                 .singleElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onError(
@@ -519,7 +519,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleWithPredicateAndEmpty() {
-        Maybe<Integer> observable = Flowable.just(1)
+        Maybe<Integer> maybe = Flowable.just(1)
                 .filter(
                 new Predicate<Integer>() {
 
@@ -531,7 +531,7 @@ public class FlowableSingleTest {
                 .singleElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
-        observable.subscribe(observer);
+        maybe.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer).onComplete();
@@ -541,10 +541,10 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefault() {
-        Single<Integer> observable = Flowable.just(1).single(2);
+        Single<Integer> single = Flowable.just(1).single(2);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(1);
@@ -553,10 +553,10 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefaultWithTooManyElements() {
-        Single<Integer> observable = Flowable.just(1, 2).single(3);
+        Single<Integer> single = Flowable.just(1, 2).single(3);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onError(
@@ -566,11 +566,11 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefaultWithEmpty() {
-        Single<Integer> observable = Flowable.<Integer> empty()
+        Single<Integer> single = Flowable.<Integer> empty()
                 .single(1);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(1);
@@ -579,7 +579,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefaultWithPredicate() {
-        Single<Integer> observable = Flowable.just(1, 2)
+        Single<Integer> single = Flowable.just(1, 2)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -589,7 +589,7 @@ public class FlowableSingleTest {
                 .single(4);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(2);
@@ -598,7 +598,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefaultWithPredicateAndTooManyElements() {
-        Single<Integer> observable = Flowable.just(1, 2, 3, 4)
+        Single<Integer> single = Flowable.just(1, 2, 3, 4)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -608,7 +608,7 @@ public class FlowableSingleTest {
                 .single(6);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onError(
@@ -618,7 +618,7 @@ public class FlowableSingleTest {
 
     @Test
     public void testSingleOrDefaultWithPredicateAndEmpty() {
-        Single<Integer> observable = Flowable.just(1)
+        Single<Integer> single = Flowable.just(1)
                 .filter(new Predicate<Integer>() {
                     @Override
                     public boolean test(Integer t1) {
@@ -628,7 +628,7 @@ public class FlowableSingleTest {
                 .single(2);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onSuccess(2);
@@ -715,9 +715,9 @@ public class FlowableSingleTest {
             });
 
             Flowable.unsafeCreate(new Publisher<Integer>() {
-                @Override public void subscribe(final Subscriber<? super Integer> observer) {
-                    observer.onComplete();
-                    observer.onError(exception);
+                @Override public void subscribe(final Subscriber<? super Integer> subscriber) {
+                    subscriber.onComplete();
+                    subscriber.onError(exception);
                 }
             }).singleElement().test().assertComplete();
 
@@ -731,22 +731,22 @@ public class FlowableSingleTest {
     public void badSource() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
             @Override
-            public Object apply(Flowable<Object> o) throws Exception {
-                return o.singleOrError();
+            public Object apply(Flowable<Object> f) throws Exception {
+                return f.singleOrError();
             }
         }, false, 1, 1, 1);
 
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
             @Override
-            public Object apply(Flowable<Object> o) throws Exception {
-                return o.singleElement();
+            public Object apply(Flowable<Object> f) throws Exception {
+                return f.singleElement();
             }
         }, false, 1, 1, 1);
 
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
             @Override
-            public Object apply(Flowable<Object> o) throws Exception {
-                return o.singleOrError().toFlowable();
+            public Object apply(Flowable<Object> f) throws Exception {
+                return f.singleOrError().toFlowable();
             }
         }, false, 1, 1, 1);
     }
@@ -755,29 +755,29 @@ public class FlowableSingleTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, SingleSource<Object>>() {
             @Override
-            public SingleSource<Object> apply(Flowable<Object> o) throws Exception {
-                return o.singleOrError();
+            public SingleSource<Object> apply(Flowable<Object> f) throws Exception {
+                return f.singleOrError();
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.singleOrError().toFlowable();
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.singleOrError().toFlowable();
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowableToMaybe(new Function<Flowable<Object>, MaybeSource<Object>>() {
             @Override
-            public MaybeSource<Object> apply(Flowable<Object> o) throws Exception {
-                return o.singleElement();
+            public MaybeSource<Object> apply(Flowable<Object> f) throws Exception {
+                return f.singleElement();
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.singleElement().toFlowable();
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.singleElement().toFlowable();
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
@@ -36,12 +36,12 @@ public class FlowableSingleTest {
     public void testSingleFlowable() {
         Flowable<Integer> observable = Flowable.just(1).singleElement().toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(1);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -49,11 +49,11 @@ public class FlowableSingleTest {
     public void testSingleWithTooManyElementsFlowable() {
         Flowable<Integer> observable = Flowable.just(1, 2).singleElement().toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onError(
                 isA(IllegalArgumentException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -62,12 +62,12 @@ public class FlowableSingleTest {
     public void testSingleWithEmptyFlowable() {
         Flowable<Integer> observable = Flowable.<Integer> empty().singleElement().toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onComplete();
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onComplete();
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -206,12 +206,12 @@ public class FlowableSingleTest {
                 })
                 .singleElement().toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -228,11 +228,11 @@ public class FlowableSingleTest {
                 })
                 .singleElement().toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onError(
                 isA(IllegalArgumentException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -249,12 +249,12 @@ public class FlowableSingleTest {
                     }
                 })
                 .singleElement().toFlowable();
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onComplete();
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onComplete();
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -262,12 +262,12 @@ public class FlowableSingleTest {
     public void testSingleOrDefaultFlowable() {
         Flowable<Integer> observable = Flowable.just(1).single(2).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(1);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -275,11 +275,11 @@ public class FlowableSingleTest {
     public void testSingleOrDefaultWithTooManyElementsFlowable() {
         Flowable<Integer> observable = Flowable.just(1, 2).single(3).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onError(
                 isA(IllegalArgumentException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -289,12 +289,12 @@ public class FlowableSingleTest {
         Flowable<Integer> observable = Flowable.<Integer> empty()
                 .single(1).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(1);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(1);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -309,12 +309,12 @@ public class FlowableSingleTest {
                 })
                 .single(4).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -329,11 +329,11 @@ public class FlowableSingleTest {
                 })
                 .single(6).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onError(
                 isA(IllegalArgumentException.class));
         inOrder.verifyNoMoreInteractions();
     }
@@ -349,12 +349,12 @@ public class FlowableSingleTest {
                 })
                 .single(2).toFlowable();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTest.java
@@ -32,10 +32,10 @@ public class FlowableSkipLastTest {
 
     @Test
     public void testSkipLastEmpty() {
-        Flowable<String> observable = Flowable.<String> empty().skipLast(2);
+        Flowable<String> flowable = Flowable.<String> empty().skipLast(2);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, never()).onNext(any(String.class));
         verify(subscriber, never()).onError(any(Throwable.class));
@@ -44,11 +44,11 @@ public class FlowableSkipLastTest {
 
     @Test
     public void testSkipLast1() {
-        Flowable<String> observable = Flowable.fromIterable(Arrays.asList("one", "two", "three")).skipLast(2);
+        Flowable<String> flowable = Flowable.fromIterable(Arrays.asList("one", "two", "three")).skipLast(2);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         inOrder.verify(subscriber, never()).onNext("two");
         inOrder.verify(subscriber, never()).onNext("three");
@@ -59,10 +59,10 @@ public class FlowableSkipLastTest {
 
     @Test
     public void testSkipLast2() {
-        Flowable<String> observable = Flowable.fromIterable(Arrays.asList("one", "two")).skipLast(2);
+        Flowable<String> flowable = Flowable.fromIterable(Arrays.asList("one", "two")).skipLast(2);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, never()).onNext(any(String.class));
         verify(subscriber, never()).onError(any(Throwable.class));
@@ -72,10 +72,10 @@ public class FlowableSkipLastTest {
     @Test
     public void testSkipLastWithZeroCount() {
         Flowable<String> w = Flowable.just("one", "two");
-        Flowable<String> observable = w.skipLast(0);
+        Flowable<String> flowable = w.skipLast(0);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext("one");
         verify(subscriber, times(1)).onNext("two");
@@ -86,10 +86,10 @@ public class FlowableSkipLastTest {
     @Test
     @Ignore("Null values not allowed")
     public void testSkipLastWithNull() {
-        Flowable<String> observable = Flowable.fromIterable(Arrays.asList("one", null, "two")).skipLast(1);
+        Flowable<String> flowable = Flowable.fromIterable(Arrays.asList("one", null, "two")).skipLast(1);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext("one");
         verify(subscriber, times(1)).onNext(null);
@@ -100,9 +100,9 @@ public class FlowableSkipLastTest {
 
     @Test
     public void testSkipLastWithBackpressure() {
-        Flowable<Integer> o = Flowable.range(0, Flowable.bufferSize() * 2).skipLast(Flowable.bufferSize() + 10);
+        Flowable<Integer> f = Flowable.range(0, Flowable.bufferSize() * 2).skipLast(Flowable.bufferSize() + 10);
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        o.observeOn(Schedulers.computation()).subscribe(ts);
+        f.observeOn(Schedulers.computation()).subscribe(ts);
         ts.awaitTerminalEvent();
         ts.assertNoErrors();
         assertEquals((Flowable.bufferSize()) - 10, ts.valueCount());
@@ -131,9 +131,9 @@ public class FlowableSkipLastTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o)
+            public Flowable<Object> apply(Flowable<Object> f)
                     throws Exception {
-                return o.skipLast(1);
+                return f.skipLast(1);
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTest.java
@@ -34,36 +34,39 @@ public class FlowableSkipLastTest {
     public void testSkipLastEmpty() {
         Flowable<String> observable = Flowable.<String> empty().skipLast(2);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
-        verify(observer, never()).onNext(any(String.class));
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
+
+        verify(subscriber, never()).onNext(any(String.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testSkipLast1() {
         Flowable<String> observable = Flowable.fromIterable(Arrays.asList("one", "two", "three")).skipLast(2);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(observer);
-        observable.subscribe(observer);
-        inOrder.verify(observer, never()).onNext("two");
-        inOrder.verify(observer, never()).onNext("three");
-        verify(observer, times(1)).onNext("one");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
+        observable.subscribe(subscriber);
+
+        inOrder.verify(subscriber, never()).onNext("two");
+        inOrder.verify(subscriber, never()).onNext("three");
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testSkipLast2() {
         Flowable<String> observable = Flowable.fromIterable(Arrays.asList("one", "two")).skipLast(2);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
-        verify(observer, never()).onNext(any(String.class));
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
+
+        verify(subscriber, never()).onNext(any(String.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -71,12 +74,13 @@ public class FlowableSkipLastTest {
         Flowable<String> w = Flowable.just("one", "two");
         Flowable<String> observable = w.skipLast(0);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
+
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -84,13 +88,14 @@ public class FlowableSkipLastTest {
     public void testSkipLastWithNull() {
         Flowable<String> observable = Flowable.fromIterable(Arrays.asList("one", null, "two")).skipLast(1);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext(null);
-        verify(observer, never()).onNext("two");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
+
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext(null);
+        verify(subscriber, never()).onNext("two");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
@@ -40,9 +40,9 @@ public class FlowableSkipLastTimedTest {
         // FIXME the timeunit now matters due to rounding
         Flowable<Integer> result = source.skipLast(1000, TimeUnit.MILLISECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -57,17 +57,17 @@ public class FlowableSkipLastTimedTest {
         scheduler.advanceTimeBy(950, TimeUnit.MILLISECONDS);
         source.onComplete();
 
-        InOrder inOrder = inOrder(o);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o).onNext(3);
-        inOrder.verify(o, never()).onNext(4);
-        inOrder.verify(o, never()).onNext(5);
-        inOrder.verify(o, never()).onNext(6);
-        inOrder.verify(o).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onNext(3);
+        inOrder.verify(subscriber, never()).onNext(4);
+        inOrder.verify(subscriber, never()).onNext(5);
+        inOrder.verify(subscriber, never()).onNext(6);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -78,9 +78,9 @@ public class FlowableSkipLastTimedTest {
 
         Flowable<Integer> result = source.skipLast(1, TimeUnit.SECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -89,10 +89,10 @@ public class FlowableSkipLastTimedTest {
 
         scheduler.advanceTimeBy(1050, TimeUnit.MILLISECONDS);
 
-        verify(o).onError(any(TestException.class));
+        verify(subscriber).onError(any(TestException.class));
 
-        verify(o, never()).onComplete();
-        verify(o, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
@@ -103,9 +103,9 @@ public class FlowableSkipLastTimedTest {
 
         Flowable<Integer> result = source.skipLast(1, TimeUnit.SECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -115,12 +115,12 @@ public class FlowableSkipLastTimedTest {
 
         source.onComplete();
 
-        InOrder inOrder = inOrder(o);
-        inOrder.verify(o).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -131,9 +131,9 @@ public class FlowableSkipLastTimedTest {
 
         Flowable<Integer> result = source.skipLast(1, TimeUnit.MILLISECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -143,11 +143,11 @@ public class FlowableSkipLastTimedTest {
 
         source.onComplete();
 
-        InOrder inOrder = inOrder(o);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o).onNext(3);
-        inOrder.verify(o).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onNext(3);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -187,8 +187,8 @@ public class FlowableSkipLastTimedTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.skipLast(1, TimeUnit.DAYS);
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.skipLast(1, TimeUnit.DAYS);
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTest.java
@@ -104,19 +104,19 @@ public class FlowableSkipTest {
         Flowable<String> skip = Flowable.just("one", "two", "three")
                 .skip(2);
 
-        Subscriber<String> observer1 = TestHelper.mockSubscriber();
-        skip.subscribe(observer1);
+        Subscriber<String> subscriber1 = TestHelper.mockSubscriber();
+        skip.subscribe(subscriber1);
 
-        Subscriber<String> observer2 = TestHelper.mockSubscriber();
-        skip.subscribe(observer2);
+        Subscriber<String> subscriber2 = TestHelper.mockSubscriber();
+        skip.subscribe(subscriber2);
 
-        verify(observer1, times(1)).onNext(any(String.class));
-        verify(observer1, never()).onError(any(Throwable.class));
-        verify(observer1, times(1)).onComplete();
+        verify(subscriber1, times(1)).onNext(any(String.class));
+        verify(subscriber1, never()).onError(any(Throwable.class));
+        verify(subscriber1, times(1)).onComplete();
 
-        verify(observer2, times(1)).onNext(any(String.class));
-        verify(observer2, never()).onError(any(Throwable.class));
-        verify(observer2, times(1)).onComplete();
+        verify(subscriber2, times(1)).onNext(any(String.class));
+        verify(subscriber2, never()).onError(any(Throwable.class));
+        verify(subscriber2, times(1)).onComplete();
     }
 
     @Test
@@ -179,9 +179,9 @@ public class FlowableSkipTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o)
+            public Flowable<Object> apply(Flowable<Object> f)
                     throws Exception {
-                return o.skip(1);
+                return f.skip(1);
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTest.java
@@ -34,13 +34,13 @@ public class FlowableSkipTest {
 
         Flowable<String> skip = Flowable.just("one", "two", "three").skip(-99);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        skip.subscribe(observer);
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        skip.subscribe(subscriber);
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -48,13 +48,13 @@ public class FlowableSkipTest {
 
         Flowable<String> skip = Flowable.just("one", "two", "three").skip(0);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        skip.subscribe(observer);
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        skip.subscribe(subscriber);
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -62,13 +62,13 @@ public class FlowableSkipTest {
 
         Flowable<String> skip = Flowable.just("one", "two", "three").skip(1);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        skip.subscribe(observer);
-        verify(observer, never()).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        skip.subscribe(subscriber);
+        verify(subscriber, never()).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -76,13 +76,13 @@ public class FlowableSkipTest {
 
         Flowable<String> skip = Flowable.just("one", "two", "three").skip(2);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        skip.subscribe(observer);
-        verify(observer, never()).onNext("one");
-        verify(observer, never()).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        skip.subscribe(subscriber);
+        verify(subscriber, never()).onNext("one");
+        verify(subscriber, never()).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -91,11 +91,11 @@ public class FlowableSkipTest {
         Flowable<String> w = Flowable.empty();
         Flowable<String> skip = w.skip(1);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        skip.subscribe(observer);
-        verify(observer, never()).onNext(any(String.class));
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        skip.subscribe(subscriber);
+        verify(subscriber, never()).onNext(any(String.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -129,12 +129,12 @@ public class FlowableSkipTest {
 
         Flowable<String> skip = Flowable.concat(ok, error).skip(100);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        skip.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        skip.subscribe(subscriber);
 
-        verify(observer, never()).onNext(any(String.class));
-        verify(observer, times(1)).onError(e);
-        verify(observer, never()).onComplete();
+        verify(subscriber, never()).onNext(any(String.class));
+        verify(subscriber, times(1)).onError(e);
+        verify(subscriber, never()).onComplete();
 
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTimedTest.java
@@ -36,9 +36,9 @@ public class FlowableSkipTimedTest {
 
         Flowable<Integer> result = source.skip(1, TimeUnit.SECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -52,17 +52,17 @@ public class FlowableSkipTimedTest {
 
         source.onComplete();
 
-        InOrder inOrder = inOrder(o);
+        InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(o, never()).onNext(1);
-        inOrder.verify(o, never()).onNext(2);
-        inOrder.verify(o, never()).onNext(3);
-        inOrder.verify(o).onNext(4);
-        inOrder.verify(o).onNext(5);
-        inOrder.verify(o).onNext(6);
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber, never()).onNext(1);
+        inOrder.verify(subscriber, never()).onNext(2);
+        inOrder.verify(subscriber, never()).onNext(3);
+        inOrder.verify(subscriber).onNext(4);
+        inOrder.verify(subscriber).onNext(5);
+        inOrder.verify(subscriber).onNext(6);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -73,9 +73,9 @@ public class FlowableSkipTimedTest {
 
         Flowable<Integer> result = source.skip(1, TimeUnit.SECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -84,12 +84,12 @@ public class FlowableSkipTimedTest {
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        InOrder inOrder = inOrder(o);
+        InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onNext(any());
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -100,9 +100,9 @@ public class FlowableSkipTimedTest {
 
         Flowable<Integer> result = source.skip(1, TimeUnit.SECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -111,12 +111,12 @@ public class FlowableSkipTimedTest {
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        InOrder inOrder = inOrder(o);
+        InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(o).onError(any(TestException.class));
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -127,9 +127,9 @@ public class FlowableSkipTimedTest {
 
         Flowable<Integer> result = source.skip(1, TimeUnit.SECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -143,17 +143,17 @@ public class FlowableSkipTimedTest {
 
         source.onError(new TestException());
 
-        InOrder inOrder = inOrder(o);
+        InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(o, never()).onNext(1);
-        inOrder.verify(o, never()).onNext(2);
-        inOrder.verify(o, never()).onNext(3);
-        inOrder.verify(o).onNext(4);
-        inOrder.verify(o).onNext(5);
-        inOrder.verify(o).onNext(6);
-        inOrder.verify(o).onError(any(TestException.class));
+        inOrder.verify(subscriber, never()).onNext(1);
+        inOrder.verify(subscriber, never()).onNext(2);
+        inOrder.verify(subscriber, never()).onNext(3);
+        inOrder.verify(subscriber).onNext(4);
+        inOrder.verify(subscriber).onNext(5);
+        inOrder.verify(subscriber).onNext(6);
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onComplete();
 
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipUntilTest.java
@@ -23,11 +23,11 @@ import io.reactivex.functions.Function;
 import io.reactivex.processors.PublishProcessor;
 
 public class FlowableSkipUntilTest {
-    Subscriber<Object> observer;
+    Subscriber<Object> subscriber;
 
     @Before
     public void before() {
-        observer = TestHelper.mockSubscriber();
+        subscriber = TestHelper.mockSubscriber();
     }
 
     @Test
@@ -36,7 +36,7 @@ public class FlowableSkipUntilTest {
         PublishProcessor<Integer> other = PublishProcessor.create();
 
         Flowable<Integer> m = source.skipUntil(other);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source.onNext(0);
         source.onNext(1);
@@ -48,11 +48,11 @@ public class FlowableSkipUntilTest {
         source.onNext(4);
         source.onComplete();
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onNext(2);
-        verify(observer, times(1)).onNext(3);
-        verify(observer, times(1)).onNext(4);
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onNext(2);
+        verify(subscriber, times(1)).onNext(3);
+        verify(subscriber, times(1)).onNext(4);
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -61,7 +61,7 @@ public class FlowableSkipUntilTest {
 
         Flowable<Integer> m = source.skipUntil(Flowable.never());
 
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source.onNext(0);
         source.onNext(1);
@@ -70,9 +70,9 @@ public class FlowableSkipUntilTest {
         source.onNext(4);
         source.onComplete();
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onNext(any());
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -81,11 +81,11 @@ public class FlowableSkipUntilTest {
 
         Flowable<Integer> m = source.skipUntil(Flowable.empty());
 
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onNext(any());
-        verify(observer, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -94,7 +94,7 @@ public class FlowableSkipUntilTest {
         PublishProcessor<Integer> other = PublishProcessor.create();
 
         Flowable<Integer> m = source.skipUntil(other);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source.onNext(0);
         source.onNext(1);
@@ -107,11 +107,11 @@ public class FlowableSkipUntilTest {
         source.onNext(4);
         source.onComplete();
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onNext(2);
-        verify(observer, times(1)).onNext(3);
-        verify(observer, times(1)).onNext(4);
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onNext(2);
+        verify(subscriber, times(1)).onNext(3);
+        verify(subscriber, times(1)).onNext(4);
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -120,7 +120,7 @@ public class FlowableSkipUntilTest {
         PublishProcessor<Integer> other = PublishProcessor.create();
 
         Flowable<Integer> m = source.skipUntil(other);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source.onNext(0);
         source.onNext(1);
@@ -131,9 +131,9 @@ public class FlowableSkipUntilTest {
         source.onNext(2);
         source.onError(new RuntimeException("Forced failure"));
 
-        verify(observer, times(1)).onNext(2);
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
+        verify(subscriber, times(1)).onNext(2);
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -142,16 +142,16 @@ public class FlowableSkipUntilTest {
         PublishProcessor<Integer> other = PublishProcessor.create();
 
         Flowable<Integer> m = source.skipUntil(other);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source.onNext(0);
         source.onNext(1);
 
         other.onError(new RuntimeException("Forced failure"));
 
-        verify(observer, never()).onNext(any());
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipUntilTest.java
@@ -163,15 +163,15 @@ public class FlowableSkipUntilTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.skipUntil(Flowable.never());
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.skipUntil(Flowable.never());
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return Flowable.never().skipUntil(o);
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return Flowable.never().skipUntil(f);
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipWhileTest.java
@@ -121,16 +121,16 @@ public class FlowableSkipWhileTest {
         Flowable<Integer> src = Flowable.range(1, 10).skipWhile(LESS_THAN_FIVE);
         int n = 5;
         for (int i = 0; i < n; i++) {
-            Subscriber<Object> o = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(o);
+            Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber);
 
-            src.subscribe(o);
+            src.subscribe(subscriber);
 
             for (int j = 5; j < 10; j++) {
-                inOrder.verify(o).onNext(j);
+                inOrder.verify(subscriber).onNext(j);
             }
-            inOrder.verify(o).onComplete();
-            verify(o, never()).onError(any(Throwable.class));
+            inOrder.verify(subscriber).onComplete();
+            verify(subscriber, never()).onError(any(Throwable.class));
         }
     }
 
@@ -143,8 +143,8 @@ public class FlowableSkipWhileTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.skipWhile(Functions.alwaysFalse());
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.skipWhile(Functions.alwaysFalse());
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -40,7 +40,7 @@ public class FlowableSubscribeOnTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(1);
 
-        TestSubscriber<Integer> observer = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
         Flowable
         .unsafeCreate(new Publisher<Integer>() {
@@ -64,16 +64,16 @@ public class FlowableSubscribeOnTest {
                     doneLatch.countDown();
                 }
             }
-        }).subscribeOn(Schedulers.computation()).subscribe(observer);
+        }).subscribeOn(Schedulers.computation()).subscribe(ts);
 
         // wait for scheduling
         scheduled.await();
         // trigger unsubscribe
-        observer.dispose();
+        ts.dispose();
         latch.countDown();
         doneLatch.await();
-        observer.assertNoErrors();
-        observer.assertComplete();
+        ts.assertNoErrors();
+        ts.assertComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -35,7 +35,7 @@ public class FlowableSwitchIfEmptyTest {
     @Test
     public void testSwitchWhenNotEmpty() throws Exception {
         final AtomicBoolean subscribed = new AtomicBoolean(false);
-        final Flowable<Integer> observable = Flowable.just(4)
+        final Flowable<Integer> flowable = Flowable.just(4)
                 .switchIfEmpty(Flowable.just(2)
                 .doOnSubscribe(new Consumer<Subscription>() {
                     @Override
@@ -44,16 +44,16 @@ public class FlowableSwitchIfEmptyTest {
                     }
                 }));
 
-        assertEquals(4, observable.blockingSingle().intValue());
+        assertEquals(4, flowable.blockingSingle().intValue());
         assertFalse(subscribed.get());
     }
 
     @Test
     public void testSwitchWhenEmpty() throws Exception {
-        final Flowable<Integer> observable = Flowable.<Integer>empty()
+        final Flowable<Integer> flowable = Flowable.<Integer>empty()
                 .switchIfEmpty(Flowable.fromIterable(Arrays.asList(42)));
 
-        assertEquals(42, observable.blockingSingle().intValue());
+        assertEquals(42, flowable.blockingSingle().intValue());
     }
 
     @Test
@@ -80,8 +80,8 @@ public class FlowableSwitchIfEmptyTest {
             }
         });
 
-        final Flowable<Long> observable = Flowable.<Long>empty().switchIfEmpty(withProducer);
-        assertEquals(42, observable.blockingSingle().intValue());
+        final Flowable<Long> flowable = Flowable.<Long>empty().switchIfEmpty(withProducer);
+        assertEquals(42, flowable.blockingSingle().intValue());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -40,13 +40,13 @@ public class FlowableSwitchTest {
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
-    private Subscriber<String> observer;
+    private Subscriber<String> subscriber;
 
     @Before
     public void before() {
         scheduler = new TestScheduler();
         innerScheduler = scheduler.createWorker();
-        observer = TestHelper.mockSubscriber();
+        subscriber = TestHelper.mockSubscriber();
     }
 
     @Test
@@ -69,13 +69,13 @@ public class FlowableSwitchTest {
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
-        sampled.subscribe(observer);
+        sampled.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         scheduler.advanceTimeTo(350, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(2)).onNext(anyString());
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(2)).onNext(anyString());
+        inOrder.verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -108,20 +108,20 @@ public class FlowableSwitchTest {
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
-        sampled.subscribe(observer);
+        sampled.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         scheduler.advanceTimeTo(150, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onComplete();
-        inOrder.verify(observer, times(1)).onNext("one");
-        inOrder.verify(observer, times(1)).onNext("two");
-        inOrder.verify(observer, times(1)).onNext("three");
-        inOrder.verify(observer, times(1)).onNext("four");
+        inOrder.verify(subscriber, never()).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        inOrder.verify(subscriber, times(1)).onNext("four");
 
         scheduler.advanceTimeTo(250, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyString());
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, never()).onNext(anyString());
+        inOrder.verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -153,34 +153,34 @@ public class FlowableSwitchTest {
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
-        sampled.subscribe(observer);
+        sampled.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         scheduler.advanceTimeTo(90, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyString());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(anyString());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(125, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext("one");
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(175, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext("two");
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(225, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext("three");
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(350, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext("four");
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("four");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -212,34 +212,34 @@ public class FlowableSwitchTest {
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
-        sampled.subscribe(observer);
+        sampled.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         scheduler.advanceTimeTo(90, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyString());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(anyString());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(125, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext("one");
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(175, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext("two");
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(225, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext("three");
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(350, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyString());
-        verify(observer, never()).onComplete();
-        verify(observer, times(1)).onError(any(TestException.class));
+        inOrder.verify(subscriber, never()).onNext(anyString());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, times(1)).onError(any(TestException.class));
     }
 
     @Test
@@ -276,24 +276,24 @@ public class FlowableSwitchTest {
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
-        sampled.subscribe(observer);
+        sampled.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         scheduler.advanceTimeTo(90, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyString());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(anyString());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(125, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext("one");
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(250, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext("three");
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -331,24 +331,24 @@ public class FlowableSwitchTest {
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
-        sampled.subscribe(observer);
+        sampled.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         scheduler.advanceTimeTo(90, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext(anyString());
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onNext(anyString());
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(125, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext("one");
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         scheduler.advanceTimeTo(250, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, never()).onNext("three");
-        verify(observer, never()).onComplete();
-        verify(observer, times(1)).onError(any(TestException.class));
+        inOrder.verify(subscriber, never()).onNext("three");
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, times(1)).onError(any(TestException.class));
     }
 
     private <T> void publishCompleted(final Subscriber<T> observer, long delay) {
@@ -411,17 +411,17 @@ public class FlowableSwitchTest {
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
-        sampled.subscribe(observer);
+        sampled.subscribe(subscriber);
 
         scheduler.advanceTimeTo(1000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("1-one");
-        inOrder.verify(observer, times(1)).onNext("1-two");
-        inOrder.verify(observer, times(1)).onNext("2-one");
-        inOrder.verify(observer, times(1)).onNext("2-two");
-        inOrder.verify(observer, times(1)).onNext("2-three");
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("1-one");
+        inOrder.verify(subscriber, times(1)).onNext("1-two");
+        inOrder.verify(subscriber, times(1)).onNext("2-one");
+        inOrder.verify(subscriber, times(1)).onNext("2-two");
+        inOrder.verify(subscriber, times(1)).onNext("2-three");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -53,18 +53,18 @@ public class FlowableSwitchTest {
     public void testSwitchWhenOuterCompleteBeforeInner() {
         Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
-            public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 50, Flowable.unsafeCreate(new Publisher<String>() {
+            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber, 50, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 70, "one");
-                        publishNext(observer, 100, "two");
-                        publishCompleted(observer, 200);
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 70, "one");
+                        publishNext(subscriber, 100, "two");
+                        publishCompleted(subscriber, 200);
                     }
                 }));
-                publishCompleted(observer, 60);
+                publishCompleted(subscriber, 60);
             }
         });
 
@@ -82,28 +82,28 @@ public class FlowableSwitchTest {
     public void testSwitchWhenInnerCompleteBeforeOuter() {
         Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
-            public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 10, Flowable.unsafeCreate(new Publisher<String>() {
+            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber, 10, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 0, "one");
-                        publishNext(observer, 10, "two");
-                        publishCompleted(observer, 20);
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 0, "one");
+                        publishNext(subscriber, 10, "two");
+                        publishCompleted(subscriber, 20);
                     }
                 }));
 
-                publishNext(observer, 100, Flowable.unsafeCreate(new Publisher<String>() {
+                publishNext(subscriber, 100, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 0, "three");
-                        publishNext(observer, 10, "four");
-                        publishCompleted(observer, 20);
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 0, "three");
+                        publishNext(subscriber, 10, "four");
+                        publishCompleted(subscriber, 20);
                     }
                 }));
-                publishCompleted(observer, 200);
+                publishCompleted(subscriber, 200);
             }
         });
 
@@ -128,27 +128,27 @@ public class FlowableSwitchTest {
     public void testSwitchWithComplete() {
         Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
-            public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 50, Flowable.unsafeCreate(new Publisher<String>() {
+            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber, 50, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(final Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 60, "one");
-                        publishNext(observer, 100, "two");
+                    public void subscribe(final Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 60, "one");
+                        publishNext(subscriber, 100, "two");
                     }
                 }));
 
-                publishNext(observer, 200, Flowable.unsafeCreate(new Publisher<String>() {
+                publishNext(subscriber, 200, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(final Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 0, "three");
-                        publishNext(observer, 100, "four");
+                    public void subscribe(final Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 0, "three");
+                        publishNext(subscriber, 100, "four");
                     }
                 }));
 
-                publishCompleted(observer, 250);
+                publishCompleted(subscriber, 250);
             }
         });
 
@@ -187,27 +187,27 @@ public class FlowableSwitchTest {
     public void testSwitchWithError() {
         Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
-            public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 50, Flowable.unsafeCreate(new Publisher<String>() {
+            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber, 50, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(final Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 50, "one");
-                        publishNext(observer, 100, "two");
+                    public void subscribe(final Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 50, "one");
+                        publishNext(subscriber, 100, "two");
                     }
                 }));
 
-                publishNext(observer, 200, Flowable.unsafeCreate(new Publisher<String>() {
+                publishNext(subscriber, 200, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 0, "three");
-                        publishNext(observer, 100, "four");
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 0, "three");
+                        publishNext(subscriber, 100, "four");
                     }
                 }));
 
-                publishError(observer, 250, new TestException());
+                publishError(subscriber, 250, new TestException());
             }
         });
 
@@ -246,30 +246,30 @@ public class FlowableSwitchTest {
     public void testSwitchWithSubsequenceComplete() {
         Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
-            public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 50, Flowable.unsafeCreate(new Publisher<String>() {
+            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber, 50, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 50, "one");
-                        publishNext(observer, 100, "two");
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 50, "one");
+                        publishNext(subscriber, 100, "two");
                     }
                 }));
 
-                publishNext(observer, 130, Flowable.unsafeCreate(new Publisher<String>() {
+                publishNext(subscriber, 130, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishCompleted(observer, 0);
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishCompleted(subscriber, 0);
                     }
                 }));
 
-                publishNext(observer, 150, Flowable.unsafeCreate(new Publisher<String>() {
+                publishNext(subscriber, 150, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 50, "three");
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 50, "three");
                     }
                 }));
             }
@@ -300,30 +300,30 @@ public class FlowableSwitchTest {
     public void testSwitchWithSubsequenceError() {
         Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
-            public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 50, Flowable.unsafeCreate(new Publisher<String>() {
+            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber, 50, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 50, "one");
-                        publishNext(observer, 100, "two");
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 50, "one");
+                        publishNext(subscriber, 100, "two");
                     }
                 }));
 
-                publishNext(observer, 130, Flowable.unsafeCreate(new Publisher<String>() {
+                publishNext(subscriber, 130, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishError(observer, 0, new TestException());
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishError(subscriber, 0, new TestException());
                     }
                 }));
 
-                publishNext(observer, 150, Flowable.unsafeCreate(new Publisher<String>() {
+                publishNext(subscriber, 150, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 50, "three");
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 50, "three");
                     }
                 }));
 
@@ -351,29 +351,29 @@ public class FlowableSwitchTest {
         verify(subscriber, times(1)).onError(any(TestException.class));
     }
 
-    private <T> void publishCompleted(final Subscriber<T> observer, long delay) {
+    private <T> void publishCompleted(final Subscriber<T> subscriber, long delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onComplete();
+                subscriber.onComplete();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private <T> void publishError(final Subscriber<T> observer, long delay, final Throwable error) {
+    private <T> void publishError(final Subscriber<T> subscriber, long delay, final Throwable error) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onError(error);
+                subscriber.onError(error);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private <T> void publishNext(final Subscriber<T> observer, long delay, final T value) {
+    private <T> void publishNext(final Subscriber<T> subscriber, long delay, final T value) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onNext(value);
+                subscriber.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
@@ -383,30 +383,30 @@ public class FlowableSwitchTest {
         // https://github.com/ReactiveX/RxJava/issues/737
         Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
             @Override
-            public void subscribe(Subscriber<? super Flowable<String>> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 0, Flowable.unsafeCreate(new Publisher<String>() {
+            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber, 0, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 10, "1-one");
-                        publishNext(observer, 20, "1-two");
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 10, "1-one");
+                        publishNext(subscriber, 20, "1-two");
                         // The following events will be ignored
-                        publishNext(observer, 30, "1-three");
-                        publishCompleted(observer, 40);
+                        publishNext(subscriber, 30, "1-three");
+                        publishCompleted(subscriber, 40);
                     }
                 }));
-                publishNext(observer, 25, Flowable.unsafeCreate(new Publisher<String>() {
+                publishNext(subscriber, 25, Flowable.unsafeCreate(new Publisher<String>() {
                     @Override
-                    public void subscribe(Subscriber<? super String> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        publishNext(observer, 10, "2-one");
-                        publishNext(observer, 20, "2-two");
-                        publishNext(observer, 30, "2-three");
-                        publishCompleted(observer, 40);
+                    public void subscribe(Subscriber<? super String> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        publishNext(subscriber, 10, "2-one");
+                        publishNext(subscriber, 20, "2-two");
+                        publishNext(subscriber, 30, "2-three");
+                        publishCompleted(subscriber, 40);
                     }
                 }));
-                publishCompleted(observer, 30);
+                publishCompleted(subscriber, 30);
             }
         });
 
@@ -965,11 +965,11 @@ public class FlowableSwitchTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onComplete();
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onComplete();
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .switchMap(Functions.justFunction(Flowable.never()))
@@ -1005,12 +1005,12 @@ public class FlowableSwitchTest {
             Flowable.just(1).hide()
             .switchMap(Functions.justFunction(new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onError(new TestException());
-                    observer.onComplete();
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }))
             .test()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOneTest.java
@@ -118,7 +118,9 @@ public class FlowableTakeLastOneTest {
 
         @Override
         public void onStart() {
-            request(initialRequest);
+            if (initialRequest > 0) {
+                request(initialRequest);
+            }
         }
 
         @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
@@ -37,11 +37,12 @@ public class FlowableTakeLastTest {
         Flowable<String> w = Flowable.empty();
         Flowable<String> take = w.takeLast(2);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        take.subscribe(observer);
-        verify(observer, never()).onNext(any(String.class));
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        take.subscribe(subscriber);
+
+        verify(subscriber, never()).onNext(any(String.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -49,14 +50,15 @@ public class FlowableTakeLastTest {
         Flowable<String> w = Flowable.just("one", "two", "three");
         Flowable<String> take = w.takeLast(2);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(observer);
-        take.subscribe(observer);
-        inOrder.verify(observer, times(1)).onNext("two");
-        inOrder.verify(observer, times(1)).onNext("three");
-        verify(observer, never()).onNext("one");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
+        take.subscribe(subscriber);
+
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, never()).onNext("one");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -64,11 +66,12 @@ public class FlowableTakeLastTest {
         Flowable<String> w = Flowable.just("one");
         Flowable<String> take = w.takeLast(10);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        take.subscribe(observer);
-        verify(observer, times(1)).onNext("one");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        take.subscribe(subscriber);
+
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -76,11 +79,12 @@ public class FlowableTakeLastTest {
         Flowable<String> w = Flowable.just("one");
         Flowable<String> take = w.takeLast(0);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        take.subscribe(observer);
-        verify(observer, never()).onNext("one");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        take.subscribe(subscriber);
+
+        verify(subscriber, never()).onNext("one");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -89,13 +93,14 @@ public class FlowableTakeLastTest {
         Flowable<String> w = Flowable.just("one", null, "three");
         Flowable<String> take = w.takeLast(2);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        take.subscribe(observer);
-        verify(observer, never()).onNext("one");
-        verify(observer, times(1)).onNext(null);
-        verify(observer, times(1)).onNext("three");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        take.subscribe(subscriber);
+
+        verify(subscriber, never()).onNext("one");
+        verify(subscriber, times(1)).onNext(null);
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test(expected = IndexOutOfBoundsException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
@@ -333,8 +333,8 @@ public class FlowableTakeLastTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.takeLast(5);
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.takeLast(5);
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -44,11 +44,11 @@ public class FlowableTakeLastTimedTest {
         // FIXME time unit now matters!
         Flowable<Object> result = source.takeLast(1000, TimeUnit.MILLISECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        InOrder inOrder = inOrder(o);
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1); // T: 0ms
         scheduler.advanceTimeBy(250, TimeUnit.MILLISECONDS);
@@ -62,13 +62,13 @@ public class FlowableTakeLastTimedTest {
         scheduler.advanceTimeBy(250, TimeUnit.MILLISECONDS);
         source.onComplete(); // T: 1250ms
 
-        inOrder.verify(o, times(1)).onNext(2);
-        inOrder.verify(o, times(1)).onNext(3);
-        inOrder.verify(o, times(1)).onNext(4);
-        inOrder.verify(o, times(1)).onNext(5);
-        inOrder.verify(o, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onNext(3);
+        inOrder.verify(subscriber, times(1)).onNext(4);
+        inOrder.verify(subscriber, times(1)).onNext(5);
+        inOrder.verify(subscriber, times(1)).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -80,11 +80,11 @@ public class FlowableTakeLastTimedTest {
         // FIXME time unit now matters
         Flowable<Object> result = source.takeLast(1000, TimeUnit.MILLISECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        InOrder inOrder = inOrder(o);
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1); // T: 0ms
         scheduler.advanceTimeBy(250, TimeUnit.MILLISECONDS);
@@ -98,10 +98,10 @@ public class FlowableTakeLastTimedTest {
         scheduler.advanceTimeBy(1250, TimeUnit.MILLISECONDS);
         source.onComplete(); // T: 2250ms
 
-        inOrder.verify(o, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -113,11 +113,11 @@ public class FlowableTakeLastTimedTest {
         // FIXME time unit now matters!
         Flowable<Object> result = source.takeLast(2, 1000, TimeUnit.MILLISECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        InOrder inOrder = inOrder(o);
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1); // T: 0ms
         scheduler.advanceTimeBy(250, TimeUnit.MILLISECONDS);
@@ -131,11 +131,11 @@ public class FlowableTakeLastTimedTest {
         scheduler.advanceTimeBy(250, TimeUnit.MILLISECONDS);
         source.onComplete(); // T: 1250ms
 
-        inOrder.verify(o, times(1)).onNext(4);
-        inOrder.verify(o, times(1)).onNext(5);
-        inOrder.verify(o, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext(4);
+        inOrder.verify(subscriber, times(1)).onNext(5);
+        inOrder.verify(subscriber, times(1)).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -146,11 +146,11 @@ public class FlowableTakeLastTimedTest {
 
         Flowable<Object> result = source.takeLast(1, TimeUnit.SECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        InOrder inOrder = inOrder(o);
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1); // T: 0ms
         scheduler.advanceTimeBy(250, TimeUnit.MILLISECONDS);
@@ -164,10 +164,10 @@ public class FlowableTakeLastTimedTest {
         scheduler.advanceTimeBy(250, TimeUnit.MILLISECONDS);
         source.onError(new TestException()); // T: 1250ms
 
-        inOrder.verify(o, times(1)).onError(any(TestException.class));
+        inOrder.verify(subscriber, times(1)).onError(any(TestException.class));
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -178,11 +178,11 @@ public class FlowableTakeLastTimedTest {
 
         Flowable<Object> result = source.takeLast(0, 1, TimeUnit.SECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        InOrder inOrder = inOrder(o);
+        InOrder inOrder = inOrder(subscriber);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1); // T: 0ms
         scheduler.advanceTimeBy(250, TimeUnit.MILLISECONDS);
@@ -196,10 +196,10 @@ public class FlowableTakeLastTimedTest {
         scheduler.advanceTimeBy(250, TimeUnit.MILLISECONDS);
         source.onComplete(); // T: 1250ms
 
-        inOrder.verify(o, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
@@ -118,10 +118,10 @@ public class FlowableTakeTest {
         try {
             Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
                 @Override
-                public void subscribe(Subscriber<? super String> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onNext("one");
-                    observer.onError(new Throwable("test failed"));
+                public void subscribe(Subscriber<? super String> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onNext("one");
+                    subscriber.onError(new Throwable("test failed"));
                 }
             });
 
@@ -149,10 +149,10 @@ public class FlowableTakeTest {
         final BooleanSubscription bs = new BooleanSubscription();
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
+            public void subscribe(Subscriber<? super String> subscriber) {
                 subscribed.set(true);
-                observer.onSubscribe(bs);
-                observer.onError(new Throwable("test failed"));
+                subscriber.onSubscribe(bs);
+                subscriber.onError(new Throwable("test failed"));
             }
         });
 
@@ -252,8 +252,8 @@ public class FlowableTakeTest {
         }
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
-            observer.onSubscribe(new BooleanSubscription());
+        public void subscribe(final Subscriber<? super String> subscriber) {
+            subscriber.onSubscribe(new BooleanSubscription());
             System.out.println("TestFlowable subscribed to ...");
             t = new Thread(new Runnable() {
 
@@ -263,9 +263,9 @@ public class FlowableTakeTest {
                         System.out.println("running TestFlowable thread");
                         for (String s : values) {
                             System.out.println("TestFlowable onNext: " + s);
-                            observer.onNext(s);
+                            subscriber.onNext(s);
                         }
-                        observer.onComplete();
+                        subscriber.onComplete();
                     } catch (Throwable e) {
                         throw new RuntimeException(e);
                     }
@@ -295,18 +295,18 @@ public class FlowableTakeTest {
 
     @Test(timeout = 2000)
     public void testTakeObserveOn() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
 
         INFINITE_OBSERVABLE.onBackpressureDrop()
         .observeOn(Schedulers.newThread()).take(1).subscribe(ts);
         ts.awaitTerminalEvent();
         ts.assertNoErrors();
 
-        verify(o).onNext(1L);
-        verify(o, never()).onNext(2L);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(1L);
+        verify(subscriber, never()).onNext(2L);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -479,8 +479,8 @@ public class FlowableTakeTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.take(2);
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.take(2);
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTimedTest.java
@@ -36,9 +36,9 @@ public class FlowableTakeTimedTest {
 
         Flowable<Integer> result = source.take(1, TimeUnit.SECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -48,15 +48,15 @@ public class FlowableTakeTimedTest {
 
         source.onNext(4);
 
-        InOrder inOrder = inOrder(o);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o).onNext(3);
-        inOrder.verify(o).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onNext(3);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
 
-        verify(o, never()).onNext(4);
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(4);
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -67,9 +67,9 @@ public class FlowableTakeTimedTest {
 
         Flowable<Integer> result = source.take(1, TimeUnit.SECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -80,15 +80,15 @@ public class FlowableTakeTimedTest {
 
         source.onNext(4);
 
-        InOrder inOrder = inOrder(o);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o).onNext(3);
-        inOrder.verify(o).onError(any(TestException.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onNext(3);
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
 
-        verify(o, never()).onComplete();
-        verify(o, never()).onNext(4);
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(4);
     }
 
     @Test
@@ -99,9 +99,9 @@ public class FlowableTakeTimedTest {
 
         Flowable<Integer> result = source.take(1, TimeUnit.SECONDS, scheduler);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -112,15 +112,15 @@ public class FlowableTakeTimedTest {
         source.onNext(4);
         source.onError(new TestException());
 
-        InOrder inOrder = inOrder(o);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o).onNext(3);
-        inOrder.verify(o).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onNext(3);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
 
-        verify(o, never()).onNext(4);
-        verify(o, never()).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(4);
+        verify(subscriber, never()).onError(any(TestException.class));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
@@ -34,54 +34,54 @@ import io.reactivex.subscribers.TestSubscriber;
 public class FlowableTakeUntilPredicateTest {
     @Test
     public void takeEmpty() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         Flowable.empty().takeUntil(new Predicate<Object>() {
             @Override
             public boolean test(Object v) {
                 return true;
             }
-        }).subscribe(o);
+        }).subscribe(subscriber);
 
-        verify(o, never()).onNext(any());
-        verify(o, never()).onError(any(Throwable.class));
-        verify(o).onComplete();
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber).onComplete();
     }
     @Test
     public void takeAll() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         Flowable.just(1, 2).takeUntil(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return false;
             }
-        }).subscribe(o);
+        }).subscribe(subscriber);
 
-        verify(o).onNext(1);
-        verify(o).onNext(2);
-        verify(o, never()).onError(any(Throwable.class));
-        verify(o).onComplete();
+        verify(subscriber).onNext(1);
+        verify(subscriber).onNext(2);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber).onComplete();
     }
     @Test
     public void takeFirst() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         Flowable.just(1, 2).takeUntil(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
             }
-        }).subscribe(o);
+        }).subscribe(subscriber);
 
-        verify(o).onNext(1);
-        verify(o, never()).onNext(2);
-        verify(o, never()).onError(any(Throwable.class));
-        verify(o).onComplete();
+        verify(subscriber).onNext(1);
+        verify(subscriber, never()).onNext(2);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber).onComplete();
     }
     @Test
     public void takeSome() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         Flowable.just(1, 2, 3).takeUntil(new Predicate<Integer>() {
             @Override
@@ -89,17 +89,17 @@ public class FlowableTakeUntilPredicateTest {
                 return t1 == 2;
             }
         })
-        .subscribe(o);
+        .subscribe(subscriber);
 
-        verify(o).onNext(1);
-        verify(o).onNext(2);
-        verify(o, never()).onNext(3);
-        verify(o, never()).onError(any(Throwable.class));
-        verify(o).onComplete();
+        verify(subscriber).onNext(1);
+        verify(subscriber).onNext(2);
+        verify(subscriber, never()).onNext(3);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber).onComplete();
     }
     @Test
     public void functionThrows() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         Predicate<Integer> predicate = new Predicate<Integer>() {
             @Override
@@ -107,17 +107,17 @@ public class FlowableTakeUntilPredicateTest {
                     throw new TestException("Forced failure");
             }
         };
-        Flowable.just(1, 2, 3).takeUntil(predicate).subscribe(o);
+        Flowable.just(1, 2, 3).takeUntil(predicate).subscribe(subscriber);
 
-        verify(o).onNext(1);
-        verify(o, never()).onNext(2);
-        verify(o, never()).onNext(3);
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onComplete();
+        verify(subscriber).onNext(1);
+        verify(subscriber, never()).onNext(2);
+        verify(subscriber, never()).onNext(3);
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
     }
     @Test
     public void sourceThrows() {
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         Flowable.just(1)
         .concatWith(Flowable.<Integer>error(new TestException()))
@@ -127,12 +127,12 @@ public class FlowableTakeUntilPredicateTest {
             public boolean test(Integer v) {
                 return false;
             }
-        }).subscribe(o);
+        }).subscribe(subscriber);
 
-        verify(o).onNext(1);
-        verify(o, never()).onNext(2);
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onComplete();
+        verify(subscriber).onNext(1);
+        verify(subscriber, never()).onNext(2);
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
     }
     @Test
     public void backpressure() {
@@ -178,8 +178,8 @@ public class FlowableTakeUntilPredicateTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.takeUntil(Functions.alwaysFalse());
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.takeUntil(Functions.alwaysFalse());
             }
         });
     }
@@ -190,12 +190,12 @@ public class FlowableTakeUntilPredicateTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onComplete();
-                    observer.onNext(1);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onComplete();
+                    subscriber.onNext(1);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .takeUntil(Functions.alwaysFalse())

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
@@ -155,7 +155,7 @@ public class FlowableTakeUntilTest {
 
     private static class TestObservable implements Publisher<String> {
 
-        Subscriber<? super String> observer;
+        Subscriber<? super String> subscriber;
         Subscription s;
 
         TestObservable(Subscription s) {
@@ -164,23 +164,23 @@ public class FlowableTakeUntilTest {
 
         /* used to simulate subscription */
         public void sendOnCompleted() {
-            observer.onComplete();
+            subscriber.onComplete();
         }
 
         /* used to simulate subscription */
         public void sendOnNext(String value) {
-            observer.onNext(value);
+            subscriber.onNext(value);
         }
 
         /* used to simulate subscription */
         public void sendOnError(Throwable e) {
-            observer.onError(e);
+            subscriber.onError(e);
         }
 
         @Override
-        public void subscribe(Subscriber<? super String> observer) {
-            this.observer = observer;
-            observer.onSubscribe(s);
+        public void subscribe(Subscriber<? super String> subscriber) {
+            this.subscriber = subscriber;
+            subscriber.onSubscribe(s);
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
+
 import org.junit.*;
 import org.reactivestreams.*;
 
@@ -25,6 +27,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.*;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -40,13 +43,14 @@ public class FlowableTakeWhileTest {
             }
         });
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        take.subscribe(observer);
-        verify(observer, times(1)).onNext(1);
-        verify(observer, times(1)).onNext(2);
-        verify(observer, never()).onNext(3);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        take.subscribe(subscriber);
+
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, times(1)).onNext(2);
+        verify(subscriber, never()).onNext(3);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -59,8 +63,8 @@ public class FlowableTakeWhileTest {
             }
         });
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
-        take.subscribe(observer);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        take.subscribe(subscriber);
 
         s.onNext(1);
         s.onNext(2);
@@ -69,13 +73,13 @@ public class FlowableTakeWhileTest {
         s.onNext(5);
         s.onComplete();
 
-        verify(observer, times(1)).onNext(1);
-        verify(observer, times(1)).onNext(2);
-        verify(observer, never()).onNext(3);
-        verify(observer, never()).onNext(4);
-        verify(observer, never()).onNext(5);
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, times(1)).onNext(2);
+        verify(subscriber, never()).onNext(3);
+        verify(subscriber, never()).onNext(4);
+        verify(subscriber, never()).onNext(5);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -90,32 +94,40 @@ public class FlowableTakeWhileTest {
             }
         });
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        take.subscribe(observer);
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, never()).onNext("three");
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        take.subscribe(subscriber);
+
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, never()).onNext("three");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testTakeWhileDoesntLeakErrors() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                observer.onNext("one");
-                observer.onError(new Throwable("test failed"));
-            }
-        });
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
+                @Override
+                public void subscribe(Subscriber<? super String> observer) {
+                    observer.onSubscribe(new BooleanSubscription());
+                    observer.onNext("one");
+                    observer.onError(new TestException("test failed"));
+                }
+            });
 
-        source.takeWhile(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return false;
-            }
-        }).blockingLast("");
+            source.takeWhile(new Predicate<String>() {
+                @Override
+                public boolean test(String s) {
+                    return false;
+                }
+            }).blockingLast("");
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "test failed");
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
@@ -123,7 +135,7 @@ public class FlowableTakeWhileTest {
         TestFlowable source = new TestFlowable(mock(Subscription.class), "one");
         final RuntimeException testException = new RuntimeException("test exception");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> take = Flowable.unsafeCreate(source)
                 .takeWhile(new Predicate<String>() {
             @Override
@@ -131,7 +143,7 @@ public class FlowableTakeWhileTest {
                 throw testException;
             }
         });
-        take.subscribe(observer);
+        take.subscribe(subscriber);
 
         // wait for the Flowable to complete
         try {
@@ -141,8 +153,8 @@ public class FlowableTakeWhileTest {
             fail(e.getMessage());
         }
 
-        verify(observer, never()).onNext(any(String.class));
-        verify(observer, times(1)).onError(testException);
+        verify(subscriber, never()).onNext(any(String.class));
+        verify(subscriber, times(1)).onError(testException);
     }
 
     @Test
@@ -150,7 +162,7 @@ public class FlowableTakeWhileTest {
         Subscription s = mock(Subscription.class);
         TestFlowable w = new TestFlowable(s, "one", "two", "three");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> take = Flowable.unsafeCreate(w)
                 .takeWhile(new Predicate<String>() {
             int index;
@@ -160,7 +172,7 @@ public class FlowableTakeWhileTest {
                 return index++ < 1;
             }
         });
-        take.subscribe(observer);
+        take.subscribe(subscriber);
 
         // wait for the Flowable to complete
         try {
@@ -171,9 +183,9 @@ public class FlowableTakeWhileTest {
         }
 
         System.out.println("TestFlowable thread finished");
-        verify(observer, times(1)).onNext("one");
-        verify(observer, never()).onNext("two");
-        verify(observer, never()).onNext("three");
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, never()).onNext("two");
+        verify(subscriber, never()).onNext("three");
         verify(s, times(1)).cancel();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
@@ -110,10 +110,10 @@ public class FlowableTakeWhileTest {
         try {
             Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
                 @Override
-                public void subscribe(Subscriber<? super String> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onNext("one");
-                    observer.onError(new TestException("test failed"));
+                public void subscribe(Subscriber<? super String> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onNext("one");
+                    subscriber.onError(new TestException("test failed"));
                 }
             });
 
@@ -201,9 +201,9 @@ public class FlowableTakeWhileTest {
         }
 
         @Override
-        public void subscribe(final Subscriber<? super String> observer) {
+        public void subscribe(final Subscriber<? super String> subscriber) {
             System.out.println("TestFlowable subscribed to ...");
-            observer.onSubscribe(s);
+            subscriber.onSubscribe(s);
             t = new Thread(new Runnable() {
 
                 @Override
@@ -212,9 +212,9 @@ public class FlowableTakeWhileTest {
                         System.out.println("running TestFlowable thread");
                         for (String s : values) {
                             System.out.println("TestFlowable onNext: " + s);
-                            observer.onNext(s);
+                            subscriber.onNext(s);
                         }
-                        observer.onComplete();
+                        subscriber.onComplete();
                     } catch (Throwable e) {
                         throw new RuntimeException(e);
                     }
@@ -292,8 +292,8 @@ public class FlowableTakeWhileTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.takeWhile(Functions.alwaysTrue());
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.takeWhile(Functions.alwaysTrue());
             }
         });
     }
@@ -302,10 +302,10 @@ public class FlowableTakeWhileTest {
     public void badSource() {
         new Flowable<Integer>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                observer.onComplete();
-                observer.onComplete();
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                subscriber.onComplete();
+                subscriber.onComplete();
             }
         }
         .takeWhile(Functions.alwaysTrue())

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
@@ -47,13 +47,13 @@ public class FlowableThrottleFirstTest {
     public void testThrottlingWithCompleted() {
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                publishNext(observer, 100, "one");    // publish as it's first
-                publishNext(observer, 300, "two");    // skip as it's last within the first 400
-                publishNext(observer, 900, "three");   // publish
-                publishNext(observer, 905, "four");   // skip
-                publishCompleted(observer, 1000);     // Should be published as soon as the timeout expires.
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber, 100, "one");    // publish as it's first
+                publishNext(subscriber, 300, "two");    // skip as it's last within the first 400
+                publishNext(subscriber, 900, "three");   // publish
+                publishNext(subscriber, 905, "four");   // skip
+                publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
             }
         });
 
@@ -75,12 +75,12 @@ public class FlowableThrottleFirstTest {
     public void testThrottlingWithError() {
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 Exception error = new TestException();
-                publishNext(observer, 100, "one");    // Should be published since it is first
-                publishNext(observer, 200, "two");    // Should be skipped since onError will arrive before the timeout expires
-                publishError(observer, 300, error);   // Should be published as soon as the timeout expires.
+                publishNext(subscriber, 100, "one");    // Should be published since it is first
+                publishNext(subscriber, 200, "two");    // Should be skipped since onError will arrive before the timeout expires
+                publishError(subscriber, 300, error);   // Should be published as soon as the timeout expires.
             }
         });
 
@@ -95,29 +95,29 @@ public class FlowableThrottleFirstTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    private <T> void publishCompleted(final Subscriber<T> observer, long delay) {
+    private <T> void publishCompleted(final Subscriber<T> subscriber, long delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onComplete();
+                subscriber.onComplete();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private <T> void publishError(final Subscriber<T> observer, long delay, final Exception error) {
+    private <T> void publishError(final Subscriber<T> subscriber, long delay, final Exception error) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onError(error);
+                subscriber.onError(error);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private <T> void publishNext(final Subscriber<T> observer, long delay, final T value) {
+    private <T> void publishNext(final Subscriber<T> subscriber, long delay, final T value) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onNext(value);
+                subscriber.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
@@ -173,14 +173,14 @@ public class FlowableThrottleFirstTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onNext(1);
-                    observer.onNext(2);
-                    observer.onComplete();
-                    observer.onNext(3);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onNext(1);
+                    subscriber.onNext(2);
+                    subscriber.onComplete();
+                    subscriber.onNext(3);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .throttleFirst(1, TimeUnit.DAYS)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
@@ -34,13 +34,13 @@ public class FlowableThrottleFirstTest {
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
-    private Subscriber<String> observer;
+    private Subscriber<String> subscriber;
 
     @Before
     public void before() {
         scheduler = new TestScheduler();
         innerScheduler = scheduler.createWorker();
-        observer = TestHelper.mockSubscriber();
+        subscriber = TestHelper.mockSubscriber();
     }
 
     @Test
@@ -58,16 +58,16 @@ public class FlowableThrottleFirstTest {
         });
 
         Flowable<String> sampled = source.throttleFirst(400, TimeUnit.MILLISECONDS, scheduler);
-        sampled.subscribe(observer);
+        sampled.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         scheduler.advanceTimeTo(1000, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer, times(1)).onNext("one");
-        inOrder.verify(observer, times(0)).onNext("two");
-        inOrder.verify(observer, times(1)).onNext("three");
-        inOrder.verify(observer, times(0)).onNext("four");
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        inOrder.verify(subscriber, times(0)).onNext("two");
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        inOrder.verify(subscriber, times(0)).onNext("four");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -85,13 +85,13 @@ public class FlowableThrottleFirstTest {
         });
 
         Flowable<String> sampled = source.throttleFirst(400, TimeUnit.MILLISECONDS, scheduler);
-        sampled.subscribe(observer);
+        sampled.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         scheduler.advanceTimeTo(400, TimeUnit.MILLISECONDS);
-        inOrder.verify(observer).onNext("one");
-        inOrder.verify(observer).onError(any(TestException.class));
+        inOrder.verify(subscriber).onNext("one");
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -124,10 +124,10 @@ public class FlowableThrottleFirstTest {
 
     @Test
     public void testThrottle() {
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
         TestScheduler s = new TestScheduler();
         PublishProcessor<Integer> o = PublishProcessor.create();
-        o.throttleFirst(500, TimeUnit.MILLISECONDS, s).subscribe(observer);
+        o.throttleFirst(500, TimeUnit.MILLISECONDS, s).subscribe(subscriber);
 
         // send events with simulated time increments
         s.advanceTimeTo(0, TimeUnit.MILLISECONDS);
@@ -145,11 +145,11 @@ public class FlowableThrottleFirstTest {
         s.advanceTimeTo(1501, TimeUnit.MILLISECONDS);
         o.onComplete();
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onNext(1);
-        inOrder.verify(observer).onNext(3);
-        inOrder.verify(observer).onNext(7);
-        inOrder.verify(observer).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(3);
+        inOrder.verify(subscriber).onNext(7);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeIntervalTest.java
@@ -32,24 +32,24 @@ public class FlowableTimeIntervalTest {
 
     private static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
 
-    private Subscriber<Timed<Integer>> observer;
+    private Subscriber<Timed<Integer>> subscriber;
 
     private TestScheduler testScheduler;
     private PublishProcessor<Integer> subject;
-    private Flowable<Timed<Integer>> observable;
+    private Flowable<Timed<Integer>> flowable;
 
     @Before
     public void setUp() {
-        observer = TestHelper.mockSubscriber();
+        subscriber = TestHelper.mockSubscriber();
         testScheduler = new TestScheduler();
         subject = PublishProcessor.create();
-        observable = subject.timeInterval(testScheduler);
+        flowable = subject.timeInterval(testScheduler);
     }
 
     @Test
     public void testTimeInterval() {
-        InOrder inOrder = inOrder(observer);
-        observable.subscribe(observer);
+        InOrder inOrder = inOrder(subscriber);
+        flowable.subscribe(subscriber);
 
         testScheduler.advanceTimeBy(1000, TIME_UNIT);
         subject.onNext(1);
@@ -59,13 +59,13 @@ public class FlowableTimeIntervalTest {
         subject.onNext(3);
         subject.onComplete();
 
-        inOrder.verify(observer, times(1)).onNext(
+        inOrder.verify(subscriber, times(1)).onNext(
                 new Timed<Integer>(1, 1000, TIME_UNIT));
-        inOrder.verify(observer, times(1)).onNext(
+        inOrder.verify(subscriber, times(1)).onNext(
                 new Timed<Integer>(2, 2000, TIME_UNIT));
-        inOrder.verify(observer, times(1)).onNext(
+        inOrder.verify(subscriber, times(1)).onNext(
                 new Timed<Integer>(3, 3000, TIME_UNIT));
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeIntervalTest.java
@@ -35,15 +35,15 @@ public class FlowableTimeIntervalTest {
     private Subscriber<Timed<Integer>> subscriber;
 
     private TestScheduler testScheduler;
-    private PublishProcessor<Integer> subject;
+    private PublishProcessor<Integer> processor;
     private Flowable<Timed<Integer>> flowable;
 
     @Before
     public void setUp() {
         subscriber = TestHelper.mockSubscriber();
         testScheduler = new TestScheduler();
-        subject = PublishProcessor.create();
-        flowable = subject.timeInterval(testScheduler);
+        processor = PublishProcessor.create();
+        flowable = processor.timeInterval(testScheduler);
     }
 
     @Test
@@ -52,12 +52,12 @@ public class FlowableTimeIntervalTest {
         flowable.subscribe(subscriber);
 
         testScheduler.advanceTimeBy(1000, TIME_UNIT);
-        subject.onNext(1);
+        processor.onNext(1);
         testScheduler.advanceTimeBy(2000, TIME_UNIT);
-        subject.onNext(2);
+        processor.onNext(2);
         testScheduler.advanceTimeBy(3000, TIME_UNIT);
-        subject.onNext(3);
-        subject.onComplete();
+        processor.onNext(3);
+        processor.onComplete();
 
         inOrder.verify(subscriber, times(1)).onNext(
                 new Timed<Integer>(1, 1000, TIME_UNIT));

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -50,23 +50,23 @@ public class FlowableTimeoutTests {
 
     @Test
     public void shouldNotTimeoutIfOnNextWithinTimeout() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
 
         withTimeout.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
-        verify(observer).onNext("One");
+        verify(subscriber).onNext("One");
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
         ts.cancel();
     }
 
     @Test
     public void shouldNotTimeoutIfSecondOnNextWithinTimeout() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
 
         withTimeout.subscribe(ts);
 
@@ -74,59 +74,59 @@ public class FlowableTimeoutTests {
         underlyingSubject.onNext("One");
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("Two");
-        verify(observer).onNext("Two");
+        verify(subscriber).onNext("Two");
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
         ts.dispose();
     }
 
     @Test
     public void shouldTimeoutIfOnNextNotWithinTimeout() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
 
         withTimeout.subscribe(ts);
 
         testScheduler.advanceTimeBy(TIMEOUT + 1, TimeUnit.SECONDS);
-        verify(observer).onError(any(TimeoutException.class));
+        verify(subscriber).onError(any(TimeoutException.class));
         ts.dispose();
     }
 
     @Test
     public void shouldTimeoutIfSecondOnNextNotWithinTimeout() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
-        withTimeout.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        withTimeout.subscribe(subscriber);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
-        verify(observer).onNext("One");
+        verify(subscriber).onNext("One");
         testScheduler.advanceTimeBy(TIMEOUT + 1, TimeUnit.SECONDS);
-        verify(observer).onError(any(TimeoutException.class));
+        verify(subscriber).onError(any(TimeoutException.class));
         ts.dispose();
     }
 
     @Test
     public void shouldCompleteIfUnderlyingComletes() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
-        withTimeout.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        withTimeout.subscribe(subscriber);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onComplete();
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
-        verify(observer).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
         ts.dispose();
     }
 
     @Test
     public void shouldErrorIfUnderlyingErrors() {
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
-        withTimeout.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        withTimeout.subscribe(subscriber);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onError(new UnsupportedOperationException());
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
-        verify(observer).onError(any(UnsupportedOperationException.class));
+        verify(subscriber).onError(any(UnsupportedOperationException.class));
         ts.dispose();
     }
 
@@ -135,20 +135,20 @@ public class FlowableTimeoutTests {
         Flowable<String> other = Flowable.just("a", "b", "c");
         Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS);
         underlyingSubject.onNext("Two");
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("One");
-        inOrder.verify(observer, times(1)).onNext("a");
-        inOrder.verify(observer, times(1)).onNext("b");
-        inOrder.verify(observer, times(1)).onNext("c");
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("One");
+        inOrder.verify(subscriber, times(1)).onNext("a");
+        inOrder.verify(subscriber, times(1)).onNext("b");
+        inOrder.verify(subscriber, times(1)).onNext("c");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
         ts.dispose();
     }
@@ -158,20 +158,20 @@ public class FlowableTimeoutTests {
         Flowable<String> other = Flowable.just("a", "b", "c");
         Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS);
         underlyingSubject.onError(new UnsupportedOperationException());
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("One");
-        inOrder.verify(observer, times(1)).onNext("a");
-        inOrder.verify(observer, times(1)).onNext("b");
-        inOrder.verify(observer, times(1)).onNext("c");
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("One");
+        inOrder.verify(subscriber, times(1)).onNext("a");
+        inOrder.verify(subscriber, times(1)).onNext("b");
+        inOrder.verify(subscriber, times(1)).onNext("c");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
         ts.dispose();
     }
@@ -181,20 +181,20 @@ public class FlowableTimeoutTests {
         Flowable<String> other = Flowable.just("a", "b", "c");
         Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS);
         underlyingSubject.onComplete();
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("One");
-        inOrder.verify(observer, times(1)).onNext("a");
-        inOrder.verify(observer, times(1)).onNext("b");
-        inOrder.verify(observer, times(1)).onNext("c");
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("One");
+        inOrder.verify(subscriber, times(1)).onNext("a");
+        inOrder.verify(subscriber, times(1)).onNext("b");
+        inOrder.verify(subscriber, times(1)).onNext("c");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
         ts.dispose();
     }
@@ -204,8 +204,8 @@ public class FlowableTimeoutTests {
         PublishProcessor<String> other = PublishProcessor.create();
         Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -222,10 +222,10 @@ public class FlowableTimeoutTests {
         other.onNext("d");
         other.onComplete();
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("One");
-        inOrder.verify(observer, times(1)).onNext("a");
-        inOrder.verify(observer, times(1)).onNext("b");
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("One");
+        inOrder.verify(subscriber, times(1)).onNext("a");
+        inOrder.verify(subscriber, times(1)).onNext("b");
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -235,8 +235,8 @@ public class FlowableTimeoutTests {
         final CountDownLatch exit = new CountDownLatch(1);
         final CountDownLatch timeoutSetuped = new CountDownLatch(1);
 
-        final Subscriber<String> observer = TestHelper.mockSubscriber();
-        final TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        final Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        final TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
 
         new Thread(new Runnable() {
 
@@ -265,8 +265,8 @@ public class FlowableTimeoutTests {
         timeoutSetuped.await();
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onError(isA(TimeoutException.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onError(isA(TimeoutException.class));
         inOrder.verifyNoMoreInteractions();
 
         exit.countDown(); // exit the thread
@@ -287,14 +287,14 @@ public class FlowableTimeoutTests {
         TestScheduler testScheduler = new TestScheduler();
         Flowable<String> observableWithTimeout = never.timeout(1000, TimeUnit.MILLISECONDS, testScheduler);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         observableWithTimeout.subscribe(ts);
 
         testScheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onError(isA(TimeoutException.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onError(isA(TimeoutException.class));
         inOrder.verifyNoMoreInteractions();
 
         verify(s, times(1)).cancel();
@@ -318,14 +318,14 @@ public class FlowableTimeoutTests {
         Flowable<String> observableWithTimeout = immediatelyComplete.timeout(1000, TimeUnit.MILLISECONDS,
                 testScheduler);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         observableWithTimeout.subscribe(ts);
 
         testScheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
 
         verify(s, times(1)).cancel();
@@ -349,14 +349,14 @@ public class FlowableTimeoutTests {
         Flowable<String> observableWithTimeout = immediatelyError.timeout(1000, TimeUnit.MILLISECONDS,
                 testScheduler);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         observableWithTimeout.subscribe(ts);
 
         testScheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onError(isA(IOException.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onError(isA(IOException.class));
         inOrder.verifyNoMoreInteractions();
 
         verify(s, times(1)).cancel();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -364,18 +364,18 @@ public class FlowableTimeoutTests {
 
     @Test
     public void shouldUnsubscribeFromUnderlyingSubscriptionOnDispose() {
-        final PublishProcessor<String> subject = PublishProcessor.create();
+        final PublishProcessor<String> processor = PublishProcessor.create();
         final TestScheduler scheduler = new TestScheduler();
 
-        final TestSubscriber<String> observer = subject
+        final TestSubscriber<String> subscriber = processor
                 .timeout(100, TimeUnit.MILLISECONDS, scheduler)
                 .test();
 
-        assertTrue(subject.hasSubscribers());
+        assertTrue(processor.hasSubscribers());
 
-        observer.dispose();
+        subscriber.dispose();
 
-        assertFalse(subject.hasSubscribers());
+        assertFalse(processor.hasSubscribers());
     }
 
     @Test
@@ -431,14 +431,14 @@ public class FlowableTimeoutTests {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
 
-                    observer.onNext(1);
-                    observer.onComplete();
-                    observer.onNext(2);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                    subscriber.onNext(1);
+                    subscriber.onComplete();
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .timeout(1, TimeUnit.DAYS)
@@ -457,14 +457,14 @@ public class FlowableTimeoutTests {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
 
-                    observer.onNext(1);
-                    observer.onComplete();
-                    observer.onNext(2);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                    subscriber.onNext(1);
+                    subscriber.onComplete();
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .timeout(1, TimeUnit.DAYS, Flowable.just(3))

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -53,22 +53,22 @@ public class FlowableTimeoutWithSelectorTest {
 
         Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.timeout(timeout, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
         source.onNext(3);
         timeout.onNext(1);
 
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o).onNext(3);
-        inOrder.verify(o).onNext(100);
-        inOrder.verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber).onNext(3);
+        inOrder.verify(subscriber).onNext(100);
+        inOrder.verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
     }
 
@@ -86,16 +86,16 @@ public class FlowableTimeoutWithSelectorTest {
 
         Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.timeout(timeout, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(subscriber);
 
         timeout.onNext(1);
 
-        inOrder.verify(o).onNext(100);
-        inOrder.verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber).onNext(100);
+        inOrder.verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
     }
 
@@ -120,13 +120,13 @@ public class FlowableTimeoutWithSelectorTest {
 
         Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.timeout(Flowable.defer(firstTimeoutFunc), timeoutFunc, other).subscribe(o);
+        source.timeout(Flowable.defer(firstTimeoutFunc), timeoutFunc, other).subscribe(subscriber);
 
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
 
     }
 
@@ -144,16 +144,16 @@ public class FlowableTimeoutWithSelectorTest {
 
         Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.timeout(timeout, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(subscriber);
 
         source.onNext(1);
 
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onError(any(TestException.class));
-        verify(o, never()).onComplete();
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
 
     }
 
@@ -171,13 +171,13 @@ public class FlowableTimeoutWithSelectorTest {
 
         Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.timeout(Flowable.<Integer> error(new TestException()), timeoutFunc, other).subscribe(o);
+        source.timeout(Flowable.<Integer> error(new TestException()), timeoutFunc, other).subscribe(subscriber);
 
-        verify(o).onError(any(TestException.class));
-        verify(o, never()).onNext(any());
-        verify(o, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(any());
+        verify(subscriber, never()).onComplete();
 
     }
 
@@ -195,16 +195,16 @@ public class FlowableTimeoutWithSelectorTest {
 
         Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.timeout(timeout, timeoutFunc, other).subscribe(o);
+        source.timeout(timeout, timeoutFunc, other).subscribe(subscriber);
 
         source.onNext(1);
 
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onError(any(TestException.class));
-        verify(o, never()).onComplete();
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
 
     }
 
@@ -220,13 +220,13 @@ public class FlowableTimeoutWithSelectorTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        source.timeout(timeout, timeoutFunc).subscribe(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        source.timeout(timeout, timeoutFunc).subscribe(subscriber);
 
         timeout.onNext(1);
 
-        InOrder inOrder = inOrder(o);
-        inOrder.verify(o).onError(isA(TimeoutException.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onError(isA(TimeoutException.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -242,15 +242,15 @@ public class FlowableTimeoutWithSelectorTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
-        source.timeout(PublishProcessor.create(), timeoutFunc).subscribe(o);
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        source.timeout(PublishProcessor.create(), timeoutFunc).subscribe(subscriber);
         source.onNext(1);
 
         timeout.onNext(1);
 
-        InOrder inOrder = inOrder(o);
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onError(isA(TimeoutException.class));
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onError(isA(TimeoutException.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -308,7 +308,7 @@ public class FlowableTimeoutWithSelectorTest {
             }
         };
 
-        final Subscriber<Integer> o = TestHelper.mockSubscriber();
+        final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
         doAnswer(new Answer<Void>() {
 
             @Override
@@ -317,7 +317,7 @@ public class FlowableTimeoutWithSelectorTest {
                 return null;
             }
 
-        }).when(o).onNext(2);
+        }).when(subscriber).onNext(2);
         doAnswer(new Answer<Void>() {
 
             @Override
@@ -326,9 +326,9 @@ public class FlowableTimeoutWithSelectorTest {
                 return null;
             }
 
-        }).when(o).onComplete();
+        }).when(subscriber).onComplete();
 
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(o);
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(subscriber);
 
         new Thread(new Runnable() {
 
@@ -363,12 +363,12 @@ public class FlowableTimeoutWithSelectorTest {
 
         assertFalse("CoundDownLatch timeout", latchTimeout.get());
 
-        InOrder inOrder = inOrder(o);
-        inOrder.verify(o).onSubscribe((Subscription)notNull());
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onNext(2);
-        inOrder.verify(o, never()).onNext(3);
-        inOrder.verify(o).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber).onSubscribe((Subscription)notNull());
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onNext(2);
+        inOrder.verify(subscriber, never()).onNext(3);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -383,15 +383,15 @@ public class FlowableTimeoutWithSelectorTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.timeout(Functions.justFunction(Flowable.never()));
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.timeout(Functions.justFunction(Flowable.never()));
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.timeout(Functions.justFunction(Flowable.never()), Flowable.never());
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.timeout(Functions.justFunction(Flowable.never()), Flowable.never());
             }
         });
     }
@@ -434,12 +434,12 @@ public class FlowableTimeoutWithSelectorTest {
             TestSubscriber<Integer> ts = pp
             .timeout(Functions.justFunction(new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onError(new TestException("First"));
-                    observer.onNext(2);
-                    observer.onError(new TestException("Second"));
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onError(new TestException("First"));
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException("Second"));
+                    subscriber.onComplete();
                 }
             }))
             .test();
@@ -463,12 +463,12 @@ public class FlowableTimeoutWithSelectorTest {
             TestSubscriber<Integer> ts = pp
             .timeout(Functions.justFunction(new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onError(new TestException("First"));
-                    observer.onNext(2);
-                    observer.onError(new TestException("Second"));
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onError(new TestException("First"));
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException("Second"));
+                    subscriber.onComplete();
                 }
             }), Flowable.just(2))
             .test();
@@ -497,14 +497,14 @@ public class FlowableTimeoutWithSelectorTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onNext(1);
-                    observer.onNext(2);
-                    observer.onError(new TestException("First"));
-                    observer.onNext(3);
-                    observer.onComplete();
-                    observer.onError(new TestException("Second"));
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onNext(1);
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException("First"));
+                    subscriber.onNext(3);
+                    subscriber.onComplete();
+                    subscriber.onError(new TestException("Second"));
                 }
             }
             .timeout(Functions.justFunction(Flowable.never()), Flowable.<Integer>never())

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimerTest.java
@@ -35,29 +35,29 @@ import io.reactivex.subscribers.*;
 
 public class FlowableTimerTest {
     @Mock
-    Subscriber<Object> observer;
+    Subscriber<Object> subscriber;
     @Mock
-    Subscriber<Long> observer2;
+    Subscriber<Long> subscriber2;
 
     TestScheduler scheduler;
 
     @Before
     public void before() {
-        observer = TestHelper.mockSubscriber();
+        subscriber = TestHelper.mockSubscriber();
 
-        observer2 = TestHelper.mockSubscriber();
+        subscriber2 = TestHelper.mockSubscriber();
 
         scheduler = new TestScheduler();
     }
 
     @Test
     public void testTimerOnce() {
-        Flowable.timer(100, TimeUnit.MILLISECONDS, scheduler).subscribe(observer);
+        Flowable.timer(100, TimeUnit.MILLISECONDS, scheduler).subscribe(subscriber);
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
 
-        verify(observer, times(1)).onNext(0L);
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onNext(0L);
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -239,26 +239,26 @@ public class FlowableTimerTest {
 
             @Override
             public void onError(Throwable e) {
-                observer.onError(e);
+                subscriber.onError(e);
             }
 
             @Override
             public void onComplete() {
-                observer.onComplete();
+                subscriber.onComplete();
             }
         });
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        verify(observer).onError(any(TestException.class));
-        verify(observer, never()).onNext(anyLong());
-        verify(observer, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
+        verify(subscriber, never()).onNext(anyLong());
+        verify(subscriber, never()).onComplete();
     }
     @Test
     public void testPeriodicObserverThrows() {
         Flowable<Long> source = Flowable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
         source.safeSubscribe(new DefaultSubscriber<Long>() {
 
@@ -267,26 +267,26 @@ public class FlowableTimerTest {
                 if (t > 0) {
                     throw new TestException();
                 }
-                observer.onNext(t);
+                subscriber.onNext(t);
             }
 
             @Override
             public void onError(Throwable e) {
-                observer.onError(e);
+                subscriber.onError(e);
             }
 
             @Override
             public void onComplete() {
-                observer.onComplete();
+                subscriber.onComplete();
             }
         });
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        inOrder.verify(observer).onNext(0L);
-        inOrder.verify(observer).onError(any(TestException.class));
+        inOrder.verify(subscriber).onNext(0L);
+        inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(observer, never()).onComplete();
+        verify(subscriber, never()).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimestampTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimestampTest.java
@@ -28,11 +28,11 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.*;
 
 public class FlowableTimestampTest {
-    Subscriber<Object> observer;
+    Subscriber<Object> subscriber;
 
     @Before
     public void before() {
-        observer = TestHelper.mockSubscriber();
+        subscriber = TestHelper.mockSubscriber();
     }
 
     @Test
@@ -41,7 +41,7 @@ public class FlowableTimestampTest {
 
         PublishProcessor<Integer> source = PublishProcessor.create();
         Flowable<Timed<Integer>> m = source.timestamp(scheduler);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source.onNext(1);
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
@@ -49,14 +49,14 @@ public class FlowableTimestampTest {
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
         source.onNext(3);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(2, 100, TimeUnit.MILLISECONDS));
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(2, 100, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -65,7 +65,7 @@ public class FlowableTimestampTest {
 
         PublishProcessor<Integer> source = PublishProcessor.create();
         Flowable<Timed<Integer>> m = source.timestamp(scheduler);
-        m.subscribe(observer);
+        m.subscribe(subscriber);
 
         source.onNext(1);
         source.onNext(2);
@@ -73,14 +73,14 @@ public class FlowableTimestampTest {
         scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
         source.onNext(3);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(2, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(2, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToFutureTest.java
@@ -34,17 +34,17 @@ public class FlowableToFutureTest {
         Object value = new Object();
         when(future.get()).thenReturn(value);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
 
         Flowable.fromFuture(future).subscribe(ts);
 
         ts.dispose();
 
-        verify(o, times(1)).onNext(value);
-        verify(o, times(1)).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onNext(value);
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
         verify(future, never()).cancel(anyBoolean());
     }
 
@@ -55,18 +55,18 @@ public class FlowableToFutureTest {
         Object value = new Object();
         when(future.get()).thenReturn(value);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         TestScheduler scheduler = new TestScheduler();
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
 
         Flowable.fromFuture(future, scheduler).subscribe(ts);
 
-        verify(o, never()).onNext(value);
+        verify(subscriber, never()).onNext(value);
 
         scheduler.triggerActions();
 
-        verify(o, times(1)).onNext(value);
+        verify(subscriber, times(1)).onNext(value);
     }
 
     @Test
@@ -76,17 +76,17 @@ public class FlowableToFutureTest {
         RuntimeException e = new RuntimeException();
         when(future.get()).thenThrow(e);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
 
         Flowable.fromFuture(future).subscribe(ts);
 
         ts.dispose();
 
-        verify(o, never()).onNext(null);
-        verify(o, never()).onComplete();
-        verify(o, times(1)).onError(e);
+        verify(subscriber, never()).onNext(null);
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, times(1)).onError(e);
         verify(future, never()).cancel(anyBoolean());
     }
 
@@ -97,9 +97,9 @@ public class FlowableToFutureTest {
         CancellationException e = new CancellationException("unit test synthetic cancellation");
         when(future.get()).thenThrow(e);
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
         ts.dispose();
 
         Flowable.fromFuture(future).subscribe(ts);
@@ -143,9 +143,9 @@ public class FlowableToFutureTest {
             }
         };
 
-        Subscriber<Object> o = TestHelper.mockSubscriber();
+        Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(o);
+        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
         Flowable<Object> futureObservable = Flowable.fromFuture(future);
 
         futureObservable.subscribeOn(Schedulers.computation()).subscribe(ts);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
@@ -38,11 +38,12 @@ public class FlowableToListTest {
         Flowable<String> w = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
         Flowable<List<String>> observable = w.toList().toFlowable();
 
-        Subscriber<List<String>> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
-        verify(observer, times(1)).onNext(Arrays.asList("one", "two", "three"));
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<List<String>> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
+
+        verify(subscriber, times(1)).onNext(Arrays.asList("one", "two", "three"));
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -50,11 +51,12 @@ public class FlowableToListTest {
         Flowable<String> w = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
         Flowable<List<String>> observable = w.toList().toFlowable();
 
-        Subscriber<List<String>> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
-        verify(observer, times(1)).onNext(Arrays.asList("one", "two", "three"));
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<List<String>> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
+
+        verify(subscriber, times(1)).onNext(Arrays.asList("one", "two", "three"));
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -85,11 +87,12 @@ public class FlowableToListTest {
         Flowable<String> w = Flowable.fromIterable(Arrays.asList("one", null, "three"));
         Flowable<List<String>> observable = w.toList().toFlowable();
 
-        Subscriber<List<String>> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
-        verify(observer, times(1)).onNext(Arrays.asList("one", null, "three"));
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<List<String>> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
+
+        verify(subscriber, times(1)).onNext(Arrays.asList("one", null, "three"));
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
@@ -36,10 +36,10 @@ public class FlowableToListTest {
     @Test
     public void testListFlowable() {
         Flowable<String> w = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
-        Flowable<List<String>> observable = w.toList().toFlowable();
+        Flowable<List<String>> flowable = w.toList().toFlowable();
 
         Subscriber<List<String>> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(Arrays.asList("one", "two", "three"));
         verify(subscriber, Mockito.never()).onError(any(Throwable.class));
@@ -49,10 +49,10 @@ public class FlowableToListTest {
     @Test
     public void testListViaFlowableFlowable() {
         Flowable<String> w = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
-        Flowable<List<String>> observable = w.toList().toFlowable();
+        Flowable<List<String>> flowable = w.toList().toFlowable();
 
         Subscriber<List<String>> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(Arrays.asList("one", "two", "three"));
         verify(subscriber, Mockito.never()).onError(any(Throwable.class));
@@ -62,33 +62,33 @@ public class FlowableToListTest {
     @Test
     public void testListMultipleSubscribersFlowable() {
         Flowable<String> w = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
-        Flowable<List<String>> observable = w.toList().toFlowable();
+        Flowable<List<String>> flowable = w.toList().toFlowable();
 
-        Subscriber<List<String>> o1 = TestHelper.mockSubscriber();
-        observable.subscribe(o1);
+        Subscriber<List<String>> subscriber1 = TestHelper.mockSubscriber();
+        flowable.subscribe(subscriber1);
 
-        Subscriber<List<String>> o2 = TestHelper.mockSubscriber();
-        observable.subscribe(o2);
+        Subscriber<List<String>> subscriber2 = TestHelper.mockSubscriber();
+        flowable.subscribe(subscriber2);
 
         List<String> expected = Arrays.asList("one", "two", "three");
 
-        verify(o1, times(1)).onNext(expected);
-        verify(o1, Mockito.never()).onError(any(Throwable.class));
-        verify(o1, times(1)).onComplete();
+        verify(subscriber1, times(1)).onNext(expected);
+        verify(subscriber1, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber1, times(1)).onComplete();
 
-        verify(o2, times(1)).onNext(expected);
-        verify(o2, Mockito.never()).onError(any(Throwable.class));
-        verify(o2, times(1)).onComplete();
+        verify(subscriber2, times(1)).onNext(expected);
+        verify(subscriber2, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber2, times(1)).onComplete();
     }
 
     @Test
     @Ignore("Null values are not allowed")
     public void testListWithNullValueFlowable() {
         Flowable<String> w = Flowable.fromIterable(Arrays.asList("one", null, "three"));
-        Flowable<List<String>> observable = w.toList().toFlowable();
+        Flowable<List<String>> flowable = w.toList().toFlowable();
 
         Subscriber<List<String>> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(Arrays.asList("one", null, "three"));
         verify(subscriber, Mockito.never()).onError(any(Throwable.class));
@@ -97,8 +97,8 @@ public class FlowableToListTest {
 
     @Test
     public void testListWithBlockingFirstFlowable() {
-        Flowable<String> o = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
-        List<String> actual = o.toList().toFlowable().blockingFirst();
+        Flowable<String> f = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
+        List<String> actual = f.toList().toFlowable().blockingFirst();
         Assert.assertEquals(Arrays.asList("one", "two", "three"), actual);
     }
     @Test
@@ -173,10 +173,10 @@ public class FlowableToListTest {
     @Test
     public void testList() {
         Flowable<String> w = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
-        Single<List<String>> observable = w.toList();
+        Single<List<String>> single = w.toList();
 
         SingleObserver<List<String>> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
         verify(observer, times(1)).onSuccess(Arrays.asList("one", "two", "three"));
         verify(observer, Mockito.never()).onError(any(Throwable.class));
     }
@@ -184,10 +184,10 @@ public class FlowableToListTest {
     @Test
     public void testListViaFlowable() {
         Flowable<String> w = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
-        Single<List<String>> observable = w.toList();
+        Single<List<String>> single = w.toList();
 
         SingleObserver<List<String>> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
         verify(observer, times(1)).onSuccess(Arrays.asList("one", "two", "three"));
         verify(observer, Mockito.never()).onError(any(Throwable.class));
     }
@@ -195,13 +195,13 @@ public class FlowableToListTest {
     @Test
     public void testListMultipleSubscribers() {
         Flowable<String> w = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
-        Single<List<String>> observable = w.toList();
+        Single<List<String>> single = w.toList();
 
         SingleObserver<List<String>> o1 = TestHelper.mockSingleObserver();
-        observable.subscribe(o1);
+        single.subscribe(o1);
 
         SingleObserver<List<String>> o2 = TestHelper.mockSingleObserver();
-        observable.subscribe(o2);
+        single.subscribe(o2);
 
         List<String> expected = Arrays.asList("one", "two", "three");
 
@@ -216,18 +216,18 @@ public class FlowableToListTest {
     @Ignore("Null values are not allowed")
     public void testListWithNullValue() {
         Flowable<String> w = Flowable.fromIterable(Arrays.asList("one", null, "three"));
-        Single<List<String>> observable = w.toList();
+        Single<List<String>> single = w.toList();
 
         SingleObserver<List<String>> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
         verify(observer, times(1)).onSuccess(Arrays.asList("one", null, "three"));
         verify(observer, Mockito.never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testListWithBlockingFirst() {
-        Flowable<String> o = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
-        List<String> actual = o.toList().blockingGet();
+        Flowable<String> f = Flowable.fromIterable(Arrays.asList("one", "two", "three"));
+        List<String> actual = f.toList().blockingGet();
         Assert.assertEquals(Arrays.asList("one", "two", "three"), actual);
     }
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMapTest.java
@@ -25,12 +25,12 @@ import io.reactivex.*;
 import io.reactivex.functions.Function;
 
 public class FlowableToMapTest {
-    Subscriber<Object> objectObserver;
+    Subscriber<Object> objectSubscriber;
     SingleObserver<Object> singleObserver;
 
     @Before
     public void before() {
-        objectObserver = TestHelper.mockSubscriber();
+        objectSubscriber = TestHelper.mockSubscriber();
         singleObserver = TestHelper.mockSingleObserver();
     }
 
@@ -59,11 +59,11 @@ public class FlowableToMapTest {
         expected.put(3, "ccc");
         expected.put(4, "dddd");
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, never()).onError(any(Throwable.class));
-        verify(objectObserver, times(1)).onNext(expected);
-        verify(objectObserver, times(1)).onComplete();
+        verify(objectSubscriber, never()).onError(any(Throwable.class));
+        verify(objectSubscriber, times(1)).onNext(expected);
+        verify(objectSubscriber, times(1)).onComplete();
     }
 
     @Test
@@ -78,11 +78,11 @@ public class FlowableToMapTest {
         expected.put(3, "cccccc");
         expected.put(4, "dddddddd");
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, never()).onError(any(Throwable.class));
-        verify(objectObserver, times(1)).onNext(expected);
-        verify(objectObserver, times(1)).onComplete();
+        verify(objectSubscriber, never()).onError(any(Throwable.class));
+        verify(objectSubscriber, times(1)).onNext(expected);
+        verify(objectSubscriber, times(1)).onComplete();
     }
 
     @Test
@@ -106,11 +106,11 @@ public class FlowableToMapTest {
         expected.put(3, "ccc");
         expected.put(4, "dddd");
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, never()).onNext(expected);
-        verify(objectObserver, never()).onComplete();
-        verify(objectObserver, times(1)).onError(any(Throwable.class));
+        verify(objectSubscriber, never()).onNext(expected);
+        verify(objectSubscriber, never()).onComplete();
+        verify(objectSubscriber, times(1)).onError(any(Throwable.class));
 
     }
 
@@ -136,11 +136,11 @@ public class FlowableToMapTest {
         expected.put(3, "cccccc");
         expected.put(4, "dddddddd");
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, never()).onNext(expected);
-        verify(objectObserver, never()).onComplete();
-        verify(objectObserver, times(1)).onError(any(Throwable.class));
+        verify(objectSubscriber, never()).onNext(expected);
+        verify(objectSubscriber, never()).onComplete();
+        verify(objectSubscriber, times(1)).onError(any(Throwable.class));
 
     }
 
@@ -181,11 +181,11 @@ public class FlowableToMapTest {
         expected.put(3, "ccc");
         expected.put(4, "dddd");
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, never()).onError(any(Throwable.class));
-        verify(objectObserver, times(1)).onNext(expected);
-        verify(objectObserver, times(1)).onComplete();
+        verify(objectSubscriber, never()).onError(any(Throwable.class));
+        verify(objectSubscriber, times(1)).onNext(expected);
+        verify(objectSubscriber, times(1)).onComplete();
     }
 
     @Test
@@ -217,11 +217,11 @@ public class FlowableToMapTest {
         expected.put(3, "ccc");
         expected.put(4, "dddd");
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, never()).onNext(expected);
-        verify(objectObserver, never()).onComplete();
-        verify(objectObserver, times(1)).onError(any(Throwable.class));
+        verify(objectSubscriber, never()).onNext(expected);
+        verify(objectSubscriber, never()).onComplete();
+        verify(objectSubscriber, times(1)).onError(any(Throwable.class));
     }
 
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMultimapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMultimapTest.java
@@ -25,13 +25,13 @@ import io.reactivex.*;
 import io.reactivex.functions.Function;
 
 public class FlowableToMultimapTest {
-    Subscriber<Object> objectObserver;
+    Subscriber<Object> objectSubscriber;
 
     SingleObserver<Object> singleObserver;
 
     @Before
     public void before() {
-        objectObserver = TestHelper.mockSubscriber();
+        objectSubscriber = TestHelper.mockSubscriber();
         singleObserver = TestHelper.mockSingleObserver();
     }
 
@@ -58,11 +58,11 @@ public class FlowableToMultimapTest {
         expected.put(1, Arrays.asList("a", "b"));
         expected.put(2, Arrays.asList("cc", "dd"));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, never()).onError(any(Throwable.class));
-        verify(objectObserver, times(1)).onNext(expected);
-        verify(objectObserver, times(1)).onComplete();
+        verify(objectSubscriber, never()).onError(any(Throwable.class));
+        verify(objectSubscriber, times(1)).onNext(expected);
+        verify(objectSubscriber, times(1)).onComplete();
     }
 
     @Test
@@ -75,11 +75,11 @@ public class FlowableToMultimapTest {
         expected.put(1, Arrays.asList("aa", "bb"));
         expected.put(2, Arrays.asList("cccc", "dddd"));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, never()).onError(any(Throwable.class));
-        verify(objectObserver, times(1)).onNext(expected);
-        verify(objectObserver, times(1)).onComplete();
+        verify(objectSubscriber, never()).onError(any(Throwable.class));
+        verify(objectSubscriber, times(1)).onNext(expected);
+        verify(objectSubscriber, times(1)).onComplete();
     }
 
     @Test
@@ -121,11 +121,11 @@ public class FlowableToMultimapTest {
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Arrays.asList("eee", "fff"));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, never()).onError(any(Throwable.class));
-        verify(objectObserver, times(1)).onNext(expected);
-        verify(objectObserver, times(1)).onComplete();
+        verify(objectSubscriber, never()).onError(any(Throwable.class));
+        verify(objectSubscriber, times(1)).onNext(expected);
+        verify(objectSubscriber, times(1)).onComplete();
     }
 
     @Test
@@ -163,11 +163,11 @@ public class FlowableToMultimapTest {
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, new HashSet<String>(Arrays.asList("eee")));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, never()).onError(any(Throwable.class));
-        verify(objectObserver, times(1)).onNext(expected);
-        verify(objectObserver, times(1)).onComplete();
+        verify(objectSubscriber, never()).onError(any(Throwable.class));
+        verify(objectSubscriber, times(1)).onNext(expected);
+        verify(objectSubscriber, times(1)).onComplete();
     }
 
     @Test
@@ -190,11 +190,11 @@ public class FlowableToMultimapTest {
         expected.put(1, Arrays.asList("a", "b"));
         expected.put(2, Arrays.asList("cc", "dd"));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, times(1)).onError(any(Throwable.class));
-        verify(objectObserver, never()).onNext(expected);
-        verify(objectObserver, never()).onComplete();
+        verify(objectSubscriber, times(1)).onError(any(Throwable.class));
+        verify(objectSubscriber, never()).onNext(expected);
+        verify(objectSubscriber, never()).onComplete();
     }
 
     @Test
@@ -217,11 +217,11 @@ public class FlowableToMultimapTest {
         expected.put(1, Arrays.asList("aa", "bb"));
         expected.put(2, Arrays.asList("cccc", "dddd"));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, times(1)).onError(any(Throwable.class));
-        verify(objectObserver, never()).onNext(expected);
-        verify(objectObserver, never()).onComplete();
+        verify(objectSubscriber, times(1)).onError(any(Throwable.class));
+        verify(objectSubscriber, never()).onNext(expected);
+        verify(objectSubscriber, never()).onComplete();
     }
 
     @Test
@@ -247,11 +247,11 @@ public class FlowableToMultimapTest {
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Arrays.asList("eee", "fff"));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, times(1)).onError(any(Throwable.class));
-        verify(objectObserver, never()).onNext(expected);
-        verify(objectObserver, never()).onComplete();
+        verify(objectSubscriber, times(1)).onError(any(Throwable.class));
+        verify(objectSubscriber, never()).onNext(expected);
+        verify(objectSubscriber, never()).onComplete();
     }
 
     @Test
@@ -289,11 +289,11 @@ public class FlowableToMultimapTest {
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Collections.singleton("eee"));
 
-        mapped.subscribe(objectObserver);
+        mapped.subscribe(objectSubscriber);
 
-        verify(objectObserver, times(1)).onError(any(Throwable.class));
-        verify(objectObserver, never()).onNext(expected);
-        verify(objectObserver, never()).onComplete();
+        verify(objectSubscriber, times(1)).onError(any(Throwable.class));
+        verify(objectSubscriber, never()).onNext(expected);
+        verify(objectSubscriber, never()).onComplete();
     }
 
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
@@ -34,10 +34,10 @@ public class FlowableToSortedListTest {
     @Test
     public void testSortedListFlowable() {
         Flowable<Integer> w = Flowable.just(1, 3, 2, 5, 4);
-        Flowable<List<Integer>> observable = w.toSortedList().toFlowable();
+        Flowable<List<Integer>> flowable = w.toSortedList().toFlowable();
 
         Subscriber<List<Integer>> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(Arrays.asList(1, 2, 3, 4, 5));
         verify(subscriber, Mockito.never()).onError(any(Throwable.class));
@@ -47,7 +47,7 @@ public class FlowableToSortedListTest {
     @Test
     public void testSortedListWithCustomFunctionFlowable() {
         Flowable<Integer> w = Flowable.just(1, 3, 2, 5, 4);
-        Flowable<List<Integer>> observable = w.toSortedList(new Comparator<Integer>() {
+        Flowable<List<Integer>> flowable = w.toSortedList(new Comparator<Integer>() {
 
             @Override
             public int compare(Integer t1, Integer t2) {
@@ -57,7 +57,7 @@ public class FlowableToSortedListTest {
         }).toFlowable();
 
         Subscriber<List<Integer>> subscriber = TestHelper.mockSubscriber();
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(Arrays.asList(5, 4, 3, 2, 1));
         verify(subscriber, Mockito.never()).onError(any(Throwable.class));
@@ -66,8 +66,8 @@ public class FlowableToSortedListTest {
 
     @Test
     public void testWithFollowingFirstFlowable() {
-        Flowable<Integer> o = Flowable.just(1, 3, 2, 5, 4);
-        assertEquals(Arrays.asList(1, 2, 3, 4, 5), o.toSortedList().toFlowable().blockingFirst());
+        Flowable<Integer> f = Flowable.just(1, 3, 2, 5, 4);
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), f.toSortedList().toFlowable().blockingFirst());
     }
     @Test
     public void testBackpressureHonoredFlowable() {
@@ -171,10 +171,10 @@ public class FlowableToSortedListTest {
     @Test
     public void testSortedList() {
         Flowable<Integer> w = Flowable.just(1, 3, 2, 5, 4);
-        Single<List<Integer>> observable = w.toSortedList();
+        Single<List<Integer>> single = w.toSortedList();
 
         SingleObserver<List<Integer>> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
         verify(observer, times(1)).onSuccess(Arrays.asList(1, 2, 3, 4, 5));
         verify(observer, Mockito.never()).onError(any(Throwable.class));
     }
@@ -182,7 +182,7 @@ public class FlowableToSortedListTest {
     @Test
     public void testSortedListWithCustomFunction() {
         Flowable<Integer> w = Flowable.just(1, 3, 2, 5, 4);
-        Single<List<Integer>> observable = w.toSortedList(new Comparator<Integer>() {
+        Single<List<Integer>> single = w.toSortedList(new Comparator<Integer>() {
 
             @Override
             public int compare(Integer t1, Integer t2) {
@@ -192,15 +192,15 @@ public class FlowableToSortedListTest {
         });
 
         SingleObserver<List<Integer>> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
         verify(observer, times(1)).onSuccess(Arrays.asList(5, 4, 3, 2, 1));
         verify(observer, Mockito.never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testWithFollowingFirst() {
-        Flowable<Integer> o = Flowable.just(1, 3, 2, 5, 4);
-        assertEquals(Arrays.asList(1, 2, 3, 4, 5), o.toSortedList().blockingGet());
+        Flowable<Integer> f = Flowable.just(1, 3, 2, 5, 4);
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), f.toSortedList().blockingGet());
     }
     @Test
     @Ignore("Single doesn't do backpressure")

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
@@ -36,11 +36,12 @@ public class FlowableToSortedListTest {
         Flowable<Integer> w = Flowable.just(1, 3, 2, 5, 4);
         Flowable<List<Integer>> observable = w.toSortedList().toFlowable();
 
-        Subscriber<List<Integer>> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
-        verify(observer, times(1)).onNext(Arrays.asList(1, 2, 3, 4, 5));
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<List<Integer>> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
+
+        verify(subscriber, times(1)).onNext(Arrays.asList(1, 2, 3, 4, 5));
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -55,11 +56,12 @@ public class FlowableToSortedListTest {
 
         }).toFlowable();
 
-        Subscriber<List<Integer>> observer = TestHelper.mockSubscriber();
-        observable.subscribe(observer);
-        verify(observer, times(1)).onNext(Arrays.asList(5, 4, 3, 2, 1));
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        Subscriber<List<Integer>> subscriber = TestHelper.mockSubscriber();
+        observable.subscribe(subscriber);
+
+        verify(subscriber, times(1)).onNext(Arrays.asList(5, 4, 3, 2, 1));
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
@@ -97,13 +97,13 @@ public class FlowableUnsubscribeOnTest {
                 }
             });
 
-            TestSubscriber<Integer> observer = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
             w.subscribeOn(Schedulers.newThread()).observeOn(Schedulers.computation())
             .unsubscribeOn(uiEventLoop)
             .take(2)
-            .subscribe(observer);
+            .subscribe(ts);
 
-            observer.awaitTerminalEvent(1, TimeUnit.SECONDS);
+            ts.awaitTerminalEvent(1, TimeUnit.SECONDS);
 
             Thread unsubscribeThread = subscription.getThread();
 
@@ -119,8 +119,8 @@ public class FlowableUnsubscribeOnTest {
             System.out.println("subscribeThread.get(): " + subscribeThread.get());
             assertSame(unsubscribeThread, uiEventLoop.getThread());
 
-            observer.assertValues(1, 2);
-            observer.assertTerminated();
+            ts.assertValues(1, 2);
+            ts.assertTerminated();
         } finally {
             uiEventLoop.shutdown();
         }
@@ -250,12 +250,12 @@ public class FlowableUnsubscribeOnTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onNext(1);
-                    observer.onNext(2);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onNext(1);
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .unsubscribeOn(Schedulers.single())

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
@@ -87,16 +87,16 @@ public class FlowableUsingTest {
             }
         };
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), disposeEagerly);
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext("Hello");
-        inOrder.verify(observer, times(1)).onNext("world!");
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext("Hello");
+        inOrder.verify(subscriber, times(1)).onNext("world!");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
 
         // The resouce should be closed
@@ -147,22 +147,22 @@ public class FlowableUsingTest {
             }
         };
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), disposeEagerly);
-        observable.subscribe(observer);
-        observable.subscribe(observer);
+        observable.subscribe(subscriber);
+        observable.subscribe(subscriber);
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(observer, times(1)).onNext("Hello");
-        inOrder.verify(observer, times(1)).onNext("world!");
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("Hello");
+        inOrder.verify(subscriber, times(1)).onNext("world!");
+        inOrder.verify(subscriber, times(1)).onComplete();
 
-        inOrder.verify(observer, times(1)).onNext("Hello");
-        inOrder.verify(observer, times(1)).onNext("world!");
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("Hello");
+        inOrder.verify(subscriber, times(1)).onNext("world!");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -291,14 +291,14 @@ public class FlowableUsingTest {
             }
         };
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), true)
         .doOnCancel(unsub)
         .doOnComplete(completion);
 
-        observable.safeSubscribe(observer);
+        observable.safeSubscribe(subscriber);
 
         assertEquals(Arrays.asList("disposed", "completed"), events);
 
@@ -318,14 +318,14 @@ public class FlowableUsingTest {
             }
         };
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), false)
         .doOnCancel(unsub)
         .doOnComplete(completion);
 
-        observable.safeSubscribe(observer);
+        observable.safeSubscribe(subscriber);
 
         assertEquals(Arrays.asList("completed", "disposed"), events);
 
@@ -348,14 +348,14 @@ public class FlowableUsingTest {
             }
         };
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), true)
         .doOnCancel(unsub)
         .doOnError(onError);
 
-        observable.safeSubscribe(observer);
+        observable.safeSubscribe(subscriber);
 
         assertEquals(Arrays.asList("disposed", "error"), events);
 
@@ -376,14 +376,14 @@ public class FlowableUsingTest {
             }
         };
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), false)
         .doOnCancel(unsub)
         .doOnError(onError);
 
-        observable.safeSubscribe(observer);
+        observable.safeSubscribe(subscriber);
 
         assertEquals(Arrays.asList("error", "disposed"), events);
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
@@ -89,9 +89,9 @@ public class FlowableUsingTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
+        Flowable<String> flowable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), disposeEagerly);
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber, times(1)).onNext("Hello");
@@ -149,10 +149,10 @@ public class FlowableUsingTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
+        Flowable<String> flowable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), disposeEagerly);
-        observable.subscribe(subscriber);
-        observable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
+        flowable.subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
 
@@ -293,12 +293,12 @@ public class FlowableUsingTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
+        Flowable<String> flowable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), true)
         .doOnCancel(unsub)
         .doOnComplete(completion);
 
-        observable.safeSubscribe(subscriber);
+        flowable.safeSubscribe(subscriber);
 
         assertEquals(Arrays.asList("disposed", "completed"), events);
 
@@ -320,12 +320,12 @@ public class FlowableUsingTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
+        Flowable<String> flowable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), false)
         .doOnCancel(unsub)
         .doOnComplete(completion);
 
-        observable.safeSubscribe(subscriber);
+        flowable.safeSubscribe(subscriber);
 
         assertEquals(Arrays.asList("completed", "disposed"), events);
 
@@ -350,12 +350,12 @@ public class FlowableUsingTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
+        Flowable<String> flowable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), true)
         .doOnCancel(unsub)
         .doOnError(onError);
 
-        observable.safeSubscribe(subscriber);
+        flowable.safeSubscribe(subscriber);
 
         assertEquals(Arrays.asList("disposed", "error"), events);
 
@@ -378,12 +378,12 @@ public class FlowableUsingTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable<String> observable = Flowable.using(resourceFactory, observableFactory,
+        Flowable<String> flowable = Flowable.using(resourceFactory, observableFactory,
                 new DisposeAction(), false)
         .doOnCancel(unsub)
         .doOnError(onError);
 
-        observable.safeSubscribe(subscriber);
+        flowable.safeSubscribe(subscriber);
 
         assertEquals(Arrays.asList("error", "disposed"), events);
     }
@@ -643,9 +643,9 @@ public class FlowableUsingTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o)
+            public Flowable<Object> apply(Flowable<Object> f)
                     throws Exception {
-                return Flowable.using(Functions.justCallable(1), Functions.justFunction(o), Functions.emptyConsumer());
+                return Flowable.using(Functions.justCallable(1), Functions.justFunction(f), Functions.emptyConsumer());
             }
         });
     }
@@ -656,10 +656,10 @@ public class FlowableUsingTest {
 
         Flowable.using(Functions.justCallable(1), Functions.justFunction(new Flowable<Integer>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 ts.cancel();
-                observer.onComplete();
+                subscriber.onComplete();
             }
         }), Functions.emptyConsumer(), true)
         .subscribe(ts);
@@ -671,10 +671,10 @@ public class FlowableUsingTest {
 
         Flowable.using(Functions.justCallable(1), Functions.justFunction(new Flowable<Integer>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> observer) {
-                observer.onSubscribe(new BooleanSubscription());
+            protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
                 ts.cancel();
-                observer.onError(new TestException());
+                subscriber.onError(new TestException());
             }
         }), Functions.emptyConsumer(), true)
         .subscribe(ts);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -40,7 +40,7 @@ public class FlowableWindowWithFlowableTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        final Subscriber<Object> o = TestHelper.mockSubscriber();
+        final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
 
@@ -55,12 +55,12 @@ public class FlowableWindowWithFlowableTest {
 
             @Override
             public void onError(Throwable e) {
-                o.onError(e);
+                subscriber.onError(e);
             }
 
             @Override
             public void onComplete() {
-                o.onComplete();
+                subscriber.onComplete();
             }
         };
 
@@ -76,7 +76,7 @@ public class FlowableWindowWithFlowableTest {
         source.onComplete();
 
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         assertEquals(n / 3, values.size());
 
@@ -90,7 +90,7 @@ public class FlowableWindowWithFlowableTest {
             j += 3;
         }
 
-        verify(o).onComplete();
+        verify(subscriber).onComplete();
     }
 
     @Test
@@ -98,7 +98,7 @@ public class FlowableWindowWithFlowableTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        final Subscriber<Object> o = TestHelper.mockSubscriber();
+        final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
 
@@ -113,12 +113,12 @@ public class FlowableWindowWithFlowableTest {
 
             @Override
             public void onError(Throwable e) {
-                o.onError(e);
+                subscriber.onError(e);
             }
 
             @Override
             public void onComplete() {
-                o.onComplete();
+                subscriber.onComplete();
             }
         };
 
@@ -145,8 +145,8 @@ public class FlowableWindowWithFlowableTest {
             j += 3;
         }
 
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -154,7 +154,7 @@ public class FlowableWindowWithFlowableTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        final Subscriber<Object> o = TestHelper.mockSubscriber();
+        final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
 
@@ -169,12 +169,12 @@ public class FlowableWindowWithFlowableTest {
 
             @Override
             public void onError(Throwable e) {
-                o.onError(e);
+                subscriber.onError(e);
             }
 
             @Override
             public void onComplete() {
-                o.onComplete();
+                subscriber.onComplete();
             }
         };
 
@@ -195,8 +195,8 @@ public class FlowableWindowWithFlowableTest {
         verify(mo).onNext(2);
         verify(mo).onError(any(TestException.class));
 
-        verify(o, never()).onComplete();
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
     }
 
     @Test
@@ -204,7 +204,7 @@ public class FlowableWindowWithFlowableTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        final Subscriber<Object> o = TestHelper.mockSubscriber();
+        final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
 
@@ -219,12 +219,12 @@ public class FlowableWindowWithFlowableTest {
 
             @Override
             public void onError(Throwable e) {
-                o.onError(e);
+                subscriber.onError(e);
             }
 
             @Override
             public void onComplete() {
-                o.onComplete();
+                subscriber.onComplete();
             }
         };
 
@@ -245,8 +245,8 @@ public class FlowableWindowWithFlowableTest {
         verify(mo).onNext(2);
         verify(mo).onError(any(TestException.class));
 
-        verify(o, never()).onComplete();
-        verify(o).onError(any(TestException.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(TestException.class));
     }
 
     @Test
@@ -497,8 +497,8 @@ public class FlowableWindowWithFlowableTest {
     public void innerBadSource() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
-            public Object apply(Flowable<Integer> o) throws Exception {
-                return Flowable.just(1).window(o).flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return Flowable.just(1).window(f).flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
                     @Override
                     public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
                         return v;
@@ -509,7 +509,7 @@ public class FlowableWindowWithFlowableTest {
 
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
-            public Object apply(final Flowable<Integer> o) throws Exception {
+            public Object apply(final Flowable<Integer> f) throws Exception {
                 return Flowable.just(1).window(new Callable<Publisher<Integer>>() {
                     int count;
                     @Override
@@ -517,7 +517,7 @@ public class FlowableWindowWithFlowableTest {
                         if (++count > 1) {
                             return Flowable.never();
                         }
-                        return o;
+                        return f;
                     }
                 })
                         .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
@@ -606,8 +606,8 @@ public class FlowableWindowWithFlowableTest {
     public void badSource() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
             @Override
-            public Object apply(Flowable<Object> o) throws Exception {
-                return o.window(Flowable.never()).flatMap(new Function<Flowable<Object>, Flowable<Object>>() {
+            public Object apply(Flowable<Object> f) throws Exception {
+                return f.window(Flowable.never()).flatMap(new Function<Flowable<Object>, Flowable<Object>>() {
                     @Override
                     public Flowable<Object> apply(Flowable<Object> v) throws Exception {
                         return v;
@@ -621,8 +621,8 @@ public class FlowableWindowWithFlowableTest {
     public void badSourceCallable() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
             @Override
-            public Object apply(Flowable<Object> o) throws Exception {
-                return o.window(Functions.justCallable(Flowable.never())).flatMap(new Function<Flowable<Object>, Flowable<Object>>() {
+            public Object apply(Flowable<Object> f) throws Exception {
+                return f.window(Functions.justCallable(Flowable.never())).flatMap(new Function<Flowable<Object>, Flowable<Object>>() {
                     @Override
                     public Flowable<Object> apply(Flowable<Object> v) throws Exception {
                         return v;
@@ -781,9 +781,9 @@ public class FlowableWindowWithFlowableTest {
             TestSubscriber<Flowable<Object>> ts = Flowable.error(new TestException("main"))
             .window(new Flowable<Object>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Object> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    ref.set(observer);
+                protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    ref.set(subscriber);
                 }
             })
             .test();
@@ -814,16 +814,16 @@ public class FlowableWindowWithFlowableTest {
 
                 TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                     @Override
-                    protected void subscribeActual(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        refMain.set(observer);
+                    protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        refMain.set(subscriber);
                     }
                 }
                 .window(new Flowable<Object>() {
                     @Override
-                    protected void subscribeActual(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        ref.set(observer);
+                    protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        ref.set(subscriber);
                     }
                 })
                 .test();
@@ -864,16 +864,16 @@ public class FlowableWindowWithFlowableTest {
 
             TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Object> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    refMain.set(observer);
+                protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    refMain.set(subscriber);
                 }
             }
             .window(new Flowable<Object>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Object> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    ref.set(observer);
+                protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    ref.set(subscriber);
                 }
             })
             .test();
@@ -907,16 +907,16 @@ public class FlowableWindowWithFlowableTest {
 
         TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Object> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                refMain.set(observer);
+            protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                refMain.set(subscriber);
             }
         }
         .window(new Flowable<Object>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Object> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                ref.set(observer);
+            protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                ref.set(subscriber);
             }
         })
         .test();
@@ -939,16 +939,16 @@ public class FlowableWindowWithFlowableTest {
 
             final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                  @Override
-                 protected void subscribeActual(Subscriber<? super Object> observer) {
-                     observer.onSubscribe(new BooleanSubscription());
-                     refMain.set(observer);
+                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                     subscriber.onSubscribe(new BooleanSubscription());
+                     refMain.set(subscriber);
                  }
              }
              .window(new Flowable<Object>() {
                  @Override
-                 protected void subscribeActual(Subscriber<? super Object> observer) {
+                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                      final AtomicInteger counter = new AtomicInteger();
-                     observer.onSubscribe(new Subscription() {
+                     subscriber.onSubscribe(new Subscription() {
 
                          @Override
                          public void cancel() {
@@ -962,7 +962,7 @@ public class FlowableWindowWithFlowableTest {
                         public void request(long n) {
                         }
                      });
-                     ref.set(observer);
+                     ref.set(subscriber);
                  }
              })
              .test();
@@ -976,9 +976,9 @@ public class FlowableWindowWithFlowableTest {
              Runnable r2 = new Runnable() {
                  @Override
                  public void run() {
-                     Subscriber<Object> o = ref.get();
-                     o.onNext(1);
-                     o.onComplete();
+                     Subscriber<Object> subscriber = ref.get();
+                     subscriber.onNext(1);
+                     subscriber.onComplete();
                  }
              };
 
@@ -996,16 +996,16 @@ public class FlowableWindowWithFlowableTest {
 
            final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                @Override
-               protected void subscribeActual(Subscriber<? super Object> observer) {
-                   observer.onSubscribe(new BooleanSubscription());
-                   refMain.set(observer);
+               protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                   subscriber.onSubscribe(new BooleanSubscription());
+                   refMain.set(subscriber);
                }
            }
            .window(new Flowable<Object>() {
                @Override
-               protected void subscribeActual(Subscriber<? super Object> observer) {
+               protected void subscribeActual(Subscriber<? super Object> subscriber) {
                    final AtomicInteger counter = new AtomicInteger();
-                   observer.onSubscribe(new Subscription() {
+                   subscriber.onSubscribe(new Subscription() {
 
                        @Override
                        public void cancel() {
@@ -1019,7 +1019,7 @@ public class FlowableWindowWithFlowableTest {
                       public void request(long n) {
                       }
                    });
-                   ref.set(observer);
+                   ref.set(subscriber);
                }
            })
            .test();
@@ -1033,9 +1033,9 @@ public class FlowableWindowWithFlowableTest {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    Subscriber<Object> o = ref.get();
-                    o.onNext(1);
-                    o.onError(ex);
+                    Subscriber<Object> subscriber = ref.get();
+                    subscriber.onNext(1);
+                    subscriber.onError(ex);
                 }
             };
 
@@ -1087,9 +1087,9 @@ public class FlowableWindowWithFlowableTest {
             TestSubscriber<Flowable<Object>> ts = Flowable.error(new TestException("main"))
             .window(Functions.justCallable(new Flowable<Object>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Object> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    ref.set(observer);
+                protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    ref.set(subscriber);
                 }
             }))
             .test();
@@ -1120,16 +1120,16 @@ public class FlowableWindowWithFlowableTest {
 
                 TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                     @Override
-                    protected void subscribeActual(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        refMain.set(observer);
+                    protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        refMain.set(subscriber);
                     }
                 }
                 .window(Functions.justCallable(new Flowable<Object>() {
                     @Override
-                    protected void subscribeActual(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        ref.set(observer);
+                    protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        ref.set(subscriber);
                     }
                 }))
                 .test();
@@ -1170,16 +1170,16 @@ public class FlowableWindowWithFlowableTest {
 
             TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Object> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    refMain.set(observer);
+                protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    refMain.set(subscriber);
                 }
             }
             .window(Functions.justCallable(new Flowable<Object>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Object> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    ref.set(observer);
+                protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    ref.set(subscriber);
                 }
             }))
             .test();
@@ -1213,16 +1213,16 @@ public class FlowableWindowWithFlowableTest {
 
         TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Object> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                refMain.set(observer);
+            protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                refMain.set(subscriber);
             }
         }
         .window(Functions.justCallable(new Flowable<Object>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Object> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                ref.set(observer);
+            protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                ref.set(subscriber);
             }
         }))
         .test();
@@ -1245,16 +1245,16 @@ public class FlowableWindowWithFlowableTest {
 
             final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                  @Override
-                 protected void subscribeActual(Subscriber<? super Object> observer) {
-                     observer.onSubscribe(new BooleanSubscription());
-                     refMain.set(observer);
+                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                     subscriber.onSubscribe(new BooleanSubscription());
+                     refMain.set(subscriber);
                  }
              }
              .window(Functions.justCallable(new Flowable<Object>() {
                  @Override
-                 protected void subscribeActual(Subscriber<? super Object> observer) {
+                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                      final AtomicInteger counter = new AtomicInteger();
-                     observer.onSubscribe(new Subscription() {
+                     subscriber.onSubscribe(new Subscription() {
 
                          @Override
                          public void cancel() {
@@ -1268,7 +1268,7 @@ public class FlowableWindowWithFlowableTest {
                          public void request(long n) {
                          }
                       });
-                     ref.set(observer);
+                     ref.set(subscriber);
                  }
              }))
              .test();
@@ -1282,9 +1282,9 @@ public class FlowableWindowWithFlowableTest {
              Runnable r2 = new Runnable() {
                  @Override
                  public void run() {
-                     Subscriber<Object> o = ref.get();
-                     o.onNext(1);
-                     o.onComplete();
+                     Subscriber<Object> subscriber = ref.get();
+                     subscriber.onNext(1);
+                     subscriber.onComplete();
                  }
              };
 
@@ -1304,9 +1304,9 @@ public class FlowableWindowWithFlowableTest {
 
                 final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                     @Override
-                    protected void subscribeActual(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        refMain.set(observer);
+                    protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        refMain.set(subscriber);
                     }
                 }
                 .window(new Callable<Flowable<Object>>() {
@@ -1318,9 +1318,9 @@ public class FlowableWindowWithFlowableTest {
                         }
                         return (new Flowable<Object>() {
                             @Override
-                            protected void subscribeActual(Subscriber<? super Object> observer) {
+                            protected void subscribeActual(Subscriber<? super Object> subscriber) {
                                 final AtomicInteger counter = new AtomicInteger();
-                                observer.onSubscribe(new Subscription() {
+                                subscriber.onSubscribe(new Subscription() {
 
                                     @Override
                                     public void cancel() {
@@ -1334,7 +1334,7 @@ public class FlowableWindowWithFlowableTest {
                                     public void request(long n) {
                                     }
                                 });
-                                ref.set(observer);
+                                ref.set(subscriber);
                             }
                         });
                     }
@@ -1350,9 +1350,9 @@ public class FlowableWindowWithFlowableTest {
                 Runnable r2 = new Runnable() {
                     @Override
                     public void run() {
-                        Subscriber<Object> o = ref.get();
-                        o.onNext(1);
-                        o.onError(ex);
+                        Subscriber<Object> subscriber = ref.get();
+                        subscriber.onNext(1);
+                        subscriber.onError(ex);
                     }
                 };
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -698,19 +698,33 @@ public class FlowableWindowWithFlowableTest {
     @SuppressWarnings("unchecked")
     @Test
     public void boundaryDirectMissingBackpressure() {
-        BehaviorProcessor.create()
-        .window(Flowable.error(new TestException()))
-        .test(0)
-        .assertFailure(MissingBackpressureException.class);
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            BehaviorProcessor.create()
+            .window(Flowable.error(new TestException()))
+            .test(0)
+            .assertFailure(MissingBackpressureException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void boundaryDirectMissingBackpressureNoNullPointerException() {
-        BehaviorProcessor.createDefault(1)
-        .window(Flowable.error(new TestException()))
-        .test(0)
-        .assertFailure(MissingBackpressureException.class);
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            BehaviorProcessor.createDefault(1)
+            .window(Flowable.error(new TestException()))
+            .test(0)
+            .assertFailure(MissingBackpressureException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -204,7 +204,7 @@ public class FlowableWindowWithSizeTest {
 
         final List<Integer> list = new ArrayList<Integer>();
 
-        final Subscriber<Integer> o = TestHelper.mockSubscriber();
+        final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         source.subscribe(new DefaultSubscriber<Flowable<Integer>>() {
             @Override
@@ -220,28 +220,28 @@ public class FlowableWindowWithSizeTest {
                     }
                     @Override
                     public void onError(Throwable e) {
-                        o.onError(e);
+                        subscriber.onError(e);
                     }
                     @Override
                     public void onComplete() {
-                        o.onComplete();
+                        subscriber.onComplete();
                     }
                 });
             }
             @Override
             public void onError(Throwable e) {
-                o.onError(e);
+                subscriber.onError(e);
             }
             @Override
             public void onComplete() {
-                o.onComplete();
+                subscriber.onComplete();
             }
         });
 
         assertEquals(Arrays.asList(1, 2, 3), list);
 
-        verify(o, never()).onError(any(Throwable.class));
-        verify(o, times(1)).onComplete(); // 1 inner
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete(); // 1 inner
     }
 
     public static Flowable<Integer> hotStream() {
@@ -343,22 +343,22 @@ public class FlowableWindowWithSizeTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Flowable<Object>>>() {
             @Override
-            public Flowable<Flowable<Object>> apply(Flowable<Object> o) throws Exception {
-                return o.window(1);
+            public Flowable<Flowable<Object>> apply(Flowable<Object> f) throws Exception {
+                return f.window(1);
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Flowable<Object>>>() {
             @Override
-            public Flowable<Flowable<Object>> apply(Flowable<Object> o) throws Exception {
-                return o.window(2, 1);
+            public Flowable<Flowable<Object>> apply(Flowable<Object> f) throws Exception {
+                return f.window(2, 1);
             }
         });
 
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Flowable<Object>>>() {
             @Override
-            public Flowable<Flowable<Object>> apply(Flowable<Object> o) throws Exception {
-                return o.window(1, 2);
+            public Flowable<Flowable<Object>> apply(Flowable<Object> f) throws Exception {
+                return f.window(1, 2);
             }
         });
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -49,24 +49,24 @@ public class FlowableWindowWithStartEndFlowableTest {
 
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                push(observer, "one", 10);
-                push(observer, "two", 60);
-                push(observer, "three", 110);
-                push(observer, "four", 160);
-                push(observer, "five", 210);
-                complete(observer, 500);
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                push(subscriber, "one", 10);
+                push(subscriber, "two", 60);
+                push(subscriber, "three", 110);
+                push(subscriber, "four", 160);
+                push(subscriber, "five", 210);
+                complete(subscriber, 500);
             }
         });
 
         Flowable<Object> openings = Flowable.unsafeCreate(new Publisher<Object>() {
             @Override
-            public void subscribe(Subscriber<? super Object> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                push(observer, new Object(), 50);
-                push(observer, new Object(), 200);
-                complete(observer, 250);
+            public void subscribe(Subscriber<? super Object> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                push(subscriber, new Object(), 50);
+                push(subscriber, new Object(), 200);
+                complete(subscriber, 250);
             }
         });
 
@@ -75,10 +75,10 @@ public class FlowableWindowWithStartEndFlowableTest {
             public Flowable<Object> apply(Object opening) {
                 return Flowable.unsafeCreate(new Publisher<Object>() {
                     @Override
-                    public void subscribe(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
-                        push(observer, new Object(), 100);
-                        complete(observer, 101);
+                    public void subscribe(Subscriber<? super Object> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
+                        push(subscriber, new Object(), 100);
+                        complete(subscriber, 101);
                     }
                 });
             }
@@ -100,14 +100,14 @@ public class FlowableWindowWithStartEndFlowableTest {
 
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                push(observer, "one", 10);
-                push(observer, "two", 60);
-                push(observer, "three", 110);
-                push(observer, "four", 160);
-                push(observer, "five", 210);
-                complete(observer, 250);
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                push(subscriber, "one", 10);
+                push(subscriber, "two", 60);
+                push(subscriber, "three", 110);
+                push(subscriber, "four", 160);
+                push(subscriber, "five", 210);
+                complete(subscriber, 250);
             }
         });
 
@@ -117,16 +117,16 @@ public class FlowableWindowWithStartEndFlowableTest {
             public Flowable<Object> call() {
                 return Flowable.unsafeCreate(new Publisher<Object>() {
                     @Override
-                    public void subscribe(Subscriber<? super Object> observer) {
-                        observer.onSubscribe(new BooleanSubscription());
+                    public void subscribe(Subscriber<? super Object> subscriber) {
+                        subscriber.onSubscribe(new BooleanSubscription());
                         int c = calls++;
                         if (c == 0) {
-                            push(observer, new Object(), 100);
+                            push(subscriber, new Object(), 100);
                         } else
                         if (c == 1) {
-                            push(observer, new Object(), 100);
+                            push(subscriber, new Object(), 100);
                         } else {
-                            complete(observer, 101);
+                            complete(subscriber, 101);
                         }
                     }
                 });
@@ -151,20 +151,20 @@ public class FlowableWindowWithStartEndFlowableTest {
         return list;
     }
 
-    private <T> void push(final Subscriber<T> observer, final T value, int delay) {
+    private <T> void push(final Subscriber<T> subscriber, final T value, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onNext(value);
+                subscriber.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private void complete(final Subscriber<?> observer, int delay) {
+    private void complete(final Subscriber<?> subscriber, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onComplete();
+                subscriber.onComplete();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
@@ -300,8 +300,8 @@ public class FlowableWindowWithStartEndFlowableTest {
     public void badSourceCallable() {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
             @Override
-            public Object apply(Flowable<Object> o) throws Exception {
-                return o.window(Flowable.just(1), Functions.justFunction(Flowable.never()));
+            public Object apply(Flowable<Object> f) throws Exception {
+                return f.window(Flowable.just(1), Functions.justFunction(Flowable.never()));
             }
         }, false, 1, 1, (Object[])null);
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -51,14 +51,14 @@ public class FlowableWindowWithTimeTest {
 
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                push(observer, "one", 10);
-                push(observer, "two", 90);
-                push(observer, "three", 110);
-                push(observer, "four", 190);
-                push(observer, "five", 210);
-                complete(observer, 250);
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                push(subscriber, "one", 10);
+                push(subscriber, "two", 90);
+                push(subscriber, "three", 110);
+                push(subscriber, "four", 190);
+                push(subscriber, "five", 210);
+                complete(subscriber, 250);
             }
         });
 
@@ -85,14 +85,14 @@ public class FlowableWindowWithTimeTest {
 
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
-            public void subscribe(Subscriber<? super String> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                push(observer, "one", 98);
-                push(observer, "two", 99);
-                push(observer, "three", 99); // FIXME happens after the window is open
-                push(observer, "four", 101);
-                push(observer, "five", 102);
-                complete(observer, 150);
+            public void subscribe(Subscriber<? super String> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                push(subscriber, "one", 98);
+                push(subscriber, "two", 99);
+                push(subscriber, "three", 99); // FIXME happens after the window is open
+                push(subscriber, "four", 101);
+                push(subscriber, "five", 102);
+                complete(subscriber, 150);
             }
         });
 
@@ -116,20 +116,20 @@ public class FlowableWindowWithTimeTest {
         return list;
     }
 
-    private <T> void push(final Subscriber<T> observer, final T value, int delay) {
+    private <T> void push(final Subscriber<T> subscriber, final T value, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onNext(value);
+                subscriber.onNext(value);
             }
         }, delay, TimeUnit.MILLISECONDS);
     }
 
-    private void complete(final Subscriber<?> observer, int delay) {
+    private void complete(final Subscriber<?> subscriber, int delay) {
         innerScheduler.schedule(new Runnable() {
             @Override
             public void run() {
-                observer.onComplete();
+                subscriber.onComplete();
             }
         }, delay, TimeUnit.MILLISECONDS);
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -27,6 +27,7 @@ import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.*;
 import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
@@ -366,47 +367,68 @@ public class FlowableWindowWithTimeTest {
 
     @Test
     public void exactOnError() {
-        TestScheduler scheduler = new TestScheduler();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestScheduler scheduler = new TestScheduler();
 
-        PublishProcessor<Integer> pp = PublishProcessor.create();
+            PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = pp.window(1, 1, TimeUnit.SECONDS, scheduler)
-        .flatMap(Functions.<Flowable<Integer>>identity())
-        .test();
+            TestSubscriber<Integer> ts = pp.window(1, 1, TimeUnit.SECONDS, scheduler)
+            .flatMap(Functions.<Flowable<Integer>>identity())
+            .test();
 
-        pp.onError(new TestException());
+            pp.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+            ts.assertFailure(TestException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void overlappingOnError() {
-        TestScheduler scheduler = new TestScheduler();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestScheduler scheduler = new TestScheduler();
 
-        PublishProcessor<Integer> pp = PublishProcessor.create();
+            PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = pp.window(2, 1, TimeUnit.SECONDS, scheduler)
-        .flatMap(Functions.<Flowable<Integer>>identity())
-        .test();
+            TestSubscriber<Integer> ts = pp.window(2, 1, TimeUnit.SECONDS, scheduler)
+            .flatMap(Functions.<Flowable<Integer>>identity())
+            .test();
 
-        pp.onError(new TestException());
+            pp.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+            ts.assertFailure(TestException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void skipOnError() {
-        TestScheduler scheduler = new TestScheduler();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestScheduler scheduler = new TestScheduler();
 
-        PublishProcessor<Integer> pp = PublishProcessor.create();
+            PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = pp.window(1, 2, TimeUnit.SECONDS, scheduler)
-        .flatMap(Functions.<Flowable<Integer>>identity())
-        .test();
+            TestSubscriber<Integer> ts = pp.window(1, 2, TimeUnit.SECONDS, scheduler)
+            .flatMap(Functions.<Flowable<Integer>>identity())
+            .test();
 
-        pp.onError(new TestException());
+            pp.onError(new TestException());
 
-        ts.assertFailure(TestException.class);
+            ts.assertFailure(TestException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
@@ -484,16 +506,23 @@ public class FlowableWindowWithTimeTest {
 
     @Test
     public void overlapBackpressure2() {
-        TestScheduler scheduler = new TestScheduler();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            TestScheduler scheduler = new TestScheduler();
 
-        PublishProcessor<Integer> pp = PublishProcessor.create();
+            PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Flowable<Integer>> ts = pp.window(2, 1, TimeUnit.SECONDS, scheduler)
-        .test(1L);
+            TestSubscriber<Flowable<Integer>> ts = pp.window(2, 1, TimeUnit.SECONDS, scheduler)
+            .test(1L);
 
-        scheduler.advanceTimeBy(2, TimeUnit.SECONDS);
+            scheduler.advanceTimeBy(2, TimeUnit.SECONDS);
 
-        ts.assertError(MissingBackpressureException.class);
+            ts.assertError(MissingBackpressureException.class);
+
+            TestHelper.assertError(errors, 0, MissingBackpressureException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -51,35 +51,35 @@ public class FlowableWithLatestFromTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> other = PublishProcessor.create();
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
         Flowable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        result.subscribe(o);
+        result.subscribe(subscriber);
 
         source.onNext(1);
-        inOrder.verify(o, never()).onNext(anyInt());
+        inOrder.verify(subscriber, never()).onNext(anyInt());
 
         other.onNext(1);
-        inOrder.verify(o, never()).onNext(anyInt());
+        inOrder.verify(subscriber, never()).onNext(anyInt());
 
         source.onNext(2);
-        inOrder.verify(o).onNext((2 << 8) + 1);
+        inOrder.verify(subscriber).onNext((2 << 8) + 1);
 
         other.onNext(2);
-        inOrder.verify(o, never()).onNext(anyInt());
+        inOrder.verify(subscriber, never()).onNext(anyInt());
 
         other.onComplete();
-        inOrder.verify(o, never()).onComplete();
+        inOrder.verify(subscriber, never()).onComplete();
 
         source.onNext(3);
-        inOrder.verify(o).onNext((3 << 8) + 2);
+        inOrder.verify(subscriber).onNext((3 << 8) + 2);
 
         source.onComplete();
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -641,12 +641,12 @@ public class FlowableWithLatestFromTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onError(new TestException("First"));
-                    observer.onNext(1);
-                    observer.onError(new TestException("Second"));
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onError(new TestException("First"));
+                    subscriber.onNext(1);
+                    subscriber.onError(new TestException("Second"));
+                    subscriber.onComplete();
                 }
             }.withLatestFrom(Flowable.just(2), Flowable.just(3), new Function3<Integer, Integer, Integer, Object>() {
                 @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipCompletionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipCompletionTest.java
@@ -35,7 +35,7 @@ public class FlowableZipCompletionTest {
     PublishProcessor<String> s2;
     Flowable<String> zipped;
 
-    Subscriber<String> observer;
+    Subscriber<String> subscriber;
     InOrder inOrder;
 
     @Before
@@ -51,10 +51,10 @@ public class FlowableZipCompletionTest {
         s2 = PublishProcessor.create();
         zipped = Flowable.zip(s1, s2, concat2Strings);
 
-        observer = TestHelper.mockSubscriber();
-        inOrder = inOrder(observer);
+        subscriber = TestHelper.mockSubscriber();
+        inOrder = inOrder(subscriber);
 
-        zipped.subscribe(observer);
+        zipped.subscribe(subscriber);
     }
 
     @Test
@@ -63,10 +63,10 @@ public class FlowableZipCompletionTest {
         s1.onNext("b");
         s1.onComplete();
         s2.onNext("1");
-        inOrder.verify(observer, times(1)).onNext("a-1");
+        inOrder.verify(subscriber, times(1)).onNext("a-1");
         s2.onNext("2");
-        inOrder.verify(observer, times(1)).onNext("b-2");
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("b-2");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -75,11 +75,11 @@ public class FlowableZipCompletionTest {
         s2.onNext("1");
         s2.onNext("2");
         s1.onNext("a");
-        inOrder.verify(observer, times(1)).onNext("a-1");
+        inOrder.verify(subscriber, times(1)).onNext("a-1");
         s1.onNext("b");
-        inOrder.verify(observer, times(1)).onNext("b-2");
+        inOrder.verify(subscriber, times(1)).onNext("b-2");
         s1.onComplete();
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -89,10 +89,10 @@ public class FlowableZipCompletionTest {
         s2.onNext("2");
         s2.onComplete();
         s1.onNext("a");
-        inOrder.verify(observer, times(1)).onNext("a-1");
+        inOrder.verify(subscriber, times(1)).onNext("a-1");
         s1.onNext("b");
-        inOrder.verify(observer, times(1)).onNext("b-2");
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("b-2");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -101,11 +101,11 @@ public class FlowableZipCompletionTest {
         s1.onNext("a");
         s1.onNext("b");
         s2.onNext("1");
-        inOrder.verify(observer, times(1)).onNext("a-1");
+        inOrder.verify(subscriber, times(1)).onNext("a-1");
         s2.onNext("2");
-        inOrder.verify(observer, times(1)).onNext("b-2");
+        inOrder.verify(subscriber, times(1)).onNext("b-2");
         s2.onComplete();
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipIterableTest.java
@@ -38,7 +38,7 @@ public class FlowableZipIterableTest {
     PublishProcessor<String> s2;
     Flowable<String> zipped;
 
-    Subscriber<String> observer;
+    Subscriber<String> subscriber;
     InOrder inOrder;
 
     @Before
@@ -54,10 +54,10 @@ public class FlowableZipIterableTest {
         s2 = PublishProcessor.create();
         zipped = Flowable.zip(s1, s2, concat2Strings);
 
-        observer = TestHelper.mockSubscriber();
-        inOrder = inOrder(observer);
+        subscriber = TestHelper.mockSubscriber();
+        inOrder = inOrder(subscriber);
 
-        zipped.subscribe(observer);
+        zipped.subscribe(subscriber);
     }
 
     BiFunction<Object, Object, String> zipr2 = new BiFunction<Object, Object, String>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipIterableTest.java
@@ -81,24 +81,24 @@ public class FlowableZipIterableTest {
     public void testZipIterableSameSize() {
         PublishProcessor<String> r1 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> o = TestHelper.mockSubscriber();
-        InOrder io = inOrder(o);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        InOrder io = inOrder(subscriber);
 
         Iterable<String> r2 = Arrays.asList("1", "2", "3");
 
-        r1.zipWith(r2, zipr2).subscribe(o);
+        r1.zipWith(r2, zipr2).subscribe(subscriber);
 
         r1.onNext("one-");
         r1.onNext("two-");
         r1.onNext("three-");
         r1.onComplete();
 
-        io.verify(o).onNext("one-1");
-        io.verify(o).onNext("two-2");
-        io.verify(o).onNext("three-3");
-        io.verify(o).onComplete();
+        io.verify(subscriber).onNext("one-1");
+        io.verify(subscriber).onNext("two-2");
+        io.verify(subscriber).onNext("three-3");
+        io.verify(subscriber).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
 
     }
 
@@ -106,19 +106,19 @@ public class FlowableZipIterableTest {
     public void testZipIterableEmptyFirstSize() {
         PublishProcessor<String> r1 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> o = TestHelper.mockSubscriber();
-        InOrder io = inOrder(o);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        InOrder io = inOrder(subscriber);
 
         Iterable<String> r2 = Arrays.asList("1", "2", "3");
 
-        r1.zipWith(r2, zipr2).subscribe(o);
+        r1.zipWith(r2, zipr2).subscribe(subscriber);
 
         r1.onComplete();
 
-        io.verify(o).onComplete();
+        io.verify(subscriber).onComplete();
 
-        verify(o, never()).onNext(any(String.class));
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any(String.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
 
     }
 
@@ -126,44 +126,44 @@ public class FlowableZipIterableTest {
     public void testZipIterableEmptySecond() {
         PublishProcessor<String> r1 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> o = TestHelper.mockSubscriber();
-        InOrder io = inOrder(o);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        InOrder io = inOrder(subscriber);
 
         Iterable<String> r2 = Arrays.asList();
 
-        r1.zipWith(r2, zipr2).subscribe(o);
+        r1.zipWith(r2, zipr2).subscribe(subscriber);
 
         r1.onNext("one-");
         r1.onNext("two-");
         r1.onNext("three-");
         r1.onComplete();
 
-        io.verify(o).onComplete();
+        io.verify(subscriber).onComplete();
 
-        verify(o, never()).onNext(any(String.class));
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any(String.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testZipIterableFirstShorter() {
         PublishProcessor<String> r1 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> o = TestHelper.mockSubscriber();
-        InOrder io = inOrder(o);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        InOrder io = inOrder(subscriber);
 
         Iterable<String> r2 = Arrays.asList("1", "2", "3");
 
-        r1.zipWith(r2, zipr2).subscribe(o);
+        r1.zipWith(r2, zipr2).subscribe(subscriber);
 
         r1.onNext("one-");
         r1.onNext("two-");
         r1.onComplete();
 
-        io.verify(o).onNext("one-1");
-        io.verify(o).onNext("two-2");
-        io.verify(o).onComplete();
+        io.verify(subscriber).onNext("one-1");
+        io.verify(subscriber).onNext("two-2");
+        io.verify(subscriber).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
 
     }
 
@@ -171,23 +171,23 @@ public class FlowableZipIterableTest {
     public void testZipIterableSecondShorter() {
         PublishProcessor<String> r1 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> o = TestHelper.mockSubscriber();
-        InOrder io = inOrder(o);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        InOrder io = inOrder(subscriber);
 
         Iterable<String> r2 = Arrays.asList("1", "2");
 
-        r1.zipWith(r2, zipr2).subscribe(o);
+        r1.zipWith(r2, zipr2).subscribe(subscriber);
 
         r1.onNext("one-");
         r1.onNext("two-");
         r1.onNext("three-");
         r1.onComplete();
 
-        io.verify(o).onNext("one-1");
-        io.verify(o).onNext("two-2");
-        io.verify(o).onComplete();
+        io.verify(subscriber).onNext("one-1");
+        io.verify(subscriber).onNext("two-2");
+        io.verify(subscriber).onComplete();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
 
     }
 
@@ -195,22 +195,22 @@ public class FlowableZipIterableTest {
     public void testZipIterableFirstThrows() {
         PublishProcessor<String> r1 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> o = TestHelper.mockSubscriber();
-        InOrder io = inOrder(o);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        InOrder io = inOrder(subscriber);
 
         Iterable<String> r2 = Arrays.asList("1", "2", "3");
 
-        r1.zipWith(r2, zipr2).subscribe(o);
+        r1.zipWith(r2, zipr2).subscribe(subscriber);
 
         r1.onNext("one-");
         r1.onNext("two-");
         r1.onError(new TestException());
 
-        io.verify(o).onNext("one-1");
-        io.verify(o).onNext("two-2");
-        io.verify(o).onError(any(TestException.class));
+        io.verify(subscriber).onNext("one-1");
+        io.verify(subscriber).onNext("two-2");
+        io.verify(subscriber).onError(any(TestException.class));
 
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onComplete();
 
     }
 
@@ -218,8 +218,8 @@ public class FlowableZipIterableTest {
     public void testZipIterableIteratorThrows() {
         PublishProcessor<String> r1 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> o = TestHelper.mockSubscriber();
-        InOrder io = inOrder(o);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        InOrder io = inOrder(subscriber);
 
         Iterable<String> r2 = new Iterable<String>() {
             @Override
@@ -228,16 +228,16 @@ public class FlowableZipIterableTest {
             }
         };
 
-        r1.zipWith(r2, zipr2).subscribe(o);
+        r1.zipWith(r2, zipr2).subscribe(subscriber);
 
         r1.onNext("one-");
         r1.onNext("two-");
         r1.onError(new TestException());
 
-        io.verify(o).onError(any(TestException.class));
+        io.verify(subscriber).onError(any(TestException.class));
 
-        verify(o, never()).onComplete();
-        verify(o, never()).onNext(any(String.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any(String.class));
 
     }
 
@@ -245,8 +245,8 @@ public class FlowableZipIterableTest {
     public void testZipIterableHasNextThrows() {
         PublishProcessor<String> r1 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> o = TestHelper.mockSubscriber();
-        InOrder io = inOrder(o);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        InOrder io = inOrder(subscriber);
 
         Iterable<String> r2 = new Iterable<String>() {
 
@@ -279,15 +279,15 @@ public class FlowableZipIterableTest {
 
         };
 
-        r1.zipWith(r2, zipr2).subscribe(o);
+        r1.zipWith(r2, zipr2).subscribe(subscriber);
 
         r1.onNext("one-");
         r1.onError(new TestException());
 
-        io.verify(o).onNext("one-1");
-        io.verify(o).onError(any(TestException.class));
+        io.verify(subscriber).onNext("one-1");
+        io.verify(subscriber).onError(any(TestException.class));
 
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onComplete();
 
     }
 
@@ -295,8 +295,8 @@ public class FlowableZipIterableTest {
     public void testZipIterableNextThrows() {
         PublishProcessor<String> r1 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> o = TestHelper.mockSubscriber();
-        InOrder io = inOrder(o);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        InOrder io = inOrder(subscriber);
 
         Iterable<String> r2 = new Iterable<String>() {
 
@@ -323,14 +323,14 @@ public class FlowableZipIterableTest {
 
         };
 
-        r1.zipWith(r2, zipr2).subscribe(o);
+        r1.zipWith(r2, zipr2).subscribe(subscriber);
 
         r1.onError(new TestException());
 
-        io.verify(o).onError(any(TestException.class));
+        io.verify(subscriber).onError(any(TestException.class));
 
-        verify(o, never()).onNext(any(String.class));
-        verify(o, never()).onComplete();
+        verify(subscriber, never()).onNext(any(String.class));
+        verify(subscriber, never()).onComplete();
 
     }
 
@@ -353,12 +353,12 @@ public class FlowableZipIterableTest {
 
     @Test
     public void testTake2() {
-        Flowable<Integer> o = Flowable.just(1, 2, 3, 4, 5);
+        Flowable<Integer> f = Flowable.just(1, 2, 3, 4, 5);
         Iterable<String> it = Arrays.asList("a", "b", "c", "d", "e");
 
         SquareStr squareStr = new SquareStr();
 
-        o.map(squareStr).zipWith(it, concat2Strings).take(2).subscribe(printer);
+        f.map(squareStr).zipWith(it, concat2Strings).take(2).subscribe(printer);
 
         assertEquals(2, squareStr.counter.get());
     }
@@ -377,8 +377,8 @@ public class FlowableZipIterableTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Integer>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Integer> o) throws Exception {
-                return o.zipWith(Arrays.asList(1), new BiFunction<Integer, Integer, Object>() {
+            public Flowable<Object> apply(Flowable<Integer> f) throws Exception {
+                return f.zipWith(Arrays.asList(1), new BiFunction<Integer, Integer, Object>() {
                     @Override
                     public Object apply(Integer a, Integer b) throws Exception {
                         return a + b;
@@ -406,13 +406,13 @@ public class FlowableZipIterableTest {
         try {
             new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onNext(1);
-                    observer.onComplete();
-                    observer.onNext(2);
-                    observer.onError(new TestException());
-                    observer.onComplete();
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onNext(1);
+                    subscriber.onComplete();
+                    subscriber.onNext(2);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
                 }
             }
             .zipWith(Arrays.asList(1), new BiFunction<Integer, Integer, Object>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
@@ -453,8 +453,8 @@ public class FlowableZipTest {
 
         Subscriber<String> obs = TestHelper.mockSubscriber();
 
-        Flowable<String> o = Flowable.zip(oA, oB, getConcat2Strings());
-        o.subscribe(obs);
+        Flowable<String> f = Flowable.zip(oA, oB, getConcat2Strings());
+        f.subscribe(obs);
 
         InOrder io = inOrder(obs);
 
@@ -503,8 +503,8 @@ public class FlowableZipTest {
 
         Subscriber<String> obs = TestHelper.mockSubscriber();
 
-        Flowable<String> o = Flowable.zip(oA, oB, getConcat2Strings());
-        o.subscribe(obs);
+        Flowable<String> f = Flowable.zip(oA, oB, getConcat2Strings());
+        f.subscribe(obs);
 
         InOrder io = inOrder(obs);
 
@@ -858,7 +858,7 @@ public class FlowableZipTest {
     public void testEmitNull() {
         Flowable<Integer> oi = Flowable.just(1, null, 3);
         Flowable<String> os = Flowable.just("a", "b", null);
-        Flowable<String> o = Flowable.zip(oi, os, new BiFunction<Integer, String, String>() {
+        Flowable<String> f = Flowable.zip(oi, os, new BiFunction<Integer, String, String>() {
 
             @Override
             public String apply(Integer t1, String t2) {
@@ -868,7 +868,7 @@ public class FlowableZipTest {
         });
 
         final ArrayList<String> list = new ArrayList<String>();
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
 
             @Override
             public void accept(String s) {
@@ -906,7 +906,7 @@ public class FlowableZipTest {
     public void testEmitMaterializedNotifications() {
         Flowable<Notification<Integer>> oi = Flowable.just(1, 2, 3).materialize();
         Flowable<Notification<String>> os = Flowable.just("a", "b", "c").materialize();
-        Flowable<String> o = Flowable.zip(oi, os, new BiFunction<Notification<Integer>, Notification<String>, String>() {
+        Flowable<String> f = Flowable.zip(oi, os, new BiFunction<Notification<Integer>, Notification<String>, String>() {
 
             @Override
             public String apply(Notification<Integer> t1, Notification<String> t2) {
@@ -916,7 +916,7 @@ public class FlowableZipTest {
         });
 
         final ArrayList<String> list = new ArrayList<String>();
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
 
             @Override
             public void accept(String s) {
@@ -935,7 +935,7 @@ public class FlowableZipTest {
     @Test
     public void testStartEmptyFlowables() {
 
-        Flowable<String> o = Flowable.zip(Flowable.<Integer> empty(), Flowable.<String> empty(), new BiFunction<Integer, String, String>() {
+        Flowable<String> f = Flowable.zip(Flowable.<Integer> empty(), Flowable.<String> empty(), new BiFunction<Integer, String, String>() {
 
             @Override
             public String apply(Integer t1, String t2) {
@@ -945,7 +945,7 @@ public class FlowableZipTest {
         });
 
         final ArrayList<String> list = new ArrayList<String>();
-        o.subscribe(new Consumer<String>() {
+        f.subscribe(new Consumer<String>() {
 
             @Override
             public void accept(String s) {
@@ -963,7 +963,7 @@ public class FlowableZipTest {
         final Object invoked = new Object();
         Collection<Flowable<Object>> observables = Collections.emptyList();
 
-        Flowable<Object> o = Flowable.zip(observables, new Function<Object[], Object>() {
+        Flowable<Object> f = Flowable.zip(observables, new Function<Object[], Object>() {
             @Override
             public Object apply(final Object[] args) {
                 assertEquals("No argument should have been passed", 0, args.length);
@@ -972,7 +972,7 @@ public class FlowableZipTest {
         });
 
         TestSubscriber<Object> ts = new TestSubscriber<Object>();
-        o.subscribe(ts);
+        f.subscribe(ts);
         ts.awaitTerminalEvent(200, TimeUnit.MILLISECONDS);
         ts.assertNoValues();
     }
@@ -987,7 +987,7 @@ public class FlowableZipTest {
         final Object invoked = new Object();
         Collection<Flowable<Object>> observables = Collections.emptyList();
 
-        Flowable<Object> o = Flowable.zip(observables, new Function<Object[], Object>() {
+        Flowable<Object> f = Flowable.zip(observables, new Function<Object[], Object>() {
             @Override
             public Object apply(final Object[] args) {
                 assertEquals("No argument should have been passed", 0, args.length);
@@ -995,18 +995,18 @@ public class FlowableZipTest {
             }
         });
 
-        o.blockingLast();
+        f.blockingLast();
     }
 
     @Test
     public void testBackpressureSync() {
         AtomicInteger generatedA = new AtomicInteger();
         AtomicInteger generatedB = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteFlowable(generatedA);
-        Flowable<Integer> o2 = createInfiniteFlowable(generatedB);
+        Flowable<Integer> f1 = createInfiniteFlowable(generatedA);
+        Flowable<Integer> f2 = createInfiniteFlowable(generatedB);
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Flowable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
+        Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
 
             @Override
             public String apply(Integer t1, Integer t2) {
@@ -1026,11 +1026,11 @@ public class FlowableZipTest {
     public void testBackpressureAsync() {
         AtomicInteger generatedA = new AtomicInteger();
         AtomicInteger generatedB = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteFlowable(generatedA).subscribeOn(Schedulers.computation());
-        Flowable<Integer> o2 = createInfiniteFlowable(generatedB).subscribeOn(Schedulers.computation());
+        Flowable<Integer> f1 = createInfiniteFlowable(generatedA).subscribeOn(Schedulers.computation());
+        Flowable<Integer> f2 = createInfiniteFlowable(generatedB).subscribeOn(Schedulers.computation());
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Flowable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
+        Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
 
             @Override
             public String apply(Integer t1, Integer t2) {
@@ -1050,11 +1050,11 @@ public class FlowableZipTest {
     public void testDownstreamBackpressureRequestsWithFiniteSyncFlowables() {
         AtomicInteger generatedA = new AtomicInteger();
         AtomicInteger generatedB = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteFlowable(generatedA).take(Flowable.bufferSize() * 2);
-        Flowable<Integer> o2 = createInfiniteFlowable(generatedB).take(Flowable.bufferSize() * 2);
+        Flowable<Integer> f1 = createInfiniteFlowable(generatedA).take(Flowable.bufferSize() * 2);
+        Flowable<Integer> f2 = createInfiniteFlowable(generatedB).take(Flowable.bufferSize() * 2);
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Flowable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
+        Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
 
             @Override
             public String apply(Integer t1, Integer t2) {
@@ -1075,11 +1075,11 @@ public class FlowableZipTest {
     public void testDownstreamBackpressureRequestsWithInfiniteAsyncFlowables() {
         AtomicInteger generatedA = new AtomicInteger();
         AtomicInteger generatedB = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteFlowable(generatedA).subscribeOn(Schedulers.computation());
-        Flowable<Integer> o2 = createInfiniteFlowable(generatedB).subscribeOn(Schedulers.computation());
+        Flowable<Integer> f1 = createInfiniteFlowable(generatedA).subscribeOn(Schedulers.computation());
+        Flowable<Integer> f2 = createInfiniteFlowable(generatedB).subscribeOn(Schedulers.computation());
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Flowable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
+        Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
 
             @Override
             public String apply(Integer t1, Integer t2) {
@@ -1100,11 +1100,11 @@ public class FlowableZipTest {
     public void testDownstreamBackpressureRequestsWithInfiniteSyncFlowables() {
         AtomicInteger generatedA = new AtomicInteger();
         AtomicInteger generatedB = new AtomicInteger();
-        Flowable<Integer> o1 = createInfiniteFlowable(generatedA);
-        Flowable<Integer> o2 = createInfiniteFlowable(generatedB);
+        Flowable<Integer> f1 = createInfiniteFlowable(generatedA);
+        Flowable<Integer> f2 = createInfiniteFlowable(generatedB);
 
         TestSubscriber<String> ts = new TestSubscriber<String>();
-        Flowable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
+        Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
 
             @Override
             public String apply(Integer t1, Integer t2) {
@@ -1122,7 +1122,7 @@ public class FlowableZipTest {
     }
 
     private Flowable<Integer> createInfiniteFlowable(final AtomicInteger generated) {
-        Flowable<Integer> observable = Flowable.fromIterable(new Iterable<Integer>() {
+        Flowable<Integer> flowable = Flowable.fromIterable(new Iterable<Integer>() {
             @Override
             public Iterator<Integer> iterator() {
                 return new Iterator<Integer>() {
@@ -1143,7 +1143,7 @@ public class FlowableZipTest {
                 };
             }
         });
-        return observable;
+        return flowable;
     }
 
     Flowable<Integer> OBSERVABLE_OF_5_INTEGERS = OBSERVABLE_OF_5_INTEGERS(new AtomicInteger());
@@ -1152,18 +1152,18 @@ public class FlowableZipTest {
         return Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
-            public void subscribe(final Subscriber<? super Integer> o) {
+            public void subscribe(final Subscriber<? super Integer> subscriber) {
                 BooleanSubscription bs = new BooleanSubscription();
-                o.onSubscribe(bs);
+                subscriber.onSubscribe(bs);
                 for (int i = 1; i <= 5; i++) {
                     if (bs.isCancelled()) {
                         break;
                     }
                     numEmitted.incrementAndGet();
-                    o.onNext(i);
+                    subscriber.onNext(i);
                     Thread.yield();
                 }
-                o.onComplete();
+                subscriber.onComplete();
             }
 
         });
@@ -1173,9 +1173,9 @@ public class FlowableZipTest {
         return Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
-            public void subscribe(final Subscriber<? super Integer> o) {
+            public void subscribe(final Subscriber<? super Integer> subscriber) {
                 final BooleanSubscription bs = new BooleanSubscription();
-                o.onSubscribe(bs);
+                subscriber.onSubscribe(bs);
                 Thread t = new Thread(new Runnable() {
 
                     @Override
@@ -1184,10 +1184,10 @@ public class FlowableZipTest {
                         System.out.println("Starting thread: " + Thread.currentThread());
                         int i = 1;
                         while (!bs.isCancelled()) {
-                            o.onNext(i++);
+                            subscriber.onNext(i++);
                             Thread.yield();
                         }
-                        o.onComplete();
+                        subscriber.onComplete();
                         latch.countDown();
                         System.out.println("Ending thread: " + Thread.currentThread());
                     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
@@ -43,7 +43,7 @@ public class FlowableZipTest {
     PublishProcessor<String> s2;
     Flowable<String> zipped;
 
-    Subscriber<String> observer;
+    Subscriber<String> subscriber;
     InOrder inOrder;
 
     @Before
@@ -59,10 +59,10 @@ public class FlowableZipTest {
         s2 = PublishProcessor.create();
         zipped = Flowable.zip(s1, s2, concat2Strings);
 
-        observer = TestHelper.mockSubscriber();
-        inOrder = inOrder(observer);
+        subscriber = TestHelper.mockSubscriber();
+        inOrder = inOrder(subscriber);
 
-        zipped.subscribe(observer);
+        zipped.subscribe(subscriber);
     }
 
     @SuppressWarnings("unchecked")
@@ -72,16 +72,16 @@ public class FlowableZipTest {
         //Function3<String, Integer, int[], String>
 
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         @SuppressWarnings("rawtypes")
         Collection ws = java.util.Collections.singleton(Flowable.just("one", "two"));
         Flowable<String> w = Flowable.zip(ws, zipr);
-        w.subscribe(observer);
+        w.subscribe(subscriber);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, never()).onNext(any(String.class));
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, never()).onNext(any(String.class));
     }
 
     @Test
@@ -99,18 +99,18 @@ public class FlowableZipTest {
 
         /* simulate sending data */
         // once for w1
-        w1.observer.onNext("1a");
-        w1.observer.onComplete();
+        w1.subscriber.onNext("1a");
+        w1.subscriber.onComplete();
         // twice for w2
-        w2.observer.onNext("2a");
-        w2.observer.onNext("2b");
-        w2.observer.onComplete();
+        w2.subscriber.onNext("2a");
+        w2.subscriber.onNext("2b");
+        w2.subscriber.onComplete();
         // 4 times for w3
-        w3.observer.onNext("3a");
-        w3.observer.onNext("3b");
-        w3.observer.onNext("3c");
-        w3.observer.onNext("3d");
-        w3.observer.onComplete();
+        w3.subscriber.onNext("3a");
+        w3.subscriber.onNext("3b");
+        w3.subscriber.onNext("3c");
+        w3.subscriber.onNext("3d");
+        w3.subscriber.onComplete();
 
         /* we should have been called 1 time on the Subscriber */
         InOrder io = inOrder(w);
@@ -132,18 +132,18 @@ public class FlowableZipTest {
 
         /* simulate sending data */
         // 4 times for w1
-        w1.observer.onNext("1a");
-        w1.observer.onNext("1b");
-        w1.observer.onNext("1c");
-        w1.observer.onNext("1d");
-        w1.observer.onComplete();
+        w1.subscriber.onNext("1a");
+        w1.subscriber.onNext("1b");
+        w1.subscriber.onNext("1c");
+        w1.subscriber.onNext("1d");
+        w1.subscriber.onComplete();
         // twice for w2
-        w2.observer.onNext("2a");
-        w2.observer.onNext("2b");
-        w2.observer.onComplete();
+        w2.subscriber.onNext("2a");
+        w2.subscriber.onNext("2b");
+        w2.subscriber.onComplete();
         // 1 times for w3
-        w3.observer.onNext("3a");
-        w3.observer.onComplete();
+        w3.subscriber.onNext("3a");
+        w3.subscriber.onComplete();
 
         /* we should have been called 1 time on the Subscriber */
         InOrder io = inOrder(w);
@@ -178,32 +178,32 @@ public class FlowableZipTest {
         PublishProcessor<String> r1 = PublishProcessor.create();
         PublishProcessor<String> r2 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.zip(r1, r2, zipr2).subscribe(observer);
+        Flowable.zip(r1, r2, zipr2).subscribe(subscriber);
 
         /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext("world");
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        inOrder.verify(observer, times(1)).onNext("helloworld");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("helloworld");
 
         r1.onNext("hello ");
         r2.onNext("again");
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        inOrder.verify(observer, times(1)).onNext("hello again");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("hello again");
 
         r1.onComplete();
         r2.onComplete();
 
-        inOrder.verify(observer, never()).onNext(anyString());
-        verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, never()).onNext(anyString());
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -213,26 +213,26 @@ public class FlowableZipTest {
         PublishProcessor<String> r1 = PublishProcessor.create();
         PublishProcessor<String> r2 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        Flowable.zip(r1, r2, zipr2).subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        Flowable.zip(r1, r2, zipr2).subscribe(subscriber);
 
         /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext("world");
         r2.onComplete();
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
-        inOrder.verify(observer, times(1)).onNext("helloworld");
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("helloworld");
+        inOrder.verify(subscriber, times(1)).onComplete();
 
         r1.onNext("hi");
         r1.onComplete();
 
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
-        inOrder.verify(observer, never()).onComplete();
-        inOrder.verify(observer, never()).onNext(anyString());
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onComplete();
+        inOrder.verify(subscriber, never()).onNext(anyString());
     }
 
     @Test
@@ -240,27 +240,27 @@ public class FlowableZipTest {
         PublishProcessor<String> r1 = PublishProcessor.create();
         PublishProcessor<Integer> r2 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.zip(r1, r2, zipr2).subscribe(observer);
+        Flowable.zip(r1, r2, zipr2).subscribe(subscriber);
 
         /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext(1);
         r2.onComplete();
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
-        inOrder.verify(observer, times(1)).onNext("hello1");
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onNext("hello1");
+        inOrder.verify(subscriber, times(1)).onComplete();
 
         r1.onNext("hi");
         r1.onComplete();
 
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
-        inOrder.verify(observer, never()).onComplete();
-        inOrder.verify(observer, never()).onNext(anyString());
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onComplete();
+        inOrder.verify(subscriber, never()).onNext(anyString());
     }
 
     @Test
@@ -269,18 +269,18 @@ public class FlowableZipTest {
         PublishProcessor<Integer> r2 = PublishProcessor.create();
         PublishProcessor<List<Integer>> r3 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.zip(r1, r2, r3, zipr3).subscribe(observer);
+        Flowable.zip(r1, r2, r3, zipr3).subscribe(subscriber);
 
         /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext(2);
         r3.onNext(Arrays.asList(5, 6, 7));
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, times(1)).onNext("hello2[5, 6, 7]");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, times(1)).onNext("hello2[5, 6, 7]");
     }
 
     @Test
@@ -288,9 +288,9 @@ public class FlowableZipTest {
         PublishProcessor<String> r1 = PublishProcessor.create();
         PublishProcessor<String> r2 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.zip(r1, r2, zipr2).subscribe(observer);
+        Flowable.zip(r1, r2, zipr2).subscribe(subscriber);
 
         /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("one");
@@ -298,24 +298,24 @@ public class FlowableZipTest {
         r1.onNext("three");
         r2.onNext("A");
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, times(1)).onNext("oneA");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, times(1)).onNext("oneA");
 
         r1.onNext("four");
         r1.onComplete();
         r2.onNext("B");
-        verify(observer, times(1)).onNext("twoB");
+        verify(subscriber, times(1)).onNext("twoB");
         r2.onNext("C");
-        verify(observer, times(1)).onNext("threeC");
+        verify(subscriber, times(1)).onNext("threeC");
         r2.onNext("D");
-        verify(observer, times(1)).onNext("fourD");
+        verify(subscriber, times(1)).onNext("fourD");
         r2.onNext("E");
-        verify(observer, never()).onNext("E");
+        verify(subscriber, never()).onNext("E");
         r2.onComplete();
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -323,26 +323,26 @@ public class FlowableZipTest {
         PublishProcessor<String> r1 = PublishProcessor.create();
         PublishProcessor<String> r2 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.zip(r1, r2, zipr2).subscribe(observer);
+        Flowable.zip(r1, r2, zipr2).subscribe(subscriber);
 
         /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("hello");
         r2.onNext("world");
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, times(1)).onNext("helloworld");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, times(1)).onNext("helloworld");
 
         r1.onError(new RuntimeException(""));
         r1.onNext("hello");
         r2.onNext("again");
 
-        verify(observer, times(1)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
+        verify(subscriber, times(1)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
         // we don't want to be called again after an error
-        verify(observer, times(0)).onNext("helloagain");
+        verify(subscriber, times(0)).onNext("helloagain");
     }
 
     @Test
@@ -350,8 +350,8 @@ public class FlowableZipTest {
         PublishProcessor<String> r1 = PublishProcessor.create();
         PublishProcessor<String> r2 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
 
         Flowable.zip(r1, r2, zipr2).subscribe(ts);
 
@@ -359,18 +359,18 @@ public class FlowableZipTest {
         r1.onNext("hello");
         r2.onNext("world");
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
-        verify(observer, times(1)).onNext("helloworld");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
+        verify(subscriber, times(1)).onNext("helloworld");
 
         ts.dispose();
         r1.onNext("hello");
         r2.onNext("again");
 
-        verify(observer, times(0)).onError(any(Throwable.class));
-        verify(observer, never()).onComplete();
+        verify(subscriber, times(0)).onError(any(Throwable.class));
+        verify(subscriber, never()).onComplete();
         // we don't want to be called again after an error
-        verify(observer, times(0)).onNext("helloagain");
+        verify(subscriber, times(0)).onNext("helloagain");
     }
 
     @Test
@@ -378,9 +378,9 @@ public class FlowableZipTest {
         PublishProcessor<String> r1 = PublishProcessor.create();
         PublishProcessor<String> r2 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.zip(r1, r2, zipr2).subscribe(observer);
+        Flowable.zip(r1, r2, zipr2).subscribe(subscriber);
 
         /* simulate the Flowables pushing data into the aggregator */
         r1.onNext("one");
@@ -388,17 +388,17 @@ public class FlowableZipTest {
         r1.onComplete();
         r2.onNext("A");
 
-        InOrder inOrder = inOrder(observer);
+        InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
-        inOrder.verify(observer, never()).onComplete();
-        inOrder.verify(observer, times(1)).onNext("oneA");
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, never()).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("oneA");
 
         r2.onComplete();
 
-        inOrder.verify(observer, never()).onError(any(Throwable.class));
-        inOrder.verify(observer, times(1)).onComplete();
-        inOrder.verify(observer, never()).onNext(anyString());
+        inOrder.verify(subscriber, never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onComplete();
+        inOrder.verify(subscriber, never()).onNext(anyString());
     }
 
     @Test
@@ -406,16 +406,16 @@ public class FlowableZipTest {
         BiFunction<String, Integer, String> zipr = getConcatStringIntegerZipr();
 
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<String> w = Flowable.zip(Flowable.just("one", "two"), Flowable.just(2, 3, 4), zipr);
-        w.subscribe(observer);
+        w.subscribe(subscriber);
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("one2");
-        verify(observer, times(1)).onNext("two3");
-        verify(observer, never()).onNext("4");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one2");
+        verify(subscriber, times(1)).onNext("two3");
+        verify(subscriber, never()).onNext("4");
     }
 
     @Test
@@ -423,27 +423,27 @@ public class FlowableZipTest {
         Function3<String, Integer, int[], String> zipr = getConcatStringIntegerIntArrayZipr();
 
         /* define a Subscriber to receive aggregated events */
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         Flowable<String> w = Flowable.zip(Flowable.just("one", "two"), Flowable.just(2), Flowable.just(new int[] { 4, 5, 6 }), zipr);
-        w.subscribe(observer);
+        w.subscribe(subscriber);
 
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
-        verify(observer, times(1)).onNext("one2[4, 5, 6]");
-        verify(observer, never()).onNext("two");
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("one2[4, 5, 6]");
+        verify(subscriber, never()).onNext("two");
     }
 
     @Test
     public void testOnNextExceptionInvokesOnError() {
         BiFunction<Integer, Integer, Integer> zipr = getDivideZipr();
 
-        Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         Flowable<Integer> w = Flowable.zip(Flowable.just(10, 20, 30), Flowable.just(0, 1, 2), zipr);
-        w.subscribe(observer);
+        w.subscribe(subscriber);
 
-        verify(observer, times(1)).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onError(any(Throwable.class));
     }
 
     @Test
@@ -619,13 +619,13 @@ public class FlowableZipTest {
 
     private static class TestFlowable implements Publisher<String> {
 
-        Subscriber<? super String> observer;
+        Subscriber<? super String> subscriber;
 
         @Override
-        public void subscribe(Subscriber<? super String> observer) {
+        public void subscribe(Subscriber<? super String> subscriber) {
             // just store the variable where it can be accessed so we can manually trigger it
-            this.observer = observer;
-            observer.onSubscribe(new BooleanSubscription());
+            this.subscriber = subscriber;
+            subscriber.onSubscribe(new BooleanSubscription());
         }
 
     }
@@ -636,10 +636,10 @@ public class FlowableZipTest {
         s1.onNext("b");
         s1.onComplete();
         s2.onNext("1");
-        inOrder.verify(observer, times(1)).onNext("a-1");
+        inOrder.verify(subscriber, times(1)).onNext("a-1");
         s2.onNext("2");
-        inOrder.verify(observer, times(1)).onNext("b-2");
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("b-2");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -648,11 +648,11 @@ public class FlowableZipTest {
         s2.onNext("1");
         s2.onNext("2");
         s1.onNext("a");
-        inOrder.verify(observer, times(1)).onNext("a-1");
+        inOrder.verify(subscriber, times(1)).onNext("a-1");
         s1.onNext("b");
-        inOrder.verify(observer, times(1)).onNext("b-2");
+        inOrder.verify(subscriber, times(1)).onNext("b-2");
         s1.onComplete();
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -662,10 +662,10 @@ public class FlowableZipTest {
         s2.onNext("2");
         s2.onComplete();
         s1.onNext("a");
-        inOrder.verify(observer, times(1)).onNext("a-1");
+        inOrder.verify(subscriber, times(1)).onNext("a-1");
         s1.onNext("b");
-        inOrder.verify(observer, times(1)).onNext("b-2");
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("b-2");
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -674,11 +674,11 @@ public class FlowableZipTest {
         s1.onNext("a");
         s1.onNext("b");
         s2.onNext("1");
-        inOrder.verify(observer, times(1)).onNext("a-1");
+        inOrder.verify(subscriber, times(1)).onNext("a-1");
         s2.onNext("2");
-        inOrder.verify(observer, times(1)).onNext("b-2");
+        inOrder.verify(subscriber, times(1)).onNext("b-2");
         s2.onComplete();
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -687,14 +687,14 @@ public class FlowableZipTest {
         s2.onNext("a");
         s1.onError(new RuntimeException("Forced failure"));
 
-        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
+        inOrder.verify(subscriber, times(1)).onError(any(RuntimeException.class));
 
         s2.onNext("b");
         s1.onNext("1");
         s1.onNext("2");
 
-        inOrder.verify(observer, never()).onComplete();
-        inOrder.verify(observer, never()).onNext(any(String.class));
+        inOrder.verify(subscriber, never()).onComplete();
+        inOrder.verify(subscriber, never()).onNext(any(String.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -704,13 +704,13 @@ public class FlowableZipTest {
         s1.onNext("b");
         s2.onError(new RuntimeException("Forced failure"));
 
-        inOrder.verify(observer, times(1)).onError(any(RuntimeException.class));
+        inOrder.verify(subscriber, times(1)).onError(any(RuntimeException.class));
 
         s2.onNext("1");
         s2.onNext("2");
 
-        inOrder.verify(observer, never()).onComplete();
-        inOrder.verify(observer, never()).onNext(any(String.class));
+        inOrder.verify(subscriber, never()).onComplete();
+        inOrder.verify(subscriber, never()).onNext(any(String.class));
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -718,14 +718,14 @@ public class FlowableZipTest {
     public void testStartWithOnCompletedTwice() {
         // issue: https://groups.google.com/forum/#!topic/rxjava/79cWTv3TFp0
         // The problem is the original "zip" implementation does not wrap
-        // an internal observer with a SafeSubscriber. However, in the "zip",
+        // an internal subscriber with a SafeSubscriber. However, in the "zip",
         // it may calls "onComplete" twice. That breaks the Rx contract.
 
         // This test tries to emulate this case.
         // As "TestHelper.mockSubscriber()" will create an instance in the package "rx",
-        // we need to wrap "TestHelper.mockSubscriber()" with an observer instance
+        // we need to wrap "TestHelper.mockSubscriber()" with an subscriber instance
         // which is in the package "rx.operators".
-        final Subscriber<Integer> observer = TestHelper.mockSubscriber();
+        final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         Flowable.zip(Flowable.just(1),
                 Flowable.just(1), new BiFunction<Integer, Integer, Integer>() {
@@ -737,24 +737,24 @@ public class FlowableZipTest {
 
             @Override
             public void onComplete() {
-                observer.onComplete();
+                subscriber.onComplete();
             }
 
             @Override
             public void onError(Throwable e) {
-                observer.onError(e);
+                subscriber.onError(e);
             }
 
             @Override
             public void onNext(Integer args) {
-                observer.onNext(args);
+                subscriber.onNext(args);
             }
 
         });
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, times(1)).onNext(2);
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, times(1)).onNext(2);
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
@@ -122,12 +122,12 @@ public class MaybeDelaySubscriptionTest {
         try {
             Flowable<Integer> f = new Flowable<Integer>() {
                 @Override
-                protected void subscribeActual(Subscriber<? super Integer> observer) {
-                    observer.onSubscribe(new BooleanSubscription());
-                    observer.onNext(1);
-                    observer.onError(new TestException());
-                    observer.onComplete();
-                    observer.onNext(2);
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onNext(1);
+                    subscriber.onError(new TestException());
+                    subscriber.onComplete();
+                    subscriber.onNext(2);
                 }
             };
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoOnEventTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoOnEventTest.java
@@ -61,11 +61,11 @@ public class MaybeDoOnEventTest {
 
             new Maybe<Integer>() {
                 @Override
-                protected void subscribeActual(MaybeObserver<? super Integer> s) {
-                    s.onSubscribe(bs);
-                    s.onError(new TestException("Second"));
-                    s.onComplete();
-                    s.onSuccess(1);
+                protected void subscribeActual(MaybeObserver<? super Integer> observer) {
+                    observer.onSubscribe(bs);
+                    observer.onError(new TestException("Second"));
+                    observer.onComplete();
+                    observer.onSuccess(1);
                 }
             }
             .doOnSubscribe(new Consumer<Disposable>() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
@@ -410,14 +410,14 @@ public class MaybeUsingTest {
                 public MaybeSource<Integer> apply(Object v) throws Exception {
                     return Maybe.wrap(new MaybeSource<Integer>() {
                         @Override
-                        public void subscribe(MaybeObserver<? super Integer> s) {
+                        public void subscribe(MaybeObserver<? super Integer> observer) {
                             Disposable d1 = Disposables.empty();
 
-                            s.onSubscribe(d1);
+                            observer.onSubscribe(d1);
 
                             Disposable d2 = Disposables.empty();
 
-                            s.onSubscribe(d2);
+                            observer.onSubscribe(d2);
 
                             assertFalse(d1.isDisposed());
 

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -240,10 +240,10 @@ public class ObservableConcatMapMaybeTest {
         try {
             new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onNext(1);
-                    s.onError(new TestException("outer"));
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onNext(1);
+                    observer.onError(new TestException("outer"));
                 }
             }
             .concatMapMaybe(

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -155,10 +155,10 @@ public class ObservableConcatMapSingleTest {
         try {
             new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onNext(1);
-                    s.onError(new TestException("outer"));
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onNext(1);
+                    observer.onError(new TestException("outer"));
                 }
             }
             .concatMapSingle(

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
@@ -312,10 +312,10 @@ public class ObservableSwitchMapCompletableTest {
         try {
             new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onNext(1);
-                    s.onError(new TestException("main"));
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onNext(1);
+                    observer.onError(new TestException("main"));
                 }
             }
             .switchMapCompletable(Functions.justFunction(Completable.error(new TestException("inner"))))

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
@@ -353,10 +353,10 @@ public class ObservableSwitchMapMaybeTest {
         try {
             new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onNext(1);
-                    s.onError(new TestException("outer"));
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onNext(1);
+                    observer.onError(new TestException("outer"));
                 }
             }
             .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
@@ -384,10 +384,10 @@ public class ObservableSwitchMapMaybeTest {
 
             TestObserver<Integer> to = new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onNext(1);
-                    s.onError(new TestException("outer"));
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onNext(1);
+                    observer.onError(new TestException("outer"));
                 }
             }
             .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
@@ -322,10 +322,10 @@ public class ObservableSwitchMapSingleTest {
         try {
             new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onNext(1);
-                    s.onError(new TestException("outer"));
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onNext(1);
+                    observer.onError(new TestException("outer"));
                 }
             }
             .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
@@ -353,10 +353,10 @@ public class ObservableSwitchMapSingleTest {
 
             TestObserver<Integer> to = new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onNext(1);
-                    s.onError(new TestException("outer"));
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onNext(1);
+                    observer.onError(new TestException("outer"));
                 }
             }
             .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAnyTest.java
@@ -267,7 +267,7 @@ public class ObservableAnyTest {
     @Test
     public void testAnyWithTwoItems() {
         Observable<Integer> w = Observable.just(1, 2);
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
@@ -276,7 +276,7 @@ public class ObservableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(false);
         verify(observer, times(1)).onSuccess(true);
@@ -286,11 +286,11 @@ public class ObservableAnyTest {
     @Test
     public void testIsEmptyWithTwoItems() {
         Observable<Integer> w = Observable.just(1, 2);
-        Single<Boolean> observable = w.isEmpty();
+        Single<Boolean> single = w.isEmpty();
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(true);
         verify(observer, times(1)).onSuccess(false);
@@ -300,7 +300,7 @@ public class ObservableAnyTest {
     @Test
     public void testAnyWithOneItem() {
         Observable<Integer> w = Observable.just(1);
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
@@ -309,7 +309,7 @@ public class ObservableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(false);
         verify(observer, times(1)).onSuccess(true);
@@ -319,11 +319,11 @@ public class ObservableAnyTest {
     @Test
     public void testIsEmptyWithOneItem() {
         Observable<Integer> w = Observable.just(1);
-        Single<Boolean> observable = w.isEmpty();
+        Single<Boolean> single = w.isEmpty();
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(true);
         verify(observer, times(1)).onSuccess(false);
@@ -333,7 +333,7 @@ public class ObservableAnyTest {
     @Test
     public void testAnyWithEmpty() {
         Observable<Integer> w = Observable.empty();
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
                 return true;
@@ -342,7 +342,7 @@ public class ObservableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(false);
         verify(observer, never()).onSuccess(true);
@@ -352,11 +352,11 @@ public class ObservableAnyTest {
     @Test
     public void testIsEmptyWithEmpty() {
         Observable<Integer> w = Observable.empty();
-        Single<Boolean> observable = w.isEmpty();
+        Single<Boolean> single = w.isEmpty();
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(true);
         verify(observer, never()).onSuccess(false);
@@ -366,7 +366,7 @@ public class ObservableAnyTest {
     @Test
     public void testAnyWithPredicate1() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 2;
@@ -375,7 +375,7 @@ public class ObservableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(false);
         verify(observer, times(1)).onSuccess(true);
@@ -385,7 +385,7 @@ public class ObservableAnyTest {
     @Test
     public void testExists1() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 2;
@@ -394,7 +394,7 @@ public class ObservableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, never()).onSuccess(false);
         verify(observer, times(1)).onSuccess(true);
@@ -404,7 +404,7 @@ public class ObservableAnyTest {
     @Test
     public void testAnyWithPredicate2() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t1) {
                 return t1 < 1;
@@ -413,7 +413,7 @@ public class ObservableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(false);
         verify(observer, never()).onSuccess(true);
@@ -424,7 +424,7 @@ public class ObservableAnyTest {
     public void testAnyWithEmptyAndPredicate() {
         // If the source is empty, always output false.
         Observable<Integer> w = Observable.empty();
-        Single<Boolean> observable = w.any(new Predicate<Integer>() {
+        Single<Boolean> single = w.any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer t) {
                 return true;
@@ -433,7 +433,7 @@ public class ObservableAnyTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         verify(observer, times(1)).onSuccess(false);
         verify(observer, never()).onSuccess(true);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -771,7 +771,7 @@ public class ObservableBufferTest {
         final Observer<Object> o = TestHelper.mockObserver();
 
         final CountDownLatch cdl = new CountDownLatch(1);
-        DisposableObserver<Object> s = new DisposableObserver<Object>() {
+        DisposableObserver<Object> observer = new DisposableObserver<Object>() {
             @Override
             public void onNext(Object t) {
                 o.onNext(t);
@@ -788,7 +788,7 @@ public class ObservableBufferTest {
             }
         };
 
-        Observable.range(1, 1).delay(1, TimeUnit.SECONDS).buffer(2, TimeUnit.SECONDS).subscribe(s);
+        Observable.range(1, 1).delay(1, TimeUnit.SECONDS).buffer(2, TimeUnit.SECONDS).subscribe(observer);
 
         cdl.await();
 
@@ -796,7 +796,7 @@ public class ObservableBufferTest {
         verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
 
-        assertFalse(s.isDisposed());
+        assertFalse(observer.isDisposed());
     }
 
     @SuppressWarnings("unchecked")
@@ -1599,24 +1599,24 @@ public class ObservableBufferTest {
         try {
             new Observable<Object>() {
                 @Override
-                protected void subscribeActual(Observer<? super Object> s) {
+                protected void subscribeActual(Observer<? super Object> observer) {
                     Disposable bs1 = Disposables.empty();
                     Disposable bs2 = Disposables.empty();
 
-                    s.onSubscribe(bs1);
+                    observer.onSubscribe(bs1);
 
                     assertFalse(bs1.isDisposed());
                     assertFalse(bs2.isDisposed());
 
-                    s.onSubscribe(bs2);
+                    observer.onSubscribe(bs2);
 
                     assertFalse(bs1.isDisposed());
                     assertTrue(bs2.isDisposed());
 
-                    s.onError(new IOException());
-                    s.onComplete();
-                    s.onNext(1);
-                    s.onError(new TestException());
+                    observer.onError(new IOException());
+                    observer.onComplete();
+                    observer.onNext(1);
+                    observer.onError(new TestException());
                 }
             }
             .buffer(Observable.never(), Functions.justFunction(Observable.never()))
@@ -1720,30 +1720,30 @@ public class ObservableBufferTest {
             Observable.never()
             .buffer(new Observable<Object>() {
                 @Override
-                protected void subscribeActual(Observer<? super Object> s) {
+                protected void subscribeActual(Observer<? super Object> observer) {
 
-                    assertFalse(((Disposable)s).isDisposed());
+                    assertFalse(((Disposable)observer).isDisposed());
 
                     Disposable bs1 = Disposables.empty();
                     Disposable bs2 = Disposables.empty();
 
-                    s.onSubscribe(bs1);
+                    observer.onSubscribe(bs1);
 
                     assertFalse(bs1.isDisposed());
                     assertFalse(bs2.isDisposed());
 
-                    s.onSubscribe(bs2);
+                    observer.onSubscribe(bs2);
 
                     assertFalse(bs1.isDisposed());
                     assertTrue(bs2.isDisposed());
 
-                    s.onError(new IOException());
+                    observer.onError(new IOException());
 
-                    assertTrue(((Disposable)s).isDisposed());
+                    assertTrue(((Disposable)observer).isDisposed());
 
-                    s.onComplete();
-                    s.onNext(1);
-                    s.onError(new TestException());
+                    observer.onComplete();
+                    observer.onNext(1);
+                    observer.onError(new TestException());
                 }
             }, Functions.justFunction(Observable.never()))
             .test()
@@ -1765,30 +1765,30 @@ public class ObservableBufferTest {
             .buffer(Observable.just(1).concatWith(Observable.<Integer>never()),
                     Functions.justFunction(new Observable<Object>() {
                 @Override
-                protected void subscribeActual(Observer<? super Object> s) {
+                protected void subscribeActual(Observer<? super Object> observer) {
 
-                    assertFalse(((Disposable)s).isDisposed());
+                    assertFalse(((Disposable)observer).isDisposed());
 
                     Disposable bs1 = Disposables.empty();
                     Disposable bs2 = Disposables.empty();
 
-                    s.onSubscribe(bs1);
+                    observer.onSubscribe(bs1);
 
                     assertFalse(bs1.isDisposed());
                     assertFalse(bs2.isDisposed());
 
-                    s.onSubscribe(bs2);
+                    observer.onSubscribe(bs2);
 
                     assertFalse(bs1.isDisposed());
                     assertTrue(bs2.isDisposed());
 
-                    s.onError(new IOException());
+                    observer.onError(new IOException());
 
-                    assertTrue(((Disposable)s).isDisposed());
+                    assertTrue(((Disposable)observer).isDisposed());
 
-                    s.onComplete();
-                    s.onNext(1);
-                    s.onError(new TestException());
+                    observer.onComplete();
+                    observer.onNext(1);
+                    observer.onError(new TestException());
                 }
             }))
             .test()
@@ -1872,10 +1872,10 @@ public class ObservableBufferTest {
             BehaviorSubject.createDefault(1)
             .buffer(Functions.justCallable(new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onError(new TestException("first"));
-                    s.onError(new TestException("second"));
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onError(new TestException("first"));
+                    observer.onError(new TestException("second"));
                 }
             }))
             .test()

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCombineLatestTest.java
@@ -483,7 +483,7 @@ public class ObservableCombineLatestTest {
 
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Observer<List<Object>> s = new DefaultObserver<List<Object>>() {
+            Observer<List<Object>> observer = new DefaultObserver<List<Object>>() {
 
                 @Override
                 public void onNext(List<Object> t) {
@@ -503,7 +503,7 @@ public class ObservableCombineLatestTest {
                 }
             };
 
-            result.subscribe(s);
+            result.subscribe(observer);
 
             cdl.await();
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
@@ -663,11 +663,11 @@ public class ObservableConcatTest {
         Observable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(Observer<? super String> s) {
-                s.onSubscribe(Disposables.empty());
-                s.onNext("hello");
-                s.onComplete();
-                s.onComplete();
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onNext("hello");
+                observer.onComplete();
+                observer.onComplete();
             }
 
         });

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithCompletableTest.java
@@ -105,17 +105,17 @@ public class ObservableConcatWithCompletableTest {
     public void badSource() {
         new Observable<Integer>() {
             @Override
-            protected void subscribeActual(Observer<? super Integer> s) {
+            protected void subscribeActual(Observer<? super Integer> observer) {
                 Disposable bs1 = Disposables.empty();
-                s.onSubscribe(bs1);
+                observer.onSubscribe(bs1);
 
                 Disposable bs2 = Disposables.empty();
-                s.onSubscribe(bs2);
+                observer.onSubscribe(bs2);
 
                 assertFalse(bs1.isDisposed());
                 assertTrue(bs2.isDisposed());
 
-                s.onComplete();
+                observer.onComplete();
             }
         }.concatWith(Completable.complete())
         .test()

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybeTest.java
@@ -138,17 +138,17 @@ public class ObservableConcatWithMaybeTest {
     public void badSource() {
         new Observable<Integer>() {
             @Override
-            protected void subscribeActual(Observer<? super Integer> s) {
+            protected void subscribeActual(Observer<? super Integer> observer) {
                 Disposable bs1 = Disposables.empty();
-                s.onSubscribe(bs1);
+                observer.onSubscribe(bs1);
 
                 Disposable bs2 = Disposables.empty();
-                s.onSubscribe(bs2);
+                observer.onSubscribe(bs2);
 
                 assertFalse(bs1.isDisposed());
                 assertTrue(bs2.isDisposed());
 
-                s.onComplete();
+                observer.onComplete();
             }
         }.concatWith(Maybe.<Integer>empty())
         .test()
@@ -159,17 +159,17 @@ public class ObservableConcatWithMaybeTest {
     public void badSource2() {
         Flowable.empty().concatWith(new Maybe<Integer>() {
             @Override
-            protected void subscribeActual(MaybeObserver<? super Integer> s) {
+            protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                 Disposable bs1 = Disposables.empty();
-                s.onSubscribe(bs1);
+                observer.onSubscribe(bs1);
 
                 Disposable bs2 = Disposables.empty();
-                s.onSubscribe(bs2);
+                observer.onSubscribe(bs2);
 
                 assertFalse(bs1.isDisposed());
                 assertTrue(bs2.isDisposed());
 
-                s.onComplete();
+                observer.onComplete();
             }
         })
         .test()

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithSingleTest.java
@@ -110,17 +110,17 @@ public class ObservableConcatWithSingleTest {
     public void badSource() {
         new Observable<Integer>() {
             @Override
-            protected void subscribeActual(Observer<? super Integer> s) {
+            protected void subscribeActual(Observer<? super Integer> observer) {
                 Disposable bs1 = Disposables.empty();
-                s.onSubscribe(bs1);
+                observer.onSubscribe(bs1);
 
                 Disposable bs2 = Disposables.empty();
-                s.onSubscribe(bs2);
+                observer.onSubscribe(bs2);
 
                 assertFalse(bs1.isDisposed());
                 assertTrue(bs2.isDisposed());
 
-                s.onComplete();
+                observer.onComplete();
             }
         }.concatWith(Single.<Integer>just(100))
         .test()
@@ -131,17 +131,17 @@ public class ObservableConcatWithSingleTest {
     public void badSource2() {
         Flowable.empty().concatWith(new Single<Integer>() {
             @Override
-            protected void subscribeActual(SingleObserver<? super Integer> s) {
+            protected void subscribeActual(SingleObserver<? super Integer> observer) {
                 Disposable bs1 = Disposables.empty();
-                s.onSubscribe(bs1);
+                observer.onSubscribe(bs1);
 
                 Disposable bs2 = Disposables.empty();
-                s.onSubscribe(bs2);
+                observer.onSubscribe(bs2);
 
                 assertFalse(bs1.isDisposed());
                 assertTrue(bs2.isDisposed());
 
-                s.onSuccess(100);
+                observer.onSuccess(100);
             }
         })
         .test()

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
@@ -471,11 +471,11 @@ public class ObservableDebounceTest {
         new Observable<Integer>() {
             @Override
             protected void subscribeActual(
-                    Observer<? super Integer> s) {
-                s.onSubscribe(Disposables.empty());
+                    Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposables.empty());
                 to.cancel();
-                s.onNext(1);
-                s.onComplete();
+                observer.onNext(1);
+                observer.onComplete();
             }
         }
         .debounce(1, TimeUnit.SECONDS)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDeferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDeferTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.observers.DefaultObserver;
 
 @SuppressWarnings("unchecked")
 public class ObservableDeferTest {
@@ -69,7 +68,7 @@ public class ObservableDeferTest {
 
         Observable<String> result = Observable.defer(factory);
 
-        DefaultObserver<String> o = mock(DefaultObserver.class);
+        Observer<String> o = TestHelper.mockObserver();
 
         result.subscribe(o);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChangedTest.java
@@ -225,13 +225,13 @@ public class ObservableDistinctUntilChangedTest {
         try {
             Observable.wrap(new ObservableSource<Integer>() {
                 @Override
-                public void subscribe(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onNext(1);
-                    s.onNext(2);
-                    s.onNext(3);
-                    s.onError(new IOException());
-                    s.onComplete();
+                public void subscribe(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onNext(1);
+                    observer.onNext(2);
+                    observer.onNext(3);
+                    observer.onError(new IOException());
+                    observer.onComplete();
                 }
             })
             .distinctUntilChanged(new BiPredicate<Integer, Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnEachTest.java
@@ -230,12 +230,12 @@ public class ObservableDoOnEachTest {
         try {
             Observable.wrap(new ObservableSource<Object>() {
                 @Override
-                public void subscribe(Observer<? super Object> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onNext(1);
-                    s.onNext(2);
-                    s.onError(new IOException());
-                    s.onComplete();
+                public void subscribe(Observer<? super Object> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onNext(1);
+                    observer.onNext(2);
+                    observer.onError(new IOException());
+                    observer.onComplete();
                 }
             })
             .doOnNext(new Consumer<Object>() {
@@ -260,9 +260,9 @@ public class ObservableDoOnEachTest {
         try {
             Observable.wrap(new ObservableSource<Object>() {
                 @Override
-                public void subscribe(Observer<? super Object> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onError(new TestException());
+                public void subscribe(Observer<? super Object> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onError(new TestException());
                 }
             })
             .doAfterTerminate(new Action() {
@@ -287,9 +287,9 @@ public class ObservableDoOnEachTest {
         try {
             Observable.wrap(new ObservableSource<Object>() {
                 @Override
-                public void subscribe(Observer<? super Object> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onComplete();
+                public void subscribe(Observer<? super Object> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onComplete();
                 }
             })
             .doAfterTerminate(new Action() {
@@ -311,9 +311,9 @@ public class ObservableDoOnEachTest {
     public void onCompleteCrash() {
         Observable.wrap(new ObservableSource<Object>() {
             @Override
-            public void subscribe(Observer<? super Object> s) {
-                s.onSubscribe(Disposables.empty());
-                s.onComplete();
+            public void subscribe(Observer<? super Object> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onComplete();
             }
         })
         .doOnComplete(new Action() {
@@ -333,12 +333,12 @@ public class ObservableDoOnEachTest {
         try {
             Observable.wrap(new ObservableSource<Object>() {
                 @Override
-                public void subscribe(Observer<? super Object> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onNext(1);
-                    s.onNext(2);
-                    s.onError(new IOException());
-                    s.onComplete();
+                public void subscribe(Observer<? super Object> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onNext(1);
+                    observer.onNext(2);
+                    observer.onError(new IOException());
+                    observer.onComplete();
                 }
             })
             .doOnNext(new Consumer<Object>() {
@@ -364,9 +364,9 @@ public class ObservableDoOnEachTest {
         try {
             Observable.wrap(new ObservableSource<Object>() {
                 @Override
-                public void subscribe(Observer<? super Object> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onError(new TestException());
+                public void subscribe(Observer<? super Object> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onError(new TestException());
                 }
             })
             .doAfterTerminate(new Action() {
@@ -408,9 +408,9 @@ public class ObservableDoOnEachTest {
         try {
             Observable.wrap(new ObservableSource<Object>() {
                 @Override
-                public void subscribe(Observer<? super Object> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onComplete();
+                public void subscribe(Observer<? super Object> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onComplete();
                 }
             })
             .doAfterTerminate(new Action() {
@@ -433,9 +433,9 @@ public class ObservableDoOnEachTest {
     public void onCompleteCrashConditional() {
         Observable.wrap(new ObservableSource<Object>() {
             @Override
-            public void subscribe(Observer<? super Object> s) {
-                s.onSubscribe(Disposables.empty());
-                s.onComplete();
+            public void subscribe(Observer<? super Object> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onComplete();
             }
         })
         .doOnComplete(new Action() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoOnSubscribeTest.java
@@ -72,10 +72,10 @@ public class ObservableDoOnSubscribeTest {
         Observable<Integer> o = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
-            public void subscribe(Observer<? super Integer> s) {
-                s.onSubscribe(Disposables.empty());
+            public void subscribe(Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposables.empty());
                 onSubscribed.incrementAndGet();
-                sref.set(s);
+                sref.set(observer);
             }
 
         }).doOnSubscribe(new Consumer<Disposable>() {
@@ -114,10 +114,10 @@ public class ObservableDoOnSubscribeTest {
 
             new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(bs);
-                    s.onError(new TestException("Second"));
-                    s.onComplete();
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(bs);
+                    observer.onError(new TestException("Second"));
+                    observer.onComplete();
                 }
             }
             .doOnSubscribe(new Consumer<Disposable>() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableTest.java
@@ -372,14 +372,14 @@ public class ObservableFlatMapCompletableTest {
             public CompletableSource apply(Integer v) throws Exception {
                 return new Completable() {
                     @Override
-                    protected void subscribeActual(CompletableObserver s) {
-                        s.onSubscribe(Disposables.empty());
+                    protected void subscribeActual(CompletableObserver observer) {
+                        observer.onSubscribe(Disposables.empty());
 
-                        assertFalse(((Disposable)s).isDisposed());
+                        assertFalse(((Disposable)observer).isDisposed());
 
-                        ((Disposable)s).dispose();
+                        ((Disposable)observer).dispose();
 
-                        assertTrue(((Disposable)s).isDisposed());
+                        assertTrue(((Disposable)observer).isDisposed());
                     }
                 };
             }
@@ -447,14 +447,14 @@ public class ObservableFlatMapCompletableTest {
             public CompletableSource apply(Integer v) throws Exception {
                 return new Completable() {
                     @Override
-                    protected void subscribeActual(CompletableObserver s) {
-                        s.onSubscribe(Disposables.empty());
+                    protected void subscribeActual(CompletableObserver observer) {
+                        observer.onSubscribe(Disposables.empty());
 
-                        assertFalse(((Disposable)s).isDisposed());
+                        assertFalse(((Disposable)observer).isDisposed());
 
-                        ((Disposable)s).dispose();
+                        ((Disposable)observer).dispose();
 
-                        assertTrue(((Disposable)s).isDisposed());
+                        assertTrue(((Disposable)observer).isDisposed());
                     }
                 };
             }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupByTest.java
@@ -993,10 +993,8 @@ public class ObservableGroupByTest {
         Observable<GroupedObservable<Boolean, Long>> stream = source.groupBy(IS_EVEN);
 
         // create two observers
-        @SuppressWarnings("unchecked")
-        DefaultObserver<GroupedObservable<Boolean, Long>> o1 = mock(DefaultObserver.class);
-        @SuppressWarnings("unchecked")
-        DefaultObserver<GroupedObservable<Boolean, Long>> o2 = mock(DefaultObserver.class);
+        Observer<GroupedObservable<Boolean, Long>> o1 = TestHelper.mockObserver();
+        Observer<GroupedObservable<Boolean, Long>> o2 = TestHelper.mockObserver();
 
         // subscribe with the observers
         stream.subscribe(o1);
@@ -1222,8 +1220,7 @@ public class ObservableGroupByTest {
 
         inner.get().subscribe();
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o2 = mock(DefaultObserver.class);
+        Observer<Integer> o2 = TestHelper.mockObserver();
 
         inner.get().subscribe(o2);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
@@ -343,7 +343,7 @@ public class ObservableMergeTest {
         Observable<String> o1 = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(Observer<? super String> s) {
+            public void subscribe(Observer<? super String> observer) {
                 throw new RuntimeException("fail");
             }
 
@@ -559,13 +559,13 @@ public class ObservableMergeTest {
         Observable<Integer> o = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
-            public void subscribe(final Observer<? super Integer> s) {
+            public void subscribe(final Observer<? super Integer> observer) {
                 Worker inner = Schedulers.newThread().createWorker();
                 final CompositeDisposable as = new CompositeDisposable();
                 as.add(Disposables.empty());
                 as.add(inner);
 
-                s.onSubscribe(as);
+                observer.onSubscribe(as);
 
                 inner.schedule(new Runnable() {
 
@@ -573,7 +573,7 @@ public class ObservableMergeTest {
                     public void run() {
                         try {
                             for (int i = 0; i < 100; i++) {
-                                s.onNext(1);
+                                observer.onNext(1);
                                 try {
                                     Thread.sleep(1);
                                 } catch (InterruptedException e) {
@@ -581,10 +581,10 @@ public class ObservableMergeTest {
                                 }
                             }
                         } catch (Exception e) {
-                            s.onError(e);
+                            observer.onError(e);
                         }
                         as.dispose();
-                        s.onComplete();
+                        observer.onComplete();
                     }
 
                 });
@@ -609,13 +609,13 @@ public class ObservableMergeTest {
         Observable<Integer> o = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
-            public void subscribe(final Observer<? super Integer> s) {
+            public void subscribe(final Observer<? super Integer> observer) {
                 Worker inner = Schedulers.newThread().createWorker();
                 final CompositeDisposable as = new CompositeDisposable();
                 as.add(Disposables.empty());
                 as.add(inner);
 
-                s.onSubscribe(as);
+                observer.onSubscribe(as);
 
                 inner.schedule(new Runnable() {
 
@@ -623,15 +623,15 @@ public class ObservableMergeTest {
                     public void run() {
                         try {
                             for (int i = 0; i < 10000; i++) {
-                                s.onNext(i);
+                                observer.onNext(i);
                             }
                         } catch (Exception e) {
-                            s.onError(e);
+                            observer.onError(e);
                         }
                         as.dispose();
-                        s.onComplete();
-                        s.onComplete();
-                        s.onComplete();
+                        observer.onComplete();
+                        observer.onComplete();
+                        observer.onComplete();
                     }
 
                 });
@@ -840,8 +840,8 @@ public class ObservableMergeTest {
         Observable<String> bad = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(Observer<? super String> s) {
-                s.onNext("two");
+            public void subscribe(Observer<? super String> observer) {
+                observer.onNext("two");
                 // FIXME can't cancel downstream
 //                s.unsubscribe();
 //                s.onComplete();
@@ -1023,8 +1023,8 @@ public class ObservableMergeTest {
                 return Observable.unsafeCreate(new ObservableSource<Integer>() {
 
                     @Override
-                    public void subscribe(Observer<? super Integer> s) {
-                        s.onSubscribe(Disposables.empty());
+                    public void subscribe(Observer<? super Integer> observer) {
+                        observer.onSubscribe(Disposables.empty());
                         if (i < 500) {
                             try {
                                 Thread.sleep(1);
@@ -1032,8 +1032,8 @@ public class ObservableMergeTest {
                                 e.printStackTrace();
                             }
                         }
-                        s.onNext(i);
-                        s.onComplete();
+                        observer.onNext(i);
+                        observer.onComplete();
                     }
 
                 }).subscribeOn(Schedulers.computation()).cache();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybeTest.java
@@ -177,18 +177,18 @@ public class ObservableMergeWithMaybeTest {
     public void onErrorMainOverflow() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<Observer<?>> subscriber = new AtomicReference<Observer<?>>();
+            final AtomicReference<Observer<?>> observerRef = new AtomicReference<Observer<?>>();
             TestObserver<Integer> to = new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    subscriber.set(s);
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observerRef.set(observer);
                 }
             }
             .mergeWith(Maybe.<Integer>error(new IOException()))
             .test();
 
-            subscriber.get().onError(new TestException());
+            observerRef.get().onError(new TestException());
 
             to.assertFailure(IOException.class)
             ;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
@@ -169,18 +169,18 @@ public class ObservableMergeWithSingleTest {
     public void onErrorMainOverflow() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<Observer<?>> subscriber = new AtomicReference<Observer<?>>();
+            final AtomicReference<Observer<?>> observerRef = new AtomicReference<Observer<?>>();
             TestObserver<Integer> to = new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    subscriber.set(s);
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observerRef.set(observer);
                 }
             }
             .mergeWith(Single.<Integer>error(new IOException()))
             .test();
 
-            subscriber.get().onError(new TestException());
+            observerRef.get().onError(new TestException());
 
             to.assertFailure(IOException.class)
             ;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableObserveOnTest.java
@@ -145,10 +145,8 @@ public class ObservableObserveOnTest {
         Observable<Integer> o = Observable.just(1, 2, 3);
         Observable<Integer> o2 = o.observeOn(scheduler);
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<Object> observer1 = mock(DefaultObserver.class);
-        @SuppressWarnings("unchecked")
-        DefaultObserver<Object> observer2 = mock(DefaultObserver.class);
+        Observer<Object> observer1 = TestHelper.mockObserver();
+        Observer<Object> observer2 = TestHelper.mockObserver();
 
         InOrder inOrder1 = inOrder(observer1);
         InOrder inOrder2 = inOrder(observer2);
@@ -368,8 +366,7 @@ public class ObservableObserveOnTest {
 
         Observable<Integer> source = Observable.concat(Observable.<Integer> error(new TestException()), Observable.just(1));
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o = mock(DefaultObserver.class);
+        Observer<Integer> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
         source.observeOn(testScheduler).subscribe(o);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaFunctionTest.java
@@ -126,8 +126,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
         };
         Observable<String> o = Observable.unsafeCreate(w).onErrorResumeNext(resume);
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        Observer<String> observer = TestHelper.mockObserver();
         o.subscribe(observer);
 
         try {
@@ -259,8 +258,7 @@ public class ObservableOnErrorResumeNextViaFunctionTest {
 
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        Observer<String> observer = TestHelper.mockObserver();
 
         TestObserver<String> to = new TestObserver<String>(observer);
         o.subscribe(to);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextViaObservableTest.java
@@ -133,8 +133,7 @@ public class ObservableOnErrorResumeNextViaObservableTest {
         Observable<String> resume = Observable.just("resume");
         Observable<String> observable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeNext(resume);
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        Observer<String> observer = TestHelper.mockObserver();
         TestObserver<String> to = new TestObserver<String>(observer);
         observable.subscribe(to);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturnTest.java
@@ -46,8 +46,7 @@ public class ObservableOnErrorReturnTest {
 
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        Observer<String> observer = TestHelper.mockObserver();
         observable.subscribe(observer);
 
         try {
@@ -82,8 +81,7 @@ public class ObservableOnErrorReturnTest {
 
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        Observer<String> observer = TestHelper.mockObserver();
         observable.subscribe(observer);
 
         try {
@@ -128,8 +126,7 @@ public class ObservableOnErrorReturnTest {
 
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<String> observer = mock(DefaultObserver.class);
+        Observer<String> observer = TestHelper.mockObserver();
         TestObserver<String> to = new TestObserver<String>(observer);
         observable.subscribe(to);
         to.awaitTerminalEvent();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -706,8 +706,8 @@ public class ObservablePublishTest {
 
         new Observable<Integer>() {
             @Override
-            protected void subscribeActual(Observer<? super Integer> s) {
-                sub[0] = s;
+            protected void subscribeActual(Observer<? super Integer> observer) {
+                sub[0] = observer;
             }
         }
         .publish()

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -232,22 +232,22 @@ public class ObservableRefCountTest {
                     }
                 });
 
-        TestObserver<Long> s = new TestObserver<Long>();
-        o.publish().refCount().subscribeOn(Schedulers.newThread()).subscribe(s);
+        TestObserver<Long> observer = new TestObserver<Long>();
+        o.publish().refCount().subscribeOn(Schedulers.newThread()).subscribe(observer);
         System.out.println("send unsubscribe");
         // wait until connected
         subscribeLatch.await();
         // now unsubscribe
-        s.dispose();
+        observer.dispose();
         System.out.println("DONE sending unsubscribe ... now waiting");
         if (!unsubscribeLatch.await(3000, TimeUnit.MILLISECONDS)) {
-            System.out.println("Errors: " + s.errors());
-            if (s.errors().size() > 0) {
-                s.errors().get(0).printStackTrace();
+            System.out.println("Errors: " + observer.errors());
+            if (observer.errors().size() > 0) {
+                observer.errors().get(0).printStackTrace();
             }
             fail("timed out waiting for unsubscribe");
         }
-        s.assertNoErrors();
+        observer.assertNoErrors();
     }
 
     @Test
@@ -277,12 +277,12 @@ public class ObservableRefCountTest {
                     }
                 });
 
-        TestObserver<Long> s = new TestObserver<Long>();
+        TestObserver<Long> observer = new TestObserver<Long>();
 
-        o.publish().refCount().subscribeOn(Schedulers.computation()).subscribe(s);
+        o.publish().refCount().subscribeOn(Schedulers.computation()).subscribe(observer);
         System.out.println("send unsubscribe");
         // now immediately unsubscribe while subscribeOn is racing to subscribe
-        s.dispose();
+        observer.dispose();
 
         // this generally will mean it won't even subscribe as it is already unsubscribed by the time connect() gets scheduled
         // give time to the counter to update
@@ -297,11 +297,11 @@ public class ObservableRefCountTest {
         assertEquals(0, subUnsubCount.get());
 
         System.out.println("DONE sending unsubscribe ... now waiting");
-        System.out.println("Errors: " + s.errors());
-        if (s.errors().size() > 0) {
-            s.errors().get(0).printStackTrace();
+        System.out.println("Errors: " + observer.errors());
+        if (observer.errors().size() > 0) {
+            observer.errors().get(0).printStackTrace();
         }
-        s.assertNoErrors();
+        observer.assertNoErrors();
     }
 
     private Observable<Long> synchronousInterval() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -1497,8 +1497,8 @@ public class ObservableReplayTest {
 
         new Observable<Integer>() {
             @Override
-            protected void subscribeActual(Observer<? super Integer> s) {
-                sub[0] = s;
+            protected void subscribeActual(Observer<? super Integer> observer) {
+                sub[0] = observer;
             }
         }
         .replay()

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
@@ -634,8 +634,7 @@ public class ObservableRetryTest {
     @Test(timeout = 10000)
     public void testTimeoutWithRetry() {
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<Long> observer = mock(DefaultObserver.class);
+        Observer<Long> observer = TestHelper.mockObserver();
 
         // Observable that sends every 100ms (timeout fails instead)
         SlowObservable so = new SlowObservable(100, 10);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
@@ -426,9 +426,9 @@ public class ObservableRetryTest {
         final AtomicInteger subsCount = new AtomicInteger(0);
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> s) {
+            public void subscribe(Observer<? super String> observer) {
                 subsCount.incrementAndGet();
-                s.onSubscribe(Disposables.fromRunnable(new Runnable() {
+                observer.onSubscribe(Disposables.fromRunnable(new Runnable() {
                     @Override
                     public void run() {
                             subsCount.decrementAndGet();
@@ -455,13 +455,13 @@ public class ObservableRetryTest {
 
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> s) {
+            public void subscribe(Observer<? super String> observer) {
                 BooleanSubscription bs = new BooleanSubscription();
                 // if isUnsubscribed is true that means we have a bug such as
                 // https://github.com/ReactiveX/RxJava/issues/1024
                 if (!bs.isCancelled()) {
                     subsCount.incrementAndGet();
-                    s.onError(new RuntimeException("failed"));
+                    observer.onError(new RuntimeException("failed"));
                     // it unsubscribes the child directly
                     // this simulates various error/completion scenarios that could occur
                     // or just a source that proactively triggers cleanup
@@ -469,7 +469,7 @@ public class ObservableRetryTest {
 //                    s.unsubscribe();
                     bs.cancel();
                 } else {
-                    s.onError(new RuntimeException());
+                    observer.onError(new RuntimeException());
                 }
             }
         };
@@ -486,10 +486,10 @@ public class ObservableRetryTest {
 
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> s) {
-                s.onSubscribe(Disposables.empty());
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
                 subsCount.incrementAndGet();
-                s.onError(new RuntimeException("failed"));
+                observer.onError(new RuntimeException("failed"));
             }
         };
 
@@ -505,10 +505,10 @@ public class ObservableRetryTest {
 
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> s) {
-                s.onSubscribe(Disposables.empty());
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
                 subsCount.incrementAndGet();
-                s.onError(new RuntimeException("failed"));
+                observer.onError(new RuntimeException("failed"));
             }
         };
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -89,8 +89,7 @@ public class ObservableRetryWithPredicateTest {
             }
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o = mock(DefaultObserver.class);
+        Observer<Integer> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
         source.retry(retryTwice).subscribe(o);
@@ -117,8 +116,7 @@ public class ObservableRetryWithPredicateTest {
             }
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o = mock(DefaultObserver.class);
+        Observer<Integer> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
         source.retry(retryTwice).subscribe(o);
@@ -153,8 +151,7 @@ public class ObservableRetryWithPredicateTest {
             }
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o = mock(DefaultObserver.class);
+        Observer<Integer> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
         source.retry(retryOnTestException).subscribe(o);
@@ -190,8 +187,7 @@ public class ObservableRetryWithPredicateTest {
             }
         });
 
-        @SuppressWarnings("unchecked")
-        DefaultObserver<Integer> o = mock(DefaultObserver.class);
+        Observer<Integer> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
         source.retry(retryOnTestException).subscribe(o);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableScalarXMapTest.java
@@ -35,8 +35,8 @@ public class ObservableScalarXMapTest {
 
     static final class CallablePublisher implements ObservableSource<Integer>, Callable<Integer> {
         @Override
-        public void subscribe(Observer<? super Integer> s) {
-            EmptyDisposable.error(new TestException(), s);
+        public void subscribe(Observer<? super Integer> observer) {
+            EmptyDisposable.error(new TestException(), observer);
         }
 
         @Override
@@ -47,8 +47,8 @@ public class ObservableScalarXMapTest {
 
     static final class EmptyCallablePublisher implements ObservableSource<Integer>, Callable<Integer> {
         @Override
-        public void subscribe(Observer<? super Integer> s) {
-            EmptyDisposable.complete(s);
+        public void subscribe(Observer<? super Integer> observer) {
+            EmptyDisposable.complete(observer);
         }
 
         @Override
@@ -59,9 +59,9 @@ public class ObservableScalarXMapTest {
 
     static final class OneCallablePublisher implements ObservableSource<Integer>, Callable<Integer> {
         @Override
-        public void subscribe(Observer<? super Integer> s) {
-            ScalarDisposable<Integer> sd = new ScalarDisposable<Integer>(s, 1);
-            s.onSubscribe(sd);
+        public void subscribe(Observer<? super Integer> observer) {
+            ScalarDisposable<Integer> sd = new ScalarDisposable<Integer>(observer, 1);
+            observer.onSubscribe(sd);
             sd.run();
         }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSequenceEqualTest.java
@@ -150,9 +150,9 @@ public class ObservableSequenceEqualTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    private void verifyError(Single<Boolean> observable) {
+    private void verifyError(Single<Boolean> single) {
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
         inOrder.verify(observer, times(1)).onError(isA(TestException.class));

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSubscribeOnTest.java
@@ -78,7 +78,7 @@ public class ObservableSubscribeOnTest {
         Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(Observer<? super String> s) {
+            public void subscribe(Observer<? super String> observer) {
                 throw new RuntimeException("fail");
             }
 
@@ -93,9 +93,9 @@ public class ObservableSubscribeOnTest {
         Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(Observer<? super String> s) {
-                s.onSubscribe(Disposables.empty());
-                s.onError(new RuntimeException("fail"));
+            public void subscribe(Observer<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onError(new RuntimeException("fail"));
             }
 
         }).subscribeOn(Schedulers.computation()).subscribe(to);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
@@ -664,9 +664,9 @@ public class ObservableSwitchTest {
             public SingleSource<Integer> apply(Object v) throws Exception {
                 return new SingleSource<Integer>() {
                     @Override
-                    public void subscribe(SingleObserver<? super Integer> s) {
-                        s.onSubscribe(Disposables.empty());
-                        s.onSuccess(1);
+                    public void subscribe(SingleObserver<? super Integer> observer) {
+                        observer.onSubscribe(Disposables.empty());
+                        observer.onSuccess(1);
                     }
                 };
             }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastOneTest.java
@@ -28,33 +28,33 @@ public class ObservableTakeLastOneTest {
 
     @Test
     public void testLastOfManyReturnsLast() {
-        TestObserver<Integer> s = new TestObserver<Integer>();
-        Observable.range(1, 10).takeLast(1).subscribe(s);
-        s.assertValue(10);
-        s.assertNoErrors();
-        s.assertTerminated();
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Observable.range(1, 10).takeLast(1).subscribe(to);
+        to.assertValue(10);
+        to.assertNoErrors();
+        to.assertTerminated();
         // NO longer assertable
 //        s.assertUnsubscribed();
     }
 
     @Test
     public void testLastOfEmptyReturnsEmpty() {
-        TestObserver<Object> s = new TestObserver<Object>();
-        Observable.empty().takeLast(1).subscribe(s);
-        s.assertNoValues();
-        s.assertNoErrors();
-        s.assertTerminated();
+        TestObserver<Object> to = new TestObserver<Object>();
+        Observable.empty().takeLast(1).subscribe(to);
+        to.assertNoValues();
+        to.assertNoErrors();
+        to.assertTerminated();
         // NO longer assertable
 //      s.assertUnsubscribed();
     }
 
     @Test
     public void testLastOfOneReturnsLast() {
-        TestObserver<Integer> s = new TestObserver<Integer>();
-        Observable.just(1).takeLast(1).subscribe(s);
-        s.assertValue(1);
-        s.assertNoErrors();
-        s.assertTerminated();
+        TestObserver<Integer> to = new TestObserver<Integer>();
+        Observable.just(1).takeLast(1).subscribe(to);
+        to.assertValue(1);
+        to.assertNoErrors();
+        to.assertTerminated();
         // NO longer assertable
 //      s.assertUnsubscribed();
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeTest.java
@@ -208,13 +208,13 @@ public class ObservableTakeTest {
         Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
-            public void subscribe(Observer<? super Integer> s) {
+            public void subscribe(Observer<? super Integer> observer) {
                 Disposable bs = Disposables.empty();
-                s.onSubscribe(bs);
+                observer.onSubscribe(bs);
                 for (int i = 0; !bs.isDisposed(); i++) {
                     System.out.println("Emit: " + i);
                     count.incrementAndGet();
-                    s.onNext(i);
+                    observer.onNext(i);
                 }
             }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -562,9 +562,9 @@ public class ObservableTimeoutWithSelectorTest {
 
                     @Override
                     protected void subscribeActual(
-                            Observer<? super Integer> s) {
-                        s.onSubscribe(Disposables.empty());
-                        sub[count++] = s;
+                            Observer<? super Integer> observer) {
+                        observer.onSubscribe(Disposables.empty());
+                        sub[count++] = observer;
                     }
                 };
 
@@ -616,10 +616,10 @@ public class ObservableTimeoutWithSelectorTest {
 
                     @Override
                     protected void subscribeActual(
-                            Observer<? super Integer> s) {
-                        assertFalse(((Disposable)s).isDisposed());
-                        s.onSubscribe(Disposables.empty());
-                        sub[count++] = s;
+                            Observer<? super Integer> observer) {
+                        assertFalse(((Disposable)observer).isDisposed());
+                        observer.onSubscribe(Disposables.empty());
+                        sub[count++] = observer;
                     }
                 };
 
@@ -671,10 +671,10 @@ public class ObservableTimeoutWithSelectorTest {
 
                     @Override
                     protected void subscribeActual(
-                            Observer<? super Integer> s) {
-                        assertFalse(((Disposable)s).isDisposed());
-                        s.onSubscribe(Disposables.empty());
-                        sub[count++] = s;
+                            Observer<? super Integer> observer) {
+                        assertFalse(((Disposable)observer).isDisposed());
+                        observer.onSubscribe(Disposables.empty());
+                        sub[count++] = observer;
                     }
                 };
 
@@ -726,10 +726,10 @@ public class ObservableTimeoutWithSelectorTest {
 
                     @Override
                     protected void subscribeActual(
-                            Observer<? super Integer> s) {
-                        assertFalse(((Disposable)s).isDisposed());
-                        s.onSubscribe(Disposables.empty());
-                        sub[count++] = s;
+                            Observer<? super Integer> observer) {
+                        assertFalse(((Disposable)observer).isDisposed());
+                        observer.onSubscribe(Disposables.empty());
+                        sub[count++] = observer;
                     }
                 };
 
@@ -779,10 +779,10 @@ public class ObservableTimeoutWithSelectorTest {
 
                     @Override
                     protected void subscribeActual(
-                            Observer<? super Integer> s) {
-                        assertFalse(((Disposable)s).isDisposed());
-                        s.onSubscribe(Disposables.empty());
-                        sub[count++] = s;
+                            Observer<? super Integer> observer) {
+                        assertFalse(((Disposable)observer).isDisposed());
+                        observer.onSubscribe(Disposables.empty());
+                        sub[count++] = observer;
                     }
                 };
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
@@ -109,10 +109,10 @@ public class ObservableToListTest {
     @Test
     public void testList() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
-        Single<List<String>> observable = w.toList();
+        Single<List<String>> single = w.toList();
 
         SingleObserver<List<String>> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
         verify(observer, times(1)).onSuccess(Arrays.asList("one", "two", "three"));
         verify(observer, Mockito.never()).onError(any(Throwable.class));
     }
@@ -120,10 +120,10 @@ public class ObservableToListTest {
     @Test
     public void testListViaObservable() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
-        Single<List<String>> observable = w.toList();
+        Single<List<String>> single = w.toList();
 
         SingleObserver<List<String>> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
         verify(observer, times(1)).onSuccess(Arrays.asList("one", "two", "three"));
         verify(observer, Mockito.never()).onError(any(Throwable.class));
     }
@@ -131,13 +131,13 @@ public class ObservableToListTest {
     @Test
     public void testListMultipleSubscribers() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", "two", "three"));
-        Single<List<String>> observable = w.toList();
+        Single<List<String>> single = w.toList();
 
         SingleObserver<List<String>> o1 = TestHelper.mockSingleObserver();
-        observable.subscribe(o1);
+        single.subscribe(o1);
 
         SingleObserver<List<String>> o2 = TestHelper.mockSingleObserver();
-        observable.subscribe(o2);
+        single.subscribe(o2);
 
         List<String> expected = Arrays.asList("one", "two", "three");
 
@@ -152,10 +152,10 @@ public class ObservableToListTest {
     @Ignore("Null values are not allowed")
     public void testListWithNullValue() {
         Observable<String> w = Observable.fromIterable(Arrays.asList("one", null, "three"));
-        Single<List<String>> observable = w.toList();
+        Single<List<String>> single = w.toList();
 
         SingleObserver<List<String>> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
         verify(observer, times(1)).onSuccess(Arrays.asList("one", null, "three"));
         verify(observer, Mockito.never()).onError(any(Throwable.class));
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToSortedListTest.java
@@ -119,10 +119,10 @@ public class ObservableToSortedListTest {
     @Test
     public void testSortedList() {
         Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);
-        Single<List<Integer>> observable = w.toSortedList();
+        Single<List<Integer>> single = w.toSortedList();
 
         SingleObserver<List<Integer>> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
         verify(observer, times(1)).onSuccess(Arrays.asList(1, 2, 3, 4, 5));
         verify(observer, Mockito.never()).onError(any(Throwable.class));
     }
@@ -130,7 +130,7 @@ public class ObservableToSortedListTest {
     @Test
     public void testSortedListWithCustomFunction() {
         Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);
-        Single<List<Integer>> observable = w.toSortedList(new Comparator<Integer>() {
+        Single<List<Integer>> single = w.toSortedList(new Comparator<Integer>() {
 
             @Override
             public int compare(Integer t1, Integer t2) {
@@ -140,7 +140,7 @@ public class ObservableToSortedListTest {
         });
 
         SingleObserver<List<Integer>> observer = TestHelper.mockSingleObserver();
-        observable.subscribe(observer);
+        single.subscribe(observer);
         verify(observer, times(1)).onSuccess(Arrays.asList(5, 4, 3, 2, 1));
         verify(observer, Mockito.never()).onError(any(Throwable.class));
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -208,13 +208,13 @@ public class ObservableWindowWithSizeTest {
     public static Observable<Integer> hotStream() {
         return Observable.unsafeCreate(new ObservableSource<Integer>() {
             @Override
-            public void subscribe(Observer<? super Integer> s) {
+            public void subscribe(Observer<? super Integer> observer) {
                 Disposable d = Disposables.empty();
-                s.onSubscribe(d);
+                observer.onSubscribe(d);
                 while (!d.isDisposed()) {
                     // burst some number of items
                     for (int i = 0; i < Math.random() * 20; i++) {
-                        s.onNext(i);
+                        observer.onNext(i);
                     }
                     try {
                         // sleep for a random amount of time

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -404,11 +404,11 @@ public class ObservableWindowWithStartEndObservableTest {
                     return new Observable<Integer>() {
                         @Override
                         protected void subscribeActual(
-                                Observer<? super Integer> s) {
-                            s.onSubscribe(Disposables.empty());
-                            s.onNext(1);
-                            s.onNext(2);
-                            s.onError(new TestException());
+                                Observer<? super Integer> observer) {
+                            observer.onSubscribe(Disposables.empty());
+                            observer.onNext(1);
+                            observer.onNext(2);
+                            observer.onError(new TestException());
                         }
                     };
                 }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
@@ -213,10 +213,10 @@ public class SingleDelayTest {
             Single.just(1)
             .delaySubscription(new Observable<Integer>() {
                 @Override
-                protected void subscribeActual(Observer<? super Integer> s) {
-                    s.onSubscribe(Disposables.empty());
-                    s.onNext(1);
-                    s.onError(new TestException());
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposables.empty());
+                    observer.onNext(1);
+                    observer.onError(new TestException());
                 }
             })
             .test()

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
@@ -336,10 +336,10 @@ public class SingleDoOnTest {
 
             new Single<Integer>() {
                 @Override
-                protected void subscribeActual(SingleObserver<? super Integer> s) {
-                    s.onSubscribe(bs);
-                    s.onError(new TestException("Second"));
-                    s.onSuccess(1);
+                protected void subscribeActual(SingleObserver<? super Integer> observer) {
+                    observer.onSubscribe(bs);
+                    observer.onError(new TestException("Second"));
+                    observer.onSuccess(1);
                 }
             }
             .doOnSubscribe(new Consumer<Disposable>() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleLiftTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleLiftTest.java
@@ -25,22 +25,22 @@ public class SingleLiftTest {
 
         Single.just(1).lift(new SingleOperator<Integer, Integer>() {
             @Override
-            public SingleObserver<Integer> apply(final SingleObserver<? super Integer> s) throws Exception {
+            public SingleObserver<Integer> apply(final SingleObserver<? super Integer> observer) throws Exception {
                 return new SingleObserver<Integer>() {
 
                     @Override
                     public void onSubscribe(Disposable d) {
-                        s.onSubscribe(d);
+                        observer.onSubscribe(d);
                     }
 
                     @Override
                     public void onSuccess(Integer value) {
-                        s.onSuccess(value + 1);
+                        observer.onSuccess(value + 1);
                     }
 
                     @Override
                     public void onError(Throwable e) {
-                        s.onError(e);
+                        observer.onError(e);
                     }
                 };
             }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
@@ -55,9 +55,9 @@ public class SingleMiscTest {
 
         Single.wrap(new SingleSource<Object>() {
             @Override
-            public void subscribe(SingleObserver<? super Object> s) {
-                s.onSubscribe(Disposables.empty());
-                s.onSuccess(1);
+            public void subscribe(SingleObserver<? super Object> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onSuccess(1);
             }
         })
         .test()

--- a/src/test/java/io/reactivex/internal/subscribers/BoundedSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/BoundedSubscriberTest.java
@@ -42,7 +42,7 @@ public class BoundedSubscriberTest {
     public void onSubscribeThrows() {
         final List<Object> received = new ArrayList<Object>();
 
-        BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
             @Override
             public void accept(Object o) throws Exception {
                 received.add(o);
@@ -64,21 +64,21 @@ public class BoundedSubscriberTest {
             }
         }, 128);
 
-        assertFalse(o.isDisposed());
+        assertFalse(subscriber.isDisposed());
 
-        Flowable.just(1).subscribe(o);
+        Flowable.just(1).subscribe(subscriber);
 
         assertTrue(received.toString(), received.get(0) instanceof TestException);
         assertEquals(received.toString(), 1, received.size());
 
-        assertTrue(o.isDisposed());
+        assertTrue(subscriber.isDisposed());
     }
 
     @Test
     public void onNextThrows() {
         final List<Object> received = new ArrayList<Object>();
 
-        BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
             @Override
             public void accept(Object o) throws Exception {
                 throw new TestException();
@@ -100,14 +100,14 @@ public class BoundedSubscriberTest {
             }
         }, 128);
 
-        assertFalse(o.isDisposed());
+        assertFalse(subscriber.isDisposed());
 
-        Flowable.just(1).subscribe(o);
+        Flowable.just(1).subscribe(subscriber);
 
         assertTrue(received.toString(), received.get(0) instanceof TestException);
         assertEquals(received.toString(), 1, received.size());
 
-        assertTrue(o.isDisposed());
+        assertTrue(subscriber.isDisposed());
     }
 
     @Test
@@ -117,7 +117,7 @@ public class BoundedSubscriberTest {
         try {
             final List<Object> received = new ArrayList<Object>();
 
-            BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+            BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
                 @Override
                 public void accept(Object o) throws Exception {
                     received.add(o);
@@ -139,13 +139,13 @@ public class BoundedSubscriberTest {
                 }
             }, 128);
 
-            assertFalse(o.isDisposed());
+            assertFalse(subscriber.isDisposed());
 
-            Flowable.<Integer>error(new TestException("Outer")).subscribe(o);
+            Flowable.<Integer>error(new TestException("Outer")).subscribe(subscriber);
 
             assertTrue(received.toString(), received.isEmpty());
 
-            assertTrue(o.isDisposed());
+            assertTrue(subscriber.isDisposed());
 
             TestHelper.assertError(errors, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(errors.get(0));
@@ -163,7 +163,7 @@ public class BoundedSubscriberTest {
         try {
             final List<Object> received = new ArrayList<Object>();
 
-            BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+            BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
                 @Override
                 public void accept(Object o) throws Exception {
                     received.add(o);
@@ -185,13 +185,13 @@ public class BoundedSubscriberTest {
                 }
             }, 128);
 
-            assertFalse(o.isDisposed());
+            assertFalse(subscriber.isDisposed());
 
-            Flowable.<Integer>empty().subscribe(o);
+            Flowable.<Integer>empty().subscribe(subscriber);
 
             assertTrue(received.toString(), received.isEmpty());
 
-            assertTrue(o.isDisposed());
+            assertTrue(subscriber.isDisposed());
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
@@ -294,7 +294,7 @@ public class BoundedSubscriberTest {
 
         final List<Object> received = new ArrayList<Object>();
 
-        BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 received.add(v);
@@ -316,7 +316,7 @@ public class BoundedSubscriberTest {
             }
         }, 128);
 
-        source.subscribe(o);
+        source.subscribe(subscriber);
 
         assertEquals(Arrays.asList(1, 100), received);
     }
@@ -339,7 +339,7 @@ public class BoundedSubscriberTest {
 
         final List<Object> received = new ArrayList<Object>();
 
-        BoundedSubscriber<Object> o = new BoundedSubscriber<Object>(new Consumer<Object>() {
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 received.add(v);
@@ -361,28 +361,28 @@ public class BoundedSubscriberTest {
             }
         }, 128);
 
-        source.subscribe(o);
+        source.subscribe(subscriber);
 
         assertEquals(Arrays.asList(1, 100), received);
     }
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        BoundedSubscriber<Integer> o = new BoundedSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+        BoundedSubscriber<Integer> subscriber = new BoundedSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING,
                 Functions.EMPTY_ACTION,
                 Functions.<Subscription>boundedConsumer(128), 128);
 
-        assertFalse(o.hasCustomOnError());
+        assertFalse(subscriber.hasCustomOnError());
     }
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        BoundedSubscriber<Integer> o = new BoundedSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+        BoundedSubscriber<Integer> subscriber = new BoundedSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION,
                 Functions.<Subscription>boundedConsumer(128), 128);
 
-        assertTrue(o.hasCustomOnError());
+        assertTrue(subscriber.hasCustomOnError());
     }
 }

--- a/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
@@ -34,7 +34,7 @@ public class LambdaSubscriberTest {
     public void onSubscribeThrows() {
         final List<Object> received = new ArrayList<Object>();
 
-        LambdaSubscriber<Object> o = new LambdaSubscriber<Object>(new Consumer<Object>() {
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 received.add(v);
@@ -57,21 +57,21 @@ public class LambdaSubscriberTest {
             }
         });
 
-        assertFalse(o.isDisposed());
+        assertFalse(subscriber.isDisposed());
 
-        Flowable.just(1).subscribe(o);
+        Flowable.just(1).subscribe(subscriber);
 
         assertTrue(received.toString(), received.get(0) instanceof TestException);
         assertEquals(received.toString(), 1, received.size());
 
-        assertTrue(o.isDisposed());
+        assertTrue(subscriber.isDisposed());
     }
 
     @Test
     public void onNextThrows() {
         final List<Object> received = new ArrayList<Object>();
 
-        LambdaSubscriber<Object> o = new LambdaSubscriber<Object>(new Consumer<Object>() {
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 throw new TestException();
@@ -94,14 +94,14 @@ public class LambdaSubscriberTest {
             }
         });
 
-        assertFalse(o.isDisposed());
+        assertFalse(subscriber.isDisposed());
 
-        Flowable.just(1).subscribe(o);
+        Flowable.just(1).subscribe(subscriber);
 
         assertTrue(received.toString(), received.get(0) instanceof TestException);
         assertEquals(received.toString(), 1, received.size());
 
-        assertTrue(o.isDisposed());
+        assertTrue(subscriber.isDisposed());
     }
 
     @Test
@@ -111,7 +111,7 @@ public class LambdaSubscriberTest {
         try {
             final List<Object> received = new ArrayList<Object>();
 
-            LambdaSubscriber<Object> o = new LambdaSubscriber<Object>(new Consumer<Object>() {
+            LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
                 @Override
                 public void accept(Object v) throws Exception {
                     received.add(v);
@@ -134,13 +134,13 @@ public class LambdaSubscriberTest {
                 }
             });
 
-            assertFalse(o.isDisposed());
+            assertFalse(subscriber.isDisposed());
 
-            Flowable.<Integer>error(new TestException("Outer")).subscribe(o);
+            Flowable.<Integer>error(new TestException("Outer")).subscribe(subscriber);
 
             assertTrue(received.toString(), received.isEmpty());
 
-            assertTrue(o.isDisposed());
+            assertTrue(subscriber.isDisposed());
 
             TestHelper.assertError(errors, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(errors.get(0));
@@ -158,7 +158,7 @@ public class LambdaSubscriberTest {
         try {
             final List<Object> received = new ArrayList<Object>();
 
-            LambdaSubscriber<Object> o = new LambdaSubscriber<Object>(new Consumer<Object>() {
+            LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
                 @Override
                 public void accept(Object v) throws Exception {
                     received.add(v);
@@ -181,13 +181,13 @@ public class LambdaSubscriberTest {
                 }
             });
 
-            assertFalse(o.isDisposed());
+            assertFalse(subscriber.isDisposed());
 
-            Flowable.<Integer>empty().subscribe(o);
+            Flowable.<Integer>empty().subscribe(subscriber);
 
             assertTrue(received.toString(), received.isEmpty());
 
-            assertTrue(o.isDisposed());
+            assertTrue(subscriber.isDisposed());
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
@@ -215,7 +215,7 @@ public class LambdaSubscriberTest {
 
         final List<Object> received = new ArrayList<Object>();
 
-        LambdaSubscriber<Object> o = new LambdaSubscriber<Object>(new Consumer<Object>() {
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 received.add(v);
@@ -238,7 +238,7 @@ public class LambdaSubscriberTest {
             }
         });
 
-        source.subscribe(o);
+        source.subscribe(subscriber);
 
         assertEquals(Arrays.asList(1, 100), received);
     }
@@ -260,7 +260,7 @@ public class LambdaSubscriberTest {
 
         final List<Object> received = new ArrayList<Object>();
 
-        LambdaSubscriber<Object> o = new LambdaSubscriber<Object>(new Consumer<Object>() {
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 received.add(v);
@@ -283,7 +283,7 @@ public class LambdaSubscriberTest {
             }
         });
 
-        source.subscribe(o);
+        source.subscribe(subscriber);
 
         assertEquals(Arrays.asList(1, 100), received);
     }
@@ -351,21 +351,21 @@ public class LambdaSubscriberTest {
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        LambdaSubscriber<Integer> o = new LambdaSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+        LambdaSubscriber<Integer> subscriber = new LambdaSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING,
                 Functions.EMPTY_ACTION,
                 FlowableInternalHelper.RequestMax.INSTANCE);
 
-        assertFalse(o.hasCustomOnError());
+        assertFalse(subscriber.hasCustomOnError());
     }
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        LambdaSubscriber<Integer> o = new LambdaSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+        LambdaSubscriber<Integer> subscriber = new LambdaSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION,
                 FlowableInternalHelper.RequestMax.INSTANCE);
 
-        assertTrue(o.hasCustomOnError());
+        assertTrue(subscriber.hasCustomOnError());
     }
 }

--- a/src/test/java/io/reactivex/internal/subscribers/SubscriberResourceWrapperTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/SubscriberResourceWrapperTest.java
@@ -88,8 +88,8 @@ public class SubscriberResourceWrapperTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
-            public Flowable<Object> apply(Flowable<Object> o) throws Exception {
-                return o.lift(new FlowableOperator<Object, Object>() {
+            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
+                return f.lift(new FlowableOperator<Object, Object>() {
                     @Override
                     public Subscriber<? super Object> apply(
                             Subscriber<? super Object> s) throws Exception {

--- a/src/test/java/io/reactivex/internal/util/HalfSerializerObserverTest.java
+++ b/src/test/java/io/reactivex/internal/util/HalfSerializerObserverTest.java
@@ -36,7 +36,7 @@ public class HalfSerializerObserverTest {
 
         final TestObserver ts = new TestObserver();
 
-        Observer s = new Observer() {
+        Observer observer = new Observer() {
             @Override
             public void onSubscribe(Disposable s) {
                 ts.onSubscribe(s);
@@ -61,11 +61,11 @@ public class HalfSerializerObserverTest {
             }
         };
 
-        a[0] = s;
+        a[0] = observer;
 
-        s.onSubscribe(Disposables.empty());
+        observer.onSubscribe(Disposables.empty());
 
-        HalfSerializer.onNext(s, 1, wip, error);
+        HalfSerializer.onNext(observer, 1, wip, error);
 
         ts.assertValue(1).assertNoErrors().assertNotComplete();
     }
@@ -80,7 +80,7 @@ public class HalfSerializerObserverTest {
 
         final TestObserver ts = new TestObserver();
 
-        Observer s = new Observer() {
+        Observer observer = new Observer() {
             @Override
             public void onSubscribe(Disposable s) {
                 ts.onSubscribe(s);
@@ -105,11 +105,11 @@ public class HalfSerializerObserverTest {
             }
         };
 
-        a[0] = s;
+        a[0] = observer;
 
-        s.onSubscribe(Disposables.empty());
+        observer.onSubscribe(Disposables.empty());
 
-        HalfSerializer.onNext(s, 1, wip, error);
+        HalfSerializer.onNext(observer, 1, wip, error);
 
         ts.assertFailure(TestException.class, 1);
     }
@@ -124,7 +124,7 @@ public class HalfSerializerObserverTest {
 
         final TestObserver ts = new TestObserver();
 
-        Observer s = new Observer() {
+        Observer observer = new Observer() {
             @Override
             public void onSubscribe(Disposable s) {
                 ts.onSubscribe(s);
@@ -149,11 +149,11 @@ public class HalfSerializerObserverTest {
             }
         };
 
-        a[0] = s;
+        a[0] = observer;
 
-        s.onSubscribe(Disposables.empty());
+        observer.onSubscribe(Disposables.empty());
 
-        HalfSerializer.onNext(s, 1, wip, error);
+        HalfSerializer.onNext(observer, 1, wip, error);
 
         ts.assertResult(1);
     }
@@ -168,7 +168,7 @@ public class HalfSerializerObserverTest {
 
         final TestObserver ts = new TestObserver();
 
-        Observer s = new Observer() {
+        Observer observer = new Observer() {
             @Override
             public void onSubscribe(Disposable s) {
                 ts.onSubscribe(s);
@@ -191,11 +191,11 @@ public class HalfSerializerObserverTest {
             }
         };
 
-        a[0] = s;
+        a[0] = observer;
 
-        s.onSubscribe(Disposables.empty());
+        observer.onSubscribe(Disposables.empty());
 
-        HalfSerializer.onError(s, new TestException(), wip, error);
+        HalfSerializer.onError(observer, new TestException(), wip, error);
 
         ts.assertFailure(TestException.class);
     }

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -1002,7 +1002,7 @@ public class MaybeTest {
         try {
             Maybe.unsafeCreate(new MaybeSource<Object>() {
                 @Override
-                public void subscribe(MaybeObserver<? super Object> s) {
+                public void subscribe(MaybeObserver<? super Object> observer) {
                     throw new NullPointerException("Forced failure");
                 }
             }).test();
@@ -1019,7 +1019,7 @@ public class MaybeTest {
         try {
             Maybe.unsafeCreate(new MaybeSource<Object>() {
                 @Override
-                public void subscribe(MaybeObserver<? super Object> s) {
+                public void subscribe(MaybeObserver<? super Object> observer) {
                     throw new IllegalArgumentException("Forced failure");
                 }
             }).test();

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1662,7 +1662,7 @@ public class ObservableNullTests {
     public void liftReturnsNull() {
         just1.lift(new ObservableOperator<Object, Integer>() {
             @Override
-            public Observer<? super Integer> apply(Observer<? super Object> s) {
+            public Observer<? super Integer> apply(Observer<? super Object> observer) {
                 return null;
             }
         }).blockingSubscribe();

--- a/src/test/java/io/reactivex/observable/ObservableSubscriberTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableSubscriberTest.java
@@ -215,7 +215,7 @@ public class ObservableSubscriberTest {
 
     static final class BadObservable extends Observable<Integer> {
         @Override
-        protected void subscribeActual(Observer<? super Integer> s) {
+        protected void subscribeActual(Observer<? super Integer> observer) {
             throw new IllegalArgumentException();
         }
     }

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -346,7 +346,7 @@ public class ObservableTest {
         final RuntimeException re = new RuntimeException("bad impl");
         Observable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
-            public void subscribe(Observer<? super String> s) { throw re; }
+            public void subscribe(Observer<? super String> observer) { throw re; }
         });
 
         o.subscribe(observer);
@@ -1151,16 +1151,16 @@ public class ObservableTest {
 
     @Test
     public void testExtend() {
-        final TestObserver<Object> subscriber = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<Object>();
         final Object value = new Object();
         Object returned = Observable.just(value).to(new Function<Observable<Object>, Object>() {
             @Override
             public Object apply(Observable<Object> onSubscribe) {
-                    onSubscribe.subscribe(subscriber);
-                    subscriber.assertNoErrors();
-                    subscriber.assertComplete();
-                    subscriber.assertValue(value);
-                    return subscriber.values().get(0);
+                    onSubscribe.subscribe(to);
+                    to.assertNoErrors();
+                    to.assertComplete();
+                    to.assertValue(value);
+                    return to.values().get(0);
                 }
         });
         assertSame(returned, value);
@@ -1168,16 +1168,16 @@ public class ObservableTest {
 
     @Test
     public void testAsExtend() {
-        final TestObserver<Object> subscriber = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<Object>();
         final Object value = new Object();
         Object returned = Observable.just(value).as(new ObservableConverter<Object, Object>() {
             @Override
             public Object apply(Observable<Object> onSubscribe) {
-                onSubscribe.subscribe(subscriber);
-                subscriber.assertNoErrors();
-                subscriber.assertComplete();
-                subscriber.assertValue(value);
-                return subscriber.values().get(0);
+                onSubscribe.subscribe(to);
+                to.assertNoErrors();
+                to.assertComplete();
+                to.assertValue(value);
+                return to.values().get(0);
             }
         });
         assertSame(returned, value);

--- a/src/test/java/io/reactivex/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SafeObserverTest.java
@@ -447,7 +447,7 @@ public class SafeObserverTest {
     @Ignore("Observers can't throw")
     public void testOnCompletedThrows() {
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
-        SafeObserver<Integer> s = new SafeObserver<Integer>(new DefaultObserver<Integer>() {
+        SafeObserver<Integer> observer = new SafeObserver<Integer>(new DefaultObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
 
@@ -463,7 +463,7 @@ public class SafeObserverTest {
         });
 
         try {
-            s.onComplete();
+            observer.onComplete();
             Assert.fail();
         } catch (RuntimeException e) {
            assertNull(error.get());
@@ -483,9 +483,9 @@ public class SafeObserverTest {
             public void onComplete() {
             }
         };
-        SafeObserver<Integer> s = new SafeObserver<Integer>(actual);
+        SafeObserver<Integer> observer = new SafeObserver<Integer>(actual);
 
-        assertSame(actual, s.actual);
+        assertSame(actual, observer.actual);
     }
 
     @Test

--- a/src/test/java/io/reactivex/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SerializedObserverTest.java
@@ -435,11 +435,11 @@ public class SerializedObserverTest {
         return Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
-            public void subscribe(Observer<? super String> s) {
+            public void subscribe(Observer<? super String> observer) {
                 Disposable bs = Disposables.empty();
-                s.onSubscribe(bs);
+                observer.onSubscribe(bs);
                 while (!bs.isDisposed()) {
-                    s.onNext("onNext");
+                    observer.onNext("onNext");
                     produced.incrementAndGet();
                 }
             }

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -48,68 +48,68 @@ public class TestObserverTest {
     @Test
     public void testAssert() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        oi.subscribe(o);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        oi.subscribe(subscriber);
 
-        o.assertValues(1, 2);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        subscriber.assertValues(1, 2);
+        subscriber.assertValueCount(2);
+        subscriber.assertTerminated();
     }
 
     @Test
     public void testAssertNotMatchCount() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        oi.subscribe(o);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        oi.subscribe(subscriber);
 
         thrown.expect(AssertionError.class);
         // FIXME different message format
 //        thrown.expectMessage("Number of items does not match. Provided: 1  Actual: 2");
 
-        o.assertValue(1);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        subscriber.assertValue(1);
+        subscriber.assertValueCount(2);
+        subscriber.assertTerminated();
     }
 
     @Test
     public void testAssertNotMatchValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        oi.subscribe(o);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        oi.subscribe(subscriber);
 
         thrown.expect(AssertionError.class);
         // FIXME different message format
 //        thrown.expectMessage("Value at index: 1 expected to be [3] (Integer) but was: [2] (Integer)");
 
-        o.assertValues(1, 3);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        subscriber.assertValues(1, 3);
+        subscriber.assertValueCount(2);
+        subscriber.assertTerminated();
     }
 
     @Test
     public void assertNeverAtNotMatchingValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        oi.subscribe(o);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        oi.subscribe(subscriber);
 
-        o.assertNever(3);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        subscriber.assertNever(3);
+        subscriber.assertValueCount(2);
+        subscriber.assertTerminated();
     }
 
     @Test
     public void assertNeverAtMatchingValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        oi.subscribe(o);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        oi.subscribe(subscriber);
 
-        o.assertValues(1, 2);
+        subscriber.assertValues(1, 2);
 
         thrown.expect(AssertionError.class);
 
-        o.assertNever(2);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        subscriber.assertNever(2);
+        subscriber.assertValueCount(2);
+        subscriber.assertTerminated();
     }
 
     @Test
@@ -147,8 +147,8 @@ public class TestObserverTest {
     @Test
     public void testAssertTerminalEventNotReceived() {
         PublishProcessor<Integer> p = PublishProcessor.create();
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        p.subscribe(o);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        p.subscribe(subscriber);
 
         p.onNext(1);
         p.onNext(2);
@@ -157,9 +157,9 @@ public class TestObserverTest {
         // FIXME different message format
 //        thrown.expectMessage("No terminal events received.");
 
-        o.assertValues(1, 2);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        subscriber.assertValues(1, 2);
+        subscriber.assertValueCount(2);
+        subscriber.assertTerminated();
     }
 
     @Test

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -166,27 +166,27 @@ public class TestObserverTest {
     public void testWrappingMock() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
 
-        Subscriber<Integer> mockObserver = TestHelper.mockSubscriber();
+        Subscriber<Integer> mockSubscriber = TestHelper.mockSubscriber();
 
-        oi.subscribe(new TestSubscriber<Integer>(mockObserver));
+        oi.subscribe(new TestSubscriber<Integer>(mockSubscriber));
 
-        InOrder inOrder = inOrder(mockObserver);
-        inOrder.verify(mockObserver, times(1)).onNext(1);
-        inOrder.verify(mockObserver, times(1)).onNext(2);
-        inOrder.verify(mockObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(mockSubscriber);
+        inOrder.verify(mockSubscriber, times(1)).onNext(1);
+        inOrder.verify(mockSubscriber, times(1)).onNext(2);
+        inOrder.verify(mockSubscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testWrappingMockWhenUnsubscribeInvolved() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9)).take(2);
-        Subscriber<Integer> mockObserver = TestHelper.mockSubscriber();
-        oi.subscribe(new TestSubscriber<Integer>(mockObserver));
+        Subscriber<Integer> mockSubscriber = TestHelper.mockSubscriber();
+        oi.subscribe(new TestSubscriber<Integer>(mockSubscriber));
 
-        InOrder inOrder = inOrder(mockObserver);
-        inOrder.verify(mockObserver, times(1)).onNext(1);
-        inOrder.verify(mockObserver, times(1)).onNext(2);
-        inOrder.verify(mockObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(mockSubscriber);
+        inOrder.verify(mockSubscriber, times(1)).onNext(1);
+        inOrder.verify(mockSubscriber, times(1)).onNext(2);
+        inOrder.verify(mockSubscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -708,7 +708,7 @@ public class RxJavaPluginsTest {
         try {
             RxJavaPlugins.setOnFlowableSubscribe(new BiFunction<Flowable, Subscriber, Subscriber>() {
                 @Override
-                public Subscriber apply(Flowable o, final Subscriber t) {
+                public Subscriber apply(Flowable f, final Subscriber t) {
                     return new Subscriber() {
 
                         @Override

--- a/src/test/java/io/reactivex/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/AsyncProcessorTest.java
@@ -44,33 +44,33 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     public void testNeverCompleted() {
         AsyncProcessor<String> processor = AsyncProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onNext("two");
         processor.onNext("three");
 
-        verify(observer, Mockito.never()).onNext(anyString());
-        verify(observer, Mockito.never()).onError(testException);
-        verify(observer, Mockito.never()).onComplete();
+        verify(subscriber, Mockito.never()).onNext(anyString());
+        verify(subscriber, Mockito.never()).onError(testException);
+        verify(subscriber, Mockito.never()).onComplete();
     }
 
     @Test
     public void testCompleted() {
         AsyncProcessor<String> processor = AsyncProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onNext("two");
         processor.onNext("three");
         processor.onComplete();
 
-        verify(observer, times(1)).onNext("three");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -78,40 +78,40 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     public void testNull() {
         AsyncProcessor<String> processor = AsyncProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext(null);
         processor.onComplete();
 
-        verify(observer, times(1)).onNext(null);
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext(null);
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testSubscribeAfterCompleted() {
         AsyncProcessor<String> processor = AsyncProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         processor.onNext("one");
         processor.onNext("two");
         processor.onNext("three");
         processor.onComplete();
 
-        processor.subscribe(observer);
+        processor.subscribe(subscriber);
 
-        verify(observer, times(1)).onNext("three");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
     public void testSubscribeAfterError() {
         AsyncProcessor<String> processor = AsyncProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         processor.onNext("one");
         processor.onNext("two");
@@ -120,19 +120,19 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
         RuntimeException re = new RuntimeException("failed");
         processor.onError(re);
 
-        processor.subscribe(observer);
+        processor.subscribe(subscriber);
 
-        verify(observer, times(1)).onError(re);
-        verify(observer, Mockito.never()).onNext(any(String.class));
-        verify(observer, Mockito.never()).onComplete();
+        verify(subscriber, times(1)).onError(re);
+        verify(subscriber, Mockito.never()).onNext(any(String.class));
+        verify(subscriber, Mockito.never()).onComplete();
     }
 
     @Test
     public void testError() {
         AsyncProcessor<String> processor = AsyncProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onNext("two");
@@ -142,17 +142,17 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
         processor.onError(new Throwable());
         processor.onComplete();
 
-        verify(observer, Mockito.never()).onNext(anyString());
-        verify(observer, times(1)).onError(testException);
-        verify(observer, Mockito.never()).onComplete();
+        verify(subscriber, Mockito.never()).onNext(anyString());
+        verify(subscriber, times(1)).onError(testException);
+        verify(subscriber, Mockito.never()).onComplete();
     }
 
     @Test
     public void testUnsubscribeBeforeCompleted() {
         AsyncProcessor<String> processor = AsyncProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         processor.subscribe(ts);
 
         processor.onNext("one");
@@ -160,31 +160,31 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
 
         ts.dispose();
 
-        verify(observer, Mockito.never()).onNext(anyString());
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, Mockito.never()).onComplete();
+        verify(subscriber, Mockito.never()).onNext(anyString());
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, Mockito.never()).onComplete();
 
         processor.onNext("three");
         processor.onComplete();
 
-        verify(observer, Mockito.never()).onNext(anyString());
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, Mockito.never()).onComplete();
+        verify(subscriber, Mockito.never()).onNext(anyString());
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, Mockito.never()).onComplete();
     }
 
     @Test
     public void testEmptySubjectCompleted() {
         AsyncProcessor<String> processor = AsyncProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onComplete();
 
-        InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer, never()).onNext(null);
-        inOrder.verify(observer, never()).onNext(any(String.class));
-        inOrder.verify(observer, times(1)).onComplete();
+        InOrder inOrder = inOrder(subscriber);
+        inOrder.verify(subscriber, never()).onNext(null);
+        inOrder.verify(subscriber, never()).onNext(any(String.class));
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
@@ -211,11 +211,11 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         verify(subscriber, never()).onNext("two");
         verify(subscriber, never()).onComplete();
 
-        Subscriber<Object> o2 = TestHelper.mockSubscriber();
-        processor.subscribe(o2);
-        verify(o2, times(1)).onError(testException);
-        verify(o2, never()).onNext(any());
-        verify(o2, never()).onComplete();
+        Subscriber<Object> subscriber2 = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber2);
+        verify(subscriber2, times(1)).onError(testException);
+        verify(subscriber2, never()).onNext(any());
+        verify(subscriber2, never()).onComplete();
     }
 
     @Test
@@ -236,10 +236,10 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         verify(subscriber, never()).onError(any(Throwable.class));
         verify(subscriber, never()).onNext("two");
 
-        Subscriber<Object> o2 = TestHelper.mockSubscriber();
-        processor.subscribe(o2);
-        verify(o2, times(1)).onComplete();
-        verify(o2, never()).onNext(any());
+        Subscriber<Object> subscriber2 = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber2);
+        verify(subscriber2, times(1)).onComplete();
+        verify(subscriber2, never()).onNext(any());
         verify(subscriber, never()).onError(any(Throwable.class));
     }
 
@@ -248,8 +248,8 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         BehaviorProcessor<String> src = BehaviorProcessor.createDefault("null"); // FIXME was plain null which is not allowed
 
         for (int i = 0; i < 10; i++) {
-            final Subscriber<Object> o = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(o);
+            final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber);
             String v = "" + i;
             src.onNext(v);
             System.out.printf("Turn: %d%n", i);
@@ -264,34 +264,34 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
                 .subscribe(new DefaultSubscriber<String>() {
                     @Override
                     public void onNext(String t) {
-                        o.onNext(t);
+                        subscriber.onNext(t);
                     }
 
                     @Override
                     public void onError(Throwable e) {
-                        o.onError(e);
+                        subscriber.onError(e);
                     }
 
                     @Override
                     public void onComplete() {
-                        o.onComplete();
+                        subscriber.onComplete();
                     }
                 });
-            inOrder.verify(o).onNext(v + ", " + v);
-            inOrder.verify(o).onComplete();
-            verify(o, never()).onError(any(Throwable.class));
+            inOrder.verify(subscriber).onNext(v + ", " + v);
+            inOrder.verify(subscriber).onComplete();
+            verify(subscriber, never()).onError(any(Throwable.class));
         }
     }
     @Test
     public void testStartEmpty() {
         BehaviorProcessor<Integer> source = BehaviorProcessor.create();
-        final Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
-        source.subscribe(o);
+        source.subscribe(subscriber);
 
-        inOrder.verify(o, never()).onNext(any());
-        inOrder.verify(o, never()).onComplete();
+        inOrder.verify(subscriber, never()).onNext(any());
+        inOrder.verify(subscriber, never()).onComplete();
 
         source.onNext(1);
 
@@ -299,10 +299,10 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
         source.onNext(2);
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
 
-        inOrder.verify(o).onNext(1);
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onNext(1);
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
 
 
@@ -310,52 +310,52 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
     @Test
     public void testStartEmptyThenAddOne() {
         BehaviorProcessor<Integer> source = BehaviorProcessor.create();
-        final Subscriber<Object> o = TestHelper.mockSubscriber();
-        InOrder inOrder = inOrder(o);
+        final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        InOrder inOrder = inOrder(subscriber);
 
         source.onNext(1);
 
-        source.subscribe(o);
+        source.subscribe(subscriber);
 
-        inOrder.verify(o).onNext(1);
+        inOrder.verify(subscriber).onNext(1);
 
         source.onComplete();
 
         source.onNext(2);
 
-        inOrder.verify(o).onComplete();
+        inOrder.verify(subscriber).onComplete();
         inOrder.verifyNoMoreInteractions();
 
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
 
     }
     @Test
     public void testStartEmptyCompleteWithOne() {
         BehaviorProcessor<Integer> source = BehaviorProcessor.create();
-        final Subscriber<Object> o = TestHelper.mockSubscriber();
+        final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         source.onNext(1);
         source.onComplete();
 
         source.onNext(2);
 
-        source.subscribe(o);
+        source.subscribe(subscriber);
 
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
-        verify(o, never()).onNext(any());
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(any());
     }
 
     @Test
     public void testTakeOneSubscriber() {
         BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
-        final Subscriber<Object> o = TestHelper.mockSubscriber();
+        final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.take(1).subscribe(o);
+        source.take(1).subscribe(subscriber);
 
-        verify(o).onNext(1);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(1);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
 
         assertEquals(0, source.subscriberCount());
         assertFalse(source.hasSubscribers());

--- a/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
@@ -47,19 +47,19 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
     public void testThatSubscriberReceivesDefaultValueAndSubsequentEvents() {
         BehaviorProcessor<String> processor = BehaviorProcessor.createDefault("default");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onNext("two");
         processor.onNext("three");
 
-        verify(observer, times(1)).onNext("default");
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, Mockito.never()).onError(testException);
-        verify(observer, Mockito.never()).onComplete();
+        verify(subscriber, times(1)).onNext("default");
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, Mockito.never()).onError(testException);
+        verify(subscriber, Mockito.never()).onComplete();
     }
 
     @Test
@@ -68,34 +68,34 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
         processor.onNext("one");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("two");
         processor.onNext("three");
 
-        verify(observer, Mockito.never()).onNext("default");
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, Mockito.never()).onError(testException);
-        verify(observer, Mockito.never()).onComplete();
+        verify(subscriber, Mockito.never()).onNext("default");
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, Mockito.never()).onError(testException);
+        verify(subscriber, Mockito.never()).onComplete();
     }
 
     @Test
     public void testSubscribeThenOnComplete() {
         BehaviorProcessor<String> processor = BehaviorProcessor.createDefault("default");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onComplete();
 
-        verify(observer, times(1)).onNext("default");
-        verify(observer, times(1)).onNext("one");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, times(1)).onNext("default");
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -104,13 +104,13 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         processor.onNext("one");
         processor.onComplete();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
-        verify(observer, never()).onNext("default");
-        verify(observer, never()).onNext("one");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+        verify(subscriber, never()).onNext("default");
+        verify(subscriber, never()).onNext("one");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -120,13 +120,13 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         RuntimeException re = new RuntimeException("test error");
         processor.onError(re);
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
-        verify(observer, never()).onNext("default");
-        verify(observer, never()).onNext("one");
-        verify(observer, times(1)).onError(re);
-        verify(observer, never()).onComplete();
+        verify(subscriber, never()).onNext("default");
+        verify(subscriber, never()).onNext("one");
+        verify(subscriber, times(1)).onError(re);
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
@@ -178,38 +178,38 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
     public void testCompletedAfterErrorIsNotSent() {
         BehaviorProcessor<String> processor = BehaviorProcessor.createDefault("default");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onError(testException);
         processor.onNext("two");
         processor.onComplete();
 
-        verify(observer, times(1)).onNext("default");
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onError(testException);
-        verify(observer, never()).onNext("two");
-        verify(observer, never()).onComplete();
+        verify(subscriber, times(1)).onNext("default");
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onError(testException);
+        verify(subscriber, never()).onNext("two");
+        verify(subscriber, never()).onComplete();
     }
 
     @Test
     public void testCompletedAfterErrorIsNotSent2() {
         BehaviorProcessor<String> processor = BehaviorProcessor.createDefault("default");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onError(testException);
         processor.onNext("two");
         processor.onComplete();
 
-        verify(observer, times(1)).onNext("default");
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onError(testException);
-        verify(observer, never()).onNext("two");
-        verify(observer, never()).onComplete();
+        verify(subscriber, times(1)).onNext("default");
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onError(testException);
+        verify(subscriber, never()).onNext("two");
+        verify(subscriber, never()).onComplete();
 
         Subscriber<Object> o2 = TestHelper.mockSubscriber();
         processor.subscribe(o2);
@@ -222,25 +222,25 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
     public void testCompletedAfterErrorIsNotSent3() {
         BehaviorProcessor<String> processor = BehaviorProcessor.createDefault("default");
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onComplete();
         processor.onNext("two");
         processor.onComplete();
 
-        verify(observer, times(1)).onNext("default");
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onComplete();
-        verify(observer, never()).onError(any(Throwable.class));
-        verify(observer, never()).onNext("two");
+        verify(subscriber, times(1)).onNext("default");
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext("two");
 
         Subscriber<Object> o2 = TestHelper.mockSubscriber();
         processor.subscribe(o2);
         verify(o2, times(1)).onComplete();
         verify(o2, never()).onNext(any());
-        verify(observer, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test(timeout = 1000)

--- a/src/test/java/io/reactivex/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/PublishProcessorTest.java
@@ -103,12 +103,12 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         inOrderC.verifyNoMoreInteractions();
     }
 
-    private void assertCompletedSubscriber(Subscriber<String> observer) {
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+    private void assertCompletedSubscriber(Subscriber<String> subscriber) {
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -134,12 +134,12 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         // todo bug?            assertNeverSubscriber(anotherSubscriber);
     }
 
-    private void assertErrorSubscriber(Subscriber<String> observer) {
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, times(1)).onError(testException);
-        verify(observer, Mockito.never()).onComplete();
+    private void assertErrorSubscriber(Subscriber<String> subscriber) {
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, times(1)).onError(testException);
+        verify(subscriber, Mockito.never()).onComplete();
     }
 
     @Test
@@ -164,12 +164,12 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         assertCompletedStartingWithThreeSubscriber(anotherSubscriber);
     }
 
-    private void assertCompletedStartingWithThreeSubscriber(Subscriber<String> observer) {
-        verify(observer, Mockito.never()).onNext("one");
-        verify(observer, Mockito.never()).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
+    private void assertCompletedStartingWithThreeSubscriber(Subscriber<String> subscriber) {
+        verify(subscriber, Mockito.never()).onNext("one");
+        verify(subscriber, Mockito.never()).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -196,12 +196,12 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         assertCompletedStartingWithThreeSubscriber(anotherSubscriber);
     }
 
-    private void assertObservedUntilTwo(Subscriber<String> observer) {
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, Mockito.never()).onNext("three");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, Mockito.never()).onComplete();
+    private void assertObservedUntilTwo(Subscriber<String> subscriber) {
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, Mockito.never()).onNext("three");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, Mockito.never()).onComplete();
     }
 
     @Test
@@ -262,16 +262,16 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     public void testReSubscribe() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        Subscriber<Integer> o1 = TestHelper.mockSubscriber();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(o1);
+        Subscriber<Integer> subscriber1 = TestHelper.mockSubscriber();
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(subscriber1);
         pp.subscribe(ts);
 
         // emit
         pp.onNext(1);
 
         // validate we got it
-        InOrder inOrder1 = inOrder(o1);
-        inOrder1.verify(o1, times(1)).onNext(1);
+        InOrder inOrder1 = inOrder(subscriber1);
+        inOrder1.verify(subscriber1, times(1)).onNext(1);
         inOrder1.verifyNoMoreInteractions();
 
         // unsubscribe
@@ -280,16 +280,16 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         // emit again but nothing will be there to receive it
         pp.onNext(2);
 
-        Subscriber<Integer> o2 = TestHelper.mockSubscriber();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(o2);
+        Subscriber<Integer> subscriber2 = TestHelper.mockSubscriber();
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(subscriber2);
         pp.subscribe(ts2);
 
         // emit
         pp.onNext(3);
 
         // validate we got it
-        InOrder inOrder2 = inOrder(o2);
-        inOrder2.verify(o2, times(1)).onNext(3);
+        InOrder inOrder2 = inOrder(subscriber2);
+        inOrder2.verify(subscriber2, times(1)).onNext(3);
         inOrder2.verifyNoMoreInteractions();
 
         ts2.dispose();
@@ -302,8 +302,8 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         PublishProcessor<String> src = PublishProcessor.create();
 
         for (int i = 0; i < 10; i++) {
-            final Subscriber<Object> o = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(o);
+            final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber);
             String v = "" + i;
             System.out.printf("Turn: %d%n", i);
             src.firstElement().toFlowable()
@@ -317,24 +317,24 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
                 .subscribe(new DefaultSubscriber<String>() {
                     @Override
                     public void onNext(String t) {
-                        o.onNext(t);
+                        subscriber.onNext(t);
                     }
 
                     @Override
                     public void onError(Throwable e) {
-                        o.onError(e);
+                        subscriber.onError(e);
                     }
 
                     @Override
                     public void onComplete() {
-                        o.onComplete();
+                        subscriber.onComplete();
                     }
                 });
             src.onNext(v);
 
-            inOrder.verify(o).onNext(v + ", " + v);
-            inOrder.verify(o).onComplete();
-            verify(o, never()).onError(any(Throwable.class));
+            inOrder.verify(subscriber).onNext(v + ", " + v);
+            inOrder.verify(subscriber).onComplete();
+            verify(subscriber, never()).onError(any(Throwable.class));
         }
     }
 

--- a/src/test/java/io/reactivex/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/PublishProcessorTest.java
@@ -42,8 +42,8 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     public void testCompleted() {
         PublishProcessor<String> processor = PublishProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onNext("two");
@@ -57,7 +57,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         processor.onComplete();
         processor.onError(new Throwable());
 
-        assertCompletedSubscriber(observer);
+        assertCompletedSubscriber(subscriber);
         // todo bug?            assertNeverSubscriber(anotherSubscriber);
     }
 
@@ -115,8 +115,8 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     public void testError() {
         PublishProcessor<String> processor = PublishProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onNext("two");
@@ -130,7 +130,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         processor.onError(new Throwable());
         processor.onComplete();
 
-        assertErrorSubscriber(observer);
+        assertErrorSubscriber(subscriber);
         // todo bug?            assertNeverSubscriber(anotherSubscriber);
     }
 
@@ -146,13 +146,13 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     public void testSubscribeMidSequence() {
         PublishProcessor<String> processor = PublishProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onNext("two");
 
-        assertObservedUntilTwo(observer);
+        assertObservedUntilTwo(subscriber);
 
         Subscriber<String> anotherSubscriber = TestHelper.mockSubscriber();
         processor.subscribe(anotherSubscriber);
@@ -160,7 +160,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         processor.onNext("three");
         processor.onComplete();
 
-        assertCompletedSubscriber(observer);
+        assertCompletedSubscriber(subscriber);
         assertCompletedStartingWithThreeSubscriber(anotherSubscriber);
     }
 
@@ -176,15 +176,15 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     public void testUnsubscribeFirstSubscriber() {
         PublishProcessor<String> processor = PublishProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         processor.subscribe(ts);
 
         processor.onNext("one");
         processor.onNext("two");
 
         ts.dispose();
-        assertObservedUntilTwo(observer);
+        assertObservedUntilTwo(subscriber);
 
         Subscriber<String> anotherSubscriber = TestHelper.mockSubscriber();
         processor.subscribe(anotherSubscriber);
@@ -192,7 +192,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         processor.onNext("three");
         processor.onComplete();
 
-        assertObservedUntilTwo(observer);
+        assertObservedUntilTwo(subscriber);
         assertCompletedStartingWithThreeSubscriber(anotherSubscriber);
     }
 

--- a/src/test/java/io/reactivex/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -39,13 +39,13 @@ public class ReplayProcessorBoundedConcurrencyTest {
                 Flowable.unsafeCreate(new Publisher<Long>() {
 
                     @Override
-                    public void subscribe(Subscriber<? super Long> o) {
+                    public void subscribe(Subscriber<? super Long> subscriber) {
                         System.out.println("********* Start Source Data ***********");
                         for (long l = 1; l <= 10000; l++) {
-                            o.onNext(l);
+                            subscriber.onNext(l);
                         }
                         System.out.println("********* Finished Source Data ***********");
-                        o.onComplete();
+                        subscriber.onComplete();
                     }
                 }).subscribe(replay);
             }
@@ -148,13 +148,13 @@ public class ReplayProcessorBoundedConcurrencyTest {
                 Flowable.unsafeCreate(new Publisher<Long>() {
 
                     @Override
-                    public void subscribe(Subscriber<? super Long> o) {
+                    public void subscribe(Subscriber<? super Long> subscriber) {
                         System.out.println("********* Start Source Data ***********");
                         for (long l = 1; l <= 10000; l++) {
-                            o.onNext(l);
+                            subscriber.onNext(l);
                         }
                         System.out.println("********* Finished Source Data ***********");
-                        o.onComplete();
+                        subscriber.onComplete();
                     }
                 }).subscribe(replay);
             }

--- a/src/test/java/io/reactivex/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorConcurrencyTest.java
@@ -39,13 +39,13 @@ public class ReplayProcessorConcurrencyTest {
                 Flowable.unsafeCreate(new Publisher<Long>() {
 
                     @Override
-                    public void subscribe(Subscriber<? super Long> o) {
+                    public void subscribe(Subscriber<? super Long> subscriber) {
                         System.out.println("********* Start Source Data ***********");
                         for (long l = 1; l <= 10000; l++) {
-                            o.onNext(l);
+                            subscriber.onNext(l);
                         }
                         System.out.println("********* Finished Source Data ***********");
-                        o.onComplete();
+                        subscriber.onComplete();
                     }
                 }).subscribe(replay);
             }
@@ -148,13 +148,13 @@ public class ReplayProcessorConcurrencyTest {
                 Flowable.unsafeCreate(new Publisher<Long>() {
 
                     @Override
-                    public void subscribe(Subscriber<? super Long> o) {
+                    public void subscribe(Subscriber<? super Long> subscriber) {
                         System.out.println("********* Start Source Data ***********");
                         for (long l = 1; l <= 10000; l++) {
-                            o.onNext(l);
+                            subscriber.onNext(l);
                         }
                         System.out.println("********* Finished Source Data ***********");
-                        o.onComplete();
+                        subscriber.onComplete();
                     }
                 }).subscribe(replay);
             }

--- a/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
@@ -140,7 +140,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     public void testCompletedAfterError() {
         ReplayProcessor<String> processor = ReplayProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         processor.onNext("one");
         processor.onError(testException);
@@ -148,11 +148,11 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         processor.onComplete();
         processor.onError(new RuntimeException());
 
-        processor.subscribe(observer);
-        verify(observer).onSubscribe((Subscription)notNull());
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onError(testException);
-        verifyNoMoreInteractions(observer);
+        processor.subscribe(subscriber);
+        verify(subscriber).onSubscribe((Subscription)notNull());
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onError(testException);
+        verifyNoMoreInteractions(subscriber);
     }
 
     private void assertCompletedSubscriber(Subscriber<String> observer) {
@@ -170,8 +170,8 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     public void testError() {
         ReplayProcessor<String> processor = ReplayProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onNext("two");
@@ -182,32 +182,32 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         processor.onError(new Throwable());
         processor.onComplete();
 
-        assertErrorSubscriber(observer);
+        assertErrorSubscriber(subscriber);
 
-        observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
-        assertErrorSubscriber(observer);
+        subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
+        assertErrorSubscriber(subscriber);
     }
 
-    private void assertErrorSubscriber(Subscriber<String> observer) {
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, times(1)).onNext("three");
-        verify(observer, times(1)).onError(testException);
-        verify(observer, Mockito.never()).onComplete();
+    private void assertErrorSubscriber(Subscriber<String> subscriber) {
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, times(1)).onNext("three");
+        verify(subscriber, times(1)).onError(testException);
+        verify(subscriber, Mockito.never()).onComplete();
     }
 
     @Test
     public void testSubscribeMidSequence() {
         ReplayProcessor<String> processor = ReplayProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        processor.subscribe(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber);
 
         processor.onNext("one");
         processor.onNext("two");
 
-        assertObservedUntilTwo(observer);
+        assertObservedUntilTwo(subscriber);
 
         Subscriber<String> anotherSubscriber = TestHelper.mockSubscriber();
         processor.subscribe(anotherSubscriber);
@@ -216,7 +216,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         processor.onNext("three");
         processor.onComplete();
 
-        assertCompletedSubscriber(observer);
+        assertCompletedSubscriber(subscriber);
         assertCompletedSubscriber(anotherSubscriber);
     }
 
@@ -224,15 +224,15 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     public void testUnsubscribeFirstSubscriber() {
         ReplayProcessor<String> processor = ReplayProcessor.create();
 
-        Subscriber<String> observer = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(observer);
+        Subscriber<String> subscriber = TestHelper.mockSubscriber();
+        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
         processor.subscribe(ts);
 
         processor.onNext("one");
         processor.onNext("two");
 
         ts.dispose();
-        assertObservedUntilTwo(observer);
+        assertObservedUntilTwo(subscriber);
 
         Subscriber<String> anotherSubscriber = TestHelper.mockSubscriber();
         processor.subscribe(anotherSubscriber);
@@ -241,7 +241,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         processor.onNext("three");
         processor.onComplete();
 
-        assertObservedUntilTwo(observer);
+        assertObservedUntilTwo(subscriber);
         assertCompletedSubscriber(anotherSubscriber);
     }
 

--- a/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
@@ -47,8 +47,8 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     public void testCompleted() {
         ReplayProcessor<String> processor = ReplayProcessor.create();
 
-        Subscriber<String> o1 = TestHelper.mockSubscriber();
-        processor.subscribe(o1);
+        Subscriber<String> subscriber1 = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber1);
 
         processor.onNext("one");
         processor.onNext("two");
@@ -59,12 +59,12 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         processor.onComplete();
         processor.onError(new Throwable());
 
-        assertCompletedSubscriber(o1);
+        assertCompletedSubscriber(subscriber1);
 
         // assert that subscribing a 2nd time gets the same data
-        Subscriber<String> o2 = TestHelper.mockSubscriber();
-        processor.subscribe(o2);
-        assertCompletedSubscriber(o2);
+        Subscriber<String> subscriber2 = TestHelper.mockSubscriber();
+        processor.subscribe(subscriber2);
+        assertCompletedSubscriber(subscriber2);
     }
 
     @Test
@@ -155,14 +155,14 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         verifyNoMoreInteractions(subscriber);
     }
 
-    private void assertCompletedSubscriber(Subscriber<String> observer) {
-        InOrder inOrder = inOrder(observer);
+    private void assertCompletedSubscriber(Subscriber<String> subscriber) {
+        InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(observer, times(1)).onNext("one");
-        inOrder.verify(observer, times(1)).onNext("two");
-        inOrder.verify(observer, times(1)).onNext("three");
-        inOrder.verify(observer, Mockito.never()).onError(any(Throwable.class));
-        inOrder.verify(observer, times(1)).onComplete();
+        inOrder.verify(subscriber, times(1)).onNext("one");
+        inOrder.verify(subscriber, times(1)).onNext("two");
+        inOrder.verify(subscriber, times(1)).onNext("three");
+        inOrder.verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -245,19 +245,19 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         assertCompletedSubscriber(anotherSubscriber);
     }
 
-    private void assertObservedUntilTwo(Subscriber<String> observer) {
-        verify(observer, times(1)).onNext("one");
-        verify(observer, times(1)).onNext("two");
-        verify(observer, Mockito.never()).onNext("three");
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, Mockito.never()).onComplete();
+    private void assertObservedUntilTwo(Subscriber<String> subscriber) {
+        verify(subscriber, times(1)).onNext("one");
+        verify(subscriber, times(1)).onNext("two");
+        verify(subscriber, Mockito.never()).onNext("three");
+        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
+        verify(subscriber, Mockito.never()).onComplete();
     }
 
     @Test(timeout = 2000)
     public void testNewSubscriberDoesntBlockExisting() throws InterruptedException {
 
         final AtomicReference<String> lastValueForSubscriber1 = new AtomicReference<String>();
-        Subscriber<String> observer1 = new DefaultSubscriber<String>() {
+        Subscriber<String> subscriber1 = new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -281,7 +281,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         final CountDownLatch oneReceived = new CountDownLatch(1);
         final CountDownLatch makeSlow = new CountDownLatch(1);
         final CountDownLatch completed = new CountDownLatch(1);
-        Subscriber<String> observer2 = new DefaultSubscriber<String>() {
+        Subscriber<String> subscriber2 = new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -311,14 +311,14 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         };
 
         ReplayProcessor<String> processor = ReplayProcessor.create();
-        processor.subscribe(observer1);
+        processor.subscribe(subscriber1);
         processor.onNext("one");
         assertEquals("one", lastValueForSubscriber1.get());
         processor.onNext("two");
         assertEquals("two", lastValueForSubscriber1.get());
 
         // use subscribeOn to make this async otherwise we deadlock as we are using CountDownLatches
-        processor.subscribeOn(Schedulers.newThread()).subscribe(observer2);
+        processor.subscribeOn(Schedulers.newThread()).subscribe(subscriber2);
 
         System.out.println("before waiting for one");
 
@@ -368,8 +368,8 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         ReplayProcessor<String> src = ReplayProcessor.create();
 
         for (int i = 0; i < 10; i++) {
-            final Subscriber<Object> o = TestHelper.mockSubscriber();
-            InOrder inOrder = inOrder(o);
+            final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+            InOrder inOrder = inOrder(subscriber);
             String v = "" + i;
             src.onNext(v);
             System.out.printf("Turn: %d%n", i);
@@ -385,22 +385,22 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
                     @Override
                     public void onNext(String t) {
                         System.out.println(t);
-                        o.onNext(t);
+                        subscriber.onNext(t);
                     }
 
                     @Override
                     public void onError(Throwable e) {
-                        o.onError(e);
+                        subscriber.onError(e);
                     }
 
                     @Override
                     public void onComplete() {
-                        o.onComplete();
+                        subscriber.onComplete();
                     }
                 });
-            inOrder.verify(o).onNext("0, 0");
-            inOrder.verify(o).onComplete();
-            verify(o, never()).onError(any(Throwable.class));
+            inOrder.verify(subscriber).onNext("0, 0");
+            inOrder.verify(subscriber).onComplete();
+            verify(subscriber, never()).onError(any(Throwable.class));
         }
     }
     @Test
@@ -410,30 +410,30 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         source.onNext(2);
         source.onComplete();
 
-        final Subscriber<Integer> o = TestHelper.mockSubscriber();
+        final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         source.subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onNext(Integer t) {
-                o.onNext(t);
+                subscriber.onNext(t);
             }
 
             @Override
             public void onError(Throwable e) {
-                o.onError(e);
+                subscriber.onError(e);
             }
 
             @Override
             public void onComplete() {
-                o.onComplete();
+                subscriber.onComplete();
             }
         });
 
-        verify(o).onNext(1);
-        verify(o).onNext(2);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(1);
+        verify(subscriber).onNext(2);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -445,35 +445,35 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         source.onComplete();
 
         for (int i = 0; i < 1; i++) {
-            Subscriber<Integer> o = TestHelper.mockSubscriber();
+            Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-            source.subscribe(o);
+            source.subscribe(subscriber);
 
-            verify(o, never()).onNext(1);
-            verify(o).onNext(2);
-            verify(o).onComplete();
-            verify(o, never()).onError(any(Throwable.class));
+            verify(subscriber, never()).onNext(1);
+            verify(subscriber).onNext(2);
+            verify(subscriber).onComplete();
+            verify(subscriber, never()).onError(any(Throwable.class));
         }
     }
     @Test
     public void testReplay1Directly() {
         ReplayProcessor<Integer> source = ReplayProcessor.createWithSize(1);
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         source.onNext(1);
         source.onNext(2);
 
-        source.subscribe(o);
+        source.subscribe(subscriber);
 
         source.onNext(3);
         source.onComplete();
 
-        verify(o, never()).onNext(1);
-        verify(o).onNext(2);
-        verify(o).onNext(3);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(1);
+        verify(subscriber).onNext(2);
+        verify(subscriber).onNext(3);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -494,15 +494,15 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        source.subscribe(o);
+        source.subscribe(subscriber);
 
-        verify(o, never()).onNext(1);
-        verify(o, never()).onNext(2);
-        verify(o, never()).onNext(3);
-        verify(o).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(1);
+        verify(subscriber, never()).onNext(2);
+        verify(subscriber, never()).onNext(3);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
     }
 
     @Test
@@ -514,9 +514,9 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        Subscriber<Integer> o = TestHelper.mockSubscriber();
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        source.subscribe(o);
+        source.subscribe(subscriber);
 
         source.onNext(2);
 
@@ -530,11 +530,11 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-        verify(o, never()).onError(any(Throwable.class));
-        verify(o, never()).onNext(1);
-        verify(o).onNext(2);
-        verify(o).onNext(3);
-        verify(o).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, never()).onNext(1);
+        verify(subscriber).onNext(2);
+        verify(subscriber).onNext(3);
+        verify(subscriber).onComplete();
     }
 
     // FIXME RS subscribers can't throw

--- a/src/test/java/io/reactivex/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/io/reactivex/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -290,11 +290,11 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         try {
             Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() {
                 @Override
-                public void subscribe(final Subscriber<? super Integer> observer) {
+                public void subscribe(final Subscriber<? super Integer> subscriber) {
                     inner.schedule(new Runnable() {
                         @Override
                         public void run() {
-                            observer.onNext(42);
+                            subscriber.onNext(42);
                             latch.countDown();
 
                             // this will recursively schedule this task for execution again
@@ -302,12 +302,12 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
                         }
                     });
 
-                    observer.onSubscribe(new Subscription() {
+                    subscriber.onSubscribe(new Subscription() {
 
                         @Override
                         public void cancel() {
                             inner.dispose();
-                            observer.onComplete();
+                            subscriber.onComplete();
                             completionLatch.countDown();
                         }
 
@@ -368,9 +368,9 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
 
         final AtomicInteger count = new AtomicInteger();
 
-        Flowable<Integer> o1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
+        Flowable<Integer> f1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
 
-        o1.subscribe(new Consumer<Integer>() {
+        f1.subscribe(new Consumer<Integer>() {
 
             @Override
             public void accept(Integer t) {
@@ -393,7 +393,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch latch = new CountDownLatch(5);
         final CountDownLatch first = new CountDownLatch(1);
 
-        o1.subscribeOn(scheduler).subscribe(new Consumer<Integer>() {
+        f1.subscribeOn(scheduler).subscribe(new Consumer<Integer>() {
 
             @Override
             public void accept(Integer t) {

--- a/src/test/java/io/reactivex/schedulers/CachedThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/CachedThreadSchedulerTest.java
@@ -38,9 +38,9 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
     @Test
     public final void testIOScheduler() {
 
-        Flowable<Integer> o1 = Flowable.just(1, 2, 3, 4, 5);
-        Flowable<Integer> o2 = Flowable.just(6, 7, 8, 9, 10);
-        Flowable<String> o = Flowable.merge(o1, o2).map(new Function<Integer, String>() {
+        Flowable<Integer> f1 = Flowable.just(1, 2, 3, 4, 5);
+        Flowable<Integer> f2 = Flowable.just(6, 7, 8, 9, 10);
+        Flowable<String> f = Flowable.merge(f1, f2).map(new Function<Integer, String>() {
 
             @Override
             public String apply(Integer t) {
@@ -49,7 +49,7 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
             }
         });
 
-        o.subscribeOn(Schedulers.io()).blockingForEach(new Consumer<String>() {
+        f.subscribeOn(Schedulers.io()).blockingForEach(new Consumer<String>() {
 
             @Override
             public void accept(String t) {

--- a/src/test/java/io/reactivex/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/io/reactivex/schedulers/ComputationSchedulerTests.java
@@ -91,9 +91,9 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
 
     @Test
     public final void testComputationThreadPool1() {
-        Flowable<Integer> o1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
-        Flowable<Integer> o2 = Flowable.<Integer> just(6, 7, 8, 9, 10);
-        Flowable<String> o = Flowable.<Integer> merge(o1, o2).map(new Function<Integer, String>() {
+        Flowable<Integer> f1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
+        Flowable<Integer> f2 = Flowable.<Integer> just(6, 7, 8, 9, 10);
+        Flowable<String> f = Flowable.<Integer> merge(f1, f2).map(new Function<Integer, String>() {
 
             @Override
             public String apply(Integer t) {
@@ -102,7 +102,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
             }
         });
 
-        o.subscribeOn(Schedulers.computation()).blockingForEach(new Consumer<String>() {
+        f.subscribeOn(Schedulers.computation()).blockingForEach(new Consumer<String>() {
 
             @Override
             public void accept(String t) {
@@ -117,9 +117,9 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
 
         final String currentThreadName = Thread.currentThread().getName();
 
-        Flowable<Integer> o1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
-        Flowable<Integer> o2 = Flowable.<Integer> just(6, 7, 8, 9, 10);
-        Flowable<String> o = Flowable.<Integer> merge(o1, o2).subscribeOn(Schedulers.computation()).map(new Function<Integer, String>() {
+        Flowable<Integer> f1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
+        Flowable<Integer> f2 = Flowable.<Integer> just(6, 7, 8, 9, 10);
+        Flowable<String> f = Flowable.<Integer> merge(f1, f2).subscribeOn(Schedulers.computation()).map(new Function<Integer, String>() {
 
             @Override
             public String apply(Integer t) {
@@ -129,7 +129,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
             }
         });
 
-        o.blockingForEach(new Consumer<String>() {
+        f.blockingForEach(new Consumer<String>() {
 
             @Override
             public void accept(String t) {

--- a/src/test/java/io/reactivex/schedulers/TrampolineSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/TrampolineSchedulerTest.java
@@ -45,9 +45,9 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
 
         final String currentThreadName = Thread.currentThread().getName();
 
-        Flowable<Integer> o1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
-        Flowable<Integer> o2 = Flowable.<Integer> just(6, 7, 8, 9, 10);
-        Flowable<String> o = Flowable.<Integer> merge(o1, o2).subscribeOn(Schedulers.trampoline()).map(new Function<Integer, String>() {
+        Flowable<Integer> f1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
+        Flowable<Integer> f2 = Flowable.<Integer> just(6, 7, 8, 9, 10);
+        Flowable<String> f = Flowable.<Integer> merge(f1, f2).subscribeOn(Schedulers.trampoline()).map(new Function<Integer, String>() {
 
             @Override
             public String apply(Integer t) {
@@ -56,7 +56,7 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
             }
         });
 
-        o.blockingForEach(new Consumer<String>() {
+        f.blockingForEach(new Consumer<String>() {
 
             @Override
             public void accept(String t) {

--- a/src/test/java/io/reactivex/schedulers/TrampolineSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/TrampolineSchedulerTest.java
@@ -110,8 +110,8 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
     @Test
     public void testTrampolineWorkerHandlesConcurrentScheduling() {
         final Worker trampolineWorker = Schedulers.trampoline().createWorker();
-        final Subscriber<Object> observer = TestHelper.mockSubscriber();
-        final TestSubscriber<Disposable> ts = new TestSubscriber<Disposable>(observer);
+        final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
+        final TestSubscriber<Disposable> ts = new TestSubscriber<Disposable>(subscriber);
 
         // Spam the trampoline with actions.
         Flowable.range(0, 50)

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -664,7 +664,7 @@ public class SingleNullTests {
     public void liftFunctionReturnsNull() {
         just1.lift(new SingleOperator<Object, Integer>() {
             @Override
-            public SingleObserver<? super Integer> apply(SingleObserver<? super Object> s) {
+            public SingleObserver<? super Integer> apply(SingleObserver<? super Object> observer) {
                 return null;
             }
         }).blockingGet();

--- a/src/test/java/io/reactivex/single/SingleTest.java
+++ b/src/test/java/io/reactivex/single/SingleTest.java
@@ -131,9 +131,9 @@ public class SingleTest {
 
         Single.unsafeCreate(new SingleSource<Object>() {
             @Override
-            public void subscribe(SingleObserver<? super Object> s) {
-                s.onSubscribe(Disposables.empty());
-                s.onSuccess("Hello");
+            public void subscribe(SingleObserver<? super Object> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onSuccess("Hello");
             }
         }).toFlowable().subscribe(ts);
 
@@ -145,9 +145,9 @@ public class SingleTest {
         TestSubscriber<Object> ts = new TestSubscriber<Object>();
         Single.unsafeCreate(new SingleSource<Object>() {
             @Override
-            public void subscribe(SingleObserver<? super Object> s) {
-                s.onSubscribe(Disposables.empty());
-                s.onError(new RuntimeException("fail"));
+            public void subscribe(SingleObserver<? super Object> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onError(new RuntimeException("fail"));
             }
         }).toFlowable().subscribe(ts);
 
@@ -202,14 +202,14 @@ public class SingleTest {
         TestSubscriber<String> ts = new TestSubscriber<String>();
         Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
             @Override
-            public void subscribe(SingleObserver<? super String> s) {
-                s.onSubscribe(Disposables.empty());
+            public void subscribe(SingleObserver<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
                 try {
                     Thread.sleep(5000);
                 } catch (InterruptedException e) {
                     // ignore as we expect this for the test
                 }
-                s.onSuccess("success");
+                observer.onSuccess("success");
             }
         }).subscribeOn(Schedulers.io());
 
@@ -224,14 +224,14 @@ public class SingleTest {
         TestSubscriber<String> ts = new TestSubscriber<String>();
         Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
             @Override
-            public void subscribe(SingleObserver<? super String> s) {
-                s.onSubscribe(Disposables.empty());
+            public void subscribe(SingleObserver<? super String> observer) {
+                observer.onSubscribe(Disposables.empty());
                     try {
                         Thread.sleep(5000);
                     } catch (InterruptedException e) {
                         // ignore as we expect this for the test
                     }
-                    s.onSuccess("success");
+                    observer.onSuccess("success");
             }
         }).subscribeOn(Schedulers.io());
 
@@ -251,16 +251,16 @@ public class SingleTest {
 
         Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
             @Override
-            public void subscribe(final SingleObserver<? super String> s) {
+            public void subscribe(final SingleObserver<? super String> observer) {
                 SerialDisposable sd = new SerialDisposable();
-                s.onSubscribe(sd);
+                observer.onSubscribe(sd);
                 final Thread t = new Thread(new Runnable() {
 
                     @Override
                     public void run() {
                         try {
                             Thread.sleep(5000);
-                            s.onSuccess("success");
+                            observer.onSuccess("success");
                         } catch (InterruptedException e) {
                             interrupted.set(true);
                             latch.countDown();
@@ -325,16 +325,16 @@ public class SingleTest {
 
         Single<String> s1 = Single.unsafeCreate(new SingleSource<String>() {
             @Override
-            public void subscribe(final SingleObserver<? super String> s) {
+            public void subscribe(final SingleObserver<? super String> observer) {
                 SerialDisposable sd = new SerialDisposable();
-                s.onSubscribe(sd);
+                observer.onSubscribe(sd);
                 final Thread t = new Thread(new Runnable() {
 
                     @Override
                     public void run() {
                         try {
                             Thread.sleep(5000);
-                            s.onSuccess("success");
+                            observer.onSuccess("success");
                         } catch (InterruptedException e) {
                             interrupted.set(true);
                             latch.countDown();
@@ -381,16 +381,16 @@ public class SingleTest {
 
         Single<String> s1 = Single.unsafeCreate(new SingleSource<String>() {
             @Override
-            public void subscribe(final SingleObserver<? super String> s) {
+            public void subscribe(final SingleObserver<? super String> observer) {
                 SerialDisposable sd = new SerialDisposable();
-                s.onSubscribe(sd);
+                observer.onSubscribe(sd);
                 final Thread t = new Thread(new Runnable() {
 
                     @Override
                     public void run() {
                         try {
                             Thread.sleep(5000);
-                            s.onSuccess("success");
+                            observer.onSuccess("success");
                         } catch (InterruptedException e) {
                             interrupted.set(true);
                             latch.countDown();

--- a/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
@@ -117,27 +117,27 @@ public class SafeSubscriberTest {
      */
     private static class TestObservable implements Publisher<String> {
 
-        Subscriber<? super String> observer;
+        Subscriber<? super String> subscriber;
 
         /* used to simulate subscription */
         public void sendOnCompleted() {
-            observer.onComplete();
+            subscriber.onComplete();
         }
 
         /* used to simulate subscription */
         public void sendOnNext(String value) {
-            observer.onNext(value);
+            subscriber.onNext(value);
         }
 
         /* used to simulate subscription */
         public void sendOnError(Throwable e) {
-            observer.onError(e);
+            subscriber.onError(e);
         }
 
         @Override
-        public void subscribe(Subscriber<? super String> observer) {
-            this.observer = observer;
-            observer.onSubscribe(new Subscription() {
+        public void subscribe(Subscriber<? super String> subscriber) {
+            this.subscriber = subscriber;
+            subscriber.onSubscribe(new Subscription() {
 
                 @Override
                 public void cancel() {
@@ -199,7 +199,7 @@ public class SafeSubscriberTest {
     @Test
     public void onErrorFailure() {
         try {
-            OBSERVER_ONERROR_FAIL().onError(new SafeSubscriberTestException("error!"));
+            subscriberOnErrorFail().onError(new SafeSubscriberTestException("error!"));
             fail("expects exception to be thrown");
         } catch (Exception e) {
             assertTrue(e instanceof SafeSubscriberTestException);
@@ -211,7 +211,7 @@ public class SafeSubscriberTest {
     @Ignore("Observers can't throw")
     public void onErrorFailureSafe() {
         try {
-            new SafeSubscriber<String>(OBSERVER_ONERROR_FAIL()).onError(new SafeSubscriberTestException("error!"));
+            new SafeSubscriber<String>(subscriberOnErrorFail()).onError(new SafeSubscriberTestException("error!"));
             fail("expects exception to be thrown");
         } catch (Exception e) {
             e.printStackTrace();
@@ -237,7 +237,7 @@ public class SafeSubscriberTest {
     @Ignore("Observers can't throw")
     public void onErrorNotImplementedFailureSafe() {
         try {
-            new SafeSubscriber<String>(OBSERVER_ONERROR_NOTIMPLEMENTED()).onError(new SafeSubscriberTestException("error!"));
+            new SafeSubscriber<String>(subscriberOnErrorNotImplemented()).onError(new SafeSubscriberTestException("error!"));
             fail("expects exception to be thrown");
         } catch (Exception e) {
 //            assertTrue(e instanceof OnErrorNotImplementedException);
@@ -301,10 +301,10 @@ public class SafeSubscriberTest {
     @Test
     @Ignore("Observers can't throw")
     public void onCompleteSuccessWithUnsubscribeFailure() {
-        Subscriber<String> o = OBSERVER_SUCCESS();
+        Subscriber<String> subscriber = subscriberSuccess();
         try {
-            o.onSubscribe(THROWING_DISPOSABLE);
-            new SafeSubscriber<String>(o).onComplete();
+            subscriber.onSubscribe(THROWING_DISPOSABLE);
+            new SafeSubscriber<String>(subscriber).onComplete();
             fail("expects exception to be thrown");
         } catch (Exception e) {
             e.printStackTrace();
@@ -322,10 +322,10 @@ public class SafeSubscriberTest {
     @Ignore("Observers can't throw")
     public void onErrorSuccessWithUnsubscribeFailure() {
         AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
-        Subscriber<String> o = OBSERVER_SUCCESS(onError);
+        Subscriber<String> subscriber = subscriberSuccess(onError);
         try {
-            o.onSubscribe(THROWING_DISPOSABLE);
-            new SafeSubscriber<String>(o).onError(new SafeSubscriberTestException("failed"));
+            subscriber.onSubscribe(THROWING_DISPOSABLE);
+            new SafeSubscriber<String>(subscriber).onError(new SafeSubscriberTestException("failed"));
             fail("we expect the unsubscribe failure to cause an exception to be thrown");
         } catch (Exception e) {
             e.printStackTrace();
@@ -348,10 +348,10 @@ public class SafeSubscriberTest {
     @Test
     @Ignore("Observers can't throw")
     public void onErrorFailureWithUnsubscribeFailure() {
-        Subscriber<String> o = OBSERVER_ONERROR_FAIL();
+        Subscriber<String> subscriber = subscriberOnErrorFail();
         try {
-            o.onSubscribe(THROWING_DISPOSABLE);
-            new SafeSubscriber<String>(o).onError(new SafeSubscriberTestException("onError failure"));
+            subscriber.onSubscribe(THROWING_DISPOSABLE);
+            new SafeSubscriber<String>(subscriber).onError(new SafeSubscriberTestException("onError failure"));
             fail("expects exception to be thrown");
         } catch (Exception e) {
             e.printStackTrace();
@@ -385,10 +385,10 @@ public class SafeSubscriberTest {
     @Test
     @Ignore("Observers can't throw")
     public void onErrorNotImplementedFailureWithUnsubscribeFailure() {
-        Subscriber<String> o = OBSERVER_ONERROR_NOTIMPLEMENTED();
+        Subscriber<String> subscriber = subscriberOnErrorNotImplemented();
         try {
-            o.onSubscribe(THROWING_DISPOSABLE);
-            new SafeSubscriber<String>(o).onError(new SafeSubscriberTestException("error!"));
+            subscriber.onSubscribe(THROWING_DISPOSABLE);
+            new SafeSubscriber<String>(subscriber).onError(new SafeSubscriberTestException("error!"));
             fail("expects exception to be thrown");
         } catch (Exception e) {
             e.printStackTrace();
@@ -415,7 +415,7 @@ public class SafeSubscriberTest {
         }
     }
 
-    private static Subscriber<String> OBSERVER_SUCCESS() {
+    private static Subscriber<String> subscriberSuccess() {
         return new DefaultSubscriber<String>() {
 
             @Override
@@ -436,7 +436,7 @@ public class SafeSubscriberTest {
 
     }
 
-    private static Subscriber<String> OBSERVER_SUCCESS(final AtomicReference<Throwable> onError) {
+    private static Subscriber<String> subscriberSuccess(final AtomicReference<Throwable> onError) {
         return new DefaultSubscriber<String>() {
 
             @Override
@@ -499,7 +499,7 @@ public class SafeSubscriberTest {
         };
     }
 
-    private static Subscriber<String> OBSERVER_ONERROR_FAIL() {
+    private static Subscriber<String> subscriberOnErrorFail() {
         return new DefaultSubscriber<String>() {
 
             @Override
@@ -520,7 +520,7 @@ public class SafeSubscriberTest {
         };
     }
 
-    private static Subscriber<String> OBSERVER_ONERROR_NOTIMPLEMENTED() {
+    private static Subscriber<String> subscriberOnErrorNotImplemented() {
         return new DefaultSubscriber<String>() {
 
             @Override

--- a/src/test/java/io/reactivex/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SerializedSubscriberTest.java
@@ -39,8 +39,8 @@ public class SerializedSubscriberTest {
         subscriber = TestHelper.mockSubscriber();
     }
 
-    private Subscriber<String> serializedSubscriber(Subscriber<String> o) {
-        return new SerializedSubscriber<String>(o);
+    private Subscriber<String> serializedSubscriber(Subscriber<String> subscriber) {
+        return new SerializedSubscriber<String>(subscriber);
     }
 
     @Test
@@ -290,10 +290,10 @@ public class SerializedSubscriberTest {
                     }
 
                 });
-                Subscriber<String> o = serializedSubscriber(ts);
+                Subscriber<String> subscriber = serializedSubscriber(ts);
 
-                Future<?> f1 = tp1.submit(new OnNextThread(o, 1, onNextCount, running));
-                Future<?> f2 = tp2.submit(new OnNextThread(o, 1, onNextCount, running));
+                Future<?> f1 = tp1.submit(new OnNextThread(subscriber, 1, onNextCount, running));
+                Future<?> f2 = tp2.submit(new OnNextThread(subscriber, 1, onNextCount, running));
 
                 running.await(); // let one of the OnNextThread actually run before proceeding
 
@@ -315,7 +315,7 @@ public class SerializedSubscriberTest {
                 assertSame(t1, t2);
 
                 System.out.println(ts.values());
-                o.onComplete();
+                subscriber.onComplete();
                 System.out.println(ts.values());
             }
         } finally {
@@ -370,16 +370,16 @@ public class SerializedSubscriberTest {
             }
 
         });
-        final Subscriber<String> o = serializedSubscriber(ts);
+        final Subscriber<String> subscriber = serializedSubscriber(ts);
 
         AtomicInteger p1 = new AtomicInteger();
         AtomicInteger p2 = new AtomicInteger();
 
-        o.onSubscribe(new BooleanSubscription());
+        subscriber.onSubscribe(new BooleanSubscription());
         ResourceSubscriber<String> as1 = new ResourceSubscriber<String>() {
             @Override
             public void onNext(String t) {
-                o.onNext(t);
+                subscriber.onNext(t);
             }
 
             @Override
@@ -396,7 +396,7 @@ public class SerializedSubscriberTest {
         ResourceSubscriber<String> as2 = new ResourceSubscriber<String>() {
             @Override
             public void onNext(String t) {
-                o.onNext(t);
+                subscriber.onNext(t);
             }
 
             @Override

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -164,27 +164,27 @@ public class TestSubscriberTest {
     @Test
     public void testWrappingMock() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        Subscriber<Integer> mockObserver = TestHelper.mockSubscriber();
+        Subscriber<Integer> mockSubscriber = TestHelper.mockSubscriber();
 
-        oi.subscribe(new TestSubscriber<Integer>(mockObserver));
+        oi.subscribe(new TestSubscriber<Integer>(mockSubscriber));
 
-        InOrder inOrder = inOrder(mockObserver);
-        inOrder.verify(mockObserver, times(1)).onNext(1);
-        inOrder.verify(mockObserver, times(1)).onNext(2);
-        inOrder.verify(mockObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(mockSubscriber);
+        inOrder.verify(mockSubscriber, times(1)).onNext(1);
+        inOrder.verify(mockSubscriber, times(1)).onNext(2);
+        inOrder.verify(mockSubscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testWrappingMockWhenUnsubscribeInvolved() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9)).take(2);
-        Subscriber<Integer> mockObserver = TestHelper.mockSubscriber();
-        oi.subscribe(new TestSubscriber<Integer>(mockObserver));
+        Subscriber<Integer> mockSubscriber = TestHelper.mockSubscriber();
+        oi.subscribe(new TestSubscriber<Integer>(mockSubscriber));
 
-        InOrder inOrder = inOrder(mockObserver);
-        inOrder.verify(mockObserver, times(1)).onNext(1);
-        inOrder.verify(mockObserver, times(1)).onNext(2);
-        inOrder.verify(mockObserver, times(1)).onComplete();
+        InOrder inOrder = inOrder(mockSubscriber);
+        inOrder.verify(mockSubscriber, times(1)).onNext(1);
+        inOrder.verify(mockSubscriber, times(1)).onNext(2);
+        inOrder.verify(mockSubscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -46,69 +46,69 @@ public class TestSubscriberTest {
     @Test
     public void testAssert() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        oi.subscribe(o);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        oi.subscribe(ts);
 
-        o.assertValues(1, 2);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        ts.assertValues(1, 2);
+        ts.assertValueCount(2);
+        ts.assertTerminated();
     }
 
     @Test
     public void testAssertNotMatchCount() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        oi.subscribe(o);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        oi.subscribe(ts);
 
         thrown.expect(AssertionError.class);
         // FIXME different message pattern
         // thrown.expectMessage("Number of items does not match. Provided: 1  Actual: 2");
 
-        o.assertValues(1);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        ts.assertValues(1);
+        ts.assertValueCount(2);
+        ts.assertTerminated();
     }
 
     @Test
     public void testAssertNotMatchValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        oi.subscribe(o);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        oi.subscribe(ts);
 
         thrown.expect(AssertionError.class);
         // FIXME different message pattern
         // thrown.expectMessage("Value at index: 1 expected to be [3] (Integer) but was: [2] (Integer)");
 
 
-        o.assertValues(1, 3);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        ts.assertValues(1, 3);
+        ts.assertValueCount(2);
+        ts.assertTerminated();
     }
 
     @Test
     public void assertNeverAtNotMatchingValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        oi.subscribe(o);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        oi.subscribe(ts);
 
-        o.assertNever(3);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        ts.assertNever(3);
+        ts.assertValueCount(2);
+        ts.assertTerminated();
     }
 
     @Test
     public void assertNeverAtMatchingValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        oi.subscribe(o);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        oi.subscribe(ts);
 
-        o.assertValues(1, 2);
+        ts.assertValues(1, 2);
 
         thrown.expect(AssertionError.class);
 
-        o.assertNever(2);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        ts.assertNever(2);
+        ts.assertValueCount(2);
+        ts.assertTerminated();
     }
 
     @Test
@@ -146,8 +146,8 @@ public class TestSubscriberTest {
     @Test
     public void testAssertTerminalEventNotReceived() {
         PublishProcessor<Integer> p = PublishProcessor.create();
-        TestSubscriber<Integer> o = new TestSubscriber<Integer>();
-        p.subscribe(o);
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        p.subscribe(ts);
 
         p.onNext(1);
         p.onNext(2);
@@ -156,9 +156,9 @@ public class TestSubscriberTest {
         // FIXME different message pattern
         // thrown.expectMessage("No terminal events received.");
 
-        o.assertValues(1, 2);
-        o.assertValueCount(2);
-        o.assertTerminated();
+        ts.assertValues(1, 2);
+        ts.assertValueCount(2);
+        ts.assertTerminated();
     }
 
     @Test

--- a/src/test/java/io/reactivex/tck/MulticastProcessorRefCountedTckTest.java
+++ b/src/test/java/io/reactivex/tck/MulticastProcessorRefCountedTckTest.java
@@ -26,7 +26,7 @@ import io.reactivex.processors.*;
 public class MulticastProcessorRefCountedTckTest extends IdentityProcessorVerification<Integer> {
 
     public MulticastProcessorRefCountedTckTest() {
-        super(new TestEnvironment(50));
+        super(new TestEnvironment(200));
     }
 
     @Override


### PR DESCRIPTION
This PR cleans up the tests:

- Reduce stacktrace printouts due to undeliverable errors and turn them into assertions instead.
- Rename local variables & arguments of `Subscriber`s from `o` and `observer` to the proper `subscriber`
- Rename local variables & arguments of `Flowable`s from `o` and `observable` to the more appropriate `f` and `flowable`
- Add more naming tests to `CheckLocalVariablesInTests` to support the previous two points.