### PR TITLE
2.x: Improve Completable.onErrorResumeNext internals

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.completable;
 
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
@@ -21,6 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
 
 public final class CompletableResumeNext extends Completable {
 
@@ -82,7 +82,7 @@ public final class CompletableResumeNext extends Completable {
             CompletableSource c;
 
             try {
-                c = Objects.requireNonNull(errorMapper.apply(e), "The errorMapper returned a null CompletableSource");
+                c = ObjectHelper.requireNonNull(errorMapper.apply(e), "The errorMapper returned a null CompletableSource");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 downstream.onError(new CompositeException(e, ex));

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -2170,8 +2170,11 @@ public class CompletableTest {
         try {
             c.blockingAwait();
             Assert.fail("Did not throw an exception");
-        } catch (NullPointerException ex) {
-            Assert.assertTrue(ex.getCause() instanceof TestException);
+        } catch (CompositeException ex) {
+            List<Throwable> errors = ex.getExceptions();
+            TestHelper.assertError(errors, 0, TestException.class);
+            TestHelper.assertError(errors, 1, NullPointerException.class);
+            assertEquals(2, errors.size());
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableResumeNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableResumeNextTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.completable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
+
+public class CompletableResumeNextTest {
+
+    @Test
+    public void resumeWithError() {
+        Completable.error(new TestException())
+        .onErrorResumeNext(Functions.justFunction(Completable.error(new TestException("second"))))
+        .test()
+        .assertFailureAndMessage(TestException.class, "second");
+    }
+
+    @Test
+    public void disposeInMain() {
+        TestHelper.checkDisposedCompletable(new Function<Completable, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Completable c) throws Exception {
+                return c.onErrorResumeNext(Functions.justFunction(Completable.complete()));
+            }
+        });
+    }
+
+
+    @Test
+    public void disposeInResume() {
+        TestHelper.checkDisposedCompletable(new Function<Completable, CompletableSource>() {
+            @Override
+            public CompletableSource apply(Completable c) throws Exception {
+                return Completable.error(new TestException()).onErrorResumeNext(Functions.justFunction(c));
+            }
+        });
+    }
+
+    @Test
+    public void disposed() {
+        TestHelper.checkDisposed(
+                Completable.error(new TestException())
+                .onErrorResumeNext(Functions.justFunction(Completable.never()))
+        );
+    }
+}


### PR DESCRIPTION
This PR improves the internals of the `Completable.onErrorResumeNext` operator:

- Inline the `Disposable` management.
- Reuse the same instance for observing the fallback `CompletableSource`.
- Report null return of the `errorMapper` the same way as a crash via `CompositeException`.
- The exceptions in the composite should be in the order **original** -> **mapper exception**.