### PR TITLE
Fix terminology of cancel/dispose in the JavaDocs

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -432,7 +432,7 @@ public abstract class Completable implements CompletableSource {
      * <p>
      * <img width="640" height="628" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.fromFuture.png" alt="">
      * <p>
-     * Note that if any of the subscribers to this Completable call dispose, this Completable will cancel the future.
+     * Note that if any of the observers to this Completable call dispose, this Completable will cancel the future.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -90,7 +90,7 @@ import io.reactivex.schedulers.Schedulers;
  * d.dispose();
  * </code></pre>
  * <p>
- * Note that by design, subscriptions via {@link #subscribe(CompletableObserver)} can't be cancelled/disposed
+ * Note that by design, subscriptions via {@link #subscribe(CompletableObserver)} can't be disposed
  * from the outside (hence the
  * {@code void} return of the {@link #subscribe(CompletableObserver)} method) and it is the
  * responsibility of the implementor of the {@code CompletableObserver} to allow this to happen.
@@ -105,7 +105,7 @@ import io.reactivex.schedulers.Schedulers;
 public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable which terminates as soon as one of the source Completables
-     * terminates (normally or with an error) and cancels all other Completables.
+     * terminates (normally or with an error) and disposes all other Completables.
      * <p>
      * <img width="640" height="518" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.ambArray.png" alt="">
      * <dl>
@@ -133,7 +133,7 @@ public abstract class Completable implements CompletableSource {
 
     /**
      * Returns a Completable which terminates as soon as one of the source Completables
-     * terminates (normally or with an error) and cancels all other Completables.
+     * terminates (normally or with an error) and disposes all other Completables.
      * <p>
      * <img width="640" height="518" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.amb.png" alt="">
      * <dl>
@@ -306,7 +306,7 @@ public abstract class Completable implements CompletableSource {
     /**
      * Constructs a Completable instance by wrapping the given source callback
      * <strong>without any safeguards; you should manage the lifecycle and response
-     * to downstream cancellation/dispose</strong>.
+     * to downstream disposal</strong>.
      * <p>
      * <img width="640" height="260" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.unsafeCreate.png" alt="">
      * <dl>
@@ -432,7 +432,7 @@ public abstract class Completable implements CompletableSource {
      * <p>
      * <img width="640" height="628" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.fromFuture.png" alt="">
      * <p>
-     * Note that cancellation from any of the subscribers to this Completable will cancel the future.
+     * Note that if any of the subscribers to this Completable call dispose, this Completable will cancel the future.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -580,13 +580,13 @@ public abstract class Completable implements CompletableSource {
      *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code CompletableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Completable} terminates with that {@code Throwable} and all other source {@code CompletableSource}s are cancelled.
+     *  {@code Completable} terminates with that {@code Throwable} and all other source {@code CompletableSource}s are disposed.
      *  If more than one {@code CompletableSource} signals an error, the resulting {@code Completable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Completable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Completable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeArrayDelayError(CompletableSource...)} to merge sources and terminate only when all source {@code CompletableSource}s
      *  have completed or failed with an error.
@@ -620,13 +620,13 @@ public abstract class Completable implements CompletableSource {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code CompletableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Completable} terminates with that {@code Throwable} and all other source {@code CompletableSource}s are cancelled.
+     *  {@code Completable} terminates with that {@code Throwable} and all other source {@code CompletableSource}s are disposed.
      *  If more than one {@code CompletableSource} signals an error, the resulting {@code Completable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Completable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Completable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Iterable)} to merge sources and terminate only when all source {@code CompletableSource}s
      *  have completed or failed with an error.
@@ -657,13 +657,13 @@ public abstract class Completable implements CompletableSource {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code CompletableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Completable} terminates with that {@code Throwable} and all other source {@code CompletableSource}s are cancelled.
+     *  {@code Completable} terminates with that {@code Throwable} and all other source {@code CompletableSource}s are disposed.
      *  If more than one {@code CompletableSource} signals an error, the resulting {@code Completable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Completable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Completable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher)} to merge sources and terminate only when all source {@code CompletableSource}s
      *  have completed or failed with an error.
@@ -694,13 +694,13 @@ public abstract class Completable implements CompletableSource {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code CompletableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Completable} terminates with that {@code Throwable} and all other source {@code CompletableSource}s are cancelled.
+     *  {@code Completable} terminates with that {@code Throwable} and all other source {@code CompletableSource}s are disposed.
      *  If more than one {@code CompletableSource} signals an error, the resulting {@code Completable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Completable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Completable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher, int)} to merge sources and terminate only when all source {@code CompletableSource}s
      *  have completed or failed with an error.
@@ -938,7 +938,7 @@ public abstract class Completable implements CompletableSource {
      * <p>
      * <img width="640" height="332" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.using.b.png" alt="">
      * <p>
-     * If this overload performs a lazy cancellation after the terminal event is emitted.
+     * If this overload performs a lazy disposal after the terminal event is emitted.
      * Exceptions thrown at this time will be delivered to RxJavaPlugins only.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1571,7 +1571,7 @@ public abstract class Completable implements CompletableSource {
      *  <dd>{@code doFinally} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.0.1 - experimental
-     * @param onFinally the action called when this Completable terminates or gets cancelled
+     * @param onFinally the action called when this Completable terminates or gets disposed
      * @return the new Completable instance
      * @since 2.1
      */
@@ -1838,7 +1838,7 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Returns a Completable that repeatedly subscribes to this Completable until cancelled.
+     * Returns a Completable that repeatedly subscribes to this Completable until disposed.
      * <p>
      * <img width="640" height="373" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.repeat.png" alt="">
      * <dl>
@@ -2141,7 +2141,7 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Subscribes to this CompletableConsumable and returns a Disposable which can be used to cancel
+     * Subscribes to this CompletableConsumable and returns a Disposable which can be used to dispose
      * the subscription.
      * <p>
      * <img width="640" height="352" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.subscribe.png" alt="">
@@ -2149,7 +2149,7 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the Disposable that allows cancelling the subscription
+     * @return the Disposable that allows disposing the subscription
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe() {
@@ -2231,7 +2231,7 @@ public abstract class Completable implements CompletableSource {
      * </dl>
      * @param onComplete the runnable that is called if the Completable completes normally
      * @param onError the consumer that is called if this Completable emits an error
-     * @return the Disposable that can be used for cancelling the subscription asynchronously
+     * @return the Disposable that can be used for disposing the subscription asynchronously
      * @throws NullPointerException if either callback is null
      */
     @CheckReturnValue
@@ -2259,7 +2259,7 @@ public abstract class Completable implements CompletableSource {
      *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param onComplete the runnable called when this Completable completes normally
-     * @return the Disposable that allows cancelling the subscription
+     * @return the Disposable that allows disposing the subscription
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2569,7 +2569,7 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Returns a Completable which makes sure when a subscriber cancels the subscription, the
+     * Returns a Completable which makes sure when a subscriber disposes the subscription, the
      * dispose is called on the specified scheduler.
      * <p>
      * <img width="640" height="716" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.unsubscribeOn.png" alt="">
@@ -2577,7 +2577,7 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code unsubscribeOn} calls dispose() of the upstream on the {@link Scheduler} you specify.</dd>
      * </dl>
-     * @param scheduler the target scheduler where to execute the cancellation
+     * @param scheduler the target scheduler where to execute the disposing
      * @return the new Completable instance
      * @throws NullPointerException if scheduler is null
      */

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -93,7 +93,7 @@ import io.reactivex.schedulers.Schedulers;
  * d.dispose();
  * </code></pre>
  * <p>
- * Note that by design, subscriptions via {@link #subscribe(MaybeObserver)} can't be cancelled/disposed
+ * Note that by design, subscriptions via {@link #subscribe(MaybeObserver)} can't be disposed
  * from the outside (hence the
  * {@code void} return of the {@link #subscribe(MaybeObserver)} method) and it is the
  * responsibility of the implementor of the {@code MaybeObserver} to allow this to happen.
@@ -110,7 +110,7 @@ import io.reactivex.schedulers.Schedulers;
 public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
-     * Runs multiple MaybeSources and signals the events of the first one that signals (cancelling
+     * Runs multiple MaybeSources and signals the events of the first one that signals (disposing
      * the rest).
      * <p>
      * <img width="640" height="519" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.amb.png" alt="">
@@ -131,7 +131,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Runs multiple MaybeSources and signals the events of the first one that signals (cancelling
+     * Runs multiple MaybeSources and signals the events of the first one that signals (disposing
      * the rest).
      * <p>
      * <img width="640" height="519" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.ambArray.png" alt="">
@@ -760,7 +760,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <p>
      * <em>Important note:</em> This Maybe is blocking; you cannot dispose it.
      * <p>
-     * Unlike 1.x, cancelling the Maybe won't cancel the future. If necessary, one can use composition to achieve the
+     * Unlike 1.x, disposing the Maybe won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futureMaybe.doOnDispose(() -> future.cancel(true));}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -791,7 +791,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * return value of the {@link Future#get} method of that object, by passing the object into the {@code fromFuture}
      * method.
      * <p>
-     * Unlike 1.x, cancelling the Maybe won't cancel the future. If necessary, one can use composition to achieve the
+     * Unlike 1.x, disposing the Maybe won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futureMaybe.doOnCancel(() -> future.cancel(true));}.
      * <p>
      * <em>Important note:</em> This Maybe is blocking on the thread it gets subscribed on; you cannot dispose it.
@@ -875,7 +875,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -909,7 +909,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -943,7 +943,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -1016,7 +1016,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -1064,7 +1064,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -1116,7 +1116,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -1167,7 +1167,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -2693,7 +2693,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code doFinally} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.0.1 - experimental
-     * @param onFinally the action called when this Maybe terminates or gets cancelled
+     * @param onFinally the action called when this Maybe terminates or gets disposed
      * @return the new Maybe instance
      * @since 2.1
      */
@@ -2711,7 +2711,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnDispose} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param onDispose the action called when the subscription is cancelled (disposed)
+     * @param onDispose the action called when the subscription is disposed
      * @throws NullPointerException if onDispose is null
      * @return the new Maybe instance
      */
@@ -3492,7 +3492,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Converts this Maybe into an Observable instance composing cancellation
+     * Converts this Maybe into an Observable instance composing disposal
      * through.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -3511,7 +3511,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Converts this Maybe into a Single instance composing cancellation
+     * Converts this Maybe into a Single instance composing disposal
      * through and turning an empty Maybe into a Single that emits the given
      * value through onSuccess.
      * <dl>
@@ -3529,7 +3529,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Converts this Maybe into a Single instance composing cancellation
+     * Converts this Maybe into a Single instance composing disposal
      * through and turning an empty Maybe into a signal of NoSuchElementException.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -4444,7 +4444,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * If the current {@code Maybe} didn't signal an event before the {@code timeoutIndicator} {@link MaybeSource} signals,
-     * the current {@code Maybe} is cancelled and the {@code fallback} {@code MaybeSource} subscribed to
+     * the current {@code Maybe} is disposed and the {@code fallback} {@code MaybeSource} subscribed to
      * as a continuation.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -4489,7 +4489,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * If the current {@code Maybe} didn't signal an event before the {@code timeoutIndicator} {@link Publisher} signals,
-     * the current {@code Maybe} is cancelled and the {@code fallback} {@code MaybeSource} subscribed to
+     * the current {@code Maybe} is disposed and the {@code fallback} {@code MaybeSource} subscribed to
      * as a continuation.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -4520,7 +4520,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code unsubscribeOn} calls dispose() of the upstream on the {@link Scheduler} you specify.</dd>
      * </dl>
-     * @param scheduler the target scheduler where to execute the cancellation
+     * @param scheduler the target scheduler where to execute the disposal
      * @return the new Maybe instance
      * @throws NullPointerException if scheduler is null
      */

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -53,7 +53,7 @@ import io.reactivex.schedulers.*;
  * The design of this class was derived from the
  * <a href="https://github.com/reactive-streams/reactive-streams-jvm">Reactive-Streams design and specification</a>
  * by removing any backpressure-related infrastructure and implementation detail, replacing the
- * {@code org.reactivestreams.Subscription} with {@link Disposable} as the primary means to cancel
+ * {@code org.reactivestreams.Subscription} with {@link Disposable} as the primary means to dispose of
  * a flow.
  * <p>
  * The {@code Observable} follows the protocol
@@ -64,7 +64,7 @@ import io.reactivex.schedulers.*;
  * the stream can be disposed through the {@code Disposable} instance provided to consumers through
  * {@code Observer.onSubscribe}.
  * <p>
- * Unlike the {@code Observable} of version 1.x, {@link #subscribe(Observer)} does not allow external cancellation
+ * Unlike the {@code Observable} of version 1.x, {@link #subscribe(Observer)} does not allow external disposal
  * of a subscription and the {@code Observer} instance is expected to expose such capability.
  * <p>Example:
  * <pre><code>
@@ -86,7 +86,7 @@ import io.reactivex.schedulers.*;
  *     });
  * 
  * Thread.sleep(500);
- * // the sequence now can be cancelled via dispose()
+ * // the sequence can now be disposed via dispose()
  * d.dispose();
  * </code></pre>
  * 
@@ -2048,7 +2048,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code onComplete} to signal a value or a terminal event. Signalling multiple {@code onNext}
      * in a call will make the operator signal {@code IllegalStateException}.
      * @param disposeState the Consumer that is called with the current state when the generator
-     * terminates the sequence or it gets cancelled
+     * terminates the sequence or it gets disposed
      * @return the new Observable instance
      */
     @CheckReturnValue
@@ -2104,7 +2104,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * the next invocation. Signalling multiple {@code onNext}
      * in a call will make the operator signal {@code IllegalStateException}.
      * @param disposeState the Consumer that is called with the current state when the generator
-     * terminates the sequence or it gets cancelled
+     * terminates the sequence or it gets disposed
      * @return the new Observable instance
      */
     @CheckReturnValue
@@ -2692,13 +2692,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code ObservableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are cancelled.
+     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
      *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Iterable, int, int)} to merge sources and terminate only when all source {@code ObservableSource}s
      *  have completed or failed with an error.
@@ -2739,13 +2739,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code ObservableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are cancelled.
+     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
      *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeArrayDelayError(int, int, ObservableSource...)} to merge sources and terminate only when all source {@code ObservableSource}s
      *  have completed or failed with an error.
@@ -2785,13 +2785,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code ObservableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are cancelled.
+     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
      *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Iterable)} to merge sources and terminate only when all source {@code ObservableSource}s
      *  have completed or failed with an error.
@@ -2826,13 +2826,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code ObservableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are cancelled.
+     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
      *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Iterable, int)} to merge sources and terminate only when all source {@code ObservableSource}s
      *  have completed or failed with an error.
@@ -2871,13 +2871,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code ObservableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are cancelled.
+     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
      *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(ObservableSource)} to merge sources and terminate only when all source {@code ObservableSource}s
      *  have completed or failed with an error.
@@ -2914,13 +2914,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code ObservableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are cancelled.
+     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
      *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(ObservableSource, int)} to merge sources and terminate only when all source {@code ObservableSource}s
      *  have completed or failed with an error.
@@ -2961,13 +2961,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code ObservableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are cancelled.
+     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
      *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(ObservableSource, ObservableSource)} to merge sources and terminate only when all source {@code ObservableSource}s
      *  have completed or failed with an error.
@@ -3004,13 +3004,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code ObservableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are cancelled.
+     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
      *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(ObservableSource, ObservableSource, ObservableSource)} to merge sources and terminate only when all source {@code ObservableSource}s
      *  have completed or failed with an error.
@@ -3050,13 +3050,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code ObservableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are cancelled.
+     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
      *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(ObservableSource, ObservableSource, ObservableSource, ObservableSource)} to merge sources and terminate only when all source {@code ObservableSource}s
      *  have completed or failed with an error.
@@ -3101,13 +3101,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code ObservableSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are cancelled.
+     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
      *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been cancelled or terminated with a
+     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeArrayDelayError(ObservableSource...)} to merge sources and terminate only when all source {@code ObservableSource}s
      *  have completed or failed with an error.
@@ -3903,7 +3903,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Create an Observable by wrapping an ObservableSource <em>which has to be implemented according
      * to the Reactive-Streams-based Observable specification by handling
-     * cancellation correctly; no safeguards are provided by the Observable itself</em>.
+     * disposal correctly; no safeguards are provided by the Observable itself</em>.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code unsafeCreate} by default doesn't operate on any particular {@link Scheduler}.</dd>
@@ -7575,10 +7575,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * When the upstream signals an {@link Notification#createOnError(Throwable) onError} or
      * {@link Notification#createOnComplete() onComplete} item, the
-     * returned Observable cancels the flow and terminates with that type of terminal event:
+     * returned Observable disposes of the flow and terminates with that type of terminal event:
      * <pre><code>
      * Observable.just(createOnNext(1), createOnComplete(), createOnNext(2))
-     * .doOnDispose(() -&gt; System.out.println("Cancelled!"));
+     * .doOnDispose(() -&gt; System.out.println("Disposed!"));
      * .test()
      * .assertResult(1);
      * </code></pre>
@@ -7876,7 +7876,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dd>This operator supports boundary-limited synchronous or asynchronous queue-fusion.</dd>
      * </dl>
      * <p>History: 2.0.1 - experimental
-     * @param onFinally the action called when this Observable terminates or gets cancelled
+     * @param onFinally the action called when this Observable terminates or gets disposed
      * @return the new Observable instance
      * @since 2.1
      */
@@ -8039,7 +8039,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Calls the appropriate onXXX method (shared between all Observer) for the lifecycle events of
-     * the sequence (subscription, cancellation, requesting).
+     * the sequence (subscription, disposal, requesting).
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnLifecycle.o.png" alt="">
      * <dl>
@@ -8912,7 +8912,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param onNext
      *            {@link Consumer} to execute for each item.
      * @return
-     *            a Disposable that allows cancelling an asynchronous sequence
+     *            a Disposable that allows disposing of an asynchronous sequence
      * @throws NullPointerException
      *             if {@code onNext} is null
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
@@ -8940,7 +8940,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param onNext
      *            {@link Predicate} to execute for each item.
      * @return
-     *            a Disposable that allows cancelling an asynchronous sequence
+     *            a Disposable that allows disposing of an asynchronous sequence
      * @throws NullPointerException
      *             if {@code onNext} is null
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
@@ -8964,7 +8964,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param onError
      *            {@link Consumer} to execute when an error is emitted.
      * @return
-     *            a Disposable that allows cancelling an asynchronous sequence
+     *            a Disposable that allows disposing of an asynchronous sequence
      * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null
@@ -8991,7 +8991,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param onComplete
      *            {@link Action} to execute when completion is signalled.
      * @return
-     *            a Disposable that allows cancelling an asynchronous sequence
+     *            a Disposable that allows disposing of an asynchronous sequence
      * @throws NullPointerException
      *             if {@code onNext} is null, or
      *             if {@code onError} is null, or

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -97,7 +97,7 @@ import io.reactivex.schedulers.Schedulers;
  * d.dispose();
  * </code></pre>
  * <p>
- * Note that by design, subscriptions via {@link #subscribe(SingleObserver)} can't be cancelled/disposed
+ * Note that by design, subscriptions via {@link #subscribe(SingleObserver)} can't be disposed
  * from the outside (hence the
  * {@code void} return of the {@link #subscribe(SingleObserver)} method) and it is the
  * responsibility of the implementor of the {@code SingleObserver} to allow this to happen.
@@ -114,7 +114,7 @@ import io.reactivex.schedulers.Schedulers;
 public abstract class Single<T> implements SingleSource<T> {
 
     /**
-     * Runs multiple SingleSources and signals the events of the first one that signals (cancelling
+     * Runs multiple SingleSources and signals the events of the first one that signals (disposing
      * the rest).
      * <p>
      * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.amb.png" alt="">
@@ -136,7 +136,7 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Runs multiple SingleSources and signals the events of the first one that signals (cancelling
+     * Runs multiple SingleSources and signals the events of the first one that signals (disposing
      * the rest).
      * <p>
      * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.ambArray.png" alt="">
@@ -823,7 +823,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code SingleSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code SingleSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code SingleSource}s are disposed.
      *  If more than one {@code SingleSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -860,7 +860,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code SingleSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code SingleSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code SingleSource}s are disposed.
      *  If more than one {@code SingleSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -931,7 +931,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code SingleSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code SingleSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code SingleSource}s are disposed.
      *  If more than one {@code SingleSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -979,7 +979,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code SingleSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code SingleSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code SingleSource}s are disposed.
      *  If more than one {@code SingleSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -1031,7 +1031,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code SingleSource}s signal a {@code Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code SingleSource}s are cancelled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code SingleSource}s are disposed.
      *  If more than one {@code SingleSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@code CompositeException} containing two or more of the various error signals.
@@ -1367,7 +1367,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *                  to be run by the operator
      * @param disposer the consumer of the generated resource that is called exactly once for
      *                  that particular resource when the generated SingleSource terminates
-     *                  (successfully or with an error) or gets cancelled.
+     *                  (successfully or with an error) or gets disposed.
      * @return the new Single instance
      * @since 2.0
      */
@@ -1394,7 +1394,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *                  to be run by the operator
      * @param disposer the consumer of the generated resource that is called exactly once for
      *                  that particular resource when the generated SingleSource terminates
-     *                  (successfully or with an error) or gets cancelled.
+     *                  (successfully or with an error) or gets disposed.
      * @param eager
      *                 if true, the disposer is called before the terminal event is signalled
      *                 if false, the disposer is called after the terminal event is delivered to downstream
@@ -1450,7 +1450,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <p>
-     * If any of the SingleSources signal an error, all other SingleSources get cancelled and the
+     * If any of the SingleSources signal an error, all other SingleSources get disposed and the
      * error emitted to downstream immediately.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -1895,7 +1895,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.png" alt="">
      * <p>
-     * If any of the SingleSources signal an error, all other SingleSources get cancelled and the
+     * If any of the SingleSources signal an error, all other SingleSources get disposed and the
      * error emitted to downstream immediately.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -2361,7 +2361,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *  <dd>{@code doFinally} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.0.1 - experimental
-     * @param onFinally the action called when this Single terminates or gets cancelled
+     * @param onFinally the action called when this Single terminates or gets disposed
      * @return the new Single instance
      * @since 2.1
      */
@@ -3622,7 +3622,7 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Runs the current Single and if it doesn't signal within the specified timeout window, it is
-     * cancelled and the other SingleSource subscribed to.
+     * disposed and the other SingleSource subscribed to.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeout} subscribes to the other SingleSource on the {@link Scheduler} you specify.</dd>
@@ -3643,7 +3643,7 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Runs the current Single and if it doesn't signal within the specified timeout window, it is
-     * cancelled and the other SingleSource subscribed to.
+     * disposed and the other SingleSource subscribed to.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeout} subscribes to the other SingleSource on
@@ -3832,7 +3832,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *  <dd>{@code unsubscribeOn} calls dispose() of the upstream on the {@link Scheduler} you specify.</dd>
      * </dl>
      * <p>History: 2.0.9 - experimental
-     * @param scheduler the target scheduler where to execute the cancellation
+     * @param scheduler the target scheduler where to execute the disposal
      * @return the new Single instance
      * @throws NullPointerException if scheduler is null
      * @since 2.2


### PR DESCRIPTION
Resolves #6196

Changing terminology from cancel -> dispose wherever appropriate in the following classes:

- `Observable.java`
- `Single.java`
- `Maybe.java`
- `Completable.java`

Areas where I did _not_ change from cancel -> disposal include: 

- where the cancellation was in reference to a `Flowable`, `Publisher`, or a `Future`
- `test()` methods where the `TestObserver` returned actually has a `cancel()` method