### PR TITLE
2.x: Make Flowable.fromCallable consistent with the other fromCallables

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromCallable.java
@@ -21,6 +21,7 @@ import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.DeferredScalarSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableFromCallable<T> extends Flowable<T> implements Callable<T> {
     final Callable<? extends T> callable;
@@ -38,7 +39,11 @@ public final class FlowableFromCallable<T> extends Flowable<T> implements Callab
             t = ObjectHelper.requireNonNull(callable.call(), "The callable returned a null value");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
-            s.onError(ex);
+            if (deferred.isCancelled()) {
+                RxJavaPlugins.onError(ex);
+            } else {
+                s.onError(ex);
+            }
             return;
         }
 


### PR DESCRIPTION
`Flowable.fromCallable` is one of [the oldest](https://github.com/ReactiveX/RxJava/commits/2.x/src/main/java/io/reactivex/internal/operators/flowable/FlowableFromCallable.java) 2.x operators and was overlooked when the handling of beyond-cancellation error delivery, aka the undeliverable exception handling was implemented across RxJava. This PR resolves this shortcoming by making it consistent with its sibling implementations.

Resolves: #6156