### PR TITLE
2.x: Update Mathematical and Aggregate Operators docs

### DIFF
--- a/docs/Mathematical-and-Aggregate-Operators.md
+++ b/docs/Mathematical-and-Aggregate-Operators.md
@@ -1,4 +1,4 @@
-This page shows operators that perform mathematical or other operations over an entire sequence of items emitted by an `Observable`. Because these operations must wait for the source `Observable` to complete emitting items before they can construct their own emissions (and must usually buffer these items), these operators are dangerous to use on `Observable`s that may have very long or infinite sequences.
+This page shows operators that perform mathematical or other operations over an entire sequence of items emitted by an `Observable` or `Flowable`. Because these operations must wait for the source `Observable`/`Flowable` to complete emitting items before they can construct their own emissions (and must usually buffer these items), these operators are dangerous to use on `Observable`s and `Flowable`s that may have very long or infinite sequences.
 
 # Outline
 

--- a/docs/Mathematical-and-Aggregate-Operators.md
+++ b/docs/Mathematical-and-Aggregate-Operators.md
@@ -1,25 +1,141 @@
 This page shows operators that perform mathematical or other operations over an entire sequence of items emitted by an Observable. Because these operations must wait for the source Observable to complete emitting items before they can construct their own emissions (and must usually buffer these items), these operators are dangerous to use on Observables that may have very long or infinite sequences.
 
-#### Operators in the `rxjava-math` module
-* [**`averageInteger( )`**](http://reactivex.io/documentation/operators/average.html) — calculates the average of Integers emitted by an Observable and emits this average
-* [**`averageLong( )`**](http://reactivex.io/documentation/operators/average.html) — calculates the average of Longs emitted by an Observable and emits this average
-* [**`averageFloat( )`**](http://reactivex.io/documentation/operators/average.html) — calculates the average of Floats emitted by an Observable and emits this average
-* [**`averageDouble( )`**](http://reactivex.io/documentation/operators/average.html) — calculates the average of Doubles emitted by an Observable and emits this average
-* [**`max( )`**](http://reactivex.io/documentation/operators/max.html) — emits the maximum value emitted by a source Observable
-* [**`maxBy( )`**](http://reactivex.io/documentation/operators/max.html) — emits the item emitted by the source Observable that has the maximum key value
-* [**`min( )`**](http://reactivex.io/documentation/operators/min.html) — emits the minimum value emitted by a source Observable
-* [**`minBy( )`**](http://reactivex.io/documentation/operators/min.html) — emits the item emitted by the source Observable that has the minimum key value
-* [**`sumInteger( )`**](http://reactivex.io/documentation/operators/sum.html) — adds the Integers emitted by an Observable and emits this sum
-* [**`sumLong( )`**](http://reactivex.io/documentation/operators/sum.html) — adds the Longs emitted by an Observable and emits this sum
-* [**`sumFloat( )`**](http://reactivex.io/documentation/operators/sum.html) — adds the Floats emitted by an Observable and emits this sum
-* [**`sumDouble( )`**](http://reactivex.io/documentation/operators/sum.html) — adds the Doubles emitted by an Observable and emits this sum
+# Outline
 
-#### Other Aggregate Operators
-* [**`concat( )`**](http://reactivex.io/documentation/operators/concat.html) — concatenate two or more Observables sequentially
-* [**`count( )` and `countLong( )`**](http://reactivex.io/documentation/operators/count.html) — counts the number of items emitted by an Observable and emits this count
-* [**`reduce( )`**](http://reactivex.io/documentation/operators/reduce.html) — apply a function to each emitted item, sequentially, and emit only the final accumulated value
-* [**`collect( )`**](http://reactivex.io/documentation/operators/reduce.html) — collect items emitted by the source Observable into a single mutable data structure and return an Observable that emits this structure
-* [**`toList( )`**](http://reactivex.io/documentation/operators/to.html) — collect all items from an Observable and emit them as a single List
-* [**`toSortedList( )`**](http://reactivex.io/documentation/operators/to.html) — collect all items from an Observable and emit them as a single, sorted List
-* [**`toMap( )`**](http://reactivex.io/documentation/operators/to.html) — convert the sequence of items emitted by an Observable into a map keyed by a specified key function
-* [**`toMultiMap( )`**](http://reactivex.io/documentation/operators/to.html) — convert the sequence of items emitted by an Observable into an ArrayList that is also a map keyed by a specified key function
+- [Mathematical Operators](#mathematical-operators)
+  - [`averageDouble`](#averagedouble)
+  - [`averageFloat`](#averagefloat)
+  - [`max`](#max)
+  - [`min`](#min)
+  - [`sumDouble`](#sumdouble)
+  - [`sumFloat`](#sumfloat)
+  - [`sumInt`](#sumint)
+  - [`sumLong`](#sumlong)
+- [Other Aggregate Operators](#other-aggregate-operators)
+  - [`count`](#count)
+  - [`reduce` and `reduceWith`](#reduce-and-reducewith)
+  - [`collect` and `collectInto`](#collect-and-collectinto)
+  - [`toList` and `toSortedList`](#tolist-and-tosortedlist)
+  - [`toMap`](#tomap)
+  - [`toMultimap`](#tomultimap)
+
+## Mathematical Operators
+
+> The operators in this section are part of the [`RxJava2Extensions`](https://github.com/akarnokd/RxJava2Extensions) project. You have to add the
+`rxjava2-extensions` module as a dependency to your project. It can be found
+at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.github.akarnokd%22).
+
+### averageDouble
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/average.html](http://reactivex.io/documentation/operators/average.html)
+
+Calculates the average of Numbers emitted by an Observable and emits this average as a Double.
+
+### averageFloat
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/average.html](http://reactivex.io/documentation/operators/average.html)
+
+Calculates the average of Numbers emitted by an Observable and emits this average as a Float.
+
+### max
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/max.html](http://reactivex.io/documentation/operators/max.html)
+
+Emits the maximum value emitted by a source Observable.
+
+### min
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/min.html](http://reactivex.io/documentation/operators/min.html)
+
+Emits the minimum value emitted by a source Observable.
+
+### sumDouble
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/sum.html](http://reactivex.io/documentation/operators/sum.html)
+
+Adds the Doubles emitted by an Observable and emits this sum.
+
+### sumFloat
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/sum.html](http://reactivex.io/documentation/operators/sum.html)
+
+Adds the Floats emitted by an Observable and emits this sum.
+
+### sumInt
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/sum.html](http://reactivex.io/documentation/operators/sum.html)
+
+Adds the Integers emitted by an Observable and emits this sum.
+
+### sumLong
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/sum.html](http://reactivex.io/documentation/operators/sum.html)
+
+Adds the Integers emitted by an Observable and emits this sum.
+
+## Other Aggregate Operators
+
+### count
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/count.html](http://reactivex.io/documentation/operators/count.html)
+
+
+Counts the number of items emitted by an Observable and emits this count.
+
+### reduce and reduceWith
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/reduce.html](http://reactivex.io/documentation/operators/reduce.html)
+
+Apply a function to each emitted item, sequentially, and emit only the final accumulated value.
+
+### collect and collectInto
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/reduce.html](http://reactivex.io/documentation/operators/reduce.html)
+
+Collect items emitted by the source Observable into a single mutable data structure and return an Observable that emits this structure.
+
+### toList and toSortedList
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/to.html](http://reactivex.io/documentation/operators/to.html)
+
+Collect all items from an Observable and emit them as a single List.
+
+### toMap
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/to.html](http://reactivex.io/documentation/operators/to.html)
+
+Convert the sequence of items emitted by an Observable into a map keyed by a specified key function.
+
+### toMultimap
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/to.html](http://reactivex.io/documentation/operators/to.html)
+
+Convert the sequence of items emitted by an Observable into an ArrayList that is also a map keyed by a specified key function.

--- a/docs/Mathematical-and-Aggregate-Operators.md
+++ b/docs/Mathematical-and-Aggregate-Operators.md
@@ -11,7 +11,7 @@ This page shows operators that perform mathematical or other operations over an 
   - [`sumFloat`](#sumfloat)
   - [`sumInt`](#sumint)
   - [`sumLong`](#sumlong)
-- [Other Aggregate Operators](#other-aggregate-operators)
+- [Standard Aggregate Operators](#standard-aggregate-operators)
   - [`count`](#count)
   - [`reduce` and `reduceWith`](#reduce-and-reducewith)
   - [`collect` and `collectInto`](#collect-and-collectinto)
@@ -178,7 +178,9 @@ MathObservable.sumLong(numbers).subscribe((Long sum) -> System.out.println(sum))
 // prints 5050
 ```
 
-## Other Aggregate Operators
+## Standard Aggregate Operators
+
+> Note that these standard aggregate operators return a `Single` or `Maybe` because the number of output items is always know to be at most one.
 
 ### count
 

--- a/docs/Mathematical-and-Aggregate-Operators.md
+++ b/docs/Mathematical-and-Aggregate-Operators.md
@@ -13,9 +13,12 @@ This page shows operators that perform mathematical or other operations over an 
   - [`sumLong`](#sumlong)
 - [Standard Aggregate Operators](#standard-aggregate-operators)
   - [`count`](#count)
-  - [`reduce` and `reduceWith`](#reduce-and-reducewith)
-  - [`collect` and `collectInto`](#collect-and-collectinto)
-  - [`toList` and `toSortedList`](#tolist-and-tosortedlist)
+  - [`reduce`](#reduce)
+  - [`reduceWith`](#reducewith)
+  - [`collect`](#collect)
+  - [`collectInto`](#collectinto)
+  - [`toList`](#tolist)
+  - [`toSortedList`](#tosortedlist)
   - [`toMap`](#tomap)
   - [`toMultimap`](#tomultimap)
 
@@ -198,7 +201,7 @@ Observable.just(1, 2, 3).count().subscribe(System.out::println);
 // prints 3
 ```
 
-### reduce and reduceWith
+### reduce
 
 **Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
 
@@ -216,6 +219,15 @@ Observable.range(1, 5)
 // prints 120
 ```
 
+### reduceWith
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/reduce.html](http://reactivex.io/documentation/operators/reduce.html)
+
+Apply a function to each emitted item, sequentially, and emit only the final accumulated value.
+
+
 #### reduceWith example
 
 ```java
@@ -229,7 +241,7 @@ Observable.just(1, 2, 2, 3, 4, 4, 4, 5)
 // prints [1, 2, 3, 4, 5]
 ```
 
-### collect and collectInto
+### collect
 
 **Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
 
@@ -248,6 +260,14 @@ Observable.just("Kirk", "Spock", "Chekov", "Sulu")
 // prints Kirk 🖖 Spock 🖖 Chekov 🖖 Sulu
 ```
 
+### collectInto
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/reduce.html](http://reactivex.io/documentation/operators/reduce.html)
+
+Collect items emitted by the source `Observable` into a single mutable data structure and return an `Observable` that emits this structure.
+
 #### collectInto example
 
 *Note: the mutable value that will collect the items (here the `StringBuilder`) will be shared between multiple subscribers.*
@@ -261,7 +281,7 @@ Observable.just('R', 'x', 'J', 'a', 'v', 'a')
 // prints RxJava
 ```
 
-### toList and toSortedList
+### toList
 
 **Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
 
@@ -278,6 +298,14 @@ Observable.just(2, 1, 3)
 
 // prints [2, 1, 3]
 ```
+
+### toSortedList
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX doumentation:** [http://reactivex.io/documentation/operators/to.html](http://reactivex.io/documentation/operators/to.html)
+
+Collect all items from an `Observable` and emit them as a single, sorted `List`.
 
 #### toSortedList example
 

--- a/docs/Mathematical-and-Aggregate-Operators.md
+++ b/docs/Mathematical-and-Aggregate-Operators.md
@@ -23,6 +23,15 @@ This page shows operators that perform mathematical or other operations over an 
 
 > The operators in this section are part of the [`RxJava2Extensions`](https://github.com/akarnokd/RxJava2Extensions) project. You have to add the `rxjava2-extensions` module as a dependency to your project. It can be found at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.github.akarnokd%22).
 
+> Note that unlike the standard RxJava aggregator operators, these mathematical operators return `Observable` and `Flowable` instead of the `Single` or `Maybe`.
+
+*The examples below assume that the `MathObservable` and `MathFlowable` classes are imported from the `rxjava2-extensions` module:*
+
+```java
+import hu.akarnokd.rxjava2.math.MathObservable;
+import hu.akarnokd.rxjava2.math.MathFlowable;
+```
+
 ### averageDouble
 
 **Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`

--- a/docs/Mathematical-and-Aggregate-Operators.md
+++ b/docs/Mathematical-and-Aggregate-Operators.md
@@ -1,4 +1,4 @@
-This page shows operators that perform mathematical or other operations over an entire sequence of items emitted by an Observable. Because these operations must wait for the source Observable to complete emitting items before they can construct their own emissions (and must usually buffer these items), these operators are dangerous to use on Observables that may have very long or infinite sequences.
+This page shows operators that perform mathematical or other operations over an entire sequence of items emitted by an `Observable`. Because these operations must wait for the source `Observable` to complete emitting items before they can construct their own emissions (and must usually buffer these items), these operators are dangerous to use on `Observable`s that may have very long or infinite sequences.
 
 # Outline
 
@@ -21,9 +21,7 @@ This page shows operators that perform mathematical or other operations over an 
 
 ## Mathematical Operators
 
-> The operators in this section are part of the [`RxJava2Extensions`](https://github.com/akarnokd/RxJava2Extensions) project. You have to add the
-`rxjava2-extensions` module as a dependency to your project. It can be found
-at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.github.akarnokd%22).
+> The operators in this section are part of the [`RxJava2Extensions`](https://github.com/akarnokd/RxJava2Extensions) project. You have to add the `rxjava2-extensions` module as a dependency to your project. It can be found at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.github.akarnokd%22).
 
 ### averageDouble
 
@@ -31,7 +29,7 @@ at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22c
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/average.html](http://reactivex.io/documentation/operators/average.html)
 
-Calculates the average of Numbers emitted by an Observable and emits this average as a Double.
+Calculates the average of `Number`s emitted by an `Observable` and emits this average as a `Double`.
 
 #### averageDouble example
 
@@ -48,7 +46,7 @@ MathObservable.averageDouble(numbers).subscribe((Double avg) -> System.out.print
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/average.html](http://reactivex.io/documentation/operators/average.html)
 
-Calculates the average of Numbers emitted by an Observable and emits this average as a Float.
+Calculates the average of `Number`s emitted by an `Observable` and emits this average as a `Float`.
 
 #### averageFloat example
 
@@ -65,8 +63,7 @@ MathObservable.averageFloat(numbers).subscribe((Float avg) -> System.out.println
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/max.html](http://reactivex.io/documentation/operators/max.html)
 
-Emits the maximum value emitted by a source Observable. A Comparator can be specified
-that will be used to compare the elements emitted by the Observable.
+Emits the maximum value emitted by a source `Observable`. A `Comparator` can be specified that will be used to compare the elements emitted by the `Observable`.
 
 #### max example
 
@@ -77,7 +74,7 @@ MathObservable.max(numbers).subscribe(System.out::println);
 // prints 9
 ```
 
-The following example specifies a Comparator to find the longest String in the source Observable:
+The following example specifies a `Comparator` to find the longest `String` in the source `Observable`:
 
 ```java
 final Observable<String> names = Observable.just("Kirk", "Spock", "Chekov", "Sulu");
@@ -93,8 +90,7 @@ MathObservable.max(names, Comparator.comparingInt(String::length))
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/min.html](http://reactivex.io/documentation/operators/min.html)
 
-Emits the minimum value emitted by a source Observable. A Comparator can be specified
-that will be used to compare the elements emitted by the Observable.
+Emits the minimum value emitted by a source `Observable`. A `Comparator` can be specified that will be used to compare the elements emitted by the `Observable`.
 
 #### min example
 
@@ -111,7 +107,7 @@ MathObservable.min(numbers).subscribe(System.out::println);
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/sum.html](http://reactivex.io/documentation/operators/sum.html)
 
-Adds the Doubles emitted by an Observable and emits this sum.
+Adds the `Double`s emitted by an `Observable` and emits this sum.
 
 #### sumDouble example
 
@@ -128,7 +124,7 @@ MathObservable.sumDouble(numbers).subscribe((Double sum) -> System.out.println(s
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/sum.html](http://reactivex.io/documentation/operators/sum.html)
 
-Adds the Floats emitted by an Observable and emits this sum.
+Adds the `Float`s emitted by an `Observable` and emits this sum.
 
 #### sumFloat example
 
@@ -145,7 +141,7 @@ MathObservable.sumFloat(numbers).subscribe((Float sum) -> System.out.println(sum
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/sum.html](http://reactivex.io/documentation/operators/sum.html)
 
-Adds the Integers emitted by an Observable and emits this sum.
+Adds the `Integer`s emitted by an `Observable` and emits this sum.
 
 #### sumInt example
 
@@ -162,7 +158,7 @@ MathObservable.sumInt(numbers).subscribe((Integer sum) -> System.out.println(sum
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/sum.html](http://reactivex.io/documentation/operators/sum.html)
 
-Adds the Integers emitted by an Observable and emits this sum.
+Adds the `Long`s emitted by an `Observable` and emits this sum.
 
 #### sumLong example
 
@@ -181,7 +177,7 @@ MathObservable.sumLong(numbers).subscribe((Long sum) -> System.out.println(sum))
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/count.html](http://reactivex.io/documentation/operators/count.html)
 
-Counts the number of items emitted by an Observable and emits this count.
+Counts the number of items emitted by an `Observable` and emits this count as a `Long`.
 
 #### count example
 
@@ -228,7 +224,7 @@ Observable.just(1, 2, 2, 3, 4, 4, 4, 5)
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/reduce.html](http://reactivex.io/documentation/operators/reduce.html)
 
-Collect items emitted by the source Observable into a single mutable data structure and return an Observable that emits this structure.
+Collect items emitted by the source `Observable` into a single mutable data structure and return an `Observable` that emits this structure.
 
 #### collect example
 
@@ -243,8 +239,7 @@ Observable.just("Kirk", "Spock", "Chekov", "Sulu")
 
 #### collectInto example
 
-*Note*: the mutable value that will collect the items will be shared between
-multiple subscribers.
+*Note: the mutable value that will collect the items (here the `StringBuilder`) will be shared between multiple subscribers.*
 
 ```java
 Observable.just('R', 'x', 'J', 'a', 'v', 'a')
@@ -261,7 +256,7 @@ Observable.just('R', 'x', 'J', 'a', 'v', 'a')
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/to.html](http://reactivex.io/documentation/operators/to.html)
 
-Collect all items from an Observable and emit them as a single List.
+Collect all items from an `Observable` and emit them as a single `List`.
 
 #### toList example
 
@@ -289,7 +284,7 @@ Observable.just(2, 1, 3)
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/to.html](http://reactivex.io/documentation/operators/to.html)
 
-Convert the sequence of items emitted by an Observable into a map keyed by a specified key function.
+Convert the sequence of items emitted by an `Observable` into a `Map` keyed by a specified key function.
 
 #### toMap example
 
@@ -313,7 +308,7 @@ Observable.just(1, 2, 3, 4)
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/to.html](http://reactivex.io/documentation/operators/to.html)
 
-Convert the sequence of items emitted by an Observable into an ArrayList that is also a map keyed by a specified key function.
+Convert the sequence of items emitted by an `Observable` into a `Collection` that is also a `Map` keyed by a specified key function.
 
 #### toMultimap example
 

--- a/docs/Mathematical-and-Aggregate-Operators.md
+++ b/docs/Mathematical-and-Aggregate-Operators.md
@@ -33,6 +33,15 @@ at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22c
 
 Calculates the average of Numbers emitted by an Observable and emits this average as a Double.
 
+#### averageDouble example
+
+```java
+Observable<Integer> numbers = Observable.just(1, 2, 3);
+MathObservable.averageDouble(numbers).subscribe((Double avg) -> System.out.println(avg));
+
+// prints 2.0
+```
+
 ### averageFloat
 
 **Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
@@ -41,13 +50,42 @@ Calculates the average of Numbers emitted by an Observable and emits this averag
 
 Calculates the average of Numbers emitted by an Observable and emits this average as a Float.
 
+#### averageFloat example
+
+```java
+Observable<Integer> numbers = Observable.just(1, 2, 3);
+MathObservable.averageFloat(numbers).subscribe((Float avg) -> System.out.println(avg));
+
+// prints 2.0
+```
+
 ### max
 
 **Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/max.html](http://reactivex.io/documentation/operators/max.html)
 
-Emits the maximum value emitted by a source Observable.
+Emits the maximum value emitted by a source Observable. A Comparator can be specified
+that will be used to compare the elements emitted by the Observable.
+
+#### max example
+
+```java
+Observable<Integer> numbers = Observable.just(4, 9, 5);
+MathObservable.max(numbers).subscribe(System.out::println);
+
+// prints 9
+```
+
+The following example specifies a Comparator to find the longest String in the source Observable:
+
+```java
+final Observable<String> names = Observable.just("Kirk", "Spock", "Chekov", "Sulu");
+MathObservable.max(names, Comparator.comparingInt(String::length))
+        .subscribe(System.out::println);
+
+// prints Chekov
+```
 
 ### min
 
@@ -55,7 +93,17 @@ Emits the maximum value emitted by a source Observable.
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/min.html](http://reactivex.io/documentation/operators/min.html)
 
-Emits the minimum value emitted by a source Observable.
+Emits the minimum value emitted by a source Observable. A Comparator can be specified
+that will be used to compare the elements emitted by the Observable.
+
+#### min example
+
+```java
+Observable<Integer> numbers = Observable.just(4, 9, 5);
+MathObservable.min(numbers).subscribe(System.out::println);
+
+// prints 4
+```
 
 ### sumDouble
 
@@ -65,6 +113,15 @@ Emits the minimum value emitted by a source Observable.
 
 Adds the Doubles emitted by an Observable and emits this sum.
 
+#### sumDouble example
+
+```java
+Observable<Double> numbers = Observable.just(1.0, 2.0, 3.0);
+MathObservable.sumDouble(numbers).subscribe((Double sum) -> System.out.println(sum));
+
+// prints 6.0
+```
+
 ### sumFloat
 
 **Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
@@ -72,6 +129,15 @@ Adds the Doubles emitted by an Observable and emits this sum.
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/sum.html](http://reactivex.io/documentation/operators/sum.html)
 
 Adds the Floats emitted by an Observable and emits this sum.
+
+#### sumFloat example
+
+```java
+Observable<Float> numbers = Observable.just(1.0F, 2.0F, 3.0F);
+MathObservable.sumFloat(numbers).subscribe((Float sum) -> System.out.println(sum));
+
+// prints 6.0
+```
 
 ### sumInt
 
@@ -81,6 +147,15 @@ Adds the Floats emitted by an Observable and emits this sum.
 
 Adds the Integers emitted by an Observable and emits this sum.
 
+#### sumInt example
+
+```java
+Observable<Integer> numbers = Observable.range(1, 100);
+MathObservable.sumInt(numbers).subscribe((Integer sum) -> System.out.println(sum));
+
+// prints 5050
+```
+
 ### sumLong
 
 **Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
@@ -88,6 +163,15 @@ Adds the Integers emitted by an Observable and emits this sum.
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/sum.html](http://reactivex.io/documentation/operators/sum.html)
 
 Adds the Integers emitted by an Observable and emits this sum.
+
+#### sumLong example
+
+```java
+Observable<Long> numbers = Observable.rangeLong(1L, 100L);
+MathObservable.sumLong(numbers).subscribe((Long sum) -> System.out.println(sum));
+
+// prints 5050
+```
 
 ## Other Aggregate Operators
 
@@ -97,8 +181,15 @@ Adds the Integers emitted by an Observable and emits this sum.
 
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/count.html](http://reactivex.io/documentation/operators/count.html)
 
-
 Counts the number of items emitted by an Observable and emits this count.
+
+#### count example
+
+```java
+Observable.just(1, 2, 3).count().subscribe(System.out::println);
+
+// prints 3
+```
 
 ### reduce and reduceWith
 
@@ -108,6 +199,29 @@ Counts the number of items emitted by an Observable and emits this count.
 
 Apply a function to each emitted item, sequentially, and emit only the final accumulated value.
 
+#### reduce example
+
+```java
+Observable.range(1, 5)
+    .reduce((product, x) -> product * x)
+    .subscribe(System.out::println);
+
+// prints 120
+```
+
+#### reduceWith example
+
+```java
+Observable.just(1, 2, 2, 3, 4, 4, 4, 5)
+        .reduceWith(TreeSet::new, (set, x) -> {
+            set.add(x);
+            return set;
+        })
+        .subscribe(System.out::println);
+
+// prints [1, 2, 3, 4, 5]
+```
+
 ### collect and collectInto
 
 **Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
@@ -115,6 +229,31 @@ Apply a function to each emitted item, sequentially, and emit only the final acc
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/reduce.html](http://reactivex.io/documentation/operators/reduce.html)
 
 Collect items emitted by the source Observable into a single mutable data structure and return an Observable that emits this structure.
+
+#### collect example
+
+```java
+Observable.just("Kirk", "Spock", "Chekov", "Sulu")
+        .collect(() -> new StringJoiner(" \uD83D\uDD96 "), StringJoiner::add)
+        .map(StringJoiner::toString)
+        .subscribe(System.out::println);
+
+// prints Kirk 🖖 Spock 🖖 Chekov 🖖 Sulu
+```
+
+#### collectInto example
+
+*Note*: the mutable value that will collect the items will be shared between
+multiple subscribers.
+
+```java
+Observable.just('R', 'x', 'J', 'a', 'v', 'a')
+        .collectInto(new StringBuilder(), StringBuilder::append)
+        .map(StringBuilder::toString)
+        .subscribe(System.out::println);
+
+// prints RxJava
+```
 
 ### toList and toSortedList
 
@@ -124,6 +263,26 @@ Collect items emitted by the source Observable into a single mutable data struct
 
 Collect all items from an Observable and emit them as a single List.
 
+#### toList example
+
+```java
+Observable.just(2, 1, 3)
+        .toList()
+        .subscribe(System.out::println);
+
+// prints [2, 1, 3]
+```
+
+#### toSortedList example
+
+```java
+Observable.just(2, 1, 3)
+        .toSortedList(Comparator.reverseOrder())
+        .subscribe(System.out::println);
+
+// prints [3, 2, 1]
+```
+
 ### toMap
 
 **Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
@@ -132,6 +291,22 @@ Collect all items from an Observable and emit them as a single List.
 
 Convert the sequence of items emitted by an Observable into a map keyed by a specified key function.
 
+#### toMap example
+
+```java
+Observable.just(1, 2, 3, 4)
+        .toMap((x) -> {
+            // defines the key in the Map
+            return x;
+        }, (x) -> {
+            // defines the value that is mapped to the key
+            return (x % 2 == 0) ? "even" : "odd";
+        })
+        .subscribe(System.out::println);
+
+// prints {1=odd, 2=even, 3=odd, 4=even}
+```
+
 ### toMultimap
 
 **Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
@@ -139,3 +314,19 @@ Convert the sequence of items emitted by an Observable into a map keyed by a spe
 **ReactiveX doumentation:** [http://reactivex.io/documentation/operators/to.html](http://reactivex.io/documentation/operators/to.html)
 
 Convert the sequence of items emitted by an Observable into an ArrayList that is also a map keyed by a specified key function.
+
+#### toMultimap example
+
+```java
+Observable.just(1, 2, 3, 4)
+        .toMultimap((x) -> {
+            // defines the key in the Map
+            return (x % 2 == 0) ? "even" : "odd";
+        }, (x) -> {
+            // defines the value that is mapped to the key
+            return x;
+        })
+        .subscribe(System.out::println);
+
+// prints {even=[2, 4], odd=[1, 3]}
+```


### PR DESCRIPTION
This PR updates the `Mathematical-and-Aggregate-Operators.md` wiki page as per issue #6132:
  
  - Remove obsolete operators
  - Link to the [RxJava2Extensions](https://github.com/akarnokd/RxJava2Extensions) project
  - Add examples

The page now follows the structure that was defined in #6131.

__Question__: Should __Available in__ in the *Mathematical Operators* section be renamed to something else (e.g. __Defined for__), because the operators are not part of the core RxJava operators?
