### PR TITLE
2.x: Add Completable.delaySubscription marble, fix some javadoc

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -1393,6 +1393,7 @@ public abstract class Completable implements CompletableSource {
     /**
      * Returns a Completable that delays the subscription to the source CompletableSource by a given amount of time.
      * <p>
+     * <img width="640" height="475" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.delaySubscription.t.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code delaySubscription} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -1415,6 +1416,7 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable that delays the subscription to the source CompletableSource by a given amount of time,
      * both waiting and subscribing on a given Scheduler.
      * <p>
+     * <img width="640" height="420" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.delaySubscription.ts.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>

--- a/src/main/java/io/reactivex/internal/fuseable/ConditionalSubscriber.java
+++ b/src/main/java/io/reactivex/internal/fuseable/ConditionalSubscriber.java
@@ -16,7 +16,7 @@ package io.reactivex.internal.fuseable;
 import io.reactivex.FlowableSubscriber;
 
 /**
- * A Subscriber with an additional onNextIf(T) method that
+ * A Subscriber with an additional {@link #tryOnNext(Object)} method that
  * tells the caller the specified value has been accepted or
  * not.
  *
@@ -30,6 +30,7 @@ public interface ConditionalSubscriber<T> extends FlowableSubscriber<T> {
      * Conditionally takes the value.
      * @param t the value to deliver
      * @return true if the value has been accepted, false if the value has been rejected
+     * and the next value can be sent immediately
      */
     boolean tryOnNext(T t);
 }


### PR DESCRIPTION
- Add marbles to the new `Completable.delaySubscription` operator.
- Fix the method name referenced in the `ConditionalSubscriber` javadoc.

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.delaySubscription.t.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.delaySubscription.ts.png)