### PR TITLE
2.x Wiki: Remove mention of i.r.f.Functions

### DIFF
--- a/docs/What's-different-in-2.0.md
+++ b/docs/What's-different-in-2.0.md
@@ -294,8 +294,6 @@ We followed the naming convention of Java 8 by defining `io.reactivex.functions.
 
 In addition, operators requiring a predicate no longer use `Func1<T, Boolean>` but have a separate, primitive-returning type of `Predicate<T>` (allows better inlining due to no autoboxing).
 
-The `io.reactivex.functions.Functions` utility class offers common function sources and conversions to `Function<Object[], R>`.
-
 # Subscriber
 
 The Reactive-Streams specification has its own Subscriber as an interface. This interface is lightweight and combines request management with cancellation into a single interface `org.reactivestreams.Subscription` instead of having `rx.Producer` and `rx.Subscription` separately. This allows creating stream consumers with less internal state than the quite heavy `rx.Subscriber` of 1.x.


### PR DESCRIPTION
The `io.reactivex.functions.Functions` utility method has been made internal a long ago and should not be mentioned.

Resolves: #6239