### PR TITLE
Add delaySubscription() methods to Completable #5081

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -1389,6 +1389,47 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
+     * Returns an Completable that delays the subscription to the source CompletableSource by a given amount of time.
+     * <p>
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This version of {@code delaySubscription} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param delay the time to delay the subscription
+     * @param unit  the time unit of {@code delay}
+     * @return a Completable that delays the subscription to the source CompletableSource by the given amount
+     * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
+    public final Completable delaySubscription(long delay, TimeUnit unit) {
+        return delaySubscription(delay, unit, Schedulers.computation());
+    }
+
+    /**
+     * Returns an Completable that delays the subscription to the source CompletableSource by a given amount of time,
+     * both waiting and subscribing on a given Scheduler.
+     * <p>
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
+     * </dl>
+     *
+     * @param delay     the time to delay the subscription
+     * @param unit      the time unit of {@code delay}
+     * @param scheduler the Scheduler on which the waiting and subscription will happen
+     * @return an Completable that delays the subscription to the source CompletableSource by a given
+     * amount, waiting and subscribing on the given Scheduler
+     * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    public final Completable delaySubscription(long delay, TimeUnit unit, Scheduler scheduler) {
+        return Completable.timer(delay, unit, scheduler).andThen(this);
+    }
+
+    /**
      * Returns a Completable which calls the given onComplete callback if this Completable completes.
      * <p>
      * <img width="640" height="304" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.doOnComplete.png" alt="">

--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -1389,7 +1389,7 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Returns an Completable that delays the subscription to the source CompletableSource by a given amount of time.
+     * Returns a Completable that delays the subscription to the source CompletableSource by a given amount of time.
      * <p>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1399,16 +1399,18 @@ public abstract class Completable implements CompletableSource {
      * @param delay the time to delay the subscription
      * @param unit  the time unit of {@code delay}
      * @return a Completable that delays the subscription to the source CompletableSource by the given amount
+     * @since 2.2.3 - experimental
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      */
     @CheckReturnValue
+    @Experimental
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Completable delaySubscription(long delay, TimeUnit unit) {
         return delaySubscription(delay, unit, Schedulers.computation());
     }
 
     /**
-     * Returns an Completable that delays the subscription to the source CompletableSource by a given amount of time,
+     * Returns a Completable that delays the subscription to the source CompletableSource by a given amount of time,
      * both waiting and subscribing on a given Scheduler.
      * <p>
      * <dl>
@@ -1419,11 +1421,13 @@ public abstract class Completable implements CompletableSource {
      * @param delay     the time to delay the subscription
      * @param unit      the time unit of {@code delay}
      * @param scheduler the Scheduler on which the waiting and subscription will happen
-     * @return an Completable that delays the subscription to the source CompletableSource by a given
+     * @return a Completable that delays the subscription to the source CompletableSource by a given
      * amount, waiting and subscribing on the given Scheduler
+     * @since 2.2.3 - experimental
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      */
     @CheckReturnValue
+    @Experimental
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Completable delaySubscription(long delay, TimeUnit unit, Scheduler scheduler) {
         return Completable.timer(delay, unit, scheduler).andThen(this);

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableDelayTest.java
@@ -14,9 +14,6 @@
 package io.reactivex.internal.operators.completable;
 
 import static org.junit.Assert.assertNotEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -24,7 +21,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 import io.reactivex.CompletableSource;
-import io.reactivex.Observer;
 import io.reactivex.TestHelper;
 import io.reactivex.Completable;
 import io.reactivex.exceptions.TestException;
@@ -153,10 +149,8 @@ public class CompletableDelayTest {
 
         Completable result = Completable.complete()
                 .delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
-        Observer<Void> o = TestHelper.mockObserver();
-        TestObserver<Void> to = new TestObserver<Void>(o);
+        TestObserver<Void> to = result.test();
 
-        result.subscribe(to);
         to.assertEmpty();
 
         scheduler.advanceTimeBy(90, TimeUnit.MILLISECONDS);
@@ -165,28 +159,21 @@ public class CompletableDelayTest {
         scheduler.advanceTimeBy(15, TimeUnit.MILLISECONDS);
 
         to.assertEmpty();
-        verify(o, never()).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
     }
 
     @Test
     public void testDelaySubscriptionDisposeBeforeTime() {
         TestScheduler scheduler = new TestScheduler();
+
         Completable result = Completable.complete()
                 .delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
-
-        Observer<Void> o = TestHelper.mockObserver();
-        TestObserver<Void> to = new TestObserver<Void>(o);
-
-        result.subscribe(to);
+        TestObserver<Void> to = result.test();
 
         to.assertEmpty();
         scheduler.advanceTimeBy(90, TimeUnit.MILLISECONDS);
         to.dispose();
         scheduler.advanceTimeBy(15, TimeUnit.MILLISECONDS);
-
-        verify(o, never()).onComplete();
-        verify(o, never()).onError(any(Throwable.class));
+        to.assertEmpty();
     }
 
     @Test
@@ -194,17 +181,11 @@ public class CompletableDelayTest {
         TestScheduler scheduler = new TestScheduler();
         Completable result = Completable.complete()
                 .delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
-
-        Observer<Void> o = TestHelper.mockObserver();
-        TestObserver<Void> to = new TestObserver<Void>(o);
-
-        result.subscribe(to);
+        TestObserver<Void> to = result.test();
 
         scheduler.advanceTimeBy(90, TimeUnit.MILLISECONDS);
         to.assertEmpty();
         scheduler.advanceTimeBy(15, TimeUnit.MILLISECONDS);
-        to.assertComplete();
-
-        verify(o, never()).onError(any(Throwable.class));
+        to.assertResult();
     }
 }

--- a/src/test/java/io/reactivex/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/validators/ParamValidationCheckerTest.java
@@ -261,6 +261,10 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Completable.class, 0, ParamMode.ANY, "delay", Long.TYPE, TimeUnit.class, Scheduler.class));
         addOverride(new ParamOverride(Completable.class, 0, ParamMode.ANY, "delay", Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE));
 
+        // negative time is considered as zero time
+        addOverride(new ParamOverride(Completable.class, 0, ParamMode.ANY, "delaySubscription", Long.TYPE, TimeUnit.class));
+        addOverride(new ParamOverride(Completable.class, 0, ParamMode.ANY, "delaySubscription", Long.TYPE, TimeUnit.class, Scheduler.class));
+
         // zero repeat is allowed
         addOverride(new ParamOverride(Completable.class, 0, ParamMode.NON_NEGATIVE, "repeat", Long.TYPE));
 


### PR DESCRIPTION
Since Observable, Single already have `delaySubscription()`, but Completable doesn't, I added these methods to the code.