### PR TITLE
Add "error handling" java docs section to from callable & co

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -399,7 +399,7 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Error handling:</b></dt>
      *  <dd> If the {@link Action} throws an exception, the respective {@link Throwable} is
      *  delivered to the downstream via {@link CompletableObserver#onError(Throwable)},
-     *  except when the downstream has canceled or disposed this {@code Completable} source.
+     *  except when the downstream has disposed this {@code Completable} source.
      *  In this latter case, the {@code Throwable} is delivered to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
      *  </dd>
@@ -426,7 +426,7 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Error handling:</b></dt>
      *  <dd> If the {@link Callable} throws an exception, the respective {@link Throwable} is
      *  delivered to the downstream via {@link CompletableObserver#onError(Throwable)},
-     *  except when the downstream has canceled or disposed this {@code Completable} source.
+     *  except when the downstream has disposed this {@code Completable} source.
      *  In this latter case, the {@code Throwable} is delivered to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
      *  </dd>

--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -396,6 +396,13 @@ public abstract class Completable implements CompletableSource {
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromAction} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd> If the {@link Action} throws an exception, the respective {@link Throwable} is
+     *  delivered to the downstream via {@link CompletableObserver#onError(Throwable)},
+     *  except when the downstream has canceled or disposed this {@code Completable} source.
+     *  In this latter case, the {@code Throwable} is delivered to the global error handler via
+     *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
+     *  </dd>
      * </dl>
      * @param run the runnable to run for each subscriber
      * @return the new Completable instance

--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -416,6 +416,13 @@ public abstract class Completable implements CompletableSource {
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromCallable} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd> If the {@link Callable} throws an exception, the respective {@link Throwable} is
+     *  delivered to the downstream via {@link CompletableObserver#onError(Throwable)},
+     *  except when the downstream has canceled or disposed this {@code Completable} source.
+     *  In this latter case, the {@code Throwable} is delivered to the global error handler via
+     *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
+     *  </dd>
      * </dl>
      * @param callable the callable instance to execute for each subscriber
      * @return the new Completable instance

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -1955,6 +1955,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      *   <dd>The operator honors backpressure from downstream.</dd>
      *   <dt><b>Scheduler:</b></dt>
      *   <dd>{@code fromCallable} does not operate by default on a particular {@link Scheduler}.</dd>
+     *   <dt><b>Error handling:</b></dt>
+     *   <dd> If the {@link Callable} throws an exception, the respective {@link Throwable} is
+     *   delivered to the downstream via {@link Subscriber#onError(Throwable)},
+     *   except when the downstream has canceled this {@code Flowable} source.
+     *   In this latter case, the {@code Throwable} is delivered to the global error handler via
+     *   {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
+     *   </dd>
      * </dl>
      *
      * @param supplier

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -660,7 +660,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Error handling:</b></dt>
      *  <dd> If the {@link Action} throws an exception, the respective {@link Throwable} is
      *  delivered to the downstream via {@link MaybeObserver#onError(Throwable)},
-     *  except when the downstream has canceled or disposed this {@code Maybe} source.
+     *  except when the downstream has disposed this {@code Maybe} source.
      *  In this latter case, the {@code Throwable} is delivered to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
      *  </dd>

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -657,6 +657,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromAction} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd> If the {@link Action} throws an exception, the respective {@link Throwable} is
+     *  delivered to the downstream via {@link MaybeObserver#onError(Throwable)},
+     *  except when the downstream has canceled or disposed this {@code Maybe} source.
+     *  In this latter case, the {@code Throwable} is delivered to the global error handler via
+     *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
+     *  </dd>
      * </dl>
      * @param <T> the target type
      * @param run the runnable to run for each subscriber

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1760,7 +1760,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *   <dt><b>Error handling:</b></dt>
      *   <dd> If the {@link Callable} throws an exception, the respective {@link Throwable} is
      *   delivered to the downstream via {@link Observer#onError(Throwable)},
-     *   except when the downstream has canceled or disposed this {@code Observable} source.
+     *   except when the downstream has disposed this {@code Observable} source.
      *   In this latter case, the {@code Throwable} is delivered to the global error handler via
      *   {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
      *   </dd>

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -1757,8 +1757,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <dl>
      *   <dt><b>Scheduler:</b></dt>
      *   <dd>{@code fromCallable} does not operate by default on a particular {@link Scheduler}.</dd>
+     *   <dt><b>Error handling:</b></dt>
+     *   <dd> If the {@link Callable} throws an exception, the respective {@link Throwable} is
+     *   delivered to the downstream via {@link Observer#onError(Throwable)},
+     *   except when the downstream has canceled or disposed this {@code Observable} source.
+     *   In this latter case, the {@code Throwable} is delivered to the global error handler via
+     *   {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
+     *   </dd>
      * </dl>
-     *
      * @param supplier
      *         a function, the execution of which should be deferred; {@code fromCallable} will invoke this
      *         function only when an observer subscribes to the ObservableSource that {@code fromCallable} returns

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -586,7 +586,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *   <dt><b>Error handling:</b></dt>
      *   <dd> If the {@link Callable} throws an exception, the respective {@link Throwable} is
      *   delivered to the downstream via {@link SingleObserver#onError(Throwable)},
-     *   except when the downstream has canceled or disposed this {@code Single} source.
+     *   except when the downstream has disposed this {@code Single} source.
      *   In this latter case, the {@code Throwable} is delivered to the global error handler via
      *   {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
      *   </dd>

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -583,6 +583,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dl>
      *   <dt><b>Scheduler:</b></dt>
      *   <dd>{@code fromCallable} does not operate by default on a particular {@link Scheduler}.</dd>
+     *   <dt><b>Error handling:</b></dt>
+     *   <dd> If the {@link Callable} throws an exception, the respective {@link Throwable} is
+     *   delivered to the downstream via {@link SingleObserver#onError(Throwable)},
+     *   except when the downstream has canceled or disposed this {@code Single} source.
+     *   In this latter case, the {@code Throwable} is delivered to the global error handler via
+     *   {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
+     *   </dd>
      * </dl>
      *
      * @param callable


### PR DESCRIPTION
Resolves #6179

Added JavaDocs describing the regular and canceled/disposed behavior for

- `Observable.fromCallable()`
- `Single.fromCallable()`
- `Maybe.fromAction()`
- `Completable.fromCallable()`
- `Completable.fromAction()`
- `Flowable.fromCallable()`

Did not alter `Maybe.fromCallable()` because the existing JavaDoc appears to be adequate.