### PR TITLE
2.x: Make observeOn not let worker.dispose() called prematurely

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromCallable.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Callable;
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableFromCallable extends Completable {
 
@@ -37,6 +38,8 @@ public final class CompletableFromCallable extends Completable {
             Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
                 observer.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
             }
             return;
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
@@ -191,6 +191,7 @@ final Scheduler scheduler;
             if (d) {
                 if (delayError) {
                     if (empty) {
+                        cancelled = true;
                         Throwable e = error;
                         if (e != null) {
                             a.onError(e);
@@ -203,12 +204,14 @@ final Scheduler scheduler;
                 } else {
                     Throwable e = error;
                     if (e != null) {
+                        cancelled = true;
                         clear();
                         a.onError(e);
                         worker.dispose();
                         return true;
                     } else
                     if (empty) {
+                        cancelled = true;
                         a.onComplete();
                         worker.dispose();
                         return true;
@@ -314,6 +317,7 @@ final Scheduler scheduler;
                         v = q.poll();
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
+                        cancelled = true;
                         upstream.cancel();
                         a.onError(ex);
                         worker.dispose();
@@ -324,6 +328,7 @@ final Scheduler scheduler;
                         return;
                     }
                     if (v == null) {
+                        cancelled = true;
                         a.onComplete();
                         worker.dispose();
                         return;
@@ -339,6 +344,7 @@ final Scheduler scheduler;
                 }
 
                 if (q.isEmpty()) {
+                    cancelled = true;
                     a.onComplete();
                     worker.dispose();
                     return;
@@ -379,6 +385,7 @@ final Scheduler scheduler;
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
 
+                        cancelled = true;
                         upstream.cancel();
                         q.clear();
 
@@ -441,6 +448,7 @@ final Scheduler scheduler;
                 downstream.onNext(null);
 
                 if (d) {
+                    cancelled = true;
                     Throwable e = error;
                     if (e != null) {
                         downstream.onError(e);
@@ -552,6 +560,7 @@ final Scheduler scheduler;
                         v = q.poll();
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
+                        cancelled = true;
                         upstream.cancel();
                         a.onError(ex);
                         worker.dispose();
@@ -562,6 +571,7 @@ final Scheduler scheduler;
                         return;
                     }
                     if (v == null) {
+                        cancelled = true;
                         a.onComplete();
                         worker.dispose();
                         return;
@@ -577,6 +587,7 @@ final Scheduler scheduler;
                 }
 
                 if (q.isEmpty()) {
+                    cancelled = true;
                     a.onComplete();
                     worker.dispose();
                     return;
@@ -617,6 +628,7 @@ final Scheduler scheduler;
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
 
+                        cancelled = true;
                         upstream.cancel();
                         q.clear();
 
@@ -680,6 +692,7 @@ final Scheduler scheduler;
                 downstream.onNext(null);
 
                 if (d) {
+                    cancelled = true;
                     Throwable e = error;
                     if (e != null) {
                         downstream.onError(e);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
@@ -47,7 +47,10 @@ public class FlowableUnsubscribeOnTest {
                     t1.onSubscribe(subscription);
                     t1.onNext(1);
                     t1.onNext(2);
-                    t1.onComplete();
+                    // observeOn will prevent canceling the upstream upon its termination now
+                    // this call is racing for that state in this test
+                    // not doing it will make sure the unsubscribeOn always gets through
+                    // t1.onComplete();
                 }
             });
 
@@ -93,7 +96,10 @@ public class FlowableUnsubscribeOnTest {
                     t1.onSubscribe(subscription);
                     t1.onNext(1);
                     t1.onNext(2);
-                    t1.onComplete();
+                    // observeOn will prevent canceling the upstream upon its termination now
+                    // this call is racing for that state in this test
+                    // not doing it will make sure the unsubscribeOn always gets through
+                    // t1.onComplete();
                 }
             });
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUnsubscribeOnTest.java
@@ -46,7 +46,10 @@ public class ObservableUnsubscribeOnTest {
                     t1.onSubscribe(subscription);
                     t1.onNext(1);
                     t1.onNext(2);
-                    t1.onComplete();
+                    // observeOn will prevent canceling the upstream upon its termination now
+                    // this call is racing for that state in this test
+                    // not doing it will make sure the unsubscribeOn always gets through
+                    // t1.onComplete();
                 }
             });
 
@@ -92,7 +95,10 @@ public class ObservableUnsubscribeOnTest {
                     t1.onSubscribe(subscription);
                     t1.onNext(1);
                     t1.onNext(2);
-                    t1.onComplete();
+                    // observeOn will prevent canceling the upstream upon its termination now
+                    // this call is racing for that state in this test
+                    // not doing it will make sure the unsubscribeOn always gets through
+                    // t1.onComplete();
                 }
             });
 


### PR DESCRIPTION
Some operators may call `dispose()`/`cancel` from `onError`/`onComplete` which could trigger a permature call to `worker.dispose()` that was about to happen anyway. This PR prevents this by moving the operator into its disposed/cancelled state before signaling the terminal event, thus a downstream `cancel()`/`dispose()` call won't trigger this premature cleanup.

Such premature cleanups may cause unwanted `Schedulers.io()` reuse in some scenarios.

Related: #6146