### PR TITLE
Add timeout and unit to TimeoutException message

### DIFF
--- a/src/main/java/io/reactivex/internal/observers/BlockingMultiObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/BlockingMultiObserver.java
@@ -19,6 +19,8 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.util.*;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
+
 /**
  * A combined Observer that awaits the success or error signal via a CountDownLatch.
  * @param <T> the value type
@@ -148,7 +150,7 @@ implements SingleObserver<T>, CompletableObserver, MaybeObserver<T> {
                 BlockingHelper.verifyNonBlocking();
                 if (!await(timeout, unit)) {
                     dispose();
-                    throw ExceptionHelper.wrapOrThrow(new TimeoutException("timeout = " + timeout + ", unit = " + unit));
+                    throw ExceptionHelper.wrapOrThrow(new TimeoutException(timeoutMessage(timeout, unit)));
                 }
             } catch (InterruptedException ex) {
                 dispose();

--- a/src/main/java/io/reactivex/internal/observers/BlockingMultiObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/BlockingMultiObserver.java
@@ -148,7 +148,7 @@ implements SingleObserver<T>, CompletableObserver, MaybeObserver<T> {
                 BlockingHelper.verifyNonBlocking();
                 if (!await(timeout, unit)) {
                     dispose();
-                    throw ExceptionHelper.wrapOrThrow(new TimeoutException());
+                    throw ExceptionHelper.wrapOrThrow(new TimeoutException("timeout = " + timeout + ", unit = " + unit));
                 }
             } catch (InterruptedException ex) {
                 dispose();

--- a/src/main/java/io/reactivex/internal/observers/FutureObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/FutureObserver.java
@@ -92,7 +92,7 @@ implements Observer<T>, Future<T>, Disposable {
         if (getCount() != 0) {
             BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {
-                throw new TimeoutException();
+                throw new TimeoutException("timeout = " + timeout + ", unit = " + unit);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/observers/FutureObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/FutureObserver.java
@@ -23,6 +23,8 @@ import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.util.BlockingHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
+
 /**
  * An Observer + Future that expects exactly one upstream value and provides it
  * via the (blocking) Future API.
@@ -92,7 +94,7 @@ implements Observer<T>, Future<T>, Disposable {
         if (getCount() != 0) {
             BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {
-                throw new TimeoutException("timeout = " + timeout + ", unit = " + unit);
+                throw new TimeoutException(timeoutMessage(timeout, unit));
             }
         }
 

--- a/src/main/java/io/reactivex/internal/observers/FutureSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/FutureSingleObserver.java
@@ -22,6 +22,8 @@ import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.util.BlockingHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
+
 /**
  * An Observer + Future that expects exactly one upstream value and provides it
  * via the (blocking) Future API.
@@ -91,7 +93,7 @@ implements SingleObserver<T>, Future<T>, Disposable {
         if (getCount() != 0) {
             BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {
-                throw new TimeoutException("timeout = " + timeout + ", unit = " + unit);
+                throw new TimeoutException(timeoutMessage(timeout, unit));
             }
         }
 

--- a/src/main/java/io/reactivex/internal/observers/FutureSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/FutureSingleObserver.java
@@ -91,7 +91,7 @@ implements SingleObserver<T>, Future<T>, Disposable {
         if (getCount() != 0) {
             BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {
-                throw new TimeoutException();
+                throw new TimeoutException("timeout = " + timeout + ", unit = " + unit);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableTimeout.java
@@ -20,6 +20,8 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
+
 public final class CompletableTimeout extends Completable {
 
     final CompletableSource source;
@@ -104,7 +106,7 @@ public final class CompletableTimeout extends Completable {
             if (once.compareAndSet(false, true)) {
                 set.clear();
                 if (other == null) {
-                    downstream.onError(new TimeoutException("timeout = " + timeout + ", unit = " + unit));
+                    downstream.onError(new TimeoutException(timeoutMessage(timeout, unit)));
                 } else {
                     other.subscribe(new DisposeObserver());
                 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableTimeout.java
@@ -104,7 +104,7 @@ public final class CompletableTimeout extends Completable {
             if (once.compareAndSet(false, true)) {
                 set.clear();
                 if (other == null) {
-                    downstream.onError(new TimeoutException());
+                    downstream.onError(new TimeoutException("timeout = " + timeout + ", unit = " + unit));
                 } else {
                     other.subscribe(new DisposeObserver());
                 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -134,7 +134,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
             if (compareAndSet(idx, Long.MAX_VALUE)) {
                 SubscriptionHelper.cancel(upstream);
 
-                downstream.onError(new TimeoutException());
+                downstream.onError(new TimeoutException("timeout = " + timeout + ", unit = " + unit));
 
                 worker.dispose();
             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -23,6 +23,8 @@ import io.reactivex.internal.disposables.SequentialDisposable;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
+
 public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<T, T> {
     final long timeout;
     final TimeUnit unit;
@@ -134,7 +136,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
             if (compareAndSet(idx, Long.MAX_VALUE)) {
                 SubscriptionHelper.cancel(upstream);
 
-                downstream.onError(new TimeoutException("timeout = " + timeout + ", unit = " + unit));
+                downstream.onError(new TimeoutException(timeoutMessage(timeout, unit)));
 
                 worker.dispose();
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
@@ -129,7 +129,7 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
             if (compareAndSet(idx, Long.MAX_VALUE)) {
                 DisposableHelper.dispose(upstream);
 
-                downstream.onError(new TimeoutException());
+                downstream.onError(new TimeoutException("timeout = " + timeout + ", unit = " + unit));
 
                 worker.dispose();
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTimeoutTimed.java
@@ -21,6 +21,8 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
+
 public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstream<T, T> {
     final long timeout;
     final TimeUnit unit;
@@ -129,7 +131,7 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
             if (compareAndSet(idx, Long.MAX_VALUE)) {
                 DisposableHelper.dispose(upstream);
 
-                downstream.onError(new TimeoutException("timeout = " + timeout + ", unit = " + unit));
+                downstream.onError(new TimeoutException(timeoutMessage(timeout, unit)));
 
                 worker.dispose();
             }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleTimeout.java
@@ -21,6 +21,8 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
+
 public final class SingleTimeout<T> extends Single<T> {
 
     final SingleSource<T> source;
@@ -118,7 +120,7 @@ public final class SingleTimeout<T> extends Single<T> {
                 }
                 SingleSource<? extends T> other = this.other;
                 if (other == null) {
-                    downstream.onError(new TimeoutException("timeout = " + timeout + ", unit = " + unit));
+                    downstream.onError(new TimeoutException(timeoutMessage(timeout, unit)));
                 } else {
                     this.other = null;
                     other.subscribe(fallback);

--- a/src/main/java/io/reactivex/internal/subscribers/FutureSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/FutureSubscriber.java
@@ -24,6 +24,8 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BlockingHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
+
 /**
  * A Subscriber + Future that expects exactly one upstream value and provides it
  * via the (blocking) Future API.
@@ -93,7 +95,7 @@ implements FlowableSubscriber<T>, Future<T>, Subscription {
         if (getCount() != 0) {
             BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {
-                throw new TimeoutException("timeout = " + timeout + ", unit = " + unit);
+                throw new TimeoutException(timeoutMessage(timeout, unit));
             }
         }
 

--- a/src/main/java/io/reactivex/internal/subscribers/FutureSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/FutureSubscriber.java
@@ -93,7 +93,7 @@ implements FlowableSubscriber<T>, Future<T>, Subscription {
         if (getCount() != 0) {
             BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {
-                throw new TimeoutException();
+                throw new TimeoutException("timeout = " + timeout + ", unit = " + unit);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/internal/util/ExceptionHelper.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.util;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.exceptions.CompositeException;
@@ -121,6 +122,14 @@ public final class ExceptionHelper {
         throw (E)e;
     }
 
+    public static String timeoutMessage(long timeout, TimeUnit unit) {
+        return "The source did not signal an event for "
+                + timeout
+                + " "
+                + unit.toString().toLowerCase()
+                + " and has been terminated.";
+    }
+    
     static final class Termination extends Throwable {
 
         private static final long serialVersionUID = -4649703670690200604L;

--- a/src/test/java/io/reactivex/internal/observers/BlockingMultiObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/BlockingMultiObserverTest.java
@@ -13,9 +13,11 @@
 
 package io.reactivex.internal.observers;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
 import static org.junit.Assert.*;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.Test;
 
@@ -131,5 +133,18 @@ public class BlockingMultiObserverTest {
         }, 100, TimeUnit.MILLISECONDS);
 
         assertTrue(bmo.blockingGetError(1, TimeUnit.MINUTES) instanceof TestException);
+    }
+
+    @Test
+    public void blockingGetErrorTimedOut() {
+        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+
+        try {
+            assertNull(bmo.blockingGetError(1, TimeUnit.NANOSECONDS));
+            fail("Should have thrown");
+        } catch (RuntimeException expected) {
+            assertEquals(TimeoutException.class, expected.getCause().getClass());
+            assertEquals(timeoutMessage(1, TimeUnit.NANOSECONDS), expected.getCause().getMessage());
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/observers/FutureObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/FutureObserverTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.observers;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
 import static org.junit.Assert.*;
 
 import java.util.*;
@@ -351,5 +352,15 @@ public class FutureObserverTest {
         }, 500, TimeUnit.MILLISECONDS);
 
         assertEquals(1, fo.get().intValue());
+    }
+
+    @Test
+    public void getTimedOut() throws Exception {
+        try {
+            fo.get(1, TimeUnit.NANOSECONDS);
+            fail("Should have thrown");
+        } catch (TimeoutException expected) {
+            assertEquals(timeoutMessage(1, TimeUnit.NANOSECONDS), expected.getMessage());
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/observers/FutureSingleObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/FutureSingleObserverTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.observers;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
 import static org.junit.Assert.*;
 
 import java.util.concurrent.*;
@@ -89,8 +90,8 @@ public class FutureSingleObserverTest {
         try {
             f.get(100, TimeUnit.MILLISECONDS);
             fail("Should have thrown");
-        } catch (TimeoutException ex) {
-            // expected
+        } catch (TimeoutException expected) {
+            assertEquals(timeoutMessage(100, TimeUnit.MILLISECONDS), expected.getMessage());
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableTimeoutTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.completable;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
 import static org.junit.Assert.*;
 
 import java.util.List;
@@ -40,7 +41,7 @@ public class CompletableTimeoutTest {
         .timeout(100, TimeUnit.MILLISECONDS, Schedulers.io())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
-        .assertFailure(TimeoutException.class);
+        .assertFailureAndMessage(TimeoutException.class, timeoutMessage(100, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTest.java
@@ -13,10 +13,12 @@
 
 package io.reactivex.internal.operators.single;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
 import static org.junit.Assert.*;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.Test;
 
@@ -208,5 +210,15 @@ public class SingleTimeoutTest {
         } finally {
             RxJavaPlugins.reset();
         }
+    }
+
+    @Test
+    public void mainTimedOut() {
+        Single
+                .never()
+                .timeout(1, TimeUnit.NANOSECONDS)
+                .test()
+                .awaitDone(5, TimeUnit.SECONDS)
+                .assertFailureAndMessage(TimeoutException.class, timeoutMessage(1, TimeUnit.NANOSECONDS));
     }
 }

--- a/src/test/java/io/reactivex/internal/subscribers/FutureSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/FutureSubscriberTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.subscribers;
 
+import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
 import static org.junit.Assert.*;
 
 import java.util.*;
@@ -280,5 +281,15 @@ public class FutureSubscriberTest {
         }, 500, TimeUnit.MILLISECONDS);
 
         assertEquals(1, fs.get().intValue());
+    }
+
+    @Test
+    public void getTimedOut() throws Exception {
+        try {
+            fs.get(1, TimeUnit.NANOSECONDS);
+            fail("Should have thrown");
+        } catch (TimeoutException expected) {
+            assertEquals(timeoutMessage(1, TimeUnit.NANOSECONDS), expected.getMessage());
+        }
     }
 }


### PR DESCRIPTION
This is a small enhancement to help with crash/log debugging.

Right now often times you get a stacktrace that points only to RxJava:

```java
java.util.concurrent.TimeoutException
        at
io.reactivex.internal.operators.flowable.FlowableTimeoutTimed$TimeoutSubscriber.onTimeout(FlowableTimeoutTimed.java:137)
        at
io.reactivex.internal.operators.flowable.FlowableTimeoutTimed$TimeoutTask.run(FlowableTimeoutTimed.java:169)
        at
io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
        at
io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at
java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at
java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748) 
```

Adding `timeout` and `unit` values can help find related user code faster.

I'm not advocating for particular message, it can be something even shorter, like `$timeout $unit`. 

It can also be extracted in a method if you see value in that. 