### PR TITLE
2.x: Fix refCount termination-reconnect race

### DIFF
--- a/src/main/java/io/reactivex/internal/disposables/ResettableConnectable.java
+++ b/src/main/java/io/reactivex/internal/disposables/ResettableConnectable.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.disposables;
+
+import io.reactivex.annotations.Experimental;
+import io.reactivex.flowables.ConnectableFlowable;
+import io.reactivex.observables.ConnectableObservable;
+
+/**
+ * Interface allowing conditional resetting of connections in {@link ConnectableObservable}s
+ * and {@link ConnectableFlowable}s.
+ * @since 2.2.2 - experimental
+ */
+@Experimental
+public interface ResettableConnectable {
+
+    /**
+     * Reset the connectable if the current internal connection object is the
+     * same as the provided object.
+     * @param connectionObject the connection object identifying the last known
+     * active connection
+     */
+    void resetIf(Object connectionObject);
+}

--- a/src/main/java/io/reactivex/internal/disposables/ResettableConnectable.java
+++ b/src/main/java/io/reactivex/internal/disposables/ResettableConnectable.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.disposables;
 
 import io.reactivex.annotations.Experimental;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.observables.ConnectableObservable;
 
@@ -26,10 +27,28 @@ import io.reactivex.observables.ConnectableObservable;
 public interface ResettableConnectable {
 
     /**
-     * Reset the connectable if the current internal connection object is the
-     * same as the provided object.
-     * @param connectionObject the connection object identifying the last known
-     * active connection
+     * Reset the connectable source only if the given {@link Disposable} {@code connection} instance
+     * is still representing a connection established by a previous {@code connect()} connection.
+     * <p>
+     * For example, an immediately previous connection should reset the connectable source:
+     * <pre><code>
+     * Disposable d = connectable.connect();
+     * 
+     * ((ResettableConnectable)connectable).resetIf(d);
+     * </code></pre>
+     * However, if the connection indicator {@code Disposable} is from a much earlier connection,
+     * it should not affect the current connection:
+     * <pre><code>
+     * Disposable d1 = connectable.connect();
+     * d.dispose();
+     *
+     * Disposable d2 = connectable.connect();
+     *
+     * ((ResettableConnectable)connectable).resetIf(d);
+     * 
+     * assertFalse(d2.isDisposed());
+     * </code></pre>
+     * @param connection the disposable received from a previous {@code connect()} call.
      */
-    void resetIf(Object connectionObject);
+    void resetIf(Disposable connection);
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
@@ -95,7 +95,7 @@ public final class FlowableRefCount<T> extends Flowable<T> {
     void cancel(RefConnection rc) {
         SequentialDisposable sd;
         synchronized (this) {
-            if (connection == null) {
+            if (connection == null || connection != rc) {
                 return;
             }
             long c = rc.subscriberCount - 1;
@@ -116,13 +116,17 @@ public final class FlowableRefCount<T> extends Flowable<T> {
 
     void terminated(RefConnection rc) {
         synchronized (this) {
-            if (connection != null) {
+            if (connection != null && connection == rc) {
                 connection = null;
                 if (rc.timer != null) {
                     rc.timer.dispose();
                 }
+            }
+            if (--rc.subscriberCount == 0) {
                 if (source instanceof Disposable) {
                     ((Disposable)source).dispose();
+                } else if (source instanceof ResettableConnectable) {
+                    ((ResettableConnectable)source).resetIf(rc.get());
                 }
             }
         }
@@ -132,9 +136,12 @@ public final class FlowableRefCount<T> extends Flowable<T> {
         synchronized (this) {
             if (rc.subscriberCount == 0 && rc == connection) {
                 connection = null;
+                Object connectionObject = rc.get();
                 DisposableHelper.dispose(rc);
                 if (source instanceof Disposable) {
                     ((Disposable)source).dispose();
+                } else if (source instanceof ResettableConnectable) {
+                    ((ResettableConnectable)source).resetIf(connectionObject);
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
@@ -136,7 +136,7 @@ public final class FlowableRefCount<T> extends Flowable<T> {
         synchronized (this) {
             if (rc.subscriberCount == 0 && rc == connection) {
                 connection = null;
-                Object connectionObject = rc.get();
+                Disposable connectionObject = rc.get();
                 DisposableHelper.dispose(rc);
                 if (source instanceof Disposable) {
                     ((Disposable)source).dispose();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -24,6 +24,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
+import io.reactivex.internal.disposables.ResettableConnectable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.HasUpstreamPublisher;
 import io.reactivex.internal.subscribers.SubscriberResourceWrapper;
@@ -32,7 +33,7 @@ import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Timed;
 
-public final class FlowableReplay<T> extends ConnectableFlowable<T> implements HasUpstreamPublisher<T>, Disposable {
+public final class FlowableReplay<T> extends ConnectableFlowable<T> implements HasUpstreamPublisher<T>, ResettableConnectable {
     /** The source observable. */
     final Flowable<T> source;
     /** Holds the current subscriber that is, will be or just was subscribed to the source observable. */
@@ -161,15 +162,10 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
         onSubscribe.subscribe(s);
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public void dispose() {
-        current.lazySet(null);
-    }
-
-    @Override
-    public boolean isDisposed() {
-        Disposable d = current.get();
-        return d == null || d.isDisposed();
+    public void resetIf(Object connectionObject) {
+        current.compareAndSet((ReplaySubscriber)connectionObject, null);
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -164,7 +164,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public void resetIf(Object connectionObject) {
+    public void resetIf(Disposable connectionObject) {
         current.compareAndSet((ReplaySubscriber)connectionObject, null);
     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
@@ -133,7 +133,7 @@ public final class ObservableRefCount<T> extends Observable<T> {
         synchronized (this) {
             if (rc.subscriberCount == 0 && rc == connection) {
                 connection = null;
-                Object connectionObject = rc.get();
+                Disposable connectionObject = rc.get();
                 DisposableHelper.dispose(rc);
                 if (source instanceof Disposable) {
                     ((Disposable)source).dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
@@ -92,7 +92,7 @@ public final class ObservableRefCount<T> extends Observable<T> {
     void cancel(RefConnection rc) {
         SequentialDisposable sd;
         synchronized (this) {
-            if (connection == null) {
+            if (connection == null || connection != rc) {
                 return;
             }
             long c = rc.subscriberCount - 1;
@@ -113,13 +113,17 @@ public final class ObservableRefCount<T> extends Observable<T> {
 
     void terminated(RefConnection rc) {
         synchronized (this) {
-            if (connection != null) {
+            if (connection != null && connection == rc) {
                 connection = null;
                 if (rc.timer != null) {
                     rc.timer.dispose();
                 }
+            }
+            if (--rc.subscriberCount == 0) {
                 if (source instanceof Disposable) {
                     ((Disposable)source).dispose();
+                } else if (source instanceof ResettableConnectable) {
+                    ((ResettableConnectable)source).resetIf(rc.get());
                 }
             }
         }
@@ -129,9 +133,12 @@ public final class ObservableRefCount<T> extends Observable<T> {
         synchronized (this) {
             if (rc.subscriberCount == 0 && rc == connection) {
                 connection = null;
+                Object connectionObject = rc.get();
                 DisposableHelper.dispose(rc);
                 if (source instanceof Disposable) {
                     ((Disposable)source).dispose();
+                } else if (source instanceof ResettableConnectable) {
+                    ((ResettableConnectable)source).resetIf(connectionObject);
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -31,7 +31,7 @@ import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Timed;
 
-public final class ObservableReplay<T> extends ConnectableObservable<T> implements HasUpstreamObservableSource<T>, Disposable {
+public final class ObservableReplay<T> extends ConnectableObservable<T> implements HasUpstreamObservableSource<T>, ResettableConnectable {
     /** The source observable. */
     final ObservableSource<T> source;
     /** Holds the current subscriber that is, will be or just was subscribed to the source observable. */
@@ -159,15 +159,10 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
         return source;
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public void dispose() {
-        current.lazySet(null);
-    }
-
-    @Override
-    public boolean isDisposed() {
-        Disposable d = current.get();
-        return d == null || d.isDisposed();
+    public void resetIf(Object connectionObject) {
+        current.compareAndSet((ReplayObserver)connectionObject, null);
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -161,7 +161,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public void resetIf(Object connectionObject) {
+    public void resetIf(Disposable connectionObject) {
         current.compareAndSet((ReplayObserver)connectionObject, null);
     }
 


### PR DESCRIPTION
This PR modifies the `refCount` operator (in both `Flowable` and `Observable` types) to avoid certain termination-reconnection races.

The original race could happen when the refCounted source terminated at the same time as new observers arrived, leaving those new observers hanging as they practically joined a dying connection and got possibly undercut by the `dispose` call.

The change involve a new internal interface `ResettableConnection` that will allow resetting the connection object inside the connectable source if it is equal to the connection object known by the initiator of the original `connect` call.

Fixes #6185 