### PR TITLE
2.x: cleanup newline separation, some field namings

### DIFF
--- a/src/jmh/java/io/reactivex/EachTypeFlatMapPerf.java
+++ b/src/jmh/java/io/reactivex/EachTypeFlatMapPerf.java
@@ -86,10 +86,12 @@ public class EachTypeFlatMapPerf {
     public void bpRange(Blackhole bh) {
         bpRange.subscribe(new PerfSubscriber(bh));
     }
+
     @Benchmark
     public void bpRangeMapJust(Blackhole bh) {
         bpRangeMapJust.subscribe(new PerfSubscriber(bh));
     }
+
     @Benchmark
     public void bpRangeMapRange(Blackhole bh) {
         bpRangeMapRange.subscribe(new PerfSubscriber(bh));
@@ -99,10 +101,12 @@ public class EachTypeFlatMapPerf {
     public void nbpRange(Blackhole bh) {
         nbpRange.subscribe(new PerfObserver(bh));
     }
+
     @Benchmark
     public void nbpRangeMapJust(Blackhole bh) {
         nbpRangeMapJust.subscribe(new PerfObserver(bh));
     }
+
     @Benchmark
     public void nbpRangeMapRange(Blackhole bh) {
         nbpRangeMapRange.subscribe(new PerfObserver(bh));
@@ -112,6 +116,7 @@ public class EachTypeFlatMapPerf {
     public void singleJust(Blackhole bh) {
         singleJust.subscribe(new LatchedSingleObserver<Integer>(bh));
     }
+
     @Benchmark
     public void singleJustMapJust(Blackhole bh) {
         singleJustMapJust.subscribe(new LatchedSingleObserver<Integer>(bh));

--- a/src/jmh/java/io/reactivex/LatchedSingleObserver.java
+++ b/src/jmh/java/io/reactivex/LatchedSingleObserver.java
@@ -26,15 +26,18 @@ public final class LatchedSingleObserver<T> implements SingleObserver<T> {
         this.bh = bh;
         this.cdl = new CountDownLatch(1);
     }
+
     @Override
     public void onSubscribe(Disposable d) {
 
     }
+
     @Override
     public void onSuccess(T value) {
         bh.consume(value);
         cdl.countDown();
     }
+
     @Override
     public void onError(Throwable e) {
         e.printStackTrace();

--- a/src/jmh/java/io/reactivex/PerfObserver.java
+++ b/src/jmh/java/io/reactivex/PerfObserver.java
@@ -26,19 +26,23 @@ public final class PerfObserver implements Observer<Object> {
         this.bh = bh;
         this.cdl = new CountDownLatch(1);
     }
+
     @Override
     public void onSubscribe(Disposable d) {
 
     }
+
     @Override
     public void onNext(Object value) {
         bh.consume(value);
     }
+
     @Override
     public void onError(Throwable e) {
         e.printStackTrace();
         cdl.countDown();
     }
+
     @Override
     public void onComplete() {
         cdl.countDown();

--- a/src/jmh/java/io/reactivex/PublishProcessorPerf.java
+++ b/src/jmh/java/io/reactivex/PublishProcessorPerf.java
@@ -71,7 +71,6 @@ public class PublishProcessorPerf {
         bounded.onNext(1);
     }
 
-
     @Benchmark
     public void bounded1k() {
         for (int i = 0; i < 1000; i++) {
@@ -86,12 +85,10 @@ public class PublishProcessorPerf {
         }
     }
 
-
     @Benchmark
     public void subject1() {
         subject.onNext(1);
     }
-
 
     @Benchmark
     public void subject1k() {

--- a/src/jmh/java/io/reactivex/ToFlowablePerf.java
+++ b/src/jmh/java/io/reactivex/ToFlowablePerf.java
@@ -78,6 +78,7 @@ public class ToFlowablePerf {
     public Object flowable() {
         return flowable.blockingGet();
     }
+
     @Benchmark
     public Object flowableInner() {
         return flowableInner.blockingLast();

--- a/src/main/java/io/reactivex/internal/disposables/EmptyDisposable.java
+++ b/src/main/java/io/reactivex/internal/disposables/EmptyDisposable.java
@@ -83,7 +83,6 @@ public enum EmptyDisposable implements QueueDisposable<Object> {
         observer.onError(e);
     }
 
-
     @Override
     public boolean offer(Object value) {
         throw new UnsupportedOperationException("Should not be called!");

--- a/src/main/java/io/reactivex/internal/observers/DisposableLambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/DisposableLambdaObserver.java
@@ -74,7 +74,6 @@ public final class DisposableLambdaObserver<T> implements Observer<T>, Disposabl
         }
     }
 
-
     @Override
     public void dispose() {
         try {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromPublisher.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromPublisher.java
@@ -53,7 +53,6 @@ public final class CompletableFromPublisher<T> extends Completable {
             }
         }
 
-
         @Override
         public void onNext(T t) {
             // ignored

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletablePeek.java
@@ -61,7 +61,6 @@ public final class CompletablePeek extends Completable {
             this.downstream = downstream;
         }
 
-
         @Override
         public void onSubscribe(final Disposable d) {
             try {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
@@ -34,8 +34,6 @@ public final class CompletableResumeNext extends Completable {
         this.errorMapper = errorMapper;
     }
 
-
-
     @Override
     protected void subscribeActual(final CompletableObserver observer) {
         ResumeNextObserver parent = new ResumeNextObserver(observer, errorMapper);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableResumeNext.java
@@ -58,7 +58,6 @@ public final class CompletableResumeNext extends Completable {
             this.errorMapper = errorMapper;
         }
 
-
         @Override
         public void onSubscribe(Disposable d) {
             DisposableHelper.replace(this, d);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableUsing.java
@@ -40,7 +40,6 @@ public final class CompletableUsing<R> extends Completable {
         this.eager = eager;
     }
 
-
     @Override
     protected void subscribeActual(CompletableObserver observer) {
         R resource;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAll.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAll.java
@@ -47,6 +47,7 @@ public final class FlowableAll<T> extends AbstractFlowableWithUpstream<T, Boolea
             super(actual);
             this.predicate = predicate;
         }
+
         @Override
         public void onSubscribe(Subscription s) {
             if (SubscriptionHelper.validate(this.upstream, s)) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAllSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAllSingle.java
@@ -57,6 +57,7 @@ public final class FlowableAllSingle<T> extends Single<Boolean> implements FuseT
             this.downstream = actual;
             this.predicate = predicate;
         }
+
         @Override
         public void onSubscribe(Subscription s) {
             if (SubscriptionHelper.validate(this.upstream, s)) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAny.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAny.java
@@ -46,6 +46,7 @@ public final class FlowableAny<T> extends AbstractFlowableWithUpstream<T, Boolea
             super(actual);
             this.predicate = predicate;
         }
+
         @Override
         public void onSubscribe(Subscription s) {
             if (SubscriptionHelper.validate(this.upstream, s)) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableAnySingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableAnySingle.java
@@ -56,6 +56,7 @@ public final class FlowableAnySingle<T> extends Single<Boolean> implements FuseT
             this.downstream = actual;
             this.predicate = predicate;
         }
+
         @Override
         public void onSubscribe(Subscription s) {
             if (SubscriptionHelper.validate(this.upstream, s)) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -518,7 +518,6 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
             return true;
         }
 
-
         @Override
         public void request(long n) {
             requested(n);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCache.java
@@ -200,6 +200,7 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
             source.subscribe(this);
             isConnected = true;
         }
+
         @Override
         public void onNext(T t) {
             if (!sourceDone) {
@@ -210,6 +211,7 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
                 }
             }
         }
+
         @SuppressWarnings("unchecked")
         @Override
         public void onError(Throwable e) {
@@ -225,6 +227,7 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
                 RxJavaPlugins.onError(e);
             }
         }
+
         @SuppressWarnings("unchecked")
         @Override
         public void onComplete() {
@@ -284,6 +287,7 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
             this.state = state;
             this.requested = new AtomicLong();
         }
+
         @Override
         public void request(long n) {
             if (SubscriptionHelper.validate(n)) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
@@ -417,7 +417,6 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
             downstream.onNext(value);
         }
 
-
         @Override
         public void innerError(Throwable e) {
             if (errors.addThrowable(e)) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounceTimed.java
@@ -125,6 +125,7 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
             if (d != null) {
                 d.dispose();
             }
+
             @SuppressWarnings("unchecked")
             DebounceEmitter<T> de = (DebounceEmitter<T>)d;
             if (de != null) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDefer.java
@@ -27,6 +27,7 @@ public final class FlowableDefer<T> extends Flowable<T> {
     public FlowableDefer(Callable<? extends Publisher<? extends T>> supplier) {
         this.supplier = supplier;
     }
+
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
         Publisher<? extends T> pub;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDematerialize.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDematerialize.java
@@ -79,6 +79,7 @@ public final class FlowableDematerialize<T> extends AbstractFlowableWithUpstream
 
             downstream.onError(t);
         }
+
         @Override
         public void onComplete() {
             if (done) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableError.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableError.java
@@ -27,6 +27,7 @@ public final class FlowableError<T> extends Flowable<T> {
     public FlowableError(Callable<? extends Throwable> errorSupplier) {
         this.errorSupplier = errorSupplier;
     }
+
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
         Throwable error;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -461,6 +461,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                         if (checkTerminate()) {
                             return;
                         }
+
                         @SuppressWarnings("unchecked")
                         InnerSubscriber<T, U> is = (InnerSubscriber<T, U>)inner[j];
 
@@ -629,6 +630,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
             this.bufferSize = parent.bufferSize;
             this.limit = bufferSize >> 2;
         }
+
         @Override
         public void onSubscribe(Subscription s) {
             if (SubscriptionHelper.setOnce(this, s)) {
@@ -654,6 +656,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                 s.request(bufferSize);
             }
         }
+
         @Override
         public void onNext(U t) {
             if (fusionMode != QueueSubscription.ASYNC) {
@@ -662,11 +665,13 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                 parent.drain();
             }
         }
+
         @Override
         public void onError(Throwable t) {
             lazySet(SubscriptionHelper.CANCELLED);
             parent.innerError(this, t);
         }
+
         @Override
         public void onComplete() {
             done = true;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
@@ -93,7 +93,6 @@ public final class FlowableFromArray<T> extends Flowable<T> {
             }
         }
 
-
         @Override
         public final void cancel() {
             cancelled = true;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromArray.java
@@ -28,6 +28,7 @@ public final class FlowableFromArray<T> extends Flowable<T> {
     public FlowableFromArray(T[] array) {
         this.array = array;
     }
+
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
         if (s instanceof ConditionalSubscriber) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromCallable.java
@@ -27,6 +27,7 @@ public final class FlowableFromCallable<T> extends Flowable<T> implements Callab
     public FlowableFromCallable(Callable<? extends T> callable) {
         this.callable = callable;
     }
+
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
         DeferredScalarSubscription<T> deferred = new DeferredScalarSubscription<T>(s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromIterable.java
@@ -104,7 +104,6 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
             return ObjectHelper.requireNonNull(it.next(), "Iterator.next() returned a null value");
         }
 
-
         @Override
         public final boolean isEmpty() {
             return it == null || !it.hasNext();
@@ -127,7 +126,6 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
                 }
             }
         }
-
 
         @Override
         public final void cancel() {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureError.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureError.java
@@ -30,7 +30,6 @@ public final class FlowableOnBackpressureError<T> extends AbstractFlowableWithUp
         super(source);
     }
 
-
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
         this.source.subscribe(new BackpressureErrorSubscriber<T>(s));

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublish.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowablePublish.java
@@ -230,6 +230,7 @@ public final class FlowablePublish<T> extends ConnectableFlowable<T> implements 
             // loop to act on the current state serially
             dispatch();
         }
+
         @Override
         public void onError(Throwable e) {
             // The observer front is accessed serially as required by spec so
@@ -243,6 +244,7 @@ public final class FlowablePublish<T> extends ConnectableFlowable<T> implements 
                 RxJavaPlugins.onError(e);
             }
         }
+
         @Override
         public void onComplete() {
             // The observer front is accessed serially as required by spec so

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
@@ -95,7 +95,6 @@ public final class FlowableRange extends Flowable<Integer> {
             }
         }
 
-
         @Override
         public final void cancel() {
             cancelled = true;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRange.java
@@ -31,6 +31,7 @@ public final class FlowableRange extends Flowable<Integer> {
         this.start = start;
         this.end = start + count;
     }
+
     @Override
     public void subscribeActual(Subscriber<? super Integer> s) {
         if (s instanceof ConditionalSubscriber) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeat.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeat.java
@@ -64,6 +64,7 @@ public final class FlowableRepeat<T> extends AbstractFlowableWithUpstream<T, T> 
             produced++;
             downstream.onNext(t);
         }
+
         @Override
         public void onError(Throwable t) {
             downstream.onError(t);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatUntil.java
@@ -66,6 +66,7 @@ public final class FlowableRepeatUntil<T> extends AbstractFlowableWithUpstream<T
             produced++;
             downstream.onNext(t);
         }
+
         @Override
         public void onError(Throwable t) {
             downstream.onError(t);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -409,6 +409,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
                 RxJavaPlugins.onError(e);
             }
         }
+
         @SuppressWarnings("unchecked")
         @Override
         public void onComplete() {
@@ -624,6 +625,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
         UnboundedReplayBuffer(int capacityHint) {
             super(capacityHint);
         }
+
         @Override
         public void next(T value) {
             add(NotificationLite.next(value));
@@ -1037,6 +1039,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
                 setFirst(prev);
             }
         }
+
         @Override
         void truncateFinal() {
             long timeLimit = scheduler.now(unit) - maxAge;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryBiPredicate.java
@@ -70,6 +70,7 @@ public final class FlowableRetryBiPredicate<T> extends AbstractFlowableWithUpstr
             produced++;
             downstream.onNext(t);
         }
+
         @Override
         public void onError(Throwable t) {
             boolean b;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryPredicate.java
@@ -73,6 +73,7 @@ public final class FlowableRetryPredicate<T> extends AbstractFlowableWithUpstrea
             produced++;
             downstream.onNext(t);
         }
+
         @Override
         public void onError(Throwable t) {
             long r = remaining;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTake.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTake.java
@@ -52,6 +52,7 @@ public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
             this.limit = limit;
             this.remaining = limit;
         }
+
         @Override
         public void onSubscribe(Subscription s) {
             if (SubscriptionHelper.validate(this.upstream, s)) {
@@ -65,6 +66,7 @@ public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
                 }
             }
         }
+
         @Override
         public void onNext(T t) {
             if (!done && remaining-- > 0) {
@@ -76,6 +78,7 @@ public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
                 }
             }
         }
+
         @Override
         public void onError(Throwable t) {
             if (!done) {
@@ -86,6 +89,7 @@ public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
                 RxJavaPlugins.onError(t);
             }
         }
+
         @Override
         public void onComplete() {
             if (!done) {
@@ -93,6 +97,7 @@ public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
                 downstream.onComplete();
             }
         }
+
         @Override
         public void request(long n) {
             if (!SubscriptionHelper.validate(n)) {
@@ -106,6 +111,7 @@ public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
             }
             upstream.request(n);
         }
+
         @Override
         public void cancel() {
             upstream.cancel();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeInterval.java
@@ -31,7 +31,6 @@ public final class FlowableTimeInterval<T> extends AbstractFlowableWithUpstream<
         this.unit = unit;
     }
 
-
     @Override
     protected void subscribeActual(Subscriber<? super Timed<T>> s) {
         source.subscribe(new TimeIntervalSubscriber<T>(s, unit, scheduler));

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -131,9 +131,9 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
 
         void subscribe(Publisher<?>[] others, int n) {
             WithLatestInnerSubscriber[] subscribers = this.subscribers;
-            AtomicReference<Subscription> s = this.upstream;
+            AtomicReference<Subscription> upstream = this.upstream;
             for (int i = 0; i < n; i++) {
-                if (SubscriptionHelper.isCancelled(s.get())) {
+                if (SubscriptionHelper.isCancelled(upstream.get())) {
                     return;
                 }
                 others[i].subscribe(subscribers[i]);

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmpty.java
@@ -99,18 +99,22 @@ public final class MaybeSwitchIfEmpty<T> extends AbstractMaybeWithUpstream<T, T>
                 this.downstream = actual;
                 this.parent = parent;
             }
+
             @Override
             public void onSubscribe(Disposable d) {
                 DisposableHelper.setOnce(parent, d);
             }
+
             @Override
             public void onSuccess(T value) {
                 downstream.onSuccess(value);
             }
+
             @Override
             public void onError(Throwable e) {
                 downstream.onError(e);
             }
+
             @Override
             public void onComplete() {
                 downstream.onComplete();

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingle.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingle.java
@@ -106,14 +106,17 @@ public final class MaybeSwitchIfEmptySingle<T> extends Single<T> implements HasU
                 this.downstream = actual;
                 this.parent = parent;
             }
+
             @Override
             public void onSubscribe(Disposable d) {
                 DisposableHelper.setOnce(parent, d);
             }
+
             @Override
             public void onSuccess(T value) {
                 downstream.onSuccess(value);
             }
+
             @Override
             public void onError(Throwable e) {
                 downstream.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservable.java
@@ -81,7 +81,6 @@ public final class CompletableAndThenObservable<R> extends Observable<R> {
             }
         }
 
-
         @Override
         public void dispose() {
             DisposableHelper.dispose(this);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAll.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAll.java
@@ -43,6 +43,7 @@ public final class ObservableAll<T> extends AbstractObservableWithUpstream<T, Bo
             this.downstream = actual;
             this.predicate = predicate;
         }
+
         @Override
         public void onSubscribe(Disposable d) {
             if (DisposableHelper.validate(this.upstream, d)) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAllSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAllSingle.java
@@ -51,6 +51,7 @@ public final class ObservableAllSingle<T> extends Single<Boolean> implements Fus
             this.downstream = actual;
             this.predicate = predicate;
         }
+
         @Override
         public void onSubscribe(Disposable d) {
             if (DisposableHelper.validate(this.upstream, d)) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAny.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAny.java
@@ -44,6 +44,7 @@ public final class ObservableAny<T> extends AbstractObservableWithUpstream<T, Bo
             this.downstream = actual;
             this.predicate = predicate;
         }
+
         @Override
         public void onSubscribe(Disposable d) {
             if (DisposableHelper.validate(this.upstream, d)) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableAnySingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableAnySingle.java
@@ -53,6 +53,7 @@ public final class ObservableAnySingle<T> extends Single<Boolean> implements Fus
             this.downstream = actual;
             this.predicate = predicate;
         }
+
         @Override
         public void onSubscribe(Disposable d) {
             if (DisposableHelper.validate(this.upstream, d)) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
@@ -168,7 +168,6 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -517,7 +517,6 @@ extends AbstractObservableWithUpstream<T, U> {
             a.onNext(v);
         }
 
-
         @Override
         public void dispose() {
             if (!cancelled) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCache.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCache.java
@@ -216,6 +216,7 @@ public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, 
             source.subscribe(this);
             isConnected = true;
         }
+
         @Override
         public void onNext(T t) {
             if (!sourceDone) {
@@ -226,6 +227,7 @@ public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, 
                 }
             }
         }
+
         @SuppressWarnings("unchecked")
         @Override
         public void onError(Throwable e) {
@@ -239,6 +241,7 @@ public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, 
                 }
             }
         }
+
         @SuppressWarnings("unchecked")
         @Override
         public void onComplete() {
@@ -296,6 +299,7 @@ public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, 
         public boolean isDisposed() {
             return cancelled;
         }
+
         @Override
         public void dispose() {
             if (!cancelled) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCollect.java
@@ -69,7 +69,6 @@ public final class ObservableCollect<T, U> extends AbstractObservableWithUpstrea
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -79,7 +78,6 @@ public final class ObservableCollect<T, U> extends AbstractObservableWithUpstrea
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCollectSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCollectSingle.java
@@ -77,7 +77,6 @@ public final class ObservableCollectSingle<T, U> extends Single<U> implements Fu
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -87,7 +86,6 @@ public final class ObservableCollectSingle<T, U> extends Single<U> implements Fu
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCombineLatest.java
@@ -43,7 +43,6 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
         this.delayError = delayError;
     }
 
-
     @Override
     @SuppressWarnings("unchecked")
     public void subscribeActual(Observer<? super R> observer) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
@@ -40,6 +40,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
         this.delayErrors = delayErrors;
         this.bufferSize = Math.max(8, bufferSize);
     }
+
     @Override
     public void subscribeActual(Observer<? super U> observer) {
 
@@ -82,6 +83,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
             this.bufferSize = bufferSize;
             this.inner = new InnerObserver<U>(actual, this);
         }
+
         @Override
         public void onSubscribe(Disposable d) {
             if (DisposableHelper.validate(this.upstream, d)) {
@@ -117,6 +119,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
                 downstream.onSubscribe(this);
             }
         }
+
         @Override
         public void onNext(T t) {
             if (done) {
@@ -127,6 +130,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
             }
             drain();
         }
+
         @Override
         public void onError(Throwable t) {
             if (done) {
@@ -137,6 +141,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
             dispose();
             downstream.onError(t);
         }
+
         @Override
         public void onComplete() {
             if (done) {
@@ -246,11 +251,13 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
             public void onNext(U t) {
                 downstream.onNext(t);
             }
+
             @Override
             public void onError(Throwable t) {
                 parent.dispose();
                 downstream.onError(t);
             }
+
             @Override
             public void onComplete() {
                 parent.innerComplete();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCount.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCount.java
@@ -46,7 +46,6 @@ public final class ObservableCount<T> extends AbstractObservableWithUpstream<T, 
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCountSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCountSingle.java
@@ -54,7 +54,6 @@ public final class ObservableCountSingle<T> extends Single<Long> implements Fuse
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounceTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounceTimed.java
@@ -117,6 +117,7 @@ public final class ObservableDebounceTimed<T> extends AbstractObservableWithUpst
             if (d != null) {
                 d.dispose();
             }
+
             @SuppressWarnings("unchecked")
             DebounceEmitter<T> de = (DebounceEmitter<T>)d;
             if (de != null) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDefer.java
@@ -25,6 +25,7 @@ public final class ObservableDefer<T> extends Observable<T> {
     public ObservableDefer(Callable<? extends ObservableSource<? extends T>> supplier) {
         this.supplier = supplier;
     }
+
     @Override
     public void subscribeActual(Observer<? super T> observer) {
         ObservableSource<? extends T> pub;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDematerialize.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDematerialize.java
@@ -49,7 +49,6 @@ public final class ObservableDematerialize<T> extends AbstractObservableWithUpst
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -59,7 +58,6 @@ public final class ObservableDematerialize<T> extends AbstractObservableWithUpst
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(Notification<T> t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDematerialize.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDematerialize.java
@@ -91,6 +91,7 @@ public final class ObservableDematerialize<T> extends AbstractObservableWithUpst
 
             downstream.onError(t);
         }
+
         @Override
         public void onComplete() {
             if (done) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoOnEach.java
@@ -74,7 +74,6 @@ public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -84,7 +83,6 @@ public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAt.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAt.java
@@ -31,6 +31,7 @@ public final class ObservableElementAt<T> extends AbstractObservableWithUpstream
         this.defaultValue = defaultValue;
         this.errorOnFewer = errorOnFewer;
     }
+
     @Override
     public void subscribeActual(Observer<? super T> t) {
         source.subscribe(new ElementAtObserver<T>(t, index, defaultValue, errorOnFewer));

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAt.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAt.java
@@ -64,7 +64,6 @@ public final class ObservableElementAt<T> extends AbstractObservableWithUpstream
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -74,7 +73,6 @@ public final class ObservableElementAt<T> extends AbstractObservableWithUpstream
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtMaybe.java
@@ -60,7 +60,6 @@ public final class ObservableElementAtMaybe<T> extends Maybe<T> implements FuseT
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -70,7 +69,6 @@ public final class ObservableElementAtMaybe<T> extends Maybe<T> implements FuseT
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtMaybe.java
@@ -26,6 +26,7 @@ public final class ObservableElementAtMaybe<T> extends Maybe<T> implements FuseT
         this.source = source;
         this.index = index;
     }
+
     @Override
     public void subscribeActual(MaybeObserver<? super T> t) {
         source.subscribe(new ElementAtObserver<T>(t, index));

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableElementAtSingle.java
@@ -67,7 +67,6 @@ public final class ObservableElementAtSingle<T> extends Single<T> implements Fus
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -77,7 +76,6 @@ public final class ObservableElementAtSingle<T> extends Single<T> implements Fus
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableError.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableError.java
@@ -25,6 +25,7 @@ public final class ObservableError<T> extends Observable<T> {
     public ObservableError(Callable<? extends Throwable> errorSupplier) {
         this.errorSupplier = errorSupplier;
     }
+
     @Override
     public void subscribeActual(Observer<? super T> observer) {
         Throwable error;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -413,6 +413,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                         if (checkTerminate()) {
                             return;
                         }
+
                         @SuppressWarnings("unchecked")
                         InnerObserver<T, U> is = (InnerObserver<T, U>)inner[j];
 
@@ -542,6 +543,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
             this.id = id;
             this.parent = parent;
         }
+
         @Override
         public void onSubscribe(Disposable d) {
             if (DisposableHelper.setOnce(this, d)) {
@@ -564,6 +566,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                 }
             }
         }
+
         @Override
         public void onNext(U t) {
             if (fusionMode == QueueDisposable.NONE) {
@@ -572,6 +575,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                 parent.drain();
             }
         }
+
         @Override
         public void onError(Throwable t) {
             if (parent.errors.addThrowable(t)) {
@@ -584,6 +588,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                 RxJavaPlugins.onError(t);
             }
         }
+
         @Override
         public void onComplete() {
             done = true;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromArray.java
@@ -23,6 +23,7 @@ public final class ObservableFromArray<T> extends Observable<T> {
     public ObservableFromArray(T[] array) {
         this.array = array;
     }
+
     @Override
     public void subscribeActual(Observer<? super T> observer) {
         FromArrayDisposable<T> d = new FromArrayDisposable<T>(observer, array);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFromCallable.java
@@ -30,6 +30,7 @@ public final class ObservableFromCallable<T> extends Observable<T> implements Ca
     public ObservableFromCallable(Callable<? extends T> callable) {
         this.callable = callable;
     }
+
     @Override
     public void subscribeActual(Observer<? super T> observer) {
         DeferredScalarDisposable<T> d = new DeferredScalarDisposable<T>(observer);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
@@ -136,7 +136,6 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
             return cancelled;
         }
 
-
         @Override
         public void onNext(T t) {
             if (!terminate) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMapNotification.java
@@ -71,7 +71,6 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -81,7 +80,6 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMaterialize.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMaterialize.java
@@ -46,7 +46,6 @@ public final class ObservableMaterialize<T> extends AbstractObservableWithUpstre
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableOnErrorReturn.java
@@ -50,7 +50,6 @@ public final class ObservableOnErrorReturn<T> extends AbstractObservableWithUpst
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservablePublish.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservablePublish.java
@@ -172,6 +172,7 @@ public final class ObservablePublish<T> extends ConnectableObservable<T> impleme
                 inner.child.onNext(t);
             }
         }
+
         @SuppressWarnings("unchecked")
         @Override
         public void onError(Throwable e) {
@@ -185,6 +186,7 @@ public final class ObservablePublish<T> extends ConnectableObservable<T> impleme
                 RxJavaPlugins.onError(e);
             }
         }
+
         @SuppressWarnings("unchecked")
         @Override
         public void onComplete() {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeat.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeat.java
@@ -59,6 +59,7 @@ public final class ObservableRepeat<T> extends AbstractObservableWithUpstream<T,
         public void onNext(T t) {
             downstream.onNext(t);
         }
+
         @Override
         public void onError(Throwable t) {
             downstream.onError(t);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeatUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeatUntil.java
@@ -61,6 +61,7 @@ public final class ObservableRepeatUntil<T> extends AbstractObservableWithUpstre
         public void onNext(T t) {
             downstream.onNext(t);
         }
+
         @Override
         public void onError(Throwable t) {
             downstream.onError(t);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -371,6 +371,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
                 replay();
             }
         }
+
         @Override
         public void onError(Throwable e) {
             // The observer front is accessed serially as required by spec so
@@ -383,6 +384,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
                 RxJavaPlugins.onError(e);
             }
         }
+
         @Override
         public void onComplete() {
             // The observer front is accessed serially as required by spec so
@@ -511,6 +513,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
         UnboundedReplayBuffer(int capacityHint) {
             super(capacityHint);
         }
+
         @Override
         public void next(T value) {
             add(NotificationLite.next(value));
@@ -862,6 +865,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
                 setFirst(prev);
             }
         }
+
         @Override
         void truncateFinal() {
             long timeLimit = scheduler.now(unit) - maxAge;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryBiPredicate.java
@@ -65,6 +65,7 @@ public final class ObservableRetryBiPredicate<T> extends AbstractObservableWithU
         public void onNext(T t) {
             downstream.onNext(t);
         }
+
         @Override
         public void onError(Throwable t) {
             boolean b;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryPredicate.java
@@ -68,6 +68,7 @@ public final class ObservableRetryPredicate<T> extends AbstractObservableWithUps
         public void onNext(T t) {
             downstream.onNext(t);
         }
+
         @Override
         public void onError(Throwable t) {
             long r = remaining;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSampleTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSampleTimed.java
@@ -36,7 +36,6 @@ public final class ObservableSampleTimed<T> extends AbstractObservableWithUpstre
         this.emitLast = emitLast;
     }
 
-
     @Override
     public void subscribeActual(Observer<? super T> t) {
         SerializedObserver<T> serial = new SerializedObserver<T>(t);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScan.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScan.java
@@ -56,7 +56,6 @@ public final class ObservableScan<T> extends AbstractObservableWithUpstream<T, T
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -66,7 +65,6 @@ public final class ObservableScan<T> extends AbstractObservableWithUpstream<T, T
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
@@ -74,7 +74,6 @@ public final class ObservableScanSeed<T, R> extends AbstractObservableWithUpstre
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSingleMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSingleMaybe.java
@@ -52,7 +52,6 @@ public final class ObservableSingleMaybe<T> extends Maybe<T> {
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -62,7 +61,6 @@ public final class ObservableSingleMaybe<T> extends Maybe<T> {
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSingleMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSingleMaybe.java
@@ -25,6 +25,7 @@ public final class ObservableSingleMaybe<T> extends Maybe<T> {
     public ObservableSingleMaybe(ObservableSource<T> source) {
         this.source = source;
     }
+
     @Override
     public void subscribeActual(MaybeObserver<? super T> t) {
         source.subscribe(new SingleElementObserver<T>(t));

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSingleSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSingleSingle.java
@@ -59,7 +59,6 @@ public final class ObservableSingleSingle<T> extends Single<T> {
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -69,7 +68,6 @@ public final class ObservableSingleSingle<T> extends Single<T> {
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipLast.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipLast.java
@@ -54,7 +54,6 @@ public final class ObservableSkipLast<T> extends AbstractObservableWithUpstream<
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSkipWhile.java
@@ -49,7 +49,6 @@ public final class ObservableSkipWhile<T> extends AbstractObservableWithUpstream
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -59,7 +58,6 @@ public final class ObservableSkipWhile<T> extends AbstractObservableWithUpstream
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTake.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTake.java
@@ -42,6 +42,7 @@ public final class ObservableTake<T> extends AbstractObservableWithUpstream<T, T
             this.downstream = actual;
             this.remaining = limit;
         }
+
         @Override
         public void onSubscribe(Disposable d) {
             if (DisposableHelper.validate(this.upstream, d)) {
@@ -55,6 +56,7 @@ public final class ObservableTake<T> extends AbstractObservableWithUpstream<T, T
                 }
             }
         }
+
         @Override
         public void onNext(T t) {
             if (!done && remaining-- > 0) {
@@ -65,6 +67,7 @@ public final class ObservableTake<T> extends AbstractObservableWithUpstream<T, T
                 }
             }
         }
+
         @Override
         public void onError(Throwable t) {
             if (done) {
@@ -76,6 +79,7 @@ public final class ObservableTake<T> extends AbstractObservableWithUpstream<T, T
             upstream.dispose();
             downstream.onError(t);
         }
+
         @Override
         public void onComplete() {
             if (!done) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeUntil.java
@@ -28,6 +28,7 @@ public final class ObservableTakeUntil<T, U> extends AbstractObservableWithUpstr
         super(source);
         this.other = other;
     }
+
     @Override
     public void subscribeActual(Observer<? super T> child) {
         TakeUntilMainObserver<T, U> parent = new TakeUntilMainObserver<T, U>(child);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeWhile.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeWhile.java
@@ -53,7 +53,6 @@ public final class ObservableTakeWhile<T> extends AbstractObservableWithUpstream
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -63,7 +62,6 @@ public final class ObservableTakeWhile<T> extends AbstractObservableWithUpstream
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeInterval.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeInterval.java
@@ -69,7 +69,6 @@ public final class ObservableTimeInterval<T> extends AbstractObservableWithUpstr
             return upstream.isDisposed();
         }
 
-
         @Override
         public void onNext(T t) {
             long now = scheduler.now(unit);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableToList.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableToList.java
@@ -71,7 +71,6 @@ extends AbstractObservableWithUpstream<T, U> {
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -81,7 +80,6 @@ extends AbstractObservableWithUpstream<T, U> {
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableToListSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableToListSingle.java
@@ -83,7 +83,6 @@ extends Single<U> implements FuseToObservable<U> {
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -93,7 +92,6 @@ extends Single<U> implements FuseToObservable<U> {
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFrom.java
@@ -61,6 +61,7 @@ public final class ObservableWithLatestFrom<T, U, R> extends AbstractObservableW
             this.downstream = actual;
             this.combiner = combiner;
         }
+
         @Override
         public void onSubscribe(Disposable d) {
             DisposableHelper.setOnce(this.upstream, d);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableZip.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableZip.java
@@ -265,6 +265,7 @@ public final class ObservableZip<T, R> extends Observable<R> {
             this.parent = parent;
             this.queue = new SpscLinkedArrayQueue<T>(bufferSize);
         }
+
         @Override
         public void onSubscribe(Disposable d) {
             DisposableHelper.setOnce(this.upstream, d);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableZipIterable.java
@@ -90,7 +90,6 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
             }
         }
 
-
         @Override
         public void dispose() {
             upstream.dispose();
@@ -100,7 +99,6 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
         public boolean isDisposed() {
             return upstream.isDisposed();
         }
-
 
         @Override
         public void onNext(T t) {

--- a/src/main/java/io/reactivex/internal/operators/single/SingleEquals.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleEquals.java
@@ -57,6 +57,7 @@ public final class SingleEquals<T> extends Single<Boolean> {
             this.downstream = observer;
             this.count = count;
         }
+
         @Override
         public void onSubscribe(Disposable d) {
             set.add(d);

--- a/src/main/java/io/reactivex/internal/operators/single/SingleInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleInternalHelper.java
@@ -110,6 +110,7 @@ public final class SingleInternalHelper {
             return new SingleToObservable(v);
         }
     }
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T> Function<SingleSource<? extends T>, Observable<? extends T>> toObservable() {
         return (Function)ToObservable.INSTANCE;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleOnErrorReturn.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleOnErrorReturn.java
@@ -32,8 +32,6 @@ public final class SingleOnErrorReturn<T> extends Single<T> {
         this.value = value;
     }
 
-
-
     @Override
     protected void subscribeActual(final SingleObserver<? super T> observer) {
 

--- a/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
+++ b/src/main/java/io/reactivex/internal/queue/SpscLinkedArrayQueue.java
@@ -113,6 +113,7 @@ public final class SpscLinkedArrayQueue<T> implements SimplePlainQueue<T> {
     private void soNext(AtomicReferenceArray<Object> curr, AtomicReferenceArray<Object> next) {
         soElement(curr, calcDirectOffset(curr.length() - 1), next);
     }
+
     @SuppressWarnings("unchecked")
     private AtomicReferenceArray<Object> lvNextBufferAndUnlink(AtomicReferenceArray<Object> curr, int nextIndex) {
         int nextOffset = calcDirectOffset(nextIndex);
@@ -179,6 +180,7 @@ public final class SpscLinkedArrayQueue<T> implements SimplePlainQueue<T> {
         final int offsetInNew = calcWrappedOffset(index, mask);
         return (T) lvElement(nextBuffer, offsetInNew);// LoadLoad
     }
+
     @Override
     public void clear() {
         while (poll() != null || !isEmpty()) { } // NOPMD

--- a/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
@@ -227,6 +227,7 @@ public final class ComputationScheduler extends Scheduler implements SchedulerMu
 
             return poolWorker.scheduleActual(action, 0, TimeUnit.MILLISECONDS, serial);
         }
+
         @NonNull
         @Override
         public Disposable schedule(@NonNull Runnable action, long delayTime, @NonNull TimeUnit unit) {

--- a/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
@@ -167,6 +167,7 @@ public final class IoScheduler extends Scheduler {
             update.shutdown();
         }
     }
+
     @Override
     public void shutdown() {
         for (;;) {

--- a/src/main/java/io/reactivex/internal/subscriptions/EmptySubscription.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/EmptySubscription.java
@@ -29,6 +29,7 @@ public enum EmptySubscription implements QueueSubscription<Object> {
     public void request(long n) {
         SubscriptionHelper.validate(n);
     }
+
     @Override
     public void cancel() {
         // no-op
@@ -67,27 +68,33 @@ public enum EmptySubscription implements QueueSubscription<Object> {
         s.onSubscribe(INSTANCE);
         s.onComplete();
     }
+
     @Nullable
     @Override
     public Object poll() {
         return null; // always empty
     }
+
     @Override
     public boolean isEmpty() {
         return true;
     }
+
     @Override
     public void clear() {
         // nothing to do
     }
+
     @Override
     public int requestFusion(int mode) {
         return mode & ASYNC; // accept async mode: an onComplete or onError will be signalled after anyway
     }
+
     @Override
     public boolean offer(Object value) {
         throw new UnsupportedOperationException("Should not be called!");
     }
+
     @Override
     public boolean offer(Object v1, Object v2) {
         throw new UnsupportedOperationException("Should not be called!");

--- a/src/main/java/io/reactivex/internal/util/LinkedArrayList.java
+++ b/src/main/java/io/reactivex/internal/util/LinkedArrayList.java
@@ -87,6 +87,7 @@ public class LinkedArrayList {
     public int size() {
         return size;
     }
+
     @Override
     public String toString() {
         final int cap = capacityHint;

--- a/src/main/java/io/reactivex/observers/SafeObserver.java
+++ b/src/main/java/io/reactivex/observers/SafeObserver.java
@@ -63,7 +63,6 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
         }
     }
 
-
     @Override
     public void dispose() {
         upstream.dispose();

--- a/src/main/java/io/reactivex/observers/SerializedObserver.java
+++ b/src/main/java/io/reactivex/observers/SerializedObserver.java
@@ -72,7 +72,6 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
         }
     }
 
-
     @Override
     public void dispose() {
         upstream.dispose();
@@ -82,7 +81,6 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
     public boolean isDisposed() {
         return upstream.isDisposed();
     }
-
 
     @Override
     public void onNext(@NonNull T t) {

--- a/src/main/java/io/reactivex/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/processors/PublishProcessor.java
@@ -141,7 +141,6 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
         subscribers = new AtomicReference<PublishSubscription<T>[]>(EMPTY);
     }
 
-
     @Override
     protected void subscribeActual(Subscriber<? super T> t) {
         PublishSubscription<T> ps = new PublishSubscription<T>(t, this);

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -605,6 +605,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
             this.state = state;
             this.requested = new AtomicLong();
         }
+
         @Override
         public void request(long n) {
             if (SubscriptionHelper.validate(n)) {

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -1118,7 +1118,6 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
             }
         }
 
-
         @Override
         public void trimHead() {
             if (head.value != null) {

--- a/src/main/java/io/reactivex/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/subjects/PublishSubject.java
@@ -129,7 +129,6 @@ public final class PublishSubject<T> extends Subject<T> {
         subscribers = new AtomicReference<PublishDisposable<T>[]>(EMPTY);
     }
 
-
     @Override
     protected void subscribeActual(Observer<? super T> t) {
         PublishDisposable<T> ps = new PublishDisposable<T>(t, this);

--- a/src/main/java/io/reactivex/subjects/SerializedSubject.java
+++ b/src/main/java/io/reactivex/subjects/SerializedSubject.java
@@ -49,7 +49,6 @@ import io.reactivex.plugins.RxJavaPlugins;
         actual.subscribe(observer);
     }
 
-
     @Override
     public void onSubscribe(Disposable d) {
         boolean cancel;

--- a/src/main/java/io/reactivex/subscribers/DisposableSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/DisposableSubscriber.java
@@ -74,11 +74,11 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * @param <T> the received value type.
  */
 public abstract class DisposableSubscriber<T> implements FlowableSubscriber<T>, Disposable {
-    final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+    final AtomicReference<Subscription> upstream = new AtomicReference<Subscription>();
 
     @Override
     public final void onSubscribe(Subscription s) {
-        if (EndConsumerHelper.setOnce(this.s, s, getClass())) {
+        if (EndConsumerHelper.setOnce(this.upstream, s, getClass())) {
             onStart();
         }
     }
@@ -87,7 +87,7 @@ public abstract class DisposableSubscriber<T> implements FlowableSubscriber<T>, 
      * Called once the single upstream Subscription is set via onSubscribe.
      */
     protected void onStart() {
-        s.get().request(Long.MAX_VALUE);
+        upstream.get().request(Long.MAX_VALUE);
     }
 
     /**
@@ -99,7 +99,7 @@ public abstract class DisposableSubscriber<T> implements FlowableSubscriber<T>, 
      * @param n the request amount, positive
      */
     protected final void request(long n) {
-        s.get().request(n);
+        upstream.get().request(n);
     }
 
     /**
@@ -113,11 +113,11 @@ public abstract class DisposableSubscriber<T> implements FlowableSubscriber<T>, 
 
     @Override
     public final boolean isDisposed() {
-        return s.get() == SubscriptionHelper.CANCELLED;
+        return upstream.get() == SubscriptionHelper.CANCELLED;
     }
 
     @Override
     public final void dispose() {
-        SubscriptionHelper.cancel(s);
+        SubscriptionHelper.cancel(upstream);
     }
 }

--- a/src/main/java/io/reactivex/subscribers/ResourceSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/ResourceSubscriber.java
@@ -94,7 +94,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  */
 public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Disposable {
     /** The active subscription. */
-    private final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+    private final AtomicReference<Subscription> upstream = new AtomicReference<Subscription>();
 
     /** The resource composite, can never be null. */
     private final ListCompositeDisposable resources = new ListCompositeDisposable();
@@ -116,7 +116,7 @@ public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Di
 
     @Override
     public final void onSubscribe(Subscription s) {
-        if (EndConsumerHelper.setOnce(this.s, s, getClass())) {
+        if (EndConsumerHelper.setOnce(this.upstream, s, getClass())) {
             long r = missedRequested.getAndSet(0L);
             if (r != 0L) {
                 s.request(r);
@@ -144,7 +144,7 @@ public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Di
      * @param n the request amount, must be positive
      */
     protected final void request(long n) {
-        SubscriptionHelper.deferredRequest(s, missedRequested, n);
+        SubscriptionHelper.deferredRequest(upstream, missedRequested, n);
     }
 
     /**
@@ -156,7 +156,7 @@ public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Di
      */
     @Override
     public final void dispose() {
-        if (SubscriptionHelper.cancel(s)) {
+        if (SubscriptionHelper.cancel(upstream)) {
             resources.dispose();
         }
     }
@@ -167,6 +167,6 @@ public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Di
      */
     @Override
     public final boolean isDisposed() {
-        return SubscriptionHelper.isCancelled(s.get());
+        return SubscriptionHelper.isCancelled(upstream.get());
     }
 }

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -2029,6 +2029,7 @@ public class CompletableTest {
             };
         }
     }
+
     @Test(timeout = 5000, expected = TestException.class)
     public void liftOnCompleteError() {
         Completable c = normal.completable.lift(new CompletableOperatorSwap());
@@ -4659,7 +4660,6 @@ public class CompletableTest {
             RxJavaPlugins.reset();
         }
     }
-
 
     @Test(timeout = 5000)
     public void subscribeTwoCallbacksDispose() {

--- a/src/test/java/io/reactivex/disposables/CompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/disposables/CompositeDisposableTest.java
@@ -277,6 +277,7 @@ public class CompositeDisposableTest {
         // we should have only disposed once
         assertEquals(1, counter.get());
     }
+
     @Test
     public void testTryRemoveIfNotIn() {
         CompositeDisposable cd = new CompositeDisposable();

--- a/src/test/java/io/reactivex/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/exceptions/CompositeExceptionTest.java
@@ -182,6 +182,7 @@ public class CompositeExceptionTest {
         composite.getCause();
         composite.printStackTrace();
     }
+
     @Test
     public void testNullElement() {
         CompositeException composite = new CompositeException(Collections.singletonList((Throwable) null));

--- a/src/test/java/io/reactivex/exceptions/OnErrorNotImplementedExceptionTest.java
+++ b/src/test/java/io/reactivex/exceptions/OnErrorNotImplementedExceptionTest.java
@@ -108,7 +108,6 @@ public class OnErrorNotImplementedExceptionTest {
         .subscribe(Functions.emptyConsumer());
     }
 
-
     @Test
     public void maybeSubscribe0() {
         Maybe.error(new TestException())

--- a/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
@@ -166,7 +166,6 @@ public final class FlowableCollectTest {
         assertFalse(added.get());
     }
 
-
     @SuppressWarnings("unchecked")
     @Test
     public void collectIntoFlowable() {
@@ -315,7 +314,6 @@ public final class FlowableCollectTest {
                 .assertNotComplete();
         assertFalse(added.get());
     }
-
 
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
@@ -83,7 +83,6 @@ public final class FlowableCollectTest {
         assertEquals("1-2-3", value);
     }
 
-
     @Test
     public void testFactoryFailureResultsInErrorEmissionFlowable() {
         final RuntimeException e = new RuntimeException();
@@ -183,7 +182,6 @@ public final class FlowableCollectTest {
         .assertResult(new HashSet<Integer>(Arrays.asList(1, 2)));
     }
 
-
     @Test
     public void testCollectToList() {
         Single<List<Integer>> o = Flowable.just(1, 2, 3)
@@ -237,7 +235,6 @@ public final class FlowableCollectTest {
 
         assertEquals("1-2-3", value);
     }
-
 
     @Test
     public void testFactoryFailureResultsInErrorEmission() {

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -2724,7 +2724,6 @@ public class FlowableNullTests {
         });
     }
 
-
     @Test(expected = NullPointerException.class)
     public void zipWithCombinerNull() {
         just1.zipWith(just1, null);

--- a/src/test/java/io/reactivex/flowable/FlowableReduceTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableReduceTests.java
@@ -77,7 +77,6 @@ public class FlowableReduceTests {
         assertNotNull(reduceResult2);
     }
 
-
     @Test
     public void reduceInts() {
         Flowable<Integer> f = Flowable.just(1, 2, 3);

--- a/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
@@ -771,7 +771,6 @@ public class FlowableSubscriberTest {
         ts.assertResult(1);
     }
 
-
     @Test
     public void methodTestNoCancel() {
         PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -148,7 +148,6 @@ public class FlowableTests {
         verify(w, times(1)).onError(any(RuntimeException.class));
     }
 
-
     @Test
     public void testCountAFewItems() {
         Flowable<String> flowable = Flowable.just("a", "b", "c", "d");
@@ -861,7 +860,6 @@ public class FlowableTests {
         verify(subscriber, never()).onError(any(Throwable.class));
         verify(subscriber, times(1)).onComplete();
     }
-
 
     @Test
     public void testContains() {

--- a/src/test/java/io/reactivex/internal/SubscribeWithTest.java
+++ b/src/test/java/io/reactivex/internal/SubscribeWithTest.java
@@ -30,7 +30,6 @@ public class SubscribeWithTest {
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
 
-
     @Test
     public void withObservable() {
         Observable.range(1, 10)

--- a/src/test/java/io/reactivex/internal/observers/BasicFuseableObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/BasicFuseableObserverTest.java
@@ -30,13 +30,16 @@ public class BasicFuseableObserverTest {
             public Integer poll() throws Exception {
                 return null;
             }
+
             @Override
             public int requestFusion(int mode) {
                 return 0;
             }
+
             @Override
             public void onNext(Integer value) {
             }
+
             @Override
             protected boolean beforeDownstream() {
                 return false;
@@ -58,10 +61,12 @@ public class BasicFuseableObserverTest {
             public Integer poll() throws Exception {
                 return null;
             }
+
             @Override
             public int requestFusion(int mode) {
                 return 0;
             }
+
             @Override
             public void onNext(Integer value) {
             }

--- a/src/test/java/io/reactivex/internal/observers/DeferredScalarObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/DeferredScalarObserverTest.java
@@ -181,7 +181,6 @@ public class DeferredScalarObserverTest {
             super(downstream);
         }
 
-
         @Override
         public void onNext(Integer value) {
             this.value = value;

--- a/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
@@ -247,6 +247,7 @@ public class LambdaObserverTest {
             RxJavaPlugins.reset();
         }
     }
+
     @Test
     public void badSourceEmitAfterDone() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableAmbTest.java
@@ -187,7 +187,6 @@ public class CompletableAmbTest {
         }
     }
 
-
     @Test
     public void untilCompletableMainComplete() {
         CompletableSubject main = CompletableSubject.create();

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableResumeNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableResumeNextTest.java
@@ -40,7 +40,6 @@ public class CompletableResumeNextTest {
         });
     }
 
-
     @Test
     public void disposeInResume() {
         TestHelper.checkDisposedCompletable(new Function<Completable, CompletableSource>() {

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableSubscribeTest.java
@@ -30,7 +30,6 @@ public class CompletableSubscribeTest {
         assertFalse(pp.hasSubscribers());
     }
 
-
     @Test
     public void methodTestNoCancel() {
         PublishSubject<Integer> ps = PublishSubject.create();

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
@@ -347,7 +347,6 @@ public class CompletableUsingTest {
         .assertFailure(TestException.class);
     }
 
-
     @Test
     public void emptyDisposerCrashes() {
         Completable.using(new Callable<Object>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecentTest.java
@@ -103,7 +103,6 @@ public class BlockingFlowableMostRecentTest {
         TestHelper.checkUtilityClass(BlockingFlowableMostRecent.class);
     }
 
-
     @Test
     public void empty() {
         Iterator<Integer> it = Flowable.<Integer>empty()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
@@ -124,6 +124,7 @@ public class FlowableAllTest {
 
         assertFalse(allOdd.blockingGet());
     }
+
     @Test(timeout = 5000)
     public void testIssue1935NoUnsubscribeDownstream() {
         Flowable<Integer> source = Flowable.just(1)
@@ -297,6 +298,7 @@ public class FlowableAllTest {
 
         assertFalse(allOdd.blockingFirst());
     }
+
     @Test(timeout = 5000)
     public void testIssue1935NoUnsubscribeDownstreamFlowable() {
         Flowable<Integer> source = Flowable.just(1)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -236,7 +236,6 @@ public class FlowableAmbTest {
         assertEquals(Flowable.bufferSize() * 2, ts.values().size());
     }
 
-
     @SuppressWarnings("unchecked")
     @Test
     public void testSubscriptionOnlyHappensOnce() throws InterruptedException {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
@@ -223,6 +223,7 @@ public class FlowableAnyTest {
 
         assertTrue(anyEven.blockingGet());
     }
+
     @Test(timeout = 5000)
     public void testIssue1935NoUnsubscribeDownstream() {
         Flowable<Integer> source = Flowable.just(1).isEmpty()
@@ -489,6 +490,7 @@ public class FlowableAnyTest {
 
         assertTrue(anyEven.blockingFirst());
     }
+
     @Test(timeout = 5000)
     public void testIssue1935NoUnsubscribeDownstreamFlowable() {
         Flowable<Integer> source = Flowable.just(1).isEmpty()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAsObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAsObservableTest.java
@@ -45,6 +45,7 @@ public class FlowableAsObservableTest {
         verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void testHidingError() {
         PublishProcessor<Integer> src = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -496,6 +496,7 @@ public class FlowableBufferTest {
         verify(subscriber, never()).onComplete();
         verify(subscriber, never()).onNext(any());
     }
+
     @Test(timeout = 2000)
     public void bufferWithSizeTake1() {
         Flowable<Integer> source = Flowable.just(1).repeat();
@@ -525,6 +526,7 @@ public class FlowableBufferTest {
         verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
     }
+
     @Test(timeout = 2000)
     public void bufferWithTimeTake1() {
         Flowable<Long> source = Flowable.interval(40, 40, TimeUnit.MILLISECONDS, scheduler);
@@ -541,6 +543,7 @@ public class FlowableBufferTest {
         verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
     }
+
     @Test(timeout = 2000)
     public void bufferWithTimeSkipTake2() {
         Flowable<Long> source = Flowable.interval(40, 40, TimeUnit.MILLISECONDS, scheduler);
@@ -614,6 +617,7 @@ public class FlowableBufferTest {
         inOrder.verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void bufferWithSizeThrows() {
         PublishProcessor<Integer> source = PublishProcessor.create();
@@ -683,6 +687,7 @@ public class FlowableBufferTest {
         inOrder.verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void bufferWithStartEndStartThrows() {
         PublishProcessor<Integer> start = PublishProcessor.create();
@@ -711,6 +716,7 @@ public class FlowableBufferTest {
         verify(subscriber, never()).onComplete();
         verify(subscriber).onError(any(TestException.class));
     }
+
     @Test
     public void bufferWithStartEndEndFunctionThrows() {
         PublishProcessor<Integer> start = PublishProcessor.create();
@@ -738,6 +744,7 @@ public class FlowableBufferTest {
         verify(subscriber, never()).onComplete();
         verify(subscriber).onError(any(TestException.class));
     }
+
     @Test
     public void bufferWithStartEndEndThrows() {
         PublishProcessor<Integer> start = PublishProcessor.create();
@@ -881,7 +888,6 @@ public class FlowableBufferTest {
         assertEquals(Long.MAX_VALUE, requested.get());
     }
 
-
     @Test
     public void testProducerRequestOverflowThroughBufferWithSize1() {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(Long.MAX_VALUE >> 1);
@@ -991,6 +997,7 @@ public class FlowableBufferTest {
         // FIXME I'm not sure why this is MAX_VALUE in 1.x because MAX_VALUE/2 is even and thus can't overflow when multiplied by 2
         assertEquals(Long.MAX_VALUE - 1, requested.get());
     }
+
     @Test(timeout = 3000)
     public void testBufferWithTimeDoesntUnsubscribeDownstream() throws InterruptedException {
         final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
@@ -1001,11 +1008,13 @@ public class FlowableBufferTest {
             public void onNext(Object t) {
                 subscriber.onNext(t);
             }
+
             @Override
             public void onError(Throwable e) {
                 subscriber.onError(e);
                 cdl.countDown();
             }
+
             @Override
             public void onComplete() {
                 subscriber.onComplete();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -54,6 +54,7 @@ public class FlowableCacheTest {
             assertEquals((Integer)i, onNextEvents.get(i));
         }
     }
+
     @Test
     public void testColdReplayBackpressure() {
         FlowableCache<Integer> source = new FlowableCache<Integer>(Flowable.range(0, 1000), 16);
@@ -178,6 +179,7 @@ public class FlowableCacheTest {
             assertEquals(10000, ts2.values().size());
         }
     }
+
     @Test
     public void testAsyncComeAndGo() {
         Flowable<Long> source = Flowable.interval(1, 1, TimeUnit.MILLISECONDS)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1206,6 +1206,7 @@ public class FlowableCombineLatestTest {
         .test()
         .assertFailure(TestException.class, "[1, 2]");
     }
+
     @SuppressWarnings("unchecked")
     @Test
     public void combineLatestEmpty() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatDelayErrorTest.java
@@ -216,7 +216,6 @@ public class FlowableConcatDelayErrorTest {
         return source.concatWith(Flowable.<T>error(new TestException()));
     }
 
-
     @Test
     public void concatDelayErrorFlowable() {
         TestSubscriber<Integer> ts = TestSubscriber.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -655,7 +655,6 @@ public class FlowableConcatMapEagerTest {
         ts.assertValue(null);
     }
 
-
     @Test
     public void testMaxConcurrent5() {
         final List<Long> requests = new ArrayList<Long>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -169,6 +169,7 @@ public class FlowableConcatTest {
                     public void request(long n) {
 
                     }
+
                     @Override
                     public void cancel() {
                         d.dispose();
@@ -636,6 +637,7 @@ public class FlowableConcatTest {
         inOrder.verify(o).onSuccess(list);
         verify(o, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void concatVeryLongObservableOfObservablesTakeHalf() {
         final int n = 10000;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybeTest.java
@@ -41,7 +41,6 @@ public class FlowableConcatWithMaybeTest {
         ts.assertResult(1, 2, 3, 4, 5, 100);
     }
 
-
     @Test
     public void normalNonEmpty() {
         final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCountTest.java
@@ -39,7 +39,6 @@ public class FlowableCountTest {
 
     }
 
-
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Flowable.just(1).count());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -1001,7 +1001,6 @@ public class FlowableCreateTest {
         }
     }
 
-
     @Test
     public void tryOnError() {
         for (BackpressureStrategy strategy : BackpressureStrategy.values()) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
@@ -239,6 +239,7 @@ public class FlowableDebounceTest {
         verify(subscriber, never()).onComplete();
         verify(subscriber).onError(any(TestException.class));
     }
+
     @Test
     public void debounceTimedLastIsNotLost() {
         PublishProcessor<Integer> source = PublishProcessor.create();
@@ -256,6 +257,7 @@ public class FlowableDebounceTest {
         verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void debounceSelectorLastIsNotLost() {
         PublishProcessor<Integer> source = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
@@ -87,7 +87,6 @@ public class FlowableDetachTest {
         ts.assertComplete();
     }
 
-
     @Test
     public void backpressured() throws Exception {
         o = new Object();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoFinallyTest.java
@@ -157,7 +157,6 @@ public class FlowableDoFinallyTest implements Action {
         assertEquals(1, calls);
     }
 
-
     @Test
     public void normalJustConditional() {
         Flowable.just(1)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
@@ -186,7 +186,6 @@ public class FlowableElementAtTest {
             .assertFailure(NoSuchElementException.class);
     }
 
-
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
@@ -228,7 +227,6 @@ public class FlowableElementAtTest {
             .test()
             .assertFailure(TestException.class);
     }
-
 
     @Test
     public void error() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
@@ -183,7 +183,6 @@ public class FlowableFlatMapCompletableTest {
         .assertFailure(TestException.class);
     }
 
-
     @Test
     public void fusedFlowable() {
         TestSubscriber<Integer> ts = SubscriberFusion.newTest(QueueFuseable.ANY);
@@ -337,7 +336,6 @@ public class FlowableFlatMapCompletableTest {
         .test()
         .assertFailure(TestException.class);
     }
-
 
     @Test
     public void fused() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -355,6 +355,7 @@ public class FlowableFlatMapTest {
         Assert.assertEquals(expected.size(), ts.valueCount());
         Assert.assertTrue(expected.containsAll(ts.values()));
     }
+
     @Test
     public void testFlatMapSelectorMaxConcurrent() {
         final int m = 4;
@@ -478,6 +479,7 @@ public class FlowableFlatMapTest {
             }
         }
     }
+
     @Test(timeout = 30000)
     public void flatMapRangeMixedAsyncLoop() {
         for (int i = 0; i < 2000; i++) {
@@ -537,6 +539,7 @@ public class FlowableFlatMapTest {
             ts.assertValueCount(1000);
         }
     }
+
     @Test
     public void flatMapTwoNestedSync() {
         for (final int n : new int[] { 1, 1000, 1000000 }) {
@@ -855,7 +858,6 @@ public class FlowableFlatMapTest {
             TestHelper.race(r1, r2);
         }
     }
-
 
     @Test
     public void fusedInnerThrows() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
@@ -33,6 +33,7 @@ public class FlowableFromArrayTest {
         }
         return Flowable.fromArray(array);
     }
+
     @Test
     public void simple() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
@@ -40,7 +40,6 @@ public class FlowableFromSourceTest {
         ts = new TestSubscriber<Integer>(0L);
     }
 
-
     @Test
     public void normalBuffered() {
         Flowable.create(source, BackpressureStrategy.BUFFER).subscribe(ts);
@@ -124,7 +123,6 @@ public class FlowableFromSourceTest {
         ts.assertNoErrors();
         ts.assertComplete();
     }
-
 
     @Test
     public void normalError() {
@@ -488,7 +486,6 @@ public class FlowableFromSourceTest {
         ts.assertNoErrors();
         ts.assertNotComplete();
     }
-
 
     @Test
     public void unsubscribeInline() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -1638,7 +1638,6 @@ public class FlowableGroupByTest {
         .assertComplete();
     }
 
-
     @Test
     public void keySelectorAndDelayError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -144,7 +144,6 @@ public class FlowableIgnoreElementsTest {
         assertEquals(0, count.get());
     }
 
-
     @Test
     public void testWithEmpty() {
         assertNull(Flowable.empty().ignoreElements().blockingGet());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -739,7 +739,6 @@ public class FlowableMergeDelayErrorTest {
         }
     }
 
-
     @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayDelayError() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -436,6 +436,7 @@ public class FlowableMergeDelayErrorTest {
         }
 
     }
+
     @Test
     @Ignore("Subscribers should not throw")
     public void testMergeSourceWhichDoesntPropagateExceptionBack() {
@@ -559,6 +560,7 @@ public class FlowableMergeDelayErrorTest {
             t.start();
         }
     }
+
     @Test
     public void testDelayErrorMaxConcurrent() {
         final List<Long> requests = new ArrayList<Long>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
@@ -129,6 +129,7 @@ public class FlowableMergeMaxConcurrentTest {
         }
         assertEquals(j, n);
     }
+
     @Test
     public void testMergeALotOfSourcesOneByOneSynchronouslyTakeHalf() {
         int n = 10000;
@@ -163,6 +164,7 @@ public class FlowableMergeMaxConcurrentTest {
             ts.assertValueSequence(result);
         }
     }
+
     @Test
     public void testSimpleOneLess() {
         for (int i = 2; i < 100; i++) {
@@ -181,6 +183,7 @@ public class FlowableMergeMaxConcurrentTest {
             ts.assertValueSequence(result);
         }
     }
+
     @Test//(timeout = 20000)
     public void testSimpleAsyncLoop() {
         IoScheduler ios = (IoScheduler)Schedulers.io();
@@ -193,6 +196,7 @@ public class FlowableMergeMaxConcurrentTest {
             }
         }
     }
+
     @Test(timeout = 10000)
     public void testSimpleAsync() {
         for (int i = 1; i < 50; i++) {
@@ -213,12 +217,14 @@ public class FlowableMergeMaxConcurrentTest {
             assertEquals(expected, actual);
         }
     }
+
     @Test(timeout = 10000)
     public void testSimpleOneLessAsyncLoop() {
         for (int i = 0; i < 200; i++) {
             testSimpleOneLessAsync();
         }
     }
+
     @Test(timeout = 10000)
     public void testSimpleOneLessAsync() {
         long t = System.currentTimeMillis();
@@ -243,6 +249,7 @@ public class FlowableMergeMaxConcurrentTest {
             assertEquals(expected, actual);
         }
     }
+
     @Test(timeout = 5000)
     public void testBackpressureHonored() throws Exception {
         List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(3);
@@ -273,6 +280,7 @@ public class FlowableMergeMaxConcurrentTest {
 
         ts.dispose();
     }
+
     @Test(timeout = 5000)
     public void testTake() throws Exception {
         List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(3);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -1465,7 +1465,6 @@ public class FlowableMergeTest {
         ts.assertComplete();
     }
 
-
     @SuppressWarnings("unchecked")
     @Test
     @Ignore("No 2-9 argument merge()")
@@ -1624,7 +1623,6 @@ public class FlowableMergeTest {
             .assertResult(expected);
         }
     }
-
 
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -1360,10 +1360,12 @@ public class FlowableMergeTest {
     public void testFastMergeFullScalar() {
         runMerge(toScalar, new TestSubscriber<Integer>());
     }
+
     @Test
     public void testFastMergeHiddenScalar() {
         runMerge(toHiddenScalar, new TestSubscriber<Integer>());
     }
+
     @Test
     public void testSlowMergeFullScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
@@ -1382,6 +1384,7 @@ public class FlowableMergeTest {
             runMerge(toScalar, ts);
         }
     }
+
     @Test
     public void testSlowMergeHiddenScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -794,7 +794,6 @@ public class FlowableObserveOnTest {
         assertEquals(Arrays.asList(128L), requests);
     }
 
-
     @Test
     public void testErrorDelayed() {
         TestScheduler s = new TestScheduler();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
@@ -37,6 +37,7 @@ public class FlowableOnBackpressureLatestTest {
         ts.assertTerminated();
         ts.assertValues(1, 2, 3, 4, 5);
     }
+
     @Test
     public void testSimpleError() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
@@ -48,6 +49,7 @@ public class FlowableOnBackpressureLatestTest {
         ts.assertError(TestException.class);
         ts.assertValues(1, 2, 3, 4, 5);
     }
+
     @Test
     public void testSimpleBackpressure() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L);
@@ -100,6 +102,7 @@ public class FlowableOnBackpressureLatestTest {
         ts.assertNoErrors();
         ts.assertTerminated();
     }
+
     @Test
     public void testAsynchronousDrop() throws InterruptedException {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
@@ -242,7 +242,6 @@ public class FlowableOnErrorReturnTest {
         ts.assertComplete();
     }
 
-
     @Test
     public void returnItem() {
         Flowable.error(new TestException())

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnExceptionResumeNextViaFlowableTest.java
@@ -186,7 +186,6 @@ public class FlowableOnExceptionResumeNextViaFlowableTest {
         verify(subscriber, times(1)).onComplete();
     }
 
-
     @Test
     public void testBackpressure() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticastTest.java
@@ -152,7 +152,6 @@ public class FlowablePublishMulticastTest {
         mp.errorAll(null);
     }
 
-
     @Test
     public void completeAllCancelled() {
         MulticastProcessor<Integer> mp = new MulticastProcessor<Integer>(128, true);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -371,6 +371,7 @@ public class FlowablePublishTest {
         ts.assertNoErrors();
         ts.assertTerminated();
     }
+
     @Test
     public void testConnectIsIdempotent() {
         final AtomicInteger calls = new AtomicInteger();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
@@ -164,18 +164,21 @@ public class FlowableRangeLongTest {
         ts.assertValueSequence(list);
         ts.assertTerminated();
     }
+
     @Test
     public void testWithBackpressure1() {
         for (long i = 0; i < 100; i++) {
             testWithBackpressureOneByOne(i);
         }
     }
+
     @Test
     public void testWithBackpressureAllAtOnce() {
         for (long i = 0; i < 100; i++) {
             testWithBackpressureAllAtOnce(i);
         }
     }
+
     @Test
     public void testWithBackpressureRequestWayMore() {
         Flowable<Long> source = Flowable.rangeLong(50, 100);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
@@ -164,18 +164,21 @@ public class FlowableRangeTest {
         ts.assertValueSequence(list);
         ts.assertTerminated();
     }
+
     @Test
     public void testWithBackpressure1() {
         for (int i = 0; i < 100; i++) {
             testWithBackpressureOneByOne(i);
         }
     }
+
     @Test
     public void testWithBackpressureAllAtOnce() {
         for (int i = 0; i < 100; i++) {
             testWithBackpressureAllAtOnce(i);
         }
     }
+
     @Test
     public void testWithBackpressureRequestWayMore() {
         Flowable<Integer> source = Flowable.range(50, 100);
@@ -260,6 +263,7 @@ public class FlowableRangeTest {
         ts.assertNoErrors();
         ts.assertValues(Integer.MAX_VALUE - 1, Integer.MAX_VALUE);
     }
+
     @Test(timeout = 1000)
     public void testNearMaxValueWithBackpressure() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(3L);
@@ -269,7 +273,6 @@ public class FlowableRangeTest {
         ts.assertNoErrors();
         ts.assertValues(Integer.MAX_VALUE - 1, Integer.MAX_VALUE);
     }
-
 
     @Test
     public void negativeCount() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
@@ -141,7 +141,6 @@ public class FlowableReduceTest {
         assertEquals(21, r.intValue());
     }
 
-
     @Test
     public void testAggregateAsIntSum() {
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -876,6 +876,7 @@ public class FlowableReplayTest {
             assertEquals((Integer)i, onNextEvents.get(i));
         }
     }
+
     @Test
     public void testColdReplayBackpressure() {
         Flowable<Integer> source = Flowable.range(0, 1000).replay().autoConnect();
@@ -995,6 +996,7 @@ public class FlowableReplayTest {
             assertEquals(10000, ts2.values().size());
         }
     }
+
     @Test
     public void testAsyncComeAndGo() {
         Flowable<Long> source = Flowable.interval(1, 1, TimeUnit.MILLISECONDS)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
@@ -433,6 +433,7 @@ public class FlowableRetryTest {
                         }
                     }
                 }
+
                 @Override
                 public void cancel() {
                     // TODO Auto-generated method stub
@@ -829,6 +830,7 @@ public class FlowableRetryTest {
 
         return sb;
     }
+
     @Test//(timeout = 3000)
     public void testIssue1900() throws InterruptedException {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
@@ -869,6 +871,7 @@ public class FlowableRetryTest {
         inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
+
     @Test//(timeout = 3000)
     public void testIssue1900SourceNotSupportingBackpressure() {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
@@ -996,7 +999,6 @@ public class FlowableRetryTest {
         .test()
         .assertResult(1, 1, 1, 1, 1);
     }
-
 
     @Test
     public void shouldDisposeInnerObservable() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -70,6 +70,7 @@ public class FlowableRetryWithPredicateTest {
         inOrder.verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void testRetryTwice() {
         Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
@@ -105,6 +106,7 @@ public class FlowableRetryWithPredicateTest {
         verify(subscriber, never()).onError(any(Throwable.class));
 
     }
+
     @Test
     public void testRetryTwiceAndGiveUp() {
         Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
@@ -132,6 +134,7 @@ public class FlowableRetryWithPredicateTest {
         verify(subscriber, never()).onComplete();
 
     }
+
     @Test
     public void testRetryOnSpecificException() {
         Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
@@ -166,6 +169,7 @@ public class FlowableRetryWithPredicateTest {
         inOrder.verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void testRetryOnSpecificExceptionAndNotOther() {
         final IOException ioe = new IOException();
@@ -289,6 +293,7 @@ public class FlowableRetryWithPredicateTest {
         assertEquals(6, c.get());
         assertEquals(Collections.singletonList(e), ts.errors());
     }
+
     @Test
     public void testJustAndRetry() throws Exception {
         final AtomicBoolean throwException = new AtomicBoolean(true);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -483,7 +483,6 @@ public class FlowableSequenceEqualTest {
         }
     }
 
-
     @Test
     public void longSequenceEquals() {
         Flowable<Integer> source = Flowable.range(1, Flowable.bufferSize() * 4).subscribeOn(Schedulers.computation());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
@@ -192,7 +192,6 @@ public class FlowableSingleTest {
         assertEquals(Arrays.asList(Long.MAX_VALUE), requests);
     }
 
-
     @Test
     public void testSingleWithPredicateFlowable() {
         Flowable<Integer> flowable = Flowable.just(1, 2)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -156,6 +156,7 @@ public class FlowableSwitchIfEmptyTest {
         ts.request(1);
         ts.assertValueCount(3);
     }
+
     @Test
     public void testBackpressureNoRequest() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -583,7 +583,6 @@ public class FlowableSwitchTest {
         assertTrue(ts.valueCount() > 0);
     }
 
-
     @Test(timeout = 10000)
     public void testSecondaryRequestsDontOverflow() throws InterruptedException {
         TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
@@ -241,7 +241,6 @@ public class FlowableTakeLastTest {
         });
     }
 
-
     @Test
     public void testIgnoreRequest4() {
         // If `takeLast` does not ignore `request` properly, StackOverflowError will be thrown.

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
@@ -451,7 +451,6 @@ public class FlowableTakeTest {
         ts.assertComplete();
     }
 
-
     @Test
     public void takeNegative() {
         try {
@@ -484,7 +483,6 @@ public class FlowableTakeTest {
             }
         });
     }
-
 
     @Test
     public void badRequest() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
@@ -47,6 +47,7 @@ public class FlowableTakeUntilPredicateTest {
         verify(subscriber, never()).onError(any(Throwable.class));
         verify(subscriber).onComplete();
     }
+
     @Test
     public void takeAll() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
@@ -63,6 +64,7 @@ public class FlowableTakeUntilPredicateTest {
         verify(subscriber, never()).onError(any(Throwable.class));
         verify(subscriber).onComplete();
     }
+
     @Test
     public void takeFirst() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
@@ -79,6 +81,7 @@ public class FlowableTakeUntilPredicateTest {
         verify(subscriber, never()).onError(any(Throwable.class));
         verify(subscriber).onComplete();
     }
+
     @Test
     public void takeSome() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
@@ -97,6 +100,7 @@ public class FlowableTakeUntilPredicateTest {
         verify(subscriber, never()).onError(any(Throwable.class));
         verify(subscriber).onComplete();
     }
+
     @Test
     public void functionThrows() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
@@ -115,6 +119,7 @@ public class FlowableTakeUntilPredicateTest {
         verify(subscriber).onError(any(TestException.class));
         verify(subscriber, never()).onComplete();
     }
+
     @Test
     public void sourceThrows() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
@@ -134,6 +139,7 @@ public class FlowableTakeUntilPredicateTest {
         verify(subscriber).onError(any(TestException.class));
         verify(subscriber, never()).onComplete();
     }
+
     @Test
     public void backpressure() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(5L);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
@@ -209,6 +209,7 @@ public class FlowableTakeUntilTest {
         assertFalse("Until still has observers", until.hasSubscribers());
         assertFalse("TestSubscriber is unsubscribed", ts.isCancelled());
     }
+
     @Test
     public void testMainCompletes() {
         PublishProcessor<Integer> source = PublishProcessor.create();
@@ -232,6 +233,7 @@ public class FlowableTakeUntilTest {
         assertFalse("Until still has observers", until.hasSubscribers());
         assertFalse("TestSubscriber is unsubscribed", ts.isCancelled());
     }
+
     @Test
     public void testDownstreamUnsubscribes() {
         PublishProcessor<Integer> source = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
@@ -153,7 +153,6 @@ public class FlowableThrottleFirstTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-
     @Test
     public void throttleFirstDefaultScheduler() {
         Flowable.just(1).throttleFirst(100, TimeUnit.MILLISECONDS)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatestTest.java
@@ -130,7 +130,6 @@ public class FlowableThrottleLatestTest {
         ts.assertResult(1, 3, 5, 6);
     }
 
-
     @Test
     public void normalEmitLast() {
         TestScheduler sch = new TestScheduler();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -477,7 +477,6 @@ public class FlowableTimeoutTests {
         }
     }
 
-
     @Test
     public void timedTake() {
         PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimerTest.java
@@ -86,6 +86,7 @@ public class FlowableTimerTest {
         ts.assertNotComplete();
         ts.assertNoErrors();
     }
+
     @Test
     public void testInterval() {
         Flowable<Long> w = Flowable.interval(1, TimeUnit.SECONDS, scheduler);
@@ -226,6 +227,7 @@ public class FlowableTimerTest {
         ts2.assertNoErrors();
         ts2.assertNotComplete();
     }
+
     @Test
     public void testOnceObserverThrows() {
         Flowable<Long> source = Flowable.timer(100, TimeUnit.MILLISECONDS, scheduler);
@@ -254,6 +256,7 @@ public class FlowableTimerTest {
         verify(subscriber, never()).onNext(anyLong());
         verify(subscriber, never()).onComplete();
     }
+
     @Test
     public void testPeriodicObserverThrows() {
         Flowable<Long> source = Flowable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
@@ -101,6 +101,7 @@ public class FlowableToListTest {
         List<String> actual = f.toList().toFlowable().blockingFirst();
         Assert.assertEquals(Arrays.asList("one", "two", "three"), actual);
     }
+
     @Test
     public void testBackpressureHonoredFlowable() {
         Flowable<List<Integer>> w = Flowable.just(1, 2, 3, 4, 5).toList().toFlowable();
@@ -124,6 +125,7 @@ public class FlowableToListTest {
         ts.assertNoErrors();
         ts.assertComplete();
     }
+
     @Test(timeout = 2000)
     @Ignore("PublishProcessor no longer emits without requests so this test fails due to the race of onComplete and request")
     public void testAsyncRequestedFlowable() {
@@ -230,6 +232,7 @@ public class FlowableToListTest {
         List<String> actual = f.toList().blockingGet();
         Assert.assertEquals(Arrays.asList("one", "two", "three"), actual);
     }
+
     @Test
     @Ignore("Single doesn't do backpressure")
     public void testBackpressureHonored() {
@@ -254,6 +257,7 @@ public class FlowableToListTest {
         to.assertNoErrors();
         to.assertComplete();
     }
+
     @Test(timeout = 2000)
     @Ignore("PublishProcessor no longer emits without requests so this test fails due to the race of onComplete and request")
     public void testAsyncRequested() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMapTest.java
@@ -224,7 +224,6 @@ public class FlowableToMapTest {
         verify(objectSubscriber, times(1)).onError(any(Throwable.class));
     }
 
-
     @Test
     public void testToMap() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMultimapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMultimapTest.java
@@ -296,7 +296,6 @@ public class FlowableToMultimapTest {
         verify(objectSubscriber, never()).onComplete();
     }
 
-
     @Test
     public void testToMultimap() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd");

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
@@ -69,6 +69,7 @@ public class FlowableToSortedListTest {
         Flowable<Integer> f = Flowable.just(1, 3, 2, 5, 4);
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), f.toSortedList().toFlowable().blockingFirst());
     }
+
     @Test
     public void testBackpressureHonoredFlowable() {
         Flowable<List<Integer>> w = Flowable.just(1, 3, 2, 5, 4).toSortedList().toFlowable();
@@ -202,6 +203,7 @@ public class FlowableToSortedListTest {
         Flowable<Integer> f = Flowable.just(1, 3, 2, 5, 4);
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), f.toSortedList().blockingGet());
     }
+
     @Test
     @Ignore("Single doesn't do backpressure")
     public void testBackpressureHonored() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
@@ -331,8 +331,6 @@ public class FlowableUsingTest {
 
     }
 
-
-
     @Test
     public void testUsingDisposesEagerlyBeforeError() {
         final List<String> events = new ArrayList<String>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -326,6 +326,7 @@ public class FlowableWindowWithFlowableTest {
         ts.assertNoErrors();
         ts.assertValueCount(1);
     }
+
     @Test
     public void testMainUnsubscribedOnBoundaryCompletion() {
         PublishProcessor<Integer> source = PublishProcessor.create();
@@ -386,6 +387,7 @@ public class FlowableWindowWithFlowableTest {
         ts.assertNoErrors();
         ts.assertValueCount(1);
     }
+
     @Test
     public void testInnerBackpressure() {
         Flowable<Integer> source = Flowable.range(1, 10);
@@ -770,7 +772,6 @@ public class FlowableWindowWithFlowableTest {
 
         ts.assertResult(1);
     }
-
 
     @Test
     public void mainAndBoundaryBothError() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -211,6 +211,7 @@ public class FlowableWindowWithSizeTest {
             public void onStart() {
                 request(1);
             }
+
             @Override
             public void onNext(Flowable<Integer> t) {
                 t.subscribe(new DefaultSubscriber<Integer>() {
@@ -218,20 +219,24 @@ public class FlowableWindowWithSizeTest {
                     public void onNext(Integer t) {
                         list.add(t);
                     }
+
                     @Override
                     public void onError(Throwable e) {
                         subscriber.onError(e);
                     }
+
                     @Override
                     public void onComplete() {
                         subscriber.onComplete();
                     }
                 });
             }
+
             @Override
             public void onError(Throwable e) {
                 subscriber.onError(e);
             }
+
             @Override
             public void onComplete() {
                 subscriber.onComplete();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -158,6 +158,7 @@ public class FlowableWindowWithTimeTest {
             }
         };
     }
+
     @Test
     public void testExactWindowSize() {
         Flowable<Flowable<Integer>> source = Flowable.range(1, 10)
@@ -221,7 +222,6 @@ public class FlowableWindowWithTimeTest {
         ts.assertComplete();
         Assert.assertTrue(ts.valueCount() != 0);
     }
-
 
     @Test
     public void timespanTimeskipCustomSchedulerBufferSize() {
@@ -811,6 +811,7 @@ public class FlowableWindowWithTimeTest {
         .assertNoErrors()
         .assertNotComplete();
     }
+
     @Test
     public void countRestartsOnTimeTick() {
         TestScheduler scheduler = new TestScheduler();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -134,7 +134,6 @@ public class FlowableWithLatestFromTest {
         assertFalse(other.hasSubscribers());
     }
 
-
     @Test
     public void testUnsubscription() {
         PublishProcessor<Integer> source = PublishProcessor.create();
@@ -189,6 +188,7 @@ public class FlowableWithLatestFromTest {
         assertFalse(source.hasSubscribers());
         assertFalse(other.hasSubscribers());
     }
+
     @Test
     public void testOtherThrows() {
         PublishProcessor<Integer> source = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
@@ -1224,6 +1224,7 @@ public class FlowableZipTest {
         }
         assertEquals(expected, zip2.toList().blockingGet());
     }
+
     @Test
     public void testUnboundedDownstreamOverrequesting() {
         Flowable<Integer> source = Flowable.range(1, 2).zipWith(Flowable.range(1, 2), new BiFunction<Integer, Integer, Integer>() {
@@ -1247,6 +1248,7 @@ public class FlowableZipTest {
         ts.assertTerminated();
         ts.assertValues(11, 22);
     }
+
     @Test(timeout = 10000)
     public void testZipRace() {
         long startTime = System.currentTimeMillis();
@@ -1570,6 +1572,7 @@ public class FlowableZipTest {
         .test()
         .assertResult("12345678");
     }
+
     @Test
     public void zip9() {
         Flowable.zip(Flowable.just(1),
@@ -1588,7 +1591,6 @@ public class FlowableZipTest {
         .test()
         .assertResult("123456789");
     }
-
 
     @Test
     public void zipArrayMany() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
@@ -52,7 +52,6 @@ public class MaybeCacheTest {
         .assertFailure(TestException.class);
     }
 
-
     @Test
     public void offlineComplete() {
         Maybe<Integer> source = Maybe.<Integer>empty().cache();

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
@@ -59,7 +59,6 @@ public class MaybeContainsTest {
         assertFalse(pp.hasSubscribers());
     }
 
-
     @Test
     public void isDisposed() {
         PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherTest.java
@@ -65,7 +65,6 @@ public class MaybeDelayOtherTest {
         to.assertResult(1);
     }
 
-
     @Test
     public void justWithOnError() {
         PublishProcessor<Object> pp = PublishProcessor.create();
@@ -101,7 +100,6 @@ public class MaybeDelayOtherTest {
 
         to.assertResult();
     }
-
 
     @Test
     public void emptyWithOnComplete() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptyTest.java
@@ -54,7 +54,6 @@ public class MaybeIsEmptyTest {
         .toMaybe() instanceof MaybeIsEmpty);
     }
 
-
     @Test
     public void normalToMaybe() {
         Maybe.just(1)

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
@@ -61,7 +61,6 @@ public class MaybeSwitchIfEmptySingleTest {
         assertFalse(pp.hasSubscribers());
     }
 
-
     @Test
     public void isDisposed() {
         PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
@@ -76,7 +76,6 @@ public class MaybeSwitchIfEmptyTest {
         assertFalse(pp.hasSubscribers());
     }
 
-
     @Test
     public void isDisposed() {
         PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
@@ -346,7 +346,6 @@ public class MaybeUsingTest {
         .assertFailure(TestException.class);
     }
 
-
     @Test
     public void emptyDisposerCrashes() {
         Maybe.using(new Callable<Object>() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipArrayTest.java
@@ -150,6 +150,7 @@ public class MaybeZipArrayTest {
             }
         }
     }
+
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipArrayOneIsNull() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservableTest.java
@@ -63,7 +63,6 @@ public class CompletableAndThenObservableTest {
         assertFalse(ps.hasObservers());
     }
 
-
     @Test
     public void errorMain() {
         CompletableSubject cs = CompletableSubject.create();

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
@@ -399,7 +399,6 @@ public class FlowableSwitchMapMaybeTest {
         }
     }
 
-
     @Test
     public void innerErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingleTest.java
@@ -347,7 +347,6 @@ public class FlowableSwitchMapSingleTest {
         }
     }
 
-
     @Test
     public void innerErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
@@ -375,7 +375,6 @@ public class ObservableSwitchMapMaybeTest {
         }
     }
 
-
     @Test
     public void innerErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
@@ -344,7 +344,6 @@ public class ObservableSwitchMapSingleTest {
         }
     }
 
-
     @Test
     public void innerErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAllTest.java
@@ -124,6 +124,7 @@ public class ObservableAllTest {
 
         assertFalse(allOdd.blockingFirst());
     }
+
     @Test(timeout = 5000)
     public void testIssue1935NoUnsubscribeDownstreamObservable() {
         Observable<Integer> source = Observable.just(1)
@@ -142,7 +143,6 @@ public class ObservableAllTest {
 
         assertEquals((Object)2, source.blockingFirst());
     }
-
 
     @Test
     public void testPredicateThrowsExceptionAndValueInCauseMessageObservable() {
@@ -165,7 +165,6 @@ public class ObservableAllTest {
         // FIXME need to decide about adding the value that probably caused the crash in some way
 //        assertTrue(ex.getCause().getMessage().contains("Boo!"));
     }
-
 
     @Test
     public void testAll() {
@@ -256,6 +255,7 @@ public class ObservableAllTest {
 
         assertFalse(allOdd.blockingGet());
     }
+
     @Test(timeout = 5000)
     public void testIssue1935NoUnsubscribeDownstream() {
         Observable<Integer> source = Observable.just(1)
@@ -274,7 +274,6 @@ public class ObservableAllTest {
 
         assertEquals((Object)2, source.blockingFirst());
     }
-
 
     @Test
     public void testPredicateThrowsExceptionAndValueInCauseMessage() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableAnyTest.java
@@ -231,6 +231,7 @@ public class ObservableAnyTest {
 
         assertTrue(anyEven.blockingFirst());
     }
+
     @Test(timeout = 5000)
     public void testIssue1935NoUnsubscribeDownstreamObservable() {
         Observable<Integer> source = Observable.just(1).isEmpty().toObservable()
@@ -452,6 +453,7 @@ public class ObservableAnyTest {
 
         assertTrue(anyEven.blockingGet());
     }
+
     @Test(timeout = 5000)
     public void testIssue1935NoUnsubscribeDownstream() {
         Observable<Integer> source = Observable.just(1).isEmpty()

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -497,6 +497,7 @@ public class ObservableBufferTest {
         verify(o, never()).onComplete();
         verify(o, never()).onNext(any());
     }
+
     @Test(timeout = 2000)
     public void bufferWithSizeTake1() {
         Observable<Integer> source = Observable.just(1).repeat();
@@ -526,6 +527,7 @@ public class ObservableBufferTest {
         verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
     }
+
     @Test(timeout = 2000)
     public void bufferWithTimeTake1() {
         Observable<Long> source = Observable.interval(40, 40, TimeUnit.MILLISECONDS, scheduler);
@@ -542,6 +544,7 @@ public class ObservableBufferTest {
         verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
     }
+
     @Test(timeout = 2000)
     public void bufferWithTimeSkipTake2() {
         Observable<Long> source = Observable.interval(40, 40, TimeUnit.MILLISECONDS, scheduler);
@@ -560,6 +563,7 @@ public class ObservableBufferTest {
         inOrder.verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
     }
+
     @Test(timeout = 2000)
     public void bufferWithBoundaryTake2() {
         Observable<Long> boundary = Observable.interval(60, 60, TimeUnit.MILLISECONDS, scheduler);
@@ -614,6 +618,7 @@ public class ObservableBufferTest {
         inOrder.verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void bufferWithSizeThrows() {
         PublishSubject<Integer> source = PublishSubject.create();
@@ -683,6 +688,7 @@ public class ObservableBufferTest {
         inOrder.verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void bufferWithStartEndStartThrows() {
         PublishSubject<Integer> start = PublishSubject.create();
@@ -711,6 +717,7 @@ public class ObservableBufferTest {
         verify(o, never()).onComplete();
         verify(o).onError(any(TestException.class));
     }
+
     @Test
     public void bufferWithStartEndEndFunctionThrows() {
         PublishSubject<Integer> start = PublishSubject.create();
@@ -738,6 +745,7 @@ public class ObservableBufferTest {
         verify(o, never()).onComplete();
         verify(o).onError(any(TestException.class));
     }
+
     @Test
     public void bufferWithStartEndEndThrows() {
         PublishSubject<Integer> start = PublishSubject.create();
@@ -776,11 +784,13 @@ public class ObservableBufferTest {
             public void onNext(Object t) {
                 o.onNext(t);
             }
+
             @Override
             public void onError(Throwable e) {
                 o.onError(e);
                 cdl.countDown();
             }
+
             @Override
             public void onComplete() {
                 o.onComplete();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
@@ -154,6 +154,7 @@ public class ObservableCacheTest {
             assertEquals(10000, to2.values().size());
         }
     }
+
     @Test
     public void testAsyncComeAndGo() {
         Observable<Long> source = Observable.interval(1, 1, TimeUnit.MILLISECONDS)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapCompletableTest.java
@@ -155,7 +155,6 @@ public class ObservableConcatMapCompletableTest {
         .assertFailure(TestException.class);
     }
 
-
     @Test
     public void fusedPollThrows() {
         Observable.just(1)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -623,7 +623,6 @@ public class ObservableConcatMapEagerTest {
         to.assertValue(null);
     }
 
-
     @Test
     @Ignore("Observable doesn't do backpressure")
     public void testMaxConcurrent5() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
@@ -623,6 +623,7 @@ public class ObservableConcatTest {
         inOrder.verify(o).onSuccess(list);
         verify(o, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void concatVeryLongObservableOfObservablesTakeHalf() {
         final int n = 10000;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatWithMaybeTest.java
@@ -42,7 +42,6 @@ public class ObservableConcatWithMaybeTest {
         to.assertResult(1, 2, 3, 4, 5, 100);
     }
 
-
     @Test
     public void normalNonEmpty() {
         final TestObserver<Integer> to = new TestObserver<Integer>();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
@@ -239,6 +239,7 @@ public class ObservableDebounceTest {
         verify(o, never()).onComplete();
         verify(o).onError(any(TestException.class));
     }
+
     @Test
     public void debounceTimedLastIsNotLost() {
         PublishSubject<Integer> source = PublishSubject.create();
@@ -256,6 +257,7 @@ public class ObservableDebounceTest {
         verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void debounceSelectorLastIsNotLost() {
         PublishSubject<Integer> source = PublishSubject.create();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
@@ -203,7 +203,6 @@ public class ObservableDelaySubscriptionOtherTest {
         }, false, 1, 1, 1);
     }
 
-
     @Test
     public void afterDelayNoInterrupt() {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDetachTest.java
@@ -85,7 +85,6 @@ public class ObservableDetachTest {
         to.assertComplete();
     }
 
-
     @Test
     @Ignore("Observable doesn't do backpressure")
     public void backpressured() throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDoFinallyTest.java
@@ -159,7 +159,6 @@ public class ObservableDoFinallyTest implements Action {
         assertEquals(1, calls);
     }
 
-
     @Test
     public void normalJustConditional() {
         Observable.just(1)
@@ -444,7 +443,6 @@ public class ObservableDoFinallyTest implements Action {
 
         assertEquals(1, calls);
     }
-
 
     @Test
     public void eventOrdering() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableTest.java
@@ -166,7 +166,6 @@ public class ObservableFlatMapCompletableTest {
         .assertFailure(TestException.class);
     }
 
-
     @Test
     public void fusedObservable() {
         TestObserver<Integer> to = ObserverFusion.newTest(QueueFuseable.ANY);
@@ -331,7 +330,6 @@ public class ObservableFlatMapCompletableTest {
         .test()
         .assertFailure(TestException.class);
     }
-
 
     @Test
     public void fused() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
@@ -350,6 +350,7 @@ public class ObservableFlatMapTest {
         Assert.assertEquals(expected.size(), to.valueCount());
         Assert.assertTrue(expected.containsAll(to.values()));
     }
+
     @Test
     public void testFlatMapSelectorMaxConcurrent() {
         final int m = 4;
@@ -471,6 +472,7 @@ public class ObservableFlatMapTest {
             }
         }
     }
+
     @Test(timeout = 30000)
     public void flatMapRangeMixedAsyncLoop() {
         for (int i = 0; i < 2000; i++) {
@@ -530,6 +532,7 @@ public class ObservableFlatMapTest {
             to.assertValueCount(1000);
         }
     }
+
     @Test
     public void flatMapTwoNestedSync() {
         for (final int n : new int[] { 1, 1000, 1000000 }) {
@@ -894,7 +897,6 @@ public class ObservableFlatMapTest {
         .test()
         .assertFailureAndMessage(NullPointerException.class, "The mapper returned a null ObservableSource");
     }
-
 
     @Test
     public void failingFusedInnerCancelsSource() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -429,6 +429,7 @@ public class ObservableMergeDelayErrorTest {
         }
 
     }
+
     @Test
     @Ignore("Subscribers should not throw")
     public void testMergeSourceWhichDoesntPropagateExceptionBack() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
@@ -137,6 +137,7 @@ public class ObservableMergeMaxConcurrentTest {
         }
         assertEquals(j, n);
     }
+
     @Test
     public void testMergeALotOfSourcesOneByOneSynchronouslyTakeHalf() {
         int n = 10000;
@@ -171,6 +172,7 @@ public class ObservableMergeMaxConcurrentTest {
             to.assertValueSequence(result);
         }
     }
+
     @Test
     public void testSimpleOneLess() {
         for (int i = 2; i < 100; i++) {
@@ -189,6 +191,7 @@ public class ObservableMergeMaxConcurrentTest {
             to.assertValueSequence(result);
         }
     }
+
     @Test//(timeout = 20000)
     public void testSimpleAsyncLoop() {
         IoScheduler ios = (IoScheduler)Schedulers.io();
@@ -201,6 +204,7 @@ public class ObservableMergeMaxConcurrentTest {
             }
         }
     }
+
     @Test(timeout = 30000)
     public void testSimpleAsync() {
         for (int i = 1; i < 50; i++) {
@@ -221,12 +225,14 @@ public class ObservableMergeMaxConcurrentTest {
             assertEquals(expected, actual);
         }
     }
+
     @Test(timeout = 30000)
     public void testSimpleOneLessAsyncLoop() {
         for (int i = 0; i < 200; i++) {
             testSimpleOneLessAsync();
         }
     }
+
     @Test(timeout = 30000)
     public void testSimpleOneLessAsync() {
         long t = System.currentTimeMillis();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeTest.java
@@ -1082,10 +1082,12 @@ public class ObservableMergeTest {
     public void testFastMergeFullScalar() {
         runMerge(toScalar, new TestObserver<Integer>());
     }
+
     @Test
     public void testFastMergeHiddenScalar() {
         runMerge(toHiddenScalar, new TestObserver<Integer>());
     }
+
     @Test
     public void testSlowMergeFullScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
@@ -1103,6 +1105,7 @@ public class ObservableMergeTest {
             runMerge(toScalar, to);
         }
     }
+
     @Test
     public void testSlowMergeHiddenScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnExceptionResumeNextViaObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnExceptionResumeNextViaObservableTest.java
@@ -183,7 +183,6 @@ public class ObservableOnExceptionResumeNextViaObservableTest {
         verify(observer, times(1)).onComplete();
     }
 
-
     @Test
     public void testBackpressure() {
         TestObserver<Integer> to = new TestObserver<Integer>();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -372,6 +372,7 @@ public class ObservablePublishTest {
 
         assertEquals(2, calls.get());
     }
+
     @Test
     public void testObserveOn() {
         ConnectableObservable<Integer> co = Observable.range(0, 1000).publish();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReduceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReduceTest.java
@@ -145,7 +145,6 @@ public class ObservableReduceTest {
         assertEquals(21, r.intValue());
     }
 
-
     @Test
     public void testAggregateAsIntSum() {
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -986,6 +986,7 @@ public class ObservableReplayTest {
             assertEquals(10000, to2.values().size());
         }
     }
+
     @Test
     public void testAsyncComeAndGo() {
         Observable<Long> source = Observable.interval(1, 1, TimeUnit.MILLISECONDS)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
@@ -779,6 +779,7 @@ public class ObservableRetryTest {
 
         return sb;
     }
+
     @Test//(timeout = 3000)
     public void testIssue1900() throws InterruptedException {
         Observer<String> observer = TestHelper.mockObserver();
@@ -819,6 +820,7 @@ public class ObservableRetryTest {
         inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }
+
     @Test//(timeout = 3000)
     public void testIssue1900SourceNotSupportingBackpressure() {
         Observer<String> observer = TestHelper.mockObserver();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -69,6 +69,7 @@ public class ObservableRetryWithPredicateTest {
         inOrder.verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void testRetryTwice() {
         Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
@@ -104,6 +105,7 @@ public class ObservableRetryWithPredicateTest {
         verify(o, never()).onError(any(Throwable.class));
 
     }
+
     @Test
     public void testRetryTwiceAndGiveUp() {
         Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
@@ -131,6 +133,7 @@ public class ObservableRetryWithPredicateTest {
         verify(o, never()).onComplete();
 
     }
+
     @Test
     public void testRetryOnSpecificException() {
         Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
@@ -165,6 +168,7 @@ public class ObservableRetryWithPredicateTest {
         inOrder.verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
     }
+
     @Test
     public void testRetryOnSpecificExceptionAndNotOther() {
         final IOException ioe = new IOException();
@@ -288,6 +292,7 @@ public class ObservableRetryWithPredicateTest {
         assertEquals(6, c.get());
         assertEquals(Collections.singletonList(e), to.errors());
     }
+
     @Test
     public void testJustAndRetry() throws Exception {
         final AtomicBoolean throwException = new AtomicBoolean(true);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableSwitchTest.java
@@ -484,7 +484,6 @@ public class ObservableSwitchTest {
         Assert.assertEquals(250, to.valueCount());
     }
 
-
     @Test
     public void delayErrors() {
         PublishSubject<ObservableSource<Integer>> source = PublishSubject.create();
@@ -607,7 +606,6 @@ public class ObservableSwitchTest {
         .assertResult(1);
 
     }
-
 
     @Test
     public void switchMapInnerCancelled() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilPredicateTest.java
@@ -46,6 +46,7 @@ public class ObservableTakeUntilPredicateTest {
         verify(o, never()).onError(any(Throwable.class));
         verify(o).onComplete();
     }
+
     @Test
     public void takeAll() {
         Observer<Object> o = TestHelper.mockObserver();
@@ -62,6 +63,7 @@ public class ObservableTakeUntilPredicateTest {
         verify(o, never()).onError(any(Throwable.class));
         verify(o).onComplete();
     }
+
     @Test
     public void takeFirst() {
         Observer<Object> o = TestHelper.mockObserver();
@@ -78,6 +80,7 @@ public class ObservableTakeUntilPredicateTest {
         verify(o, never()).onError(any(Throwable.class));
         verify(o).onComplete();
     }
+
     @Test
     public void takeSome() {
         Observer<Object> o = TestHelper.mockObserver();
@@ -96,6 +99,7 @@ public class ObservableTakeUntilPredicateTest {
         verify(o, never()).onError(any(Throwable.class));
         verify(o).onComplete();
     }
+
     @Test
     public void functionThrows() {
         Observer<Object> o = TestHelper.mockObserver();
@@ -114,6 +118,7 @@ public class ObservableTakeUntilPredicateTest {
         verify(o).onError(any(TestException.class));
         verify(o, never()).onComplete();
     }
+
     @Test
     public void sourceThrows() {
         Observer<Object> o = TestHelper.mockObserver();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeUntilTest.java
@@ -210,6 +210,7 @@ public class ObservableTakeUntilTest {
         // 2.0.2 - not anymore
 //        assertTrue("Not cancelled!", ts.isCancelled());
     }
+
     @Test
     public void testMainCompletes() {
         PublishSubject<Integer> source = PublishSubject.create();
@@ -234,6 +235,7 @@ public class ObservableTakeUntilTest {
         // 2.0.2 - not anymore
 //        assertTrue("Not cancelled!", ts.isCancelled());
     }
+
     @Test
     public void testDownstreamUnsubscribes() {
         PublishSubject<Integer> source = PublishSubject.create();
@@ -272,7 +274,6 @@ public class ObservableTakeUntilTest {
             }
         });
     }
-
 
     @Test
     public void untilPublisherMainSuccess() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleLatestTest.java
@@ -129,7 +129,6 @@ public class ObservableThrottleLatestTest {
         to.assertResult(1, 3, 5, 6);
     }
 
-
     @Test
     public void normalEmitLast() {
         TestScheduler sch = new TestScheduler();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimerTest.java
@@ -87,6 +87,7 @@ public class ObservableTimerTest {
         to.assertNotComplete();
         to.assertNoErrors();
     }
+
     @Test
     public void testInterval() {
         Observable<Long> w = Observable.interval(1, TimeUnit.SECONDS, scheduler);
@@ -227,6 +228,7 @@ public class ObservableTimerTest {
         to2.assertNoErrors();
         to2.assertNotComplete();
     }
+
     @Test
     public void testOnceObserverThrows() {
         Observable<Long> source = Observable.timer(100, TimeUnit.MILLISECONDS, scheduler);
@@ -255,6 +257,7 @@ public class ObservableTimerTest {
         verify(observer, never()).onNext(anyLong());
         verify(observer, never()).onComplete();
     }
+
     @Test
     public void testPeriodicObserverThrows() {
         Observable<Long> source = Observable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToMapTest.java
@@ -225,7 +225,6 @@ public class ObservableToMapTest {
         verify(objectObserver, times(1)).onError(any(Throwable.class));
     }
 
-
     @Test
     public void testToMap() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToMultimapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToMultimapTest.java
@@ -296,8 +296,6 @@ public class ObservableToMultimapTest {
         verify(objectObserver, never()).onComplete();
     }
 
-
-
     @Test
     public void testToMultimap() {
         Observable<String> source = Observable.just("a", "b", "cc", "dd");

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToSortedListTest.java
@@ -115,7 +115,6 @@ public class ObservableToSortedListTest {
         .assertResult(Arrays.asList(5, 4, 3, 2, 1));
     }
 
-
     @Test
     public void testSortedList() {
         Observable<Integer> w = Observable.just(1, 3, 2, 5, 4);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
@@ -330,8 +330,6 @@ public class ObservableUsingTest {
 
     }
 
-
-
     @Test
     public void testUsingDisposesEagerlyBeforeError() {
         final List<String> events = new ArrayList<String>();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithObservableTest.java
@@ -329,6 +329,7 @@ public class ObservableWindowWithObservableTest {
         to.assertNoErrors();
         to.assertValueCount(1);
     }
+
     @Test
     public void testMainUnsubscribedOnBoundaryCompletion() {
         PublishSubject<Integer> source = PublishSubject.create();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -158,6 +158,7 @@ public class ObservableWindowWithTimeTest {
             }
         };
     }
+
     @Test
     public void testExactWindowSize() {
         Observable<Observable<Integer>> source = Observable.range(1, 10)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromTest.java
@@ -134,7 +134,6 @@ public class ObservableWithLatestFromTest {
         assertFalse(other.hasObservers());
     }
 
-
     @Test
     public void testUnsubscription() {
         PublishSubject<Integer> source = PublishSubject.create();
@@ -189,6 +188,7 @@ public class ObservableWithLatestFromTest {
         assertFalse(source.hasObservers());
         assertFalse(other.hasObservers());
     }
+
     @Test
     public void testOtherThrows() {
         PublishSubject<Integer> source = PublishSubject.create();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableZipTest.java
@@ -1261,6 +1261,7 @@ public class ObservableZipTest {
         .test()
         .assertResult("12345678");
     }
+
     @Test
     public void zip9() {
         Observable.zip(Observable.just(1),

--- a/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
@@ -163,7 +163,6 @@ public class SingleConcatTest {
         assertEquals(1, calls[0]);
     }
 
-
     @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscriptionIterable() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapTest.java
@@ -105,7 +105,6 @@ public class SingleFlatMapTest {
         assertFalse(b[0]);
     }
 
-
     @Test
     public void flatMapObservable() {
         Single.just(1).flatMapObservable(new Function<Integer, Observable<Integer>>() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFromCallableTest.java
@@ -111,7 +111,6 @@ public class SingleFromCallableTest {
         verify(func).call();
     }
 
-
     @Test
     public void noErrorLoss() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMergeTest.java
@@ -125,7 +125,6 @@ public class SingleMergeTest {
         .assertFailure(TestException.class, 1, 2);
     }
 
-
     @Test
     public void mergeDelayError4() {
         Single.mergeDelayError(

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
@@ -59,7 +59,6 @@ public class SingleTakeUntilTest {
         to.assertResult(1);
     }
 
-
     @Test
     public void mainSuccessCompletable() {
         PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/single/SingleZipArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleZipArrayTest.java
@@ -150,6 +150,7 @@ public class SingleZipArrayTest {
             }
         }
     }
+
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipArrayOneIsNull() {

--- a/src/test/java/io/reactivex/internal/schedulers/AbstractDirectTaskTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/AbstractDirectTaskTest.java
@@ -115,6 +115,7 @@ public class AbstractDirectTaskTest {
 
         assertTrue(interrupted[0]);
     }
+
     @Test
     public void setFutureCancelSameThread() {
         AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE) {

--- a/src/test/java/io/reactivex/internal/schedulers/ImmediateThinSchedulerTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/ImmediateThinSchedulerTest.java
@@ -47,6 +47,7 @@ public class ImmediateThinSchedulerTest {
     public void scheduleDirectPeriodic() {
         ImmediateThinScheduler.INSTANCE.schedulePeriodicallyDirect(Functions.EMPTY_RUNNABLE, 1, 1, TimeUnit.SECONDS);
     }
+
     @Test
     public void schedule() {
         final int[] count = { 0 };

--- a/src/test/java/io/reactivex/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/ScheduledRunnableTest.java
@@ -372,7 +372,6 @@ public class ScheduledRunnableTest {
         assertEquals(ScheduledRunnable.ASYNC_DISPOSED, run.get(ScheduledRunnable.FUTURE_INDEX));
     }
 
-
     @Test
     public void noParentIsDisposed() {
         ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);

--- a/src/test/java/io/reactivex/internal/subscribers/BlockingSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/BlockingSubscriberTest.java
@@ -93,6 +93,7 @@ public class BlockingSubscriberTest {
             public void request(long n) {
                 bf.cancelled = true;
             }
+
             @Override
             public void cancel() {
                 b.set(true);
@@ -118,6 +119,7 @@ public class BlockingSubscriberTest {
             public void request(long n) {
                 b.set(true);
             }
+
             @Override
             public void cancel() {
             }

--- a/src/test/java/io/reactivex/internal/subscribers/DeferredScalarSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/DeferredScalarSubscriberTest.java
@@ -303,6 +303,7 @@ public class DeferredScalarSubscriberTest {
         ts.assertNoErrors();
         ts.assertNotComplete();
     }
+
     @Test
     public void emissionRequestRace() {
         Worker w = Schedulers.computation().createWorker();

--- a/src/test/java/io/reactivex/internal/subscribers/InnerQueuedSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/InnerQueuedSubscriberTest.java
@@ -27,12 +27,15 @@ public class InnerQueuedSubscriberTest {
             @Override
             public void innerNext(InnerQueuedSubscriber<Integer> inner, Integer value) {
             }
+
             @Override
             public void innerError(InnerQueuedSubscriber<Integer> inner, Throwable e) {
             }
+
             @Override
             public void innerComplete(InnerQueuedSubscriber<Integer> inner) {
             }
+
             @Override
             public void drain() {
             }
@@ -47,6 +50,7 @@ public class InnerQueuedSubscriberTest {
             public void request(long n) {
                 requests.add(n);
             }
+
             @Override
             public void cancel() {
                 // ignore

--- a/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
@@ -242,6 +242,7 @@ public class LambdaSubscriberTest {
 
         assertEquals(Arrays.asList(1, 100), received);
     }
+
     @Test
     public void badSourceEmitAfterDone() {
         Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {

--- a/src/test/java/io/reactivex/internal/subscriptions/SubscriptionHelperTest.java
+++ b/src/test/java/io/reactivex/internal/subscriptions/SubscriptionHelperTest.java
@@ -51,15 +51,15 @@ public class SubscriptionHelperTest {
 
     @Test
     public void set() {
-        AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+        AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
 
         BooleanSubscription bs1 = new BooleanSubscription();
 
-        assertTrue(SubscriptionHelper.set(s, bs1));
+        assertTrue(SubscriptionHelper.set(atomicSubscription, bs1));
 
         BooleanSubscription bs2 = new BooleanSubscription();
 
-        assertTrue(SubscriptionHelper.set(s, bs2));
+        assertTrue(SubscriptionHelper.set(atomicSubscription, bs2));
 
         assertTrue(bs1.isCancelled());
 
@@ -68,15 +68,15 @@ public class SubscriptionHelperTest {
 
     @Test
     public void replace() {
-        AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+        AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
 
         BooleanSubscription bs1 = new BooleanSubscription();
 
-        assertTrue(SubscriptionHelper.replace(s, bs1));
+        assertTrue(SubscriptionHelper.replace(atomicSubscription, bs1));
 
         BooleanSubscription bs2 = new BooleanSubscription();
 
-        assertTrue(SubscriptionHelper.replace(s, bs2));
+        assertTrue(SubscriptionHelper.replace(atomicSubscription, bs2));
 
         assertFalse(bs1.isCancelled());
 
@@ -86,12 +86,12 @@ public class SubscriptionHelperTest {
     @Test
     public void cancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
 
             Runnable r = new Runnable() {
                 @Override
                 public void run() {
-                    SubscriptionHelper.cancel(s);
+                    SubscriptionHelper.cancel(atomicSubscription);
                 }
             };
 
@@ -102,7 +102,7 @@ public class SubscriptionHelperTest {
     @Test
     public void setRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
 
             final BooleanSubscription bs1 = new BooleanSubscription();
             final BooleanSubscription bs2 = new BooleanSubscription();
@@ -110,14 +110,14 @@ public class SubscriptionHelperTest {
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    SubscriptionHelper.set(s, bs1);
+                    SubscriptionHelper.set(atomicSubscription, bs1);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    SubscriptionHelper.set(s, bs2);
+                    SubscriptionHelper.set(atomicSubscription, bs2);
                 }
             };
 
@@ -130,7 +130,7 @@ public class SubscriptionHelperTest {
     @Test
     public void replaceRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
 
             final BooleanSubscription bs1 = new BooleanSubscription();
             final BooleanSubscription bs2 = new BooleanSubscription();
@@ -138,14 +138,14 @@ public class SubscriptionHelperTest {
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    SubscriptionHelper.replace(s, bs1);
+                    SubscriptionHelper.replace(atomicSubscription, bs1);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    SubscriptionHelper.replace(s, bs2);
+                    SubscriptionHelper.replace(atomicSubscription, bs2);
                 }
             };
 
@@ -158,31 +158,31 @@ public class SubscriptionHelperTest {
 
     @Test
     public void cancelAndChange() {
-        AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+        AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
 
-        SubscriptionHelper.cancel(s);
+        SubscriptionHelper.cancel(atomicSubscription);
 
         BooleanSubscription bs1 = new BooleanSubscription();
-        assertFalse(SubscriptionHelper.set(s, bs1));
+        assertFalse(SubscriptionHelper.set(atomicSubscription, bs1));
         assertTrue(bs1.isCancelled());
 
-        assertFalse(SubscriptionHelper.set(s, null));
+        assertFalse(SubscriptionHelper.set(atomicSubscription, null));
 
         BooleanSubscription bs2 = new BooleanSubscription();
-        assertFalse(SubscriptionHelper.replace(s, bs2));
+        assertFalse(SubscriptionHelper.replace(atomicSubscription, bs2));
         assertTrue(bs2.isCancelled());
 
-        assertFalse(SubscriptionHelper.replace(s, null));
+        assertFalse(SubscriptionHelper.replace(atomicSubscription, null));
     }
 
     @Test
     public void invalidDeferredRequest() {
-        AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+        AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
         AtomicLong r = new AtomicLong();
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            SubscriptionHelper.deferredRequest(s, r, -99);
+            SubscriptionHelper.deferredRequest(atomicSubscription, r, -99);
 
             TestHelper.assertError(errors, 0, IllegalArgumentException.class, "n > 0 required but it was -99");
         } finally {
@@ -193,7 +193,7 @@ public class SubscriptionHelperTest {
     @Test
     public void deferredRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AtomicReference<Subscription> s = new AtomicReference<Subscription>();
+            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
             final AtomicLong r = new AtomicLong();
 
             final AtomicLong q = new AtomicLong();
@@ -213,20 +213,20 @@ public class SubscriptionHelperTest {
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    SubscriptionHelper.deferredSetOnce(s, r, a);
+                    SubscriptionHelper.deferredSetOnce(atomicSubscription, r, a);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    SubscriptionHelper.deferredRequest(s, r, 1);
+                    SubscriptionHelper.deferredRequest(atomicSubscription, r, 1);
                 }
             };
 
             TestHelper.race(r1, r2);
 
-            assertSame(a, s.get());
+            assertSame(a, atomicSubscription.get());
             assertEquals(1, q.get());
             assertEquals(0, r.get());
         }

--- a/src/test/java/io/reactivex/internal/util/EndConsumerHelperTest.java
+++ b/src/test/java/io/reactivex/internal/util/EndConsumerHelperTest.java
@@ -54,9 +54,11 @@ public class EndConsumerHelperTest {
             @Override
             public void onNext(Integer t) {
             }
+
             @Override
             public void onError(Throwable t) {
             }
+
             @Override
             public void onComplete() {
             }
@@ -85,9 +87,11 @@ public class EndConsumerHelperTest {
         @Override
         public void onNext(Integer t) {
         }
+
         @Override
         public void onError(Throwable t) {
         }
+
         @Override
         public void onComplete() {
         }
@@ -124,9 +128,11 @@ public class EndConsumerHelperTest {
             @Override
             public void onNext(Integer t) {
             }
+
             @Override
             public void onError(Throwable t) {
             }
+
             @Override
             public void onComplete() {
             }
@@ -157,9 +163,11 @@ public class EndConsumerHelperTest {
             @Override
             public void onNext(Integer t) {
             }
+
             @Override
             public void onError(Throwable t) {
             }
+
             @Override
             public void onComplete() {
             }
@@ -190,9 +198,11 @@ public class EndConsumerHelperTest {
             @Override
             public void onNext(Integer t) {
             }
+
             @Override
             public void onError(Throwable t) {
             }
+
             @Override
             public void onComplete() {
             }
@@ -223,9 +233,11 @@ public class EndConsumerHelperTest {
             @Override
             public void onNext(Integer t) {
             }
+
             @Override
             public void onError(Throwable t) {
             }
+
             @Override
             public void onComplete() {
             }
@@ -256,9 +268,11 @@ public class EndConsumerHelperTest {
             @Override
             public void onNext(Integer t) {
             }
+
             @Override
             public void onError(Throwable t) {
             }
+
             @Override
             public void onComplete() {
             }
@@ -289,6 +303,7 @@ public class EndConsumerHelperTest {
             @Override
             public void onSuccess(Integer t) {
             }
+
             @Override
             public void onError(Throwable t) {
             }
@@ -319,6 +334,7 @@ public class EndConsumerHelperTest {
             @Override
             public void onSuccess(Integer t) {
             }
+
             @Override
             public void onError(Throwable t) {
             }
@@ -349,9 +365,11 @@ public class EndConsumerHelperTest {
             @Override
             public void onSuccess(Integer t) {
             }
+
             @Override
             public void onError(Throwable t) {
             }
+
             @Override
             public void onComplete() {
             }
@@ -382,9 +400,11 @@ public class EndConsumerHelperTest {
             @Override
             public void onSuccess(Integer t) {
             }
+
             @Override
             public void onError(Throwable t) {
             }
+
             @Override
             public void onComplete() {
             }
@@ -415,6 +435,7 @@ public class EndConsumerHelperTest {
             @Override
             public void onError(Throwable t) {
             }
+
             @Override
             public void onComplete() {
             }
@@ -445,6 +466,7 @@ public class EndConsumerHelperTest {
             @Override
             public void onError(Throwable t) {
             }
+
             @Override
             public void onComplete() {
             }

--- a/src/test/java/io/reactivex/internal/util/QueueDrainHelperTest.java
+++ b/src/test/java/io/reactivex/internal/util/QueueDrainHelperTest.java
@@ -814,6 +814,7 @@ public class QueueDrainHelperTest {
 
         to.assertFailure(TestException.class);
     }
+
     @Test
     public void observerCheckTerminatedNonDelayErrorErrorResource() {
         TestObserver<Integer> to = new TestObserver<Integer>();

--- a/src/test/java/io/reactivex/maybe/MaybeCreateTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeCreateTest.java
@@ -92,7 +92,6 @@ public class MaybeCreateTest {
         assertTrue(d.isDisposed());
     }
 
-
     @Test
     public void basicWithCompletion() {
         final Disposable d = Disposables.empty();

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -2872,7 +2872,6 @@ public class MaybeTest {
         .assertResult("[1]");
     }
 
-
     @SuppressWarnings("unchecked")
     @Test
     public void zipIterable() {

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -350,7 +350,6 @@ public class MaybeTest {
         Completable.complete().toMaybe().ignoreElement().test().assertResult();
     }
 
-
     @Test
     public void unsafeCreate() {
         Maybe.unsafeCreate(new MaybeSource<Integer>() {
@@ -646,7 +645,6 @@ public class MaybeTest {
         assertNotEquals(main, name[0]);
     }
 
-
     @Test
     public void observeOnCompleteThread() {
         String main = Thread.currentThread().getName();
@@ -687,7 +685,6 @@ public class MaybeTest {
         .assertResult()
         ;
     }
-
 
     @Test
     public void fromAction() {
@@ -801,7 +798,6 @@ public class MaybeTest {
         .assertFailure(TestException.class);
     }
 
-
     @Test
     public void doOnSubscribe() {
         final Disposable[] value = { null };
@@ -829,7 +825,6 @@ public class MaybeTest {
         .test()
         .assertFailure(TestException.class);
     }
-
 
     @Test
     public void doOnCompleteThrows() {
@@ -861,7 +856,6 @@ public class MaybeTest {
 
         assertEquals(1, call[0]);
     }
-
 
     @Test
     public void doOnDisposeThrows() {
@@ -971,7 +965,6 @@ public class MaybeTest {
         assertEquals(-1, call[0]);
     }
 
-
     @Test
     public void doAfterTerminateComplete() {
         final int[] call = { 0 };
@@ -1012,7 +1005,6 @@ public class MaybeTest {
             assertEquals("Forced failure", ex.getMessage());
         }
     }
-
 
     @Test
     public void sourceThrowsIAE() {
@@ -1180,6 +1172,7 @@ public class MaybeTest {
         .test()
         .assertResult();
     }
+
     @Test
     public void ignoreElementSuccessMaybe() {
         Maybe.just(1)
@@ -2436,7 +2429,6 @@ public class MaybeTest {
         assertEquals(2, list.size());
     }
 
-
     @Test
     public void doOnEventCompleteThrows() {
         Maybe.<Integer>empty()
@@ -2982,7 +2974,6 @@ public class MaybeTest {
         .test()
         .assertResult("123456789");
     }
-
 
     @Test
     public void ambWith1SignalsSuccess() {

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -2768,7 +2768,6 @@ public class ObservableNullTests {
         });
     }
 
-
     @Test(expected = NullPointerException.class)
     public void zipWithCombinerNull() {
         just1.zipWith(just1, null);

--- a/src/test/java/io/reactivex/observable/ObservableReduceTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableReduceTests.java
@@ -77,7 +77,6 @@ public class ObservableReduceTests {
         assertNotNull(reduceResult2);
     }
 
-
     @Test
     public void reduceInts() {
         Observable<Integer> o = Observable.just(1, 2, 3);

--- a/src/test/java/io/reactivex/observable/ObservableSubscriberTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableSubscriberTest.java
@@ -180,7 +180,6 @@ public class ObservableSubscriberTest {
         to.assertResult(1);
     }
 
-
     @Test
     public void methodTestNoCancel() {
         PublishSubject<Integer> ps = PublishSubject.create();

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -145,7 +145,6 @@ public class ObservableTest {
         verify(w, times(1)).onError(any(RuntimeException.class));
     }
 
-
     @Test
     public void testCountAFewItems() {
         Observable<String> o = Observable.just("a", "b", "c", "d");

--- a/src/test/java/io/reactivex/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SafeObserverTest.java
@@ -452,10 +452,12 @@ public class SafeObserverTest {
             public void onNext(Integer t) {
 
             }
+
             @Override
             public void onError(Throwable e) {
                 error.set(e);
             }
+
             @Override
             public void onComplete() {
                 throw new TestException();
@@ -476,9 +478,11 @@ public class SafeObserverTest {
             @Override
             public void onNext(Integer t) {
             }
+
             @Override
             public void onError(Throwable e) {
             }
+
             @Override
             public void onComplete() {
             }

--- a/src/test/java/io/reactivex/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SerializedObserverTest.java
@@ -974,6 +974,7 @@ public class SerializedObserverTest {
         to.assertValue(1);
         to.assertError(TestException.class);
     }
+
     @Test
     public void testCompleteReentry() {
         final AtomicReference<Observer<Integer>> serial = new AtomicReference<Observer<Integer>>();

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -272,6 +272,7 @@ public class TestObserverTest {
         }
         fail("Failed to report multiple onError terminal events!");
     }
+
     @Test
     public void testTerminalCompletedOnce() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();

--- a/src/test/java/io/reactivex/parallel/ParallelDoOnNextTryTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelDoOnNextTryTest.java
@@ -49,6 +49,7 @@ public class ParallelDoOnNextTryTest implements Consumer<Object> {
             calls = 0;
         }
     }
+
     @Test
     public void doOnNextErrorNoError() {
         for (ParallelFailureHandling e : ParallelFailureHandling.values()) {

--- a/src/test/java/io/reactivex/parallel/ParallelFilterTryTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFilterTryTest.java
@@ -94,6 +94,7 @@ public class ParallelFilterTryTest implements Consumer<Object> {
             .assertResult(1);
         }
     }
+
     @Test
     public void filterErrorConditionalNoError() {
         for (ParallelFailureHandling e : ParallelFailureHandling.values()) {

--- a/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
@@ -454,7 +454,6 @@ public class ParallelFlowableTest {
         }
     }
 
-
     @Test
     public void collectAsync2() {
         ExecutorService exec = Executors.newFixedThreadPool(3);
@@ -550,7 +549,6 @@ public class ParallelFlowableTest {
             exec.shutdown();
         }
     }
-
 
     @Test
     public void collectAsync3Fused() {

--- a/src/test/java/io/reactivex/parallel/ParallelMapTryTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelMapTryTest.java
@@ -44,6 +44,7 @@ public class ParallelMapTryTest implements Consumer<Object> {
             .assertResult(1);
         }
     }
+
     @Test
     public void mapErrorNoError() {
         for (ParallelFailureHandling e : ParallelFailureHandling.values()) {
@@ -68,6 +69,7 @@ public class ParallelMapTryTest implements Consumer<Object> {
             .assertResult(1);
         }
     }
+
     @Test
     public void mapErrorConditionalNoError() {
         for (ParallelFailureHandling e : ParallelFailureHandling.values()) {

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -1954,7 +1954,6 @@ public class RxJavaPluginsTest {
         }
     }
 
-
     @SuppressWarnings("rawtypes")
     @Test
     public void maybeCreate() {

--- a/src/test/java/io/reactivex/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/AsyncProcessorTest.java
@@ -368,6 +368,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
         assertNull(as.getValue());
         assertNull(as.getThrowable());
     }
+
     @Test
     public void testCurrentStateMethodsError() {
         AsyncProcessor<Object> as = AsyncProcessor.create();

--- a/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
@@ -282,6 +282,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
             verify(subscriber, never()).onError(any(Throwable.class));
         }
     }
+
     @Test
     public void testStartEmpty() {
         BehaviorProcessor<Integer> source = BehaviorProcessor.create();
@@ -307,6 +308,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
 
     }
+
     @Test
     public void testStartEmptyThenAddOne() {
         BehaviorProcessor<Integer> source = BehaviorProcessor.create();
@@ -329,6 +331,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         verify(subscriber, never()).onError(any(Throwable.class));
 
     }
+
     @Test
     public void testStartEmptyCompleteWithOne() {
         BehaviorProcessor<Integer> source = BehaviorProcessor.create();
@@ -406,6 +409,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 //        // even though the onError above throws we should still receive it on the other subscriber
 //        assertEquals(1, ts.getOnErrorEvents().size());
 //    }
+
     @Test
     public void testEmissionSubscriptionRace() throws Exception {
         Scheduler s = Schedulers.io();
@@ -550,6 +554,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         assertNull(as.getValue());
         assertNull(as.getThrowable());
     }
+
     @Test
     public void testCurrentStateMethodsError() {
         BehaviorProcessor<Object> as = BehaviorProcessor.create();

--- a/src/test/java/io/reactivex/processors/MulticastProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/MulticastProcessorTest.java
@@ -185,7 +185,6 @@ public class MulticastProcessorTest {
         mp.test().assertValueCount(1000).assertNoErrors().assertComplete();
     }
 
-
     @Test
     public void oneByOne() {
         MulticastProcessor<Integer> mp = MulticastProcessor.create(16);
@@ -419,7 +418,6 @@ public class MulticastProcessorTest {
         mp.onNext(null);
     }
 
-
     @Test(expected = NullPointerException.class)
     public void onOfferNull() {
         MulticastProcessor<Integer> mp = MulticastProcessor.create(4, false);
@@ -622,7 +620,6 @@ public class MulticastProcessorTest {
 
         assertFalse(mp.hasSubscribers());
     }
-
 
     @Test
     public void cancelUpfrontOtherConsumersPresent() {

--- a/src/test/java/io/reactivex/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/PublishProcessorTest.java
@@ -384,6 +384,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 //        // even though the onError above throws we should still receive it on the other subscriber
 //        assertEquals(1, ts.getOnErrorEvents().size());
 //    }
+
     @Test
     public void testCurrentStateMethodsNormal() {
         PublishProcessor<Object> as = PublishProcessor.create();
@@ -419,6 +420,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         assertTrue(as.hasComplete());
         assertNull(as.getThrowable());
     }
+
     @Test
     public void testCurrentStateMethodsError() {
         PublishProcessor<Object> as = PublishProcessor.create();

--- a/src/test/java/io/reactivex/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -318,6 +318,7 @@ public class ReplayProcessorBoundedConcurrencyTest {
             }
         }
     }
+
     @Test
     public void testReplaySubjectEmissionSubscriptionRace() throws Exception {
         Scheduler s = Schedulers.io();
@@ -403,6 +404,7 @@ public class ReplayProcessorBoundedConcurrencyTest {
             worker.dispose();
         }
     }
+
     @Test(timeout = 5000)
     public void testConcurrentSizeAndHasAnyValue() throws InterruptedException {
         final ReplayProcessor<Object> rs = ReplayProcessor.createUnbounded();
@@ -457,6 +459,7 @@ public class ReplayProcessorBoundedConcurrencyTest {
 
         t.join();
     }
+
     @Test(timeout = 5000)
     public void testConcurrentSizeAndHasAnyValueBounded() throws InterruptedException {
         final ReplayProcessor<Object> rs = ReplayProcessor.createWithSize(3);
@@ -500,6 +503,7 @@ public class ReplayProcessorBoundedConcurrencyTest {
 
         t.join();
     }
+
     @Test(timeout = 10000)
     public void testConcurrentSizeAndHasAnyValueTimeBounded() throws InterruptedException {
         final ReplayProcessor<Object> rs = ReplayProcessor.createWithTime(1, TimeUnit.MILLISECONDS, Schedulers.computation());

--- a/src/test/java/io/reactivex/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorConcurrencyTest.java
@@ -318,6 +318,7 @@ public class ReplayProcessorConcurrencyTest {
             }
         }
     }
+
     @Test
     public void testReplaySubjectEmissionSubscriptionRace() throws Exception {
         Scheduler s = Schedulers.io();
@@ -391,6 +392,7 @@ public class ReplayProcessorConcurrencyTest {
             worker.dispose();
         }
     }
+
     @Test(timeout = 10000)
     public void testConcurrentSizeAndHasAnyValue() throws InterruptedException {
         final ReplayProcessor<Object> rs = ReplayProcessor.create();

--- a/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/ReplayProcessorTest.java
@@ -350,6 +350,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         assertEquals("three", lastValueForSubscriber2.get());
 
     }
+
     @Test
     public void testSubscriptionLeak() {
         ReplayProcessor<Object> replaySubject = ReplayProcessor.create();
@@ -403,6 +404,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
             verify(subscriber, never()).onError(any(Throwable.class));
         }
     }
+
     @Test
     public void testTerminateOnce() {
         ReplayProcessor<Integer> source = ReplayProcessor.create();
@@ -455,6 +457,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
             verify(subscriber, never()).onError(any(Throwable.class));
         }
     }
+
     @Test
     public void testReplay1Directly() {
         ReplayProcessor<Integer> source = ReplayProcessor.createWithSize(1);
@@ -618,6 +621,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         assertTrue(as.hasComplete());
         assertNull(as.getThrowable());
     }
+
     @Test
     public void testCurrentStateMethodsError() {
         ReplayProcessor<Object> as = ReplayProcessor.create();
@@ -632,6 +636,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         assertFalse(as.hasComplete());
         assertTrue(as.getThrowable() instanceof TestException);
     }
+
     @Test
     public void testSizeAndHasAnyValueUnbounded() {
         ReplayProcessor<Object> rs = ReplayProcessor.create();
@@ -654,6 +659,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         assertEquals(2, rs.size());
         assertTrue(rs.hasValue());
     }
+
     @Test
     public void testSizeAndHasAnyValueEffectivelyUnbounded() {
         ReplayProcessor<Object> rs = ReplayProcessor.createUnbounded();
@@ -699,6 +705,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         assertEquals(2, rs.size());
         assertTrue(rs.hasValue());
     }
+
     @Test
     public void testSizeAndHasAnyValueEffectivelyUnboundedError() {
         ReplayProcessor<Object> rs = ReplayProcessor.createUnbounded();
@@ -731,6 +738,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         assertEquals(0, rs.size());
         assertFalse(rs.hasValue());
     }
+
     @Test
     public void testSizeAndHasAnyValueEffectivelyUnboundedEmptyError() {
         ReplayProcessor<Object> rs = ReplayProcessor.createUnbounded();
@@ -750,6 +758,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         assertEquals(0, rs.size());
         assertFalse(rs.hasValue());
     }
+
     @Test
     public void testSizeAndHasAnyValueEffectivelyUnboundedEmptyCompleted() {
         ReplayProcessor<Object> rs = ReplayProcessor.createUnbounded();
@@ -802,6 +811,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         assertEquals(0, rs.size());
         assertFalse(rs.hasValue());
     }
+
     @Test
     public void testGetValues() {
         ReplayProcessor<Object> rs = ReplayProcessor.create();
@@ -816,6 +826,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         assertArrayEquals(expected, rs.getValues());
 
     }
+
     @Test
     public void testGetValuesUnbounded() {
         ReplayProcessor<Object> rs = ReplayProcessor.createUnbounded();
@@ -1533,6 +1544,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         source.subscribeWith(take1AndCancel())
         .assertResult(1);
     }
+
     @Test
     public void timeAndSizeBoundCancelAfterOne() {
         ReplayProcessor<Integer> source = ReplayProcessor.createWithTimeAndSize(1, TimeUnit.MINUTES, Schedulers.single(), 16);

--- a/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
@@ -121,6 +121,7 @@ public class SerializedProcessorTest {
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
     }
+
     @Test
     public void testPublishSubjectValueError() {
         PublishProcessor<Integer> async = PublishProcessor.create();
@@ -248,6 +249,7 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectValueRelayIncomplete() {
         ReplayProcessor<Integer> async = ReplayProcessor.create();
@@ -265,6 +267,7 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectValueRelayBounded() {
         ReplayProcessor<Integer> async = ReplayProcessor.createWithSize(1);
@@ -284,6 +287,7 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectValueRelayBoundedIncomplete() {
         ReplayProcessor<Integer> async = ReplayProcessor.createWithSize(1);
@@ -302,6 +306,7 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectValueRelayBoundedEmptyIncomplete() {
         ReplayProcessor<Integer> async = ReplayProcessor.createWithSize(1);
@@ -318,6 +323,7 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectValueRelayEmptyIncomplete() {
         ReplayProcessor<Integer> async = ReplayProcessor.create();
@@ -352,6 +358,7 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectError() {
         ReplayProcessor<Integer> async = ReplayProcessor.create();
@@ -388,6 +395,7 @@ public class SerializedProcessorTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectBoundedError() {
         ReplayProcessor<Integer> async = ReplayProcessor.createWithSize(1);

--- a/src/test/java/io/reactivex/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/io/reactivex/schedulers/ComputationSchedulerTests.java
@@ -111,7 +111,6 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
         });
     }
 
-
     @Test
     public final void testMergeWithExecutorScheduler() {
 

--- a/src/test/java/io/reactivex/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/ExecutorSchedulerTest.java
@@ -204,6 +204,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
             w.dispose();
         }
     }
+
     @Test
     public void testCancelledWorkerDoesntRunTasks() {
         final AtomicInteger calls = new AtomicInteger();

--- a/src/test/java/io/reactivex/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/SchedulerTest.java
@@ -204,7 +204,6 @@ public class SchedulerTest {
 
     }
 
-
     @Test
     public void periodicDirectTaskRaceIO() throws Exception {
         final Scheduler scheduler = Schedulers.io();

--- a/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
@@ -232,9 +232,9 @@ public class TestSchedulerTest {
         TimedRunnable r = new TimedRunnable((TestWorker) new TestScheduler().createWorker(), 5, new Runnable() {
             @Override
             public void run() {
-                // TODO Auto-generated method stub
-
+                // deliberately no-op
             }
+
             @Override
             public String toString() {
                 return "Runnable";

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -809,6 +809,7 @@ public class SingleNullTests {
             public void accept(Integer v) { }
         }, null);
     }
+
     @Test(expected = NullPointerException.class)
     public void subscribeSubscriberNull() {
         just1.toFlowable().subscribe((Subscriber<Integer>)null);

--- a/src/test/java/io/reactivex/subjects/AsyncSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/AsyncSubjectTest.java
@@ -367,6 +367,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
         assertNull(as.getValue());
         assertNull(as.getThrowable());
     }
+
     @Test
     public void testCurrentStateMethodsError() {
         AsyncSubject<Object> as = AsyncSubject.create();
@@ -385,7 +386,6 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
         assertNull(as.getValue());
         assertTrue(as.getThrowable() instanceof TestException);
     }
-
 
     @Test
     public void fusionLive() {

--- a/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
@@ -282,6 +282,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
             verify(o, never()).onError(any(Throwable.class));
         }
     }
+
     @Test
     public void testStartEmpty() {
         BehaviorSubject<Integer> source = BehaviorSubject.create();
@@ -307,6 +308,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
 
     }
+
     @Test
     public void testStartEmptyThenAddOne() {
         BehaviorSubject<Integer> source = BehaviorSubject.create();
@@ -329,6 +331,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         verify(o, never()).onError(any(Throwable.class));
 
     }
+
     @Test
     public void testStartEmptyCompleteWithOne() {
         BehaviorSubject<Integer> source = BehaviorSubject.create();
@@ -406,6 +409,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 //        // even though the onError above throws we should still receive it on the other subscriber
 //        assertEquals(1, to.getOnErrorEvents().size());
 //    }
+
     @Test
     public void testEmissionSubscriptionRace() throws Exception {
         Scheduler s = Schedulers.io();
@@ -550,6 +554,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         assertNull(as.getValue());
         assertNull(as.getThrowable());
     }
+
     @Test
     public void testCurrentStateMethodsError() {
         BehaviorSubject<Object> as = BehaviorSubject.create();
@@ -715,7 +720,6 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
             }
         });
     }
-
 
     @Test
     public void completeSubscribeRace() throws Exception {

--- a/src/test/java/io/reactivex/subjects/PublishSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/PublishSubjectTest.java
@@ -384,6 +384,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 //        // even though the onError above throws we should still receive it on the other subscriber
 //        assertEquals(1, to.getOnErrorEvents().size());
 //    }
+
     @Test
     public void testCurrentStateMethodsNormal() {
         PublishSubject<Object> as = PublishSubject.create();
@@ -419,6 +420,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         assertTrue(as.hasComplete());
         assertNull(as.getThrowable());
     }
+
     @Test
     public void testCurrentStateMethodsError() {
         PublishSubject<Object> as = PublishSubject.create();

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -322,6 +322,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
             }
         }
     }
+
     @Test
     public void testReplaySubjectEmissionSubscriptionRace() throws Exception {
         Scheduler s = Schedulers.io();
@@ -407,6 +408,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
             worker.dispose();
         }
     }
+
     @Test(timeout = 5000)
     public void testConcurrentSizeAndHasAnyValue() throws InterruptedException {
         final ReplaySubject<Object> rs = ReplaySubject.createUnbounded();
@@ -461,6 +463,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
 
         t.join();
     }
+
     @Test(timeout = 5000)
     public void testConcurrentSizeAndHasAnyValueBounded() throws InterruptedException {
         final ReplaySubject<Object> rs = ReplaySubject.createWithSize(3);
@@ -504,6 +507,7 @@ public class ReplaySubjectBoundedConcurrencyTest {
 
         t.join();
     }
+
     @Test(timeout = 10000)
     public void testConcurrentSizeAndHasAnyValueTimeBounded() throws InterruptedException {
         final ReplaySubject<Object> rs = ReplaySubject.createWithTime(1, TimeUnit.MILLISECONDS, Schedulers.computation());

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectConcurrencyTest.java
@@ -322,6 +322,7 @@ public class ReplaySubjectConcurrencyTest {
             }
         }
     }
+
     @Test
     public void testReplaySubjectEmissionSubscriptionRace() throws Exception {
         Scheduler s = Schedulers.io();
@@ -395,6 +396,7 @@ public class ReplaySubjectConcurrencyTest {
             worker.dispose();
         }
     }
+
     @Test(timeout = 10000)
     public void testConcurrentSizeAndHasAnyValue() throws InterruptedException {
         final ReplaySubject<Object> rs = ReplaySubject.create();

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
@@ -348,6 +348,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         assertEquals("three", lastValueForSubscriber2.get());
 
     }
+
     @Test
     public void testSubscriptionLeak() {
         ReplaySubject<Object> subject = ReplaySubject.create();
@@ -360,6 +361,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
         assertEquals(0, subject.observerCount());
     }
+
     @Test(timeout = 1000)
     public void testUnsubscriptionCase() {
         ReplaySubject<String> src = ReplaySubject.create();
@@ -401,6 +403,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
             verify(o, never()).onError(any(Throwable.class));
         }
     }
+
     @Test
     public void testTerminateOnce() {
         ReplaySubject<Integer> source = ReplaySubject.create();
@@ -453,6 +456,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
             verify(o, never()).onError(any(Throwable.class));
         }
     }
+
     @Test
     public void testReplay1Directly() {
         ReplaySubject<Integer> source = ReplaySubject.createWithSize(1);
@@ -616,6 +620,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         assertTrue(as.hasComplete());
         assertNull(as.getThrowable());
     }
+
     @Test
     public void testCurrentStateMethodsError() {
         ReplaySubject<Object> as = ReplaySubject.create();
@@ -630,6 +635,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         assertFalse(as.hasComplete());
         assertTrue(as.getThrowable() instanceof TestException);
     }
+
     @Test
     public void testSizeAndHasAnyValueUnbounded() {
         ReplaySubject<Object> rs = ReplaySubject.create();
@@ -652,6 +658,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         assertEquals(2, rs.size());
         assertTrue(rs.hasValue());
     }
+
     @Test
     public void testSizeAndHasAnyValueEffectivelyUnbounded() {
         ReplaySubject<Object> rs = ReplaySubject.createUnbounded();
@@ -697,6 +704,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         assertEquals(2, rs.size());
         assertTrue(rs.hasValue());
     }
+
     @Test
     public void testSizeAndHasAnyValueEffectivelyUnboundedError() {
         ReplaySubject<Object> rs = ReplaySubject.createUnbounded();
@@ -729,6 +737,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         assertEquals(0, rs.size());
         assertFalse(rs.hasValue());
     }
+
     @Test
     public void testSizeAndHasAnyValueEffectivelyUnboundedEmptyError() {
         ReplaySubject<Object> rs = ReplaySubject.createUnbounded();
@@ -748,6 +757,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         assertEquals(0, rs.size());
         assertFalse(rs.hasValue());
     }
+
     @Test
     public void testSizeAndHasAnyValueEffectivelyUnboundedEmptyCompleted() {
         ReplaySubject<Object> rs = ReplaySubject.createUnbounded();
@@ -800,6 +810,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         assertEquals(0, rs.size());
         assertFalse(rs.hasValue());
     }
+
     @Test
     public void testGetValues() {
         ReplaySubject<Object> rs = ReplaySubject.create();
@@ -814,6 +825,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         assertArrayEquals(expected, rs.getValues());
 
     }
+
     @Test
     public void testGetValuesUnbounded() {
         ReplaySubject<Object> rs = ReplaySubject.createUnbounded();
@@ -1204,7 +1216,6 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
         assertSame(o, buf.head);
     }
-
 
     @Test
     public void noHeadRetentionSize() {

--- a/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
@@ -122,6 +122,7 @@ public class SerializedSubjectTest {
         assertFalse(serial.hasThrowable());
         assertNull(serial.getThrowable());
     }
+
     @Test
     public void testPublishSubjectValueError() {
         PublishSubject<Integer> async = PublishSubject.create();
@@ -267,6 +268,7 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectValueRelayBounded() {
         ReplaySubject<Integer> async = ReplaySubject.createWithSize(1);
@@ -286,6 +288,7 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectValueRelayBoundedIncomplete() {
         ReplaySubject<Integer> async = ReplaySubject.createWithSize(1);
@@ -304,6 +307,7 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectValueRelayBoundedEmptyIncomplete() {
         ReplaySubject<Integer> async = ReplaySubject.createWithSize(1);
@@ -320,6 +324,7 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectValueRelayEmptyIncomplete() {
         ReplaySubject<Integer> async = ReplaySubject.create();
@@ -354,6 +359,7 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectError() {
         ReplaySubject<Integer> async = ReplaySubject.create();
@@ -390,6 +396,7 @@ public class SerializedSubjectTest {
         assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
         assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
+
     @Test
     public void testReplaySubjectBoundedError() {
         ReplaySubject<Integer> async = ReplaySubject.createWithSize(1);

--- a/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeSubscriberTest.java
@@ -579,10 +579,12 @@ public class SafeSubscriberTest {
             public void onNext(Integer t) {
 
             }
+
             @Override
             public void onError(Throwable e) {
                 error.set(e);
             }
+
             @Override
             public void onComplete() {
                 throw new TestException();
@@ -603,9 +605,11 @@ public class SafeSubscriberTest {
             @Override
             public void onNext(Integer t) {
             }
+
             @Override
             public void onError(Throwable e) {
             }
+
             @Override
             public void onComplete() {
             }
@@ -1084,7 +1088,6 @@ public class SafeSubscriberTest {
             RxJavaPlugins.reset();
         }
     }
-
 
     @Test
     public void requestCancelCrash() {

--- a/src/test/java/io/reactivex/subscribers/SafeSubscriberWithPluginTest.java
+++ b/src/test/java/io/reactivex/subscribers/SafeSubscriberWithPluginTest.java
@@ -171,6 +171,7 @@ public class SafeSubscriberWithPluginTest {
 
         safe.onError(new TestException());
     }
+
     @Test(expected = RuntimeException.class)
     @Ignore("Subscribers can't throw")
     public void testPluginExceptionWhileOnErrorThrowsAndUnsubscribeThrows() {
@@ -195,6 +196,7 @@ public class SafeSubscriberWithPluginTest {
 
         safe.onError(new TestException());
     }
+
     @Test(expected = RuntimeException.class)
     @Ignore("Subscribers can't throw")
     public void testPluginExceptionWhenUnsubscribing2() {

--- a/src/test/java/io/reactivex/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SerializedSubscriberTest.java
@@ -976,6 +976,7 @@ public class SerializedSubscriberTest {
         ts.assertValue(1);
         ts.assertError(TestException.class);
     }
+
     @Test
     public void testCompleteReentry() {
         final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<Subscriber<Integer>>();

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -746,7 +746,6 @@ public class TestSubscriberTest {
         ts.awaitTerminalEvent();
     }
 
-
     @Test
     public void createDelegate() {
         TestSubscriber<Integer> ts1 = TestSubscriber.create();
@@ -1611,7 +1610,6 @@ public class TestSubscriberTest {
         }
     }
 
-
     @Test
     public void syncQueueThrows() {
         TestSubscriber<Object> ts = new TestSubscriber<Object>();
@@ -1825,7 +1823,6 @@ public class TestSubscriberTest {
             assertTrue(ex.toString(), ex.toString().contains("timeout!"));
         }
     }
-
 
     @Test
     public void timeoutIndicated3() throws InterruptedException {

--- a/src/test/java/io/reactivex/tck/BaseTck.java
+++ b/src/test/java/io/reactivex/tck/BaseTck.java
@@ -44,7 +44,6 @@ public abstract class BaseTck<T> extends PublisherVerification<T> {
         return Flowable.error(new TestException());
     }
 
-
     @Override
     public long maxElementsFromPublisher() {
         return 1024;

--- a/src/test/java/io/reactivex/validators/CheckLocalVariablesInTests.java
+++ b/src/test/java/io/reactivex/validators/CheckLocalVariablesInTests.java
@@ -333,6 +333,11 @@ public class CheckLocalVariablesInTests {
     }
 
     @Test
+    public void atomicSubscriptionAsSInit() throws Exception {
+        findPattern("AtomicReference<Subscription>\\s+s[0-9]?\\s", true);
+    }
+
+    @Test
     public void atomicSubscriptionAsSubscription() throws Exception {
         findPattern("AtomicReference<Subscription>\\s+subscription[0-9]?", true);
     }

--- a/src/test/java/io/reactivex/validators/NewLinesBeforeAnnotation.java
+++ b/src/test/java/io/reactivex/validators/NewLinesBeforeAnnotation.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.validators;
+
+import java.io.*;
+import java.util.*;
+
+import org.junit.Test;
+
+/**
+ * These tests verify the code style that a typical closing curly brace
+ * and the next annotation &#64; indicator
+ * are not separated by less than or more than one empty line.
+ * <p>Thus this is detected:
+ * <pre><code>
+ * }
+ * &#64;Override
+ * </code></pre>
+ * <p>
+ * as well as
+ * <pre><code>
+ * }
+ * 
+ * 
+ * &#64;Override
+ * </code></pre>
+ */
+public class NewLinesBeforeAnnotation {
+
+    @Test
+    public void missingEmptyNewLine() throws Exception {
+        findPattern(0);
+    }
+
+    @Test
+    public void tooManyEmptyNewLines3() throws Exception  {
+        findPattern(3);
+    }
+
+    @Test
+    public void tooManyEmptyNewLines4() throws Exception  {
+        findPattern(5);
+    }
+
+    @Test
+    public void tooManyEmptyNewLines5() throws Exception  {
+        findPattern(5);
+    }
+
+    static void findPattern(int newLines) throws Exception {
+        File f = MaybeNo2Dot0Since.findSource("Flowable");
+        if (f == null) {
+            System.out.println("Unable to find sources of RxJava");
+            return;
+        }
+
+        Queue<File> dirs = new ArrayDeque<File>();
+
+        StringBuilder fail = new StringBuilder();
+        fail.append("The following code pattern was found: ");
+        fail.append("\\}\\R");
+        for (int i = 0; i < newLines; i++) {
+            fail.append("\\R");
+        }
+        fail.append("[    ]+@\n");
+
+        File parent = f.getParentFile();
+
+        dirs.offer(new File(parent.getAbsolutePath().replace('\\', '/')));
+        dirs.offer(new File(parent.getAbsolutePath().replace('\\', '/').replace("src/main/java", "src/test/java")));
+
+        int total = 0;
+
+        while (!dirs.isEmpty()) {
+            f = dirs.poll();
+
+            File[] list = f.listFiles();
+            if (list != null && list.length != 0) {
+
+                for (File u : list) {
+                    if (u.isDirectory()) {
+                        dirs.offer(u);
+                    } else {
+                        String fname = u.getName();
+                        if (fname.endsWith(".java")) {
+
+                            List<String> lines = new ArrayList<String>();
+                            BufferedReader in = new BufferedReader(new FileReader(u));
+                            try {
+                                for (;;) {
+                                    String line = in.readLine();
+                                    if (line == null) {
+                                        break;
+                                    }
+                                    lines.add(line);
+                                }
+                            } finally {
+                                in.close();
+                            }
+
+                            for (int i = 0; i < lines.size() - 1; i++) {
+                                String line = lines.get(i);
+                                if (line.endsWith("}") && !line.trim().startsWith("*") && !line.trim().startsWith("//")) {
+                                    int emptyLines = 0;
+                                    boolean found = false;
+                                    for (int j = i + 1; j < lines.size(); j++) {
+                                        String line2 = lines.get(j);
+                                        if (line2.trim().startsWith("@")) {
+                                            found = true;
+                                            break;
+                                        }
+                                        if (!line2.trim().isEmpty()) {
+                                            break;
+                                        }
+                                        emptyLines++;
+                                    }
+
+                                    if (emptyLines == newLines && found) {
+                                        fail
+                                        .append(fname)
+                                        .append("#L").append(i + 1)
+                                        .append("    ");
+                                        for (int k = 0; k < emptyLines + 2; k++) {
+                                            fail
+                                            .append(lines.get(k + i))
+                                            .append("\\R");
+                                        }
+                                        fail.append("\n");
+                                        total++;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (total != 0) {
+            fail.append("Found ")
+            .append(total)
+            .append(" instances");
+            System.out.println(fail);
+            throw new AssertionError(fail.toString());
+        }
+    }
+}

--- a/src/test/java/io/reactivex/validators/NewLinesBeforeAnnotation.java
+++ b/src/test/java/io/reactivex/validators/NewLinesBeforeAnnotation.java
@@ -44,6 +44,11 @@ public class NewLinesBeforeAnnotation {
     }
 
     @Test
+    public void tooManyEmptyNewLines2() throws Exception  {
+        findPattern(2);
+    }
+
+    @Test
     public void tooManyEmptyNewLines3() throws Exception  {
         findPattern(3);
     }


### PR DESCRIPTION
This PR cleans up some source code style inconsistencies:

- Rename some atomic-subscription fields to `upstream` (left out from #6129).
- Make sure `@Test` methods are separated by at most one empty newline
- Make sure a closing curly brace and an annotation is only followed by one empty newline.
- Add a test that checks for the above.