### PR TITLE
2.x: Assert instead of print Undeliverable in some tests

### DIFF
--- a/src/test/java/io/reactivex/maybe/MaybeCreateTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeCreateTest.java
@@ -15,12 +15,15 @@ package io.reactivex.maybe;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
+
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Cancellable;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public class MaybeCreateTest {
     @Test(expected = NullPointerException.class)
@@ -30,84 +33,111 @@ public class MaybeCreateTest {
 
     @Test
     public void basic() {
-        final Disposable d = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d = Disposables.empty();
 
-        Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
+                    e.setDisposable(d);
 
-                e.onSuccess(1);
-                e.onError(new TestException());
-                e.onSuccess(2);
-                e.onError(new TestException());
-            }
-        }).test().assertResult(1);
+                    e.onSuccess(1);
+                    e.onError(new TestException());
+                    e.onSuccess(2);
+                    e.onError(new TestException());
+                }
+            }).test().assertResult(1);
 
-        assertTrue(d.isDisposed());
+            assertTrue(d.isDisposed());
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void basicWithCancellable() {
-        final Disposable d1 = Disposables.empty();
-        final Disposable d2 = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d1 = Disposables.empty();
+            final Disposable d2 = Disposables.empty();
 
-        Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                e.setDisposable(d1);
-                e.setCancellable(new Cancellable() {
-                    @Override
-                    public void cancel() throws Exception {
-                        d2.dispose();
-                    }
-                });
+            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
+                    e.setDisposable(d1);
+                    e.setCancellable(new Cancellable() {
+                        @Override
+                        public void cancel() throws Exception {
+                            d2.dispose();
+                        }
+                    });
 
-                e.onSuccess(1);
-                e.onError(new TestException());
-                e.onSuccess(2);
-                e.onError(new TestException());
-            }
-        }).test().assertResult(1);
+                    e.onSuccess(1);
+                    e.onError(new TestException());
+                    e.onSuccess(2);
+                    e.onError(new TestException());
+                }
+            }).test().assertResult(1);
 
-        assertTrue(d1.isDisposed());
-        assertTrue(d2.isDisposed());
+            assertTrue(d1.isDisposed());
+            assertTrue(d2.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void basicWithError() {
-        final Disposable d = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d = Disposables.empty();
 
-        Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
+                    e.setDisposable(d);
 
-                e.onError(new TestException());
-                e.onSuccess(2);
-                e.onError(new TestException());
-            }
-        }).test().assertFailure(TestException.class);
+                    e.onError(new TestException());
+                    e.onSuccess(2);
+                    e.onError(new TestException());
+                }
+            }).test().assertFailure(TestException.class);
 
-        assertTrue(d.isDisposed());
+            assertTrue(d.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void basicWithCompletion() {
-        final Disposable d = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d = Disposables.empty();
 
-        Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
+                    e.setDisposable(d);
 
-                e.onComplete();
-                e.onSuccess(2);
-                e.onError(new TestException());
-            }
-        }).test().assertComplete();
+                    e.onComplete();
+                    e.onSuccess(2);
+                    e.onError(new TestException());
+                }
+            }).test().assertComplete();
 
-        assertTrue(d.isDisposed());
+            assertTrue(d.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -1496,68 +1496,91 @@ public class MaybeTest {
 
     @Test
     public void basic() {
-        final Disposable d = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d = Disposables.empty();
 
-        Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
+                    e.setDisposable(d);
 
-                e.onSuccess(1);
-                e.onError(new TestException());
-                e.onSuccess(2);
-                e.onError(new TestException());
-                e.onComplete();
-            }
-        })
-        .test()
-        .assertResult(1);
+                    e.onSuccess(1);
+                    e.onError(new TestException());
+                    e.onSuccess(2);
+                    e.onError(new TestException());
+                    e.onComplete();
+                }
+            })
+            .test()
+            .assertResult(1);
 
-        assertTrue(d.isDisposed());
+            assertTrue(d.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void basicWithError() {
-        final Disposable d = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d = Disposables.empty();
 
-        Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
+                    e.setDisposable(d);
 
-                e.onError(new TestException());
-                e.onSuccess(2);
-                e.onError(new TestException());
-                e.onComplete();
-            }
-        })
-        .test()
-        .assertFailure(TestException.class);
+                    e.onError(new TestException());
+                    e.onSuccess(2);
+                    e.onError(new TestException());
+                    e.onComplete();
+                }
+            })
+            .test()
+            .assertFailure(TestException.class);
 
-        assertTrue(d.isDisposed());
+            assertTrue(d.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
     public void basicWithComplete() {
-        final Disposable d = Disposables.empty();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final Disposable d = Disposables.empty();
 
-        Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
+                @Override
+                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
+                    e.setDisposable(d);
 
-                e.onComplete();
-                e.onSuccess(1);
-                e.onError(new TestException());
-                e.onComplete();
-                e.onSuccess(2);
-                e.onError(new TestException());
-            }
-        })
-        .test()
-        .assertResult();
+                    e.onComplete();
+                    e.onSuccess(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                    e.onSuccess(2);
+                    e.onError(new TestException());
+                }
+            })
+            .test()
+            .assertResult();
 
-        assertTrue(d.isDisposed());
+            assertTrue(d.isDisposed());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+            TestHelper.assertUndeliverable(errors, 1, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -2359,21 +2382,28 @@ public class MaybeTest {
 
     @Test
     public void doOnEventError() {
-        final List<Object> list = new ArrayList<Object>();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final List<Object> list = new ArrayList<Object>();
 
-        TestException ex = new TestException();
+            TestException ex = new TestException();
 
-        assertTrue(Maybe.<Integer>error(ex)
-        .doOnEvent(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer v, Throwable e) throws Exception {
-                list.add(v);
-                list.add(e);
-            }
-        })
-        .subscribe().isDisposed());
+            assertTrue(Maybe.<Integer>error(ex)
+            .doOnEvent(new BiConsumer<Integer, Throwable>() {
+                @Override
+                public void accept(Integer v, Throwable e) throws Exception {
+                    list.add(v);
+                    list.add(e);
+                }
+            })
+            .subscribe().isDisposed());
 
-        assertEquals(Arrays.asList(null, ex), list);
+            assertEquals(Arrays.asList(null, ex), list);
+
+            TestHelper.assertError(errors, 0, OnErrorNotImplementedException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SerializedObserverTest.java
@@ -156,6 +156,7 @@ public class SerializedObserverTest {
     @Test
     public void runOutOfOrderConcurrencyTest() {
         ExecutorService tp = Executors.newFixedThreadPool(20);
+        List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestConcurrencySubscriber tw = new TestConcurrencySubscriber();
             // we need Synchronized + SafeObserver to handle synchronization plus life-cycle
@@ -190,6 +191,10 @@ public class SerializedObserverTest {
             @SuppressWarnings("unused")
             int numNextEvents = tw.assertEvents(null); // no check of type since we don't want to test barging results here, just interleaving behavior
             //            System.out.println("Number of events executed: " + numNextEvents);
+
+            for (int i = 0; i < 4; i++) {
+                TestHelper.assertUndeliverable(errors, i, RuntimeException.class);
+            }
         } catch (Throwable e) {
             fail("Concurrency test failed: " + e.getMessage());
             e.printStackTrace();
@@ -200,6 +205,8 @@ public class SerializedObserverTest {
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
+
+            RxJavaPlugins.reset();
         }
     }
 
@@ -955,24 +962,31 @@ public class SerializedObserverTest {
 
     @Test
     public void testErrorReentry() {
-        final AtomicReference<Observer<Integer>> serial = new AtomicReference<Observer<Integer>>();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final AtomicReference<Observer<Integer>> serial = new AtomicReference<Observer<Integer>>();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
-            @Override
-            public void onNext(Integer v) {
-                serial.get().onError(new TestException());
-                serial.get().onError(new TestException());
-                super.onNext(v);
-            }
-        };
-        SerializedObserver<Integer> sobs = new SerializedObserver<Integer>(to);
-        sobs.onSubscribe(Disposables.empty());
-        serial.set(sobs);
+            TestObserver<Integer> to = new TestObserver<Integer>() {
+                @Override
+                public void onNext(Integer v) {
+                    serial.get().onError(new TestException());
+                    serial.get().onError(new TestException());
+                    super.onNext(v);
+                }
+            };
+            SerializedObserver<Integer> sobs = new SerializedObserver<Integer>(to);
+            sobs.onSubscribe(Disposables.empty());
+            serial.set(sobs);
 
-        sobs.onNext(1);
+            sobs.onNext(1);
 
-        to.assertValue(1);
-        to.assertError(TestException.class);
+            to.assertValue(1);
+            to.assertError(TestException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/observers/SerializedObserverTest.java
@@ -192,7 +192,7 @@ public class SerializedObserverTest {
             int numNextEvents = tw.assertEvents(null); // no check of type since we don't want to test barging results here, just interleaving behavior
             //            System.out.println("Number of events executed: " + numNextEvents);
 
-            for (int i = 0; i < 4; i++) {
+            for (int i = 0; i < errors.size(); i++) {
                 TestHelper.assertUndeliverable(errors, i, RuntimeException.class);
             }
         } catch (Throwable e) {

--- a/src/test/java/io/reactivex/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SerializedSubscriberTest.java
@@ -158,6 +158,7 @@ public class SerializedSubscriberTest {
     @Test
     public void runOutOfOrderConcurrencyTest() {
         ExecutorService tp = Executors.newFixedThreadPool(20);
+        List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestConcurrencySubscriber tw = new TestConcurrencySubscriber();
             // we need Synchronized + SafeSubscriber to handle synchronization plus life-cycle
@@ -192,6 +193,10 @@ public class SerializedSubscriberTest {
             @SuppressWarnings("unused")
             int numNextEvents = tw.assertEvents(null); // no check of type since we don't want to test barging results here, just interleaving behavior
             //            System.out.println("Number of events executed: " + numNextEvents);
+
+            for (int i = 0; i < 4; i++) {
+                TestHelper.assertUndeliverable(errors, i, RuntimeException.class);
+            }
         } catch (Throwable e) {
             fail("Concurrency test failed: " + e.getMessage());
             e.printStackTrace();
@@ -202,6 +207,8 @@ public class SerializedSubscriberTest {
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
+
+            RxJavaPlugins.reset();
         }
     }
 
@@ -957,24 +964,31 @@ public class SerializedSubscriberTest {
 
     @Test
     public void testErrorReentry() {
-        final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<Subscriber<Integer>>();
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<Subscriber<Integer>>();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
-            @Override
-            public void onNext(Integer v) {
-                serial.get().onError(new TestException());
-                serial.get().onError(new TestException());
-                super.onNext(v);
-            }
-        };
-        SerializedSubscriber<Integer> sobs = new SerializedSubscriber<Integer>(ts);
-        sobs.onSubscribe(new BooleanSubscription());
-        serial.set(sobs);
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+                @Override
+                public void onNext(Integer v) {
+                    serial.get().onError(new TestException());
+                    serial.get().onError(new TestException());
+                    super.onNext(v);
+                }
+            };
+            SerializedSubscriber<Integer> sobs = new SerializedSubscriber<Integer>(ts);
+            sobs.onSubscribe(new BooleanSubscription());
+            serial.set(sobs);
 
-        sobs.onNext(1);
+            sobs.onNext(1);
 
-        ts.assertValue(1);
-        ts.assertError(TestException.class);
+            ts.assertValue(1);
+            ts.assertError(TestException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 
     @Test
@@ -1180,38 +1194,45 @@ public class SerializedSubscriberTest {
     @Test
     public void onCompleteOnErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-            final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
+                final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
 
-            BooleanSubscription bs = new BooleanSubscription();
+                BooleanSubscription bs = new BooleanSubscription();
 
-            so.onSubscribe(bs);
+                so.onSubscribe(bs);
 
-            final Throwable ex = new TestException();
+                final Throwable ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onError(ex);
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        so.onError(ex);
+                    }
+                };
+
+                Runnable r2 = new Runnable() {
+                    @Override
+                    public void run() {
+                        so.onComplete();
+                    }
+                };
+
+                TestHelper.race(r1, r2);
+
+                ts.awaitDone(5, TimeUnit.SECONDS);
+
+                if (ts.completions() != 0) {
+                    ts.assertResult();
+                    TestHelper.assertUndeliverable(errors, 0, TestException.class);
+                } else {
+                    ts.assertFailure(TestException.class).assertError(ex);
+                    assertTrue("" + errors, errors.isEmpty());
                 }
-            };
-
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onComplete();
-                }
-            };
-
-            TestHelper.race(r1, r2);
-
-            ts.awaitDone(5, TimeUnit.SECONDS);
-
-            if (ts.completions() != 0) {
-                ts.assertResult();
-            } else {
-                ts.assertFailure(TestException.class).assertError(ex);
+            } finally {
+                RxJavaPlugins.reset();
             }
         }
 

--- a/src/test/java/io/reactivex/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/SerializedSubscriberTest.java
@@ -194,7 +194,7 @@ public class SerializedSubscriberTest {
             int numNextEvents = tw.assertEvents(null); // no check of type since we don't want to test barging results here, just interleaving behavior
             //            System.out.println("Number of events executed: " + numNextEvents);
 
-            for (int i = 0; i < 4; i++) {
+            for (int i = 0; i < errors.size(); i++) {
                 TestHelper.assertUndeliverable(errors, i, RuntimeException.class);
             }
         } catch (Throwable e) {


### PR DESCRIPTION
Set plugin error tracking in some tests to avoid printing out `UndeliverableExceptions` (sometimes repeatedly in race tests) and assert the specific exception(s) instead.