### PR TITLE
2.x: Add explanation text to Undeliverable & OnErrorNotImplemented exs

### DIFF
--- a/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
@@ -48,6 +48,6 @@ public final class OnErrorNotImplementedException extends RuntimeException {
      *          the {@code Throwable} to signal; if null, a NullPointerException is constructed
      */
     public OnErrorNotImplementedException(@NonNull Throwable e) {
-        super(e != null ? e.getMessage() : null, e != null ? e : new NullPointerException());
+        this("The onError handler in the subscribe() method is not provided. Please specify it to avoid this type of exception. Further reading: https://github.com/ReactiveX/RxJava/blob/2.x/docs/Error-Handling.md | " + (e != null ? e.getMessage() : ""), e);
     }
 }

--- a/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
@@ -48,6 +48,6 @@ public final class OnErrorNotImplementedException extends RuntimeException {
      *          the {@code Throwable} to signal; if null, a NullPointerException is constructed
      */
     public OnErrorNotImplementedException(@NonNull Throwable e) {
-        this("The onError handler in the subscribe() method is not provided. Please specify it to avoid this type of exception. Further reading: https://github.com/ReactiveX/RxJava/wiki/Error-Handling | " + (e != null ? e.getMessage() : ""), e);
+        this("The exception was not handled due to missing onError handler in the subscribe() method call. Further reading: https://github.com/ReactiveX/RxJava/wiki/Error-Handling | " + (e != null ? e.getMessage() : ""), e);
     }
 }

--- a/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/io/reactivex/exceptions/OnErrorNotImplementedException.java
@@ -48,6 +48,6 @@ public final class OnErrorNotImplementedException extends RuntimeException {
      *          the {@code Throwable} to signal; if null, a NullPointerException is constructed
      */
     public OnErrorNotImplementedException(@NonNull Throwable e) {
-        this("The onError handler in the subscribe() method is not provided. Please specify it to avoid this type of exception. Further reading: https://github.com/ReactiveX/RxJava/blob/2.x/docs/Error-Handling.md | " + (e != null ? e.getMessage() : ""), e);
+        this("The onError handler in the subscribe() method is not provided. Please specify it to avoid this type of exception. Further reading: https://github.com/ReactiveX/RxJava/wiki/Error-Handling | " + (e != null ? e.getMessage() : ""), e);
     }
 }

--- a/src/main/java/io/reactivex/exceptions/UndeliverableException.java
+++ b/src/main/java/io/reactivex/exceptions/UndeliverableException.java
@@ -28,6 +28,6 @@ public final class UndeliverableException extends IllegalStateException {
      * @param cause the cause, not null
      */
     public UndeliverableException(Throwable cause) {
-        super("The exception could not be delivered to the consumer because it has already canceled/disposed the flow or the exception has nowhere to go to begin with. Further reading: https://github.com/ReactiveX/RxJava/blob/2.x/docs/What's-different-in-2.0.md#error-handling | " + cause.getMessage(), cause);
+        super("The exception could not be delivered to the consumer because it has already canceled/disposed the flow or the exception has nowhere to go to begin with. Further reading: https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling | " + cause.getMessage(), cause);
     }
 }

--- a/src/main/java/io/reactivex/exceptions/UndeliverableException.java
+++ b/src/main/java/io/reactivex/exceptions/UndeliverableException.java
@@ -28,6 +28,6 @@ public final class UndeliverableException extends IllegalStateException {
      * @param cause the cause, not null
      */
     public UndeliverableException(Throwable cause) {
-        super(cause);
+        super("The exception could not be delivered to the consumer because it has already canceled/disposed the flow or the exception has nowhere to go to begin with. Further reading: https://github.com/ReactiveX/RxJava/blob/2.x/docs/What's-different-in-2.0.md#error-handling | " + cause.getMessage(), cause);
     }
 }

--- a/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
+++ b/src/test/java/io/reactivex/exceptions/ExceptionsTest.java
@@ -53,7 +53,8 @@ public class ExceptionsTest {
 
         });
 
-        TestHelper.assertError(errors, 0, RuntimeException.class, "hello");
+        TestHelper.assertError(errors, 0, RuntimeException.class);
+        assertTrue(errors.get(0).toString(), errors.get(0).getMessage().contains("hello"));
         RxJavaPlugins.reset();
     }
 


### PR DESCRIPTION
This PR adds detailed error message to the `UndeliverableException` and `OnErrorNotImplementedException` as they are the most common exception-related questions around.

#### UndeliverableException

> The exception could not be delivered to the consumer because it has already canceled/disposed the flow or the exception has nowhere to go to begin with. Further reading: https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling | `<original exception message>`

#### OnErrorNotImplementedException

> The onError handler in the subscribe() method is not provided. Please specify it to avoid this type of exception. Further reading: https://github.com/ReactiveX/RxJava/wiki/Error-Handling | `<original exception message>`
