### PR TITLE
2.x: Clarify TestObserver.assertValueSet in docs and via tests

### DIFF
--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -566,7 +566,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that the TestObserver/TestSubscriber received only items that are in the specified
-     * collection as well irrespective of the order they were received.
+     * collection as well, irrespective of the order they were received.
      * <p>
      * This helps asserting when the order of the values is not guaranteed, i.e., when merging
      * asynchronous streams.

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -565,9 +565,14 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     }
 
     /**
-     * Assert that the TestObserver/TestSubscriber received only the specified values in any order.
-     * <p>This helps asserting when the order of the values is not guaranteed, i.e., when merging
+     * Assert that the TestObserver/TestSubscriber received only items that are in the specified
+     * collection as well irrespective of the order they were received.
+     * <p>
+     * This helps asserting when the order of the values is not guaranteed, i.e., when merging
      * asynchronous streams.
+     * <p>
+     * To ensure that only the expected items have been received, no more and no less, in any order,
+     * apply {@link #assertValueCount(int)} with {@code expected.size()}.
      *
      * @param expected the collection of values expected in any order
      * @return this

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -1626,4 +1626,38 @@ public class TestObserverTest {
             // expected
         }
     }
+
+    @Test
+    public void assertValueSetWiderSet() {
+        Set<Integer> set = new HashSet<Integer>(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7));
+
+        Observable.just(4, 5, 1, 3, 2)
+        .test()
+        .assertValueSet(set);
+    }
+
+    @Test
+    public void assertValueSetExact() {
+        Set<Integer> set = new HashSet<Integer>(Arrays.asList(1, 2, 3, 4, 5));
+
+        Observable.just(4, 5, 1, 3, 2)
+        .test()
+        .assertValueSet(set)
+        .assertValueCount(set.size());
+    }
+
+    @Test
+    public void assertValueSetMissing() {
+        Set<Integer> set = new HashSet<Integer>(Arrays.asList(0, 1, 2, 4, 5, 6, 7));
+
+        try {
+            Observable.range(1, 5)
+            .test()
+            .assertValueSet(set);
+
+            throw new RuntimeException("Should have failed");
+        } catch (AssertionError ex) {
+            assertTrue(ex.getMessage(), ex.getMessage().contains("Value not in the expected collection: " + 3));
+        }
+    }
 }

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -2186,4 +2186,38 @@ public class TestSubscriberTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
         ts.awaitCount(0, TestWaitStrategy.SLEEP_1MS, 0);
     }
+
+    @Test
+    public void assertValueSetWiderSet() {
+        Set<Integer> set = new HashSet<Integer>(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7));
+
+        Flowable.just(4, 5, 1, 3, 2)
+        .test()
+        .assertValueSet(set);
+    }
+
+    @Test
+    public void assertValueSetExact() {
+        Set<Integer> set = new HashSet<Integer>(Arrays.asList(1, 2, 3, 4, 5));
+
+        Flowable.just(4, 5, 1, 3, 2)
+        .test()
+        .assertValueSet(set)
+        .assertValueCount(set.size());
+    }
+
+    @Test
+    public void assertValueSetMissing() {
+        Set<Integer> set = new HashSet<Integer>(Arrays.asList(0, 1, 2, 4, 5, 6, 7));
+
+        try {
+            Flowable.range(1, 5)
+            .test()
+            .assertValueSet(set);
+
+            throw new RuntimeException("Should have failed");
+        } catch (AssertionError ex) {
+            assertTrue(ex.getMessage(), ex.getMessage().contains("Value not in the expected collection: " + 3));
+        }
+    }
 }


### PR DESCRIPTION
Clarify that `{TestObserver|TestSubscriber}.assertValueSet` checks for all received items to be in the provided set, but that set can contain additional elements that could have been received. Unit tests have been added to demonstrate the expected behavior.

Resolves: #6151.