### PR TITLE
2.x: Add Maybe.flatMap that maps signal types to Singles

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3097,6 +3097,41 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
+     * Maps the {@code onSuccess}, {@code onError} or {@code onComplete} signals of this {@code Maybe} into a {@link SingleSource} and emits that
+     * {@code SingleSource}'s signals.
+     * <p>
+     * <img width="640" height="354" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.sss.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code flatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <R>
+     *            the result type
+     * @param onSuccessMapper
+     *            a function that returns a SingleSource to merge for the onSuccess item emitted by this Maybe
+     * @param onErrorMapper
+     *            a function that returns a SingleSource to merge for an onError notification from this Maybe
+     * @param onCompleteSupplier
+     *            a function that returns a SingleSource to merge for an onComplete notification this Maybe
+     * @return the new Single instance
+     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * 
+     * @since 2.2.1 - experimental
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @Experimental
+    public final <R> Single<R> flatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> onSuccessMapper,
+            Function<? super Throwable, ? extends SingleSource<? extends R>> onErrorMapper,
+            Callable<? extends SingleSource<? extends R>> onCompleteSupplier) {
+        ObjectHelper.requireNonNull(onSuccessMapper, "onSuccessMapper is null");
+        ObjectHelper.requireNonNull(onErrorMapper, "onErrorMapper is null");
+        ObjectHelper.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapEventSingle<T, R>(this, onSuccessMapper, onErrorMapper, onCompleteSupplier));
+    }
+
+    /**
      * Returns a {@link Maybe} based on applying a specified function to the item emitted by the
      * source {@link Maybe}, where that function returns a {@link Single}.
      * When this Maybe just completes the resulting {@code Maybe} completes as well.

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapEventSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapEventSingle.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.*;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+
+/**
+ * Maps the upstream {@code onSuccess}, {@code onError} and {@code onComplete} signals onto
+ * a {@link MaybeSource} provided via callback functions and relays its signal to the downstream.
+ *
+ * @param <T> the upstream success item type
+ * @param <R> the downstream success item type
+ *
+ * @since 2.2.1 - experimental
+ */
+@Experimental
+public final class MaybeFlatMapEventSingle<T, R> extends Single<R> {
+
+    final MaybeSource<T> source;
+
+    final Function<? super T, ? extends SingleSource<? extends R>> onSuccessMapper;
+
+    final Function<? super Throwable, ? extends SingleSource<? extends R>> onErrorMapper;
+
+    final Callable<? extends SingleSource<? extends R>> onCompleteSupplier;
+
+    public MaybeFlatMapEventSingle(MaybeSource<T> source,
+            Function<? super T, ? extends SingleSource<? extends R>> onSuccessMapper,
+            Function<? super Throwable, ? extends SingleSource<? extends R>> onErrorMapper,
+            Callable<? extends SingleSource<? extends R>> onCompleteSupplier) {
+        this.source = source;
+        this.onSuccessMapper = onSuccessMapper;
+        this.onErrorMapper = onErrorMapper;
+        this.onCompleteSupplier = onCompleteSupplier;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super R> observer) {
+        MapEventObserver<T, R> parent = new MapEventObserver<T, R>(observer, onSuccessMapper, onErrorMapper, onCompleteSupplier);
+        observer.onSubscribe(parent);
+        source.subscribe(parent);
+    }
+
+    static final class MapEventObserver<T, R>
+    implements MaybeObserver<T>, Disposable {
+
+        final Function<? super T, ? extends SingleSource<? extends R>> onSuccessMapper;
+
+        final Function<? super Throwable, ? extends SingleSource<? extends R>> onErrorMapper;
+
+        final Callable<? extends SingleSource<? extends R>> onCompleteSupplier;
+
+        final InnerObserver<R> inner;
+
+        MapEventObserver(SingleObserver<? super R> downstream,
+                Function<? super T, ? extends SingleSource<? extends R>> onSuccessMapper,
+                Function<? super Throwable, ? extends SingleSource<? extends R>> onErrorMapper,
+                Callable<? extends SingleSource<? extends R>> onCompleteSupplier) {
+            this.inner = new InnerObserver<R>(downstream);
+            this.onSuccessMapper = onSuccessMapper;
+            this.onErrorMapper = onErrorMapper;
+            this.onCompleteSupplier = onCompleteSupplier;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            DisposableHelper.setOnce(inner, d);
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            SingleSource<? extends R> next;
+
+            try {
+                next = ObjectHelper.requireNonNull(onSuccessMapper.apply(t), "The onSuccessMapper returned a null MaybeSource");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                inner.downstream.onError(ex);
+                return;
+            }
+
+            next.subscribe(inner);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            SingleSource<? extends R> next;
+
+            try {
+                next = ObjectHelper.requireNonNull(onErrorMapper.apply(e), "The onErrorMapper returned a null MaybeSource");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                inner.downstream.onError(new CompositeException(e, ex));
+                return;
+            }
+
+            next.subscribe(inner);
+        }
+
+        @Override
+        public void onComplete() {
+            SingleSource<? extends R> next;
+
+            try {
+                next = ObjectHelper.requireNonNull(onCompleteSupplier.call(), "The onCompleteSupplier returned a null MaybeSource");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                inner.downstream.onError(ex);
+                return;
+            }
+
+            next.subscribe(inner);
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(inner);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return DisposableHelper.isDisposed(inner.get());
+        }
+
+        static final class InnerObserver<R> extends AtomicReference<Disposable>
+        implements SingleObserver<R> {
+
+            private static final long serialVersionUID = 3364181040722735182L;
+
+            final SingleObserver<? super R> downstream;
+
+            InnerObserver(SingleObserver<? super R> downstream) {
+                this.downstream = downstream;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.replace(this, d);
+            }
+
+            @Override
+            public void onSuccess(R t) {
+                downstream.onSuccess(t);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                downstream.onError(e);
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -2224,6 +2224,31 @@ public enum TestHelper {
         assertFalse(pp.hasSubscribers());
     }
 
+
+    /**
+     * Check if the operator applied to a Maybe source propagates dispose properly.
+     * @param <T> the source value type
+     * @param <U> the output value type
+     * @param composer the function to apply an operator to the provided Maybe source
+     */
+    public static <T, U> void checkDisposedSingle(Function<Single<T>, ? extends SingleSource<U>> composer) {
+        PublishProcessor<T> pp = PublishProcessor.create();
+
+        TestSubscriber<U> ts = new TestSubscriber<U>();
+
+        try {
+            new SingleToFlowable<U>(composer.apply(pp.singleOrError())).subscribe(ts);
+        } catch (Throwable ex) {
+            throw ExceptionHelper.wrapOrThrow(ex);
+        }
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+    }
+
     /**
      * Check if the TestSubscriber has a CompositeException with the specified class
      * of Throwables in the given order.

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapEventSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapEventSingleTest.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.maybe;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.TestObserver;
+
+public class MaybeFlatMapEventSingleTest {
+
+    @Test
+    public void mapSuccess() {
+        Maybe.just(1)
+        .flatMapSingle(Functions.justFunction(Single.just(2)),
+                Functions.justFunction(Single.just(3)),
+                Functions.justCallable(Single.just(4))
+        )
+        .test()
+        .assertResult(2);
+    }
+
+    @Test
+    public void mapSuccessCrash() {
+        Maybe.just(1)
+        .flatMapSingle(
+                new Function<Object, SingleSource<? extends Integer>>() {
+                    @Override
+                    public SingleSource<? extends Integer> apply(Object v)
+                            throws Exception { throw new TestException(); }
+                },
+                Functions.justFunction(Single.just(3)),
+                Functions.justCallable(Single.just(4))
+        )
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapError() {
+        Maybe.error(new TestException())
+        .flatMapSingle(Functions.justFunction(Single.just(2)),
+                Functions.justFunction(Single.just(3)),
+                Functions.justCallable(Single.just(4))
+        )
+        .test()
+        .assertResult(3);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mapErrorCrash() {
+        TestObserver<Integer> to = Maybe.error(new IOException())
+        .flatMapSingle(
+                Functions.justFunction(Single.just(2)),
+                new Function<Object, SingleSource<? extends Integer>>() {
+                    @Override
+                    public SingleSource<? extends Integer> apply(Object v)
+                            throws Exception { throw new TestException(); }
+                },
+                Functions.justCallable(Single.just(4))
+        )
+        .test()
+        .assertFailure(CompositeException.class)
+        ;
+
+        TestHelper.assertCompositeExceptions(to, IOException.class, TestException.class);
+    }
+
+    @Test
+    public void mapComplete() {
+        Maybe.empty()
+        .flatMapSingle(Functions.justFunction(Single.just(2)),
+                Functions.justFunction(Single.just(3)),
+                Functions.justCallable(Single.just(4))
+        )
+        .test()
+        .assertResult(4);
+    }
+
+    @Test
+    public void mapCompleteCrash() {
+        Maybe.empty()
+        .flatMapSingle(
+                Functions.justFunction(Single.just(2)),
+                Functions.justFunction(Single.just(3)),
+                new Callable<SingleSource<? extends Integer>>() {
+                    @Override
+                    public SingleSource<? extends Integer> call()
+                            throws Exception { throw new TestException(); }
+                }
+        )
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapToError() {
+        Maybe.just(1)
+        .flatMapSingle(Functions.justFunction(Single.error(new TestException())),
+                Functions.justFunction(Single.just(3)),
+                Functions.justCallable(Single.just(4))
+        )
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void disposeMain() {
+        TestHelper.checkDisposedMaybeToSingle(new Function<Maybe<Object>, SingleSource<Integer>>() {
+            @Override
+            public SingleSource<Integer> apply(Maybe<Object> m)
+                    throws Exception {
+                return m.flatMapSingle(Functions.justFunction(Single.just(2)),
+                        Functions.justFunction(Single.just(3)),
+                        Functions.justCallable(Single.just(4))
+                );
+            }
+        });
+    }
+
+    @Test
+    public void disposeMain2() {
+        TestHelper.checkDisposed(
+            Maybe.never().flatMapSingle(
+                Functions.justFunction(Single.just(2)),
+                Functions.justFunction(Single.just(3)),
+                Functions.justCallable(Single.just(4))
+            )
+        );
+    }
+
+    @Test
+    public void disposeInnerSuccess() {
+        TestHelper.checkDisposedSingle(new Function<Single<Integer>, SingleSource<Integer>>() {
+            @Override
+            public SingleSource<Integer> apply(Single<Integer> m)
+                    throws Exception {
+                return Maybe.just(1).flatMapSingle(Functions.justFunction(m),
+                        Functions.justFunction(Single.just(3)),
+                        Functions.justCallable(Single.just(4))
+                );
+            }
+        });
+    }
+
+    @Test
+    public void disposeInnerError() {
+        TestHelper.checkDisposedSingle(new Function<Single<Integer>, SingleSource<Integer>>() {
+            @Override
+            public SingleSource<Integer> apply(Single<Integer> m)
+                    throws Exception {
+                return Maybe.error(new TestException()).flatMapSingle(Functions.justFunction(Single.just(2)),
+                        Functions.justFunction(m),
+                        Functions.justCallable(Single.just(4))
+                );
+            }
+        });
+    }
+
+    @Test
+    public void disposeInnerComplete() {
+        TestHelper.checkDisposedSingle(new Function<Single<Integer>, SingleSource<Integer>>() {
+            @Override
+            public SingleSource<Integer> apply(Single<Integer> m)
+                    throws Exception {
+                return Maybe.empty().flatMapSingle(Functions.justFunction(Single.just(2)),
+                        Functions.justFunction(Single.just(3)),
+                        Functions.justCallable(m)
+                );
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR proposes a new `flatMap` overload for `Maybe` that maps the upstream event types, `onSuccess`, `onError` or `onComplete` into a `SingleSource` and relays its signal to the downstream.

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.sss.png)

There is already a variant for Maybe -> Maybe flatMapping of event types.

I'm not 100% convinced the need for such an operator and could lead to all sorts of cross-mapping operators `Maybe -> Completable`, `Maybe -> Observable`, `Maybe -> Flowable`, as well as operators on the other reactive classes.

The alternative is to convert either the upstream and/or convert the mapped inner source to the right type.

Requested in: #5973