### PR TITLE
2.x: Fix marble of Maybe.flatMap events to MaybeSource

### DIFF
--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2909,7 +2909,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Maps the onSuccess, onError or onComplete signals of this Maybe into MaybeSource and emits that
      * MaybeSource's signals.
      * <p>
-     * <img width="640" height="410" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeMap.nce.png" alt="">
+     * <img width="640" height="354" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.mmm.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
Fix the marble diagram of the event-mapping [`Maybe.flatMap`](http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Maybe.html#flatMap-io.reactivex.functions.Function-io.reactivex.functions.Function-java.util.concurrent.Callable-) operator:

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.mmm.png)

Tracked in: #5806