### PR TITLE
Auto-clean up RxJavaPlugins JavaDocs HTML (#6173)

### DIFF
--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -11,6 +11,7 @@ task javadocCleanup(dependsOn: "javadoc") doLast {
 
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/subjects/ReplaySubject.html'));
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/processors/ReplayProcessor.html'));
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/plugins/RxJavaPlugins.html'));
 }
 
 def fixJavadocFile(file) {


### PR DESCRIPTION
Add 'plugins/RxJavaPlugins.html' to the javadocCleanup task in javadoc_cleanup.gradle. 

Resolves: #6173 