### PR TITLE
Implement ReplayBufferStrategy strategy for ReplaySubject

### DIFF
--- a/src/main/java/io/reactivex/ReplayBufferStrategy.java
+++ b/src/main/java/io/reactivex/ReplayBufferStrategy.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex;
+
+public enum ReplayBufferStrategy {
+    /**
+     * The replay subject would buffer <em>all</em> onNext values.
+     * */
+    ALWAYS,
+    /**
+     * The replay subject would buffer only while no downstream is available to consume the onNext values. Buffered
+     * values would be emitted to any downstream until the onNext is get called, which means <em>only</em> in
+     * onNext calls the buffered values would be cleaned.
+     * */
+    NO_OBSERVER,
+    /**
+     * The replay subject would buffer only while no downstream is available to consume the onNext values. After the
+     * first downstream is subscribed all buffered values would be emitted then buffer would be cleaned.
+     * */
+    NO_OBSERVER_EMIT_ONCE
+}

--- a/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/ReplaySubjectTest.java
@@ -196,6 +196,541 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
+    public void testCompletedStopsEmittingDataNoObserver() {
+        ReplaySubject<Integer> channel = ReplaySubject.create(ReplayBufferStrategy.NO_OBSERVER);
+
+        Observer<Object> observerA = TestHelper.mockObserver();
+        Observer<Object> observerB = TestHelper.mockObserver();
+        Observer<Object> observerC = TestHelper.mockObserver();
+
+        TestObserver<Object> to = new TestObserver<Object>(observerA);
+
+        channel.subscribe(to);
+        channel.subscribe(observerB);
+
+        InOrder inOrderA = inOrder(observerA);
+        InOrder inOrderB = inOrder(observerB);
+        InOrder inOrderC = inOrder(observerC);
+
+        channel.onNext(42);
+
+        inOrderA.verify(observerA).onNext(42);
+        inOrderB.verify(observerB).onNext(42);
+
+        to.dispose();
+        inOrderA.verifyNoMoreInteractions();
+
+        channel.onNext(4711);
+
+        inOrderB.verify(observerB).onNext(4711);
+
+        channel.onComplete();
+
+        inOrderB.verify(observerB).onComplete();
+
+        channel.subscribe(observerC);
+
+        inOrderC.verify(observerC).onComplete();
+
+        channel.onNext(13);
+
+        inOrderB.verifyNoMoreInteractions();
+        inOrderC.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSequenceNoObserver() {
+        ReplaySubject<String> subject = ReplaySubject.create(ReplayBufferStrategy.NO_OBSERVER);
+
+        Observer<String> observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+
+        Disposable disposable = getDisposable(observer);
+
+        subject.onNext("one");
+
+        disposable.dispose();
+
+        subject.onNext("two");
+        subject.onNext("three");
+
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+
+        subject.onNext("four");
+
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, times(1)).onNext("four");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testSequenceNoOnNextNoObserver() {
+        ReplaySubject<String> subject = ReplaySubject.create(ReplayBufferStrategy.NO_OBSERVER);
+
+        Observer<String> observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+
+        Disposable disposable = getDisposable(observer);
+
+        subject.onNext("one");
+
+        disposable.dispose();
+
+        subject.onNext("two");
+        subject.onNext("three");
+
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testCompletedStopsEmittingDataNoObserverEmitOnce() {
+        ReplaySubject<Integer> channel = ReplaySubject.create(ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        Observer<Object> observerA = TestHelper.mockObserver();
+        Observer<Object> observerB = TestHelper.mockObserver();
+        Observer<Object> observerC = TestHelper.mockObserver();
+
+        TestObserver<Object> to = new TestObserver<Object>(observerA);
+
+        channel.subscribe(to);
+        channel.subscribe(observerB);
+
+        InOrder inOrderA = inOrder(observerA);
+        InOrder inOrderB = inOrder(observerB);
+        InOrder inOrderC = inOrder(observerC);
+
+        channel.onNext(42);
+
+        inOrderA.verify(observerA).onNext(42);
+        inOrderB.verify(observerB).onNext(42);
+
+        to.dispose();
+        inOrderA.verifyNoMoreInteractions();
+
+        channel.onNext(4711);
+
+        inOrderB.verify(observerB).onNext(4711);
+
+        channel.onComplete();
+
+        inOrderB.verify(observerB).onComplete();
+
+        channel.subscribe(observerC);
+
+        inOrderC.verify(observerC).onComplete();
+
+        channel.onNext(13);
+
+        inOrderB.verifyNoMoreInteractions();
+        inOrderC.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testSequenceNoObserverEmitOnce() {
+        ReplaySubject<String> subject = ReplaySubject.create(ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        Observer<String> observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+
+        Disposable disposable = getDisposable(observer);
+
+        subject.onNext("one");
+
+        disposable.dispose();
+
+        subject.onNext("two");
+        subject.onNext("three");
+
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+
+        subject.onNext("four");
+
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, times(1)).onNext("four");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testSequenceNoOnNextNoObserverEmitOnce() {
+        ReplaySubject<String> subject = ReplaySubject.create(ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        Observer<String> observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+
+        Disposable disposable = getDisposable(observer);
+
+        subject.onNext("one");
+
+        disposable.dispose();
+
+        subject.onNext("two");
+        subject.onNext("three");
+
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testErrorNoObserver() {
+        ReplaySubject<String> subject = ReplaySubject.create(ReplayBufferStrategy.NO_OBSERVER);
+
+        assertErrorNoObserver(subject);
+    }
+
+    @Test
+    public void testErrorNoObserverSizeBound() {
+        ReplaySubject<String> subject = ReplaySubject.createWithSize(3, ReplayBufferStrategy.NO_OBSERVER);
+
+        assertErrorNoObserver(subject);
+    }
+
+    @Test
+    public void testErrorNoObserverUnbounded() {
+        ReplaySubject<String> subject = ReplaySubject.createUnbounded(ReplayBufferStrategy.NO_OBSERVER);
+
+        assertErrorNoObserver(subject);
+    }
+
+    @Test
+    public void testErrorNoObserverWithTime() {
+        ReplaySubject<String> subject = ReplaySubject.createWithTime(1, TimeUnit.SECONDS, new TestScheduler(),
+                ReplayBufferStrategy.NO_OBSERVER);
+
+        assertErrorNoObserver(subject);
+    }
+
+    @Test
+    public void testErrorNoObserverWithTimeAndSize() {
+        ReplaySubject<String> subject = ReplaySubject.createWithTimeAndSize(1, TimeUnit.SECONDS,
+                new TestScheduler(), 3, ReplayBufferStrategy.NO_OBSERVER);
+
+        assertErrorNoObserver(subject);
+    }
+
+    @Test
+    public void testErrorNoObserverEmitOnce() {
+        ReplaySubject<String> subject = ReplaySubject.create(ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        assertErrorNoObserverEmitOnce(subject);
+    }
+
+    @Test
+    public void testErrorNoObserverEmitOnceSizeBound() {
+        ReplaySubject<String> subject = ReplaySubject.createWithSize(3,
+                ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        assertErrorNoObserverEmitOnce(subject);
+    }
+
+    @Test
+    public void testErrorNoObserverEmitOnceUnbounded() {
+        ReplaySubject<String> subject = ReplaySubject.createUnbounded(
+                ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        assertErrorNoObserverEmitOnce(subject);
+    }
+
+    @Test
+    public void testErrorNoObserverEmitOnceWithTime() {
+        ReplaySubject<String> subject = ReplaySubject.createWithTime(1, TimeUnit.SECONDS, new TestScheduler(),
+                ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        assertErrorNoObserverEmitOnce(subject);
+    }
+
+    @Test
+    public void testErrorNoObserverEmitOnceWithTimeAndSize() {
+        ReplaySubject<String> subject = ReplaySubject.createWithTimeAndSize(1, TimeUnit.SECONDS,
+                new TestScheduler(), 3, ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        assertErrorNoObserverEmitOnce(subject);
+    }
+
+    private void assertErrorNoObserver(ReplaySubject<String> subject) {
+        assertErrorTwoFirstObserver(subject);
+        Observer<String> observer;
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, times(1)).onError(testException);
+        verify(observer, Mockito.never()).onComplete();
+    }
+
+    private void assertErrorNoObserverEmitOnce(ReplaySubject<String> subject) {
+        assertErrorTwoFirstObserver(subject);
+        Observer<String> observer;
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, times(1)).onError(testException);
+        verify(observer, Mockito.never()).onComplete();
+    }
+
+    private void assertErrorTwoFirstObserver(ReplaySubject<String> subject) {
+        Observer<String> observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+
+        Disposable disposable = getDisposable(observer);
+
+        subject.onNext("one");
+
+        disposable.dispose();
+
+        subject.onNext("two");
+        subject.onNext("three");
+        subject.onError(testException);
+
+        subject.onNext("four");
+        subject.onError(new Throwable());
+        subject.onComplete();
+
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+        verify(observer, Mockito.never()).onComplete();
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, times(1)).onError(testException);
+        verify(observer, Mockito.never()).onComplete();
+    }
+
+    @Test
+    public void testCompleteNoObserver() {
+        ReplaySubject<String> subject = ReplaySubject.create(ReplayBufferStrategy.NO_OBSERVER);
+
+        assertCompleteNoObserver(subject);
+    }
+
+    @Test
+    public void testCompleteNoObserverSizeBound() {
+        ReplaySubject<String> subject = ReplaySubject.createWithSize(3, ReplayBufferStrategy.NO_OBSERVER);
+
+        assertCompleteNoObserver(subject);
+    }
+
+    @Test
+    public void testCompleteNoObserverUnbounded() {
+        ReplaySubject<String> subject = ReplaySubject.createUnbounded(ReplayBufferStrategy.NO_OBSERVER);
+
+        assertCompleteNoObserver(subject);
+    }
+
+    @Test
+    public void testCompleteNoObserverWithTime() {
+        ReplaySubject<String> subject = ReplaySubject.createWithTime(1, TimeUnit.SECONDS, new TestScheduler(),
+                ReplayBufferStrategy.NO_OBSERVER);
+
+        assertCompleteNoObserver(subject);
+    }
+
+    @Test
+    public void testCompleteNoObserverWithTimeAndSize() {
+        ReplaySubject<String> subject = ReplaySubject.createWithTimeAndSize(1, TimeUnit.SECONDS,
+                new TestScheduler(), 3, ReplayBufferStrategy.NO_OBSERVER);
+
+        assertCompleteNoObserver(subject);
+    }
+
+    @Test
+    public void testCompleteNoObserverEmitOnce() {
+        ReplaySubject<String> subject = ReplaySubject.create(ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        assertCompleteNoObserverEmitOnce(subject);
+    }
+
+    @Test
+    public void testCompleteNoObserverEmitOnceSizeBound() {
+        ReplaySubject<String> subject = ReplaySubject.createWithSize(3, ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        assertCompleteNoObserverEmitOnce(subject);
+    }
+
+    @Test
+    public void testCompleteNoObserverEmitOnceUnbounded() {
+        ReplaySubject<String> subject = ReplaySubject.createUnbounded(
+                ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        assertCompleteNoObserverEmitOnce(subject);
+    }
+
+    @Test
+    public void testCompleteNoObserverEmitOnceWithTime() {
+        ReplaySubject<String> subject = ReplaySubject.createWithTime(1, TimeUnit.SECONDS, new TestScheduler(),
+                ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        assertCompleteNoObserverEmitOnce(subject);
+    }
+
+    @Test
+    public void testCompleteNoObserverEmitOnceWithTimeAndSize() {
+        ReplaySubject<String> subject = ReplaySubject.createWithTimeAndSize(1, TimeUnit.SECONDS,
+                new TestScheduler(), 3, ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE);
+
+        assertCompleteNoObserverEmitOnce(subject);
+    }
+
+    private void assertCompleteNoObserverEmitOnce(ReplaySubject<String> subject) {
+        assertCompleteTwoFirstObserver(subject);
+        Observer<String> observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, times(1)).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+    }
+
+    private void assertCompleteNoObserver(ReplaySubject<String> subject) {
+        assertCompleteTwoFirstObserver(subject);
+        Observer<String> observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, times(1)).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+    }
+
+    private void assertCompleteTwoFirstObserver(ReplaySubject<String> subject) {
+        Observer<String> observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+
+        Disposable disposable = getDisposable(observer);
+
+        subject.onNext("one");
+
+        disposable.dispose();
+
+        subject.onNext("two");
+        subject.onNext("three");
+        subject.onComplete();
+
+        subject.onNext("four");
+        subject.onError(new Throwable());
+        subject.onComplete();
+
+        verify(observer, times(1)).onNext("one");
+        verify(observer, Mockito.never()).onNext("two");
+        verify(observer, Mockito.never()).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, Mockito.never()).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+
+        observer = TestHelper.mockObserver();
+        subject.subscribe(observer);
+        verify(observer, Mockito.never()).onNext("one");
+        verify(observer, times(1)).onNext("two");
+        verify(observer, times(1)).onNext("three");
+        verify(observer, Mockito.never()).onNext("four");
+        verify(observer, times(1)).onComplete();
+        verify(observer, Mockito.never()).onError(any(Throwable.class));
+    }
+
+    private Disposable getDisposable(Observer<String> observer) {
+        ArgumentCaptor<Disposable> disposableCaptor = ArgumentCaptor.forClass(Disposable.class);
+        verify(observer, times(1)).onSubscribe(disposableCaptor.capture());
+        return disposableCaptor.getValue();
+    }
+
+    @Test
     public void testSubscribeMidSequence() {
         ReplaySubject<String> subject = ReplaySubject.create();
 


### PR DESCRIPTION
With this pull request, I propose strategy design pattern for handling different policies to buffer onNext values of ReplaySubject. These strategies would be useful specifically in Android, and can replace LiveData behaviour on emitting buffered values to UI components after configuration changes. For instance, when a View is subscribed to its ViewModel, by ReplaySubject instead of LiveData, and user decide to rotate the View, the observers of View would be disposed and miss new events while rotating. Such event could be a response from server, then by ReplayBufferStrategy.NO_OBSERVER strategy after rotating, the View can be notified with the response of the server.  In this scenario, after subscribing all observers of View to ReplaySubject of ViewModel, the onNext must be called to clear the buffer.

Also there is ReplayBufferStrategy.NO_OBSERVER_EMIT_ONCE strategy, which is a consequence of adding ReplayBufferStrategy.NO_OBSERVER strategy. It would be useful if in the above example the View has exactly one observer, so after all subscription we don't need to call onNext to clear the buffer.

In case of any inappropriate or wrong code, please notify me to fix it. Thank you so much.