### PR TITLE
2.x: Fix cancel/dispose upon upstream switch for some operators

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatArray.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatArray.java
@@ -59,6 +59,7 @@ public final class FlowableConcatArray<T> extends Flowable<T> {
         long produced;
 
         ConcatArraySubscriber(Publisher<? extends T>[] sources, boolean delayError, Subscriber<? super T> downstream) {
+            super(false);
             this.downstream = downstream;
             this.sources = sources;
             this.delayError = delayError;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
@@ -571,6 +571,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
         long produced;
 
         ConcatMapInner(ConcatMapSupport<R> parent) {
+            super(false);
             this.parent = parent;
         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
@@ -12,10 +12,16 @@
  */
 package io.reactivex.internal.operators.flowable;
 
-import org.reactivestreams.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.*;
-import io.reactivex.internal.subscriptions.SubscriptionArbiter;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.Flowable;
+import io.reactivex.FlowableSubscriber;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -35,94 +41,105 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
 
     @Override
     public void subscribeActual(final Subscriber<? super T> child) {
-        final SubscriptionArbiter serial = new SubscriptionArbiter();
-        child.onSubscribe(serial);
-
-        FlowableSubscriber<U> otherSubscriber = new DelaySubscriber(serial, child);
-
-        other.subscribe(otherSubscriber);
+        MainSubscriber<T> parent = new MainSubscriber<T>(child, main);
+        child.onSubscribe(parent);
+        other.subscribe(parent.other);
     }
 
-    final class DelaySubscriber implements FlowableSubscriber<U> {
-        final SubscriptionArbiter serial;
-        final Subscriber<? super T> child;
-        boolean done;
+    static final class MainSubscriber<T> extends AtomicLong implements FlowableSubscriber<T>, Subscription {
 
-        DelaySubscriber(SubscriptionArbiter serial, Subscriber<? super T> child) {
-            this.serial = serial;
-            this.child = child;
+        private static final long serialVersionUID = 2259811067697317255L;
+
+        final Subscriber<? super T> downstream;
+
+        final Publisher<? extends T> main;
+
+        final OtherSubscriber other;
+
+        final AtomicReference<Subscription> upstream;
+
+        MainSubscriber(Subscriber<? super T> downstream, Publisher<? extends T> main) {
+            this.downstream = downstream;
+            this.main = main;
+            this.other = new OtherSubscriber();
+            this.upstream = new AtomicReference<Subscription>();
+        }
+
+        void next() {
+            main.subscribe(this);
         }
 
         @Override
-        public void onSubscribe(final Subscription s) {
-            serial.setSubscription(new DelaySubscription(s));
-            s.request(Long.MAX_VALUE);
+        public void onNext(T t) {
+            downstream.onNext(t);
         }
 
         @Override
-        public void onNext(U t) {
-            onComplete();
-        }
-
-        @Override
-        public void onError(Throwable e) {
-            if (done) {
-                RxJavaPlugins.onError(e);
-                return;
-            }
-            done = true;
-            child.onError(e);
+        public void onError(Throwable t) {
+            downstream.onError(t);
         }
 
         @Override
         public void onComplete() {
-            if (done) {
-                return;
-            }
-            done = true;
-
-            main.subscribe(new OnCompleteSubscriber());
+            downstream.onComplete();
         }
 
-        final class DelaySubscription implements Subscription {
-
-            final Subscription upstream;
-
-            DelaySubscription(Subscription s) {
-                this.upstream = s;
-            }
-
-            @Override
-            public void request(long n) {
-                // ignored
-            }
-
-            @Override
-            public void cancel() {
-                upstream.cancel();
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                SubscriptionHelper.deferredRequest(upstream, this, n);
             }
         }
 
-        final class OnCompleteSubscriber implements FlowableSubscriber<T> {
+        @Override
+        public void cancel() {
+            SubscriptionHelper.cancel(other);
+            SubscriptionHelper.cancel(upstream);
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            SubscriptionHelper.deferredSetOnce(upstream, this, s);
+        }
+
+        final class OtherSubscriber extends AtomicReference<Subscription> implements FlowableSubscriber<Object> {
+
+            private static final long serialVersionUID = -3892798459447644106L;
+
             @Override
             public void onSubscribe(Subscription s) {
-                serial.setSubscription(s);
+                if (SubscriptionHelper.setOnce(this, s)) {
+                    s.request(Long.MAX_VALUE);
+                }
             }
 
             @Override
-            public void onNext(T t) {
-                child.onNext(t);
+            public void onNext(Object t) {
+                Subscription s = get();
+                if (s != SubscriptionHelper.CANCELLED) {
+                    lazySet(SubscriptionHelper.CANCELLED);
+                    s.cancel();
+                    next();
+                }
             }
 
             @Override
             public void onError(Throwable t) {
-                child.onError(t);
+                Subscription s = get();
+                if (s != SubscriptionHelper.CANCELLED) {
+                    downstream.onError(t);
+                } else {
+                    RxJavaPlugins.onError(t);
+                }
             }
 
             @Override
             public void onComplete() {
-                child.onComplete();
+                Subscription s = get();
+                if (s != SubscriptionHelper.CANCELLED) {
+                    next();
+                }
             }
         }
-    }
+}
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOther.java
@@ -12,15 +12,11 @@
  */
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.*;
 
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
+import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
-import io.reactivex.FlowableSubscriber;
+import io.reactivex.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnErrorNext.java
@@ -58,6 +58,7 @@ public final class FlowableOnErrorNext<T> extends AbstractFlowableWithUpstream<T
         long produced;
 
         OnErrorNextSubscriber(Subscriber<? super T> actual, Function<? super Throwable, ? extends Publisher<? extends T>> nextSupplier, boolean allowFatal) {
+            super(false);
             this.downstream = actual;
             this.nextSupplier = nextSupplier;
             this.allowFatal = allowFatal;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeat.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeat.java
@@ -29,7 +29,7 @@ public final class FlowableRepeat<T> extends AbstractFlowableWithUpstream<T, T> 
 
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
-        SubscriptionArbiter sa = new SubscriptionArbiter();
+        SubscriptionArbiter sa = new SubscriptionArbiter(false);
         s.onSubscribe(sa);
 
         RepeatSubscriber<T> rs = new RepeatSubscriber<T>(s, count != Long.MAX_VALUE ? count - 1 : Long.MAX_VALUE, sa, source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatUntil.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatUntil.java
@@ -31,7 +31,7 @@ public final class FlowableRepeatUntil<T> extends AbstractFlowableWithUpstream<T
 
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
-        SubscriptionArbiter sa = new SubscriptionArbiter();
+        SubscriptionArbiter sa = new SubscriptionArbiter(false);
         s.onSubscribe(sa);
 
         RepeatSubscriber<T> rs = new RepeatSubscriber<T>(s, until, sa, source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRepeatWhen.java
@@ -143,6 +143,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
 
         WhenSourceSubscriber(Subscriber<? super T> actual, FlowableProcessor<U> processor,
                 Subscription receiver) {
+            super(false);
             this.downstream = actual;
             this.processor = processor;
             this.receiver = receiver;
@@ -160,6 +161,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
         }
 
         protected final void again(U signal) {
+            setSubscription(EmptySubscription.INSTANCE);
             long p = produced;
             if (p != 0L) {
                 produced = 0L;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryBiPredicate.java
@@ -33,7 +33,7 @@ public final class FlowableRetryBiPredicate<T> extends AbstractFlowableWithUpstr
 
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
-        SubscriptionArbiter sa = new SubscriptionArbiter();
+        SubscriptionArbiter sa = new SubscriptionArbiter(false);
         s.onSubscribe(sa);
 
         RetryBiSubscriber<T> rs = new RetryBiSubscriber<T>(s, predicate, sa, source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRetryPredicate.java
@@ -35,7 +35,7 @@ public final class FlowableRetryPredicate<T> extends AbstractFlowableWithUpstrea
 
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
-        SubscriptionArbiter sa = new SubscriptionArbiter();
+        SubscriptionArbiter sa = new SubscriptionArbiter(false);
         s.onSubscribe(sa);
 
         RetrySubscriber<T> rs = new RetrySubscriber<T>(s, count, predicate, sa, source);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmpty.java
@@ -43,7 +43,7 @@ public final class FlowableSwitchIfEmpty<T> extends AbstractFlowableWithUpstream
             this.downstream = actual;
             this.other = other;
             this.empty = true;
-            this.arbiter = new SubscriptionArbiter();
+            this.arbiter = new SubscriptionArbiter(false);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeout.java
@@ -208,6 +208,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
         TimeoutFallbackSubscriber(Subscriber<? super T> actual,
                 Function<? super T, ? extends Publisher<?>> itemTimeoutIndicator,
                         Publisher<? extends T> fallback) {
+            super(true);
             this.downstream = actual;
             this.itemTimeoutIndicator = itemTimeoutIndicator;
             this.task = new SequentialDisposable();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -196,6 +196,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
 
         TimeoutFallbackSubscriber(Subscriber<? super T> actual, long timeout, TimeUnit unit,
                 Scheduler.Worker worker, Publisher<? extends T> fallback) {
+            super(true);
             this.downstream = actual;
             this.timeout = timeout;
             this.unit = unit;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
@@ -244,7 +244,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
 
             @Override
             public void onSubscribe(Disposable d) {
-                DisposableHelper.set(this, d);
+                DisposableHelper.replace(this, d);
             }
 
             @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeatWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRepeatWhen.java
@@ -92,7 +92,7 @@ public final class ObservableRepeatWhen<T> extends AbstractObservableWithUpstrea
 
         @Override
         public void onSubscribe(Disposable d) {
-            DisposableHelper.replace(this.upstream, d);
+            DisposableHelper.setOnce(this.upstream, d);
         }
 
         @Override
@@ -109,6 +109,7 @@ public final class ObservableRepeatWhen<T> extends AbstractObservableWithUpstrea
         @Override
         public void onComplete() {
             active = false;
+            DisposableHelper.replace(upstream, null);
             signaller.onNext(0);
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryBiPredicate.java
@@ -58,7 +58,7 @@ public final class ObservableRetryBiPredicate<T> extends AbstractObservableWithU
 
         @Override
         public void onSubscribe(Disposable d) {
-            upstream.update(d);
+            upstream.replace(d);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryPredicate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryPredicate.java
@@ -61,7 +61,7 @@ public final class ObservableRetryPredicate<T> extends AbstractObservableWithUps
 
         @Override
         public void onSubscribe(Disposable d) {
-            upstream.update(d);
+            upstream.replace(d);
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryWhen.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRetryWhen.java
@@ -102,6 +102,7 @@ public final class ObservableRetryWhen<T> extends AbstractObservableWithUpstream
 
         @Override
         public void onError(Throwable e) {
+            DisposableHelper.replace(upstream, null);
             active = false;
             signaller.onNext(e);
         }

--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionArbiter.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionArbiter.java
@@ -55,11 +55,14 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
 
     final AtomicLong missedProduced;
 
+    final boolean cancelOnReplace;
+
     volatile boolean cancelled;
 
     protected boolean unbounded;
 
-    public SubscriptionArbiter() {
+    public SubscriptionArbiter(boolean cancelOnReplace) {
+        this.cancelOnReplace = cancelOnReplace;
         missedSubscription = new AtomicReference<Subscription>();
         missedRequested = new AtomicLong();
         missedProduced = new AtomicLong();
@@ -80,7 +83,7 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
         if (get() == 0 && compareAndSet(0, 1)) {
             Subscription a = actual;
 
-            if (a != null) {
+            if (a != null && cancelOnReplace) {
                 a.cancel();
             }
 
@@ -100,7 +103,7 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
         }
 
         Subscription a = missedSubscription.getAndSet(s);
-        if (a != null) {
+        if (a != null && cancelOnReplace) {
             a.cancel();
         }
         drain();
@@ -240,7 +243,7 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
                 }
 
                 if (ms != null) {
-                    if (a != null) {
+                    if (a != null && cancelOnReplace) {
                         a.cancel();
                     }
                     actual = ms;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapTest.java
@@ -23,8 +23,7 @@ import org.reactivestreams.Publisher;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.operators.flowable.FlowableConcatMap.WeakScalarSubscription;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -13,63 +13,29 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.InOrder;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
+import org.reactivestreams.*;
 
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.Flowable;
-import io.reactivex.FlowableEmitter;
-import io.reactivex.FlowableOnSubscribe;
-import io.reactivex.Scheduler;
-import io.reactivex.Single;
-import io.reactivex.SingleObserver;
-import io.reactivex.TestHelper;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.disposables.Disposables;
-import io.reactivex.exceptions.CompositeException;
-import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.Function;
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.processors.FlowableProcessor;
-import io.reactivex.processors.PublishProcessor;
-import io.reactivex.processors.UnicastProcessor;
-import io.reactivex.schedulers.Schedulers;
-import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subscribers.DefaultSubscriber;
-import io.reactivex.subscribers.TestSubscriber;
+import io.reactivex.processors.*;
+import io.reactivex.schedulers.*;
+import io.reactivex.subscribers.*;
 
 public class FlowableConcatTest {
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
@@ -13,57 +13,28 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.notNull;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
+import org.mockito.*;
+import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
-import io.reactivex.TestHelper;
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.flowables.GroupedFlowable;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.BiFunction;
-import io.reactivex.functions.BiPredicate;
-import io.reactivex.functions.BooleanSupplier;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Function;
-import io.reactivex.functions.Predicate;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subscribers.DefaultSubscriber;
-import io.reactivex.subscribers.TestSubscriber;
+import io.reactivex.subscribers.*;
 
 public class FlowableRetryTest {
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -230,7 +230,7 @@ public class FlowableRetryWithPredicateTest {
         Subscriber<Long> subscriber = TestHelper.mockSubscriber();
 
         // Flowable that always fails after 100ms
-        FlowableRetryTest.SlowFlowable so = new FlowableRetryTest.SlowFlowable(100, 0);
+        FlowableRetryTest.SlowFlowable so = new FlowableRetryTest.SlowFlowable(100, 0, "testUnsubscribeAfterError");
         Flowable<Long> f = Flowable
                 .unsafeCreate(so)
                 .retry(retry5);
@@ -256,7 +256,7 @@ public class FlowableRetryWithPredicateTest {
         Subscriber<Long> subscriber = TestHelper.mockSubscriber();
 
         // Flowable that sends every 100ms (timeout fails instead)
-        FlowableRetryTest.SlowFlowable so = new FlowableRetryTest.SlowFlowable(100, 10);
+        FlowableRetryTest.SlowFlowable so = new FlowableRetryTest.SlowFlowable(100, 10, "testTimeoutWithRetry");
         Flowable<Long> f = Flowable
                 .unsafeCreate(so)
                 .timeout(80, TimeUnit.MILLISECONDS)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -127,7 +127,7 @@ public class FlowableSwitchIfEmptyTest {
     }
 
     @Test
-    public void testSwitchShouldTriggerUnsubscribe() {
+    public void testSwitchShouldNotTriggerUnsubscribe() {
         final BooleanSubscription bs = new BooleanSubscription();
 
         Flowable.unsafeCreate(new Publisher<Long>() {
@@ -137,7 +137,7 @@ public class FlowableSwitchIfEmptyTest {
                 subscriber.onComplete();
             }
         }).switchIfEmpty(Flowable.<Long>never()).subscribe();
-        assertTrue(bs.isCancelled());
+        assertFalse(bs.isCancelled());
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapTest.java
@@ -13,8 +13,7 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -22,21 +21,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableSource;
-import io.reactivex.Observer;
-import io.reactivex.TestHelper;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.disposables.Disposables;
-import io.reactivex.exceptions.CompositeException;
-import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.Function;
+import io.reactivex.*;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.subjects.PublishSubject;
-import io.reactivex.subjects.UnicastSubject;
+import io.reactivex.subjects.*;
 
 public class ObservableConcatMapTest {
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatTest.java
@@ -28,6 +28,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.*;
@@ -1154,5 +1155,43 @@ public class ObservableConcatTest {
         });
 
         assertTrue(disposable[0].isDisposed());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noCancelPreviousArray() {
+        final AtomicInteger counter = new AtomicInteger();
+
+        Observable<Integer> source = Observable.just(1).doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                counter.getAndIncrement();
+            }
+        });
+
+        Observable.concatArray(source, source, source, source, source)
+        .test()
+        .assertResult(1, 1, 1, 1, 1);
+
+        assertEquals(0, counter.get());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noCancelPreviousIterable() {
+        final AtomicInteger counter = new AtomicInteger();
+
+        Observable<Integer> source = Observable.just(1).doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                counter.getAndIncrement();
+            }
+        });
+
+        Observable.concat(Arrays.asList(source, source, source, source, source))
+        .test()
+        .assertResult(1, 1, 1, 1, 1);
+
+        assertEquals(0, counter.get());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
@@ -13,55 +13,27 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.notNull;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
+import org.mockito.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.Observable;
-import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
-import io.reactivex.TestHelper;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.disposables.Disposables;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.BiFunction;
-import io.reactivex.functions.BiPredicate;
-import io.reactivex.functions.BooleanSupplier;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Function;
-import io.reactivex.functions.Predicate;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.observables.GroupedObservable;
-import io.reactivex.observers.DefaultObserver;
-import io.reactivex.observers.TestObserver;
+import io.reactivex.observers.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
@@ -13,25 +13,55 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import org.mockito.*;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 
-import io.reactivex.*;
+import io.reactivex.Flowable;
 import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
-import io.reactivex.disposables.*;
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.*;
+import io.reactivex.functions.Action;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.functions.BiPredicate;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.observables.GroupedObservable;
-import io.reactivex.observers.*;
+import io.reactivex.observers.DefaultObserver;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
@@ -522,11 +552,14 @@ public class ObservableRetryTest {
         final AtomicInteger active = new AtomicInteger(0), maxActive = new AtomicInteger(0);
         final AtomicInteger nextBeforeFailure;
 
+        final String context;
+
         private final int emitDelay;
 
-        SlowObservable(int emitDelay, int countNext) {
+        SlowObservable(int emitDelay, int countNext, String context) {
             this.emitDelay = emitDelay;
             this.nextBeforeFailure = new AtomicInteger(countNext);
+            this.context = context;
         }
 
         @Override
@@ -542,7 +575,7 @@ public class ObservableRetryTest {
             efforts.getAndIncrement();
             active.getAndIncrement();
             maxActive.set(Math.max(active.get(), maxActive.get()));
-            final Thread thread = new Thread() {
+            final Thread thread = new Thread(context) {
                 @Override
                 public void run() {
                     long nr = 0;
@@ -552,7 +585,9 @@ public class ObservableRetryTest {
                             if (nextBeforeFailure.getAndDecrement() > 0) {
                                 observer.onNext(nr++);
                             } else {
+                                active.decrementAndGet();
                                 observer.onError(new RuntimeException("expected-failed"));
+                                break;
                             }
                         }
                     } catch (InterruptedException t) {
@@ -613,7 +648,7 @@ public class ObservableRetryTest {
         Observer<Long> observer = TestHelper.mockObserver();
 
         // Observable that always fails after 100ms
-        SlowObservable so = new SlowObservable(100, 0);
+        SlowObservable so = new SlowObservable(100, 0, "testUnsubscribeAfterError");
         Observable<Long> o = Observable.unsafeCreate(so).retry(5);
 
         AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
@@ -637,7 +672,7 @@ public class ObservableRetryTest {
         Observer<Long> observer = TestHelper.mockObserver();
 
         // Observable that sends every 100ms (timeout fails instead)
-        SlowObservable so = new SlowObservable(100, 10);
+        SlowObservable so = new SlowObservable(100, 10, "testTimeoutWithRetry");
         Observable<Long> o = Observable.unsafeCreate(so).timeout(80, TimeUnit.MILLISECONDS).retry(5);
 
         AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
@@ -931,4 +966,197 @@ public class ObservableRetryTest {
       assertFalse(subject.hasObservers());
     }
 
+    @Test
+    public void noCancelPreviousRetry() {
+        final AtomicInteger counter = new AtomicInteger();
+
+        final AtomicInteger times = new AtomicInteger();
+
+        Observable<Integer> source = Observable.defer(new Callable<ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> call() throws Exception {
+                if (times.getAndIncrement() < 4) {
+                    return Observable.error(new TestException());
+                }
+                return Observable.just(1);
+            }
+        })
+        .doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                counter.getAndIncrement();
+            }
+        });
+
+        source.retry(5)
+        .test()
+        .assertResult(1);
+
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void noCancelPreviousRetryWhile() {
+        final AtomicInteger counter = new AtomicInteger();
+
+        final AtomicInteger times = new AtomicInteger();
+
+        Observable<Integer> source = Observable.defer(new Callable<ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> call() throws Exception {
+                if (times.getAndIncrement() < 4) {
+                    return Observable.error(new TestException());
+                }
+                return Observable.just(1);
+            }
+        })
+        .doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                counter.getAndIncrement();
+            }
+        });
+
+        source.retry(5, Functions.alwaysTrue())
+        .test()
+        .assertResult(1);
+
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void noCancelPreviousRetryWhile2() {
+        final AtomicInteger counter = new AtomicInteger();
+
+        final AtomicInteger times = new AtomicInteger();
+
+        Observable<Integer> source = Observable.defer(new Callable<ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> call() throws Exception {
+                if (times.getAndIncrement() < 4) {
+                    return Observable.error(new TestException());
+                }
+                return Observable.just(1);
+            }
+        })
+        .doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                counter.getAndIncrement();
+            }
+        });
+
+        source.retry(new BiPredicate<Integer, Throwable>() {
+            @Override
+            public boolean test(Integer a, Throwable b) throws Exception {
+                return a < 5;
+            }
+        })
+        .test()
+        .assertResult(1);
+
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void noCancelPreviousRetryUntil() {
+        final AtomicInteger counter = new AtomicInteger();
+
+        final AtomicInteger times = new AtomicInteger();
+
+        Observable<Integer> source = Observable.defer(new Callable<ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> call() throws Exception {
+                if (times.getAndIncrement() < 4) {
+                    return Observable.error(new TestException());
+                }
+                return Observable.just(1);
+            }
+        })
+        .doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                counter.getAndIncrement();
+            }
+        });
+
+        source.retryUntil(new BooleanSupplier() {
+            @Override
+            public boolean getAsBoolean() throws Exception {
+                return false;
+            }
+        })
+        .test()
+        .assertResult(1);
+
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void noCancelPreviousRepeatWhen() {
+        final AtomicInteger counter = new AtomicInteger();
+
+        final AtomicInteger times = new AtomicInteger();
+
+        Observable<Integer> source = Observable.defer(new Callable<ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> call() throws Exception {
+                if (times.get() < 4) {
+                    return Observable.error(new TestException());
+                }
+                return Observable.just(1);
+            }
+        }).doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                counter.getAndIncrement();
+            }
+        });
+
+        source.retryWhen(new Function<Observable<Throwable>, ObservableSource<?>>() {
+            @Override
+            public ObservableSource<?> apply(Observable<Throwable> e) throws Exception {
+                return e.takeWhile(new Predicate<Object>() {
+                    @Override
+                    public boolean test(Object v) throws Exception {
+                        return times.getAndIncrement() < 4;
+                    }
+                });
+            }
+        })
+        .test()
+        .assertResult(1);
+
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void noCancelPreviousRepeatWhen2() {
+        final AtomicInteger counter = new AtomicInteger();
+
+        final AtomicInteger times = new AtomicInteger();
+
+        Observable<Integer> source = Observable.<Integer>error(new TestException()).doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                counter.getAndIncrement();
+            }
+        });
+
+        source.retryWhen(new Function<Observable<Throwable>, ObservableSource<?>>() {
+            @Override
+            public ObservableSource<?> apply(Observable<Throwable> e) throws Exception {
+                return e.takeWhile(new Predicate<Object>() {
+                    @Override
+                    public boolean test(Object v) throws Exception {
+                        return times.getAndIncrement() < 4;
+                    }
+                });
+            }
+        })
+        .test()
+        .assertResult();
+
+        assertEquals(0, counter.get());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -229,7 +229,7 @@ public class ObservableRetryWithPredicateTest {
         Observer<Long> observer = TestHelper.mockObserver();
 
         // Observable that always fails after 100ms
-        ObservableRetryTest.SlowObservable so = new ObservableRetryTest.SlowObservable(100, 0);
+        ObservableRetryTest.SlowObservable so = new ObservableRetryTest.SlowObservable(100, 0, "testUnsubscribeAfterError");
         Observable<Long> o = Observable
                 .unsafeCreate(so)
                 .retry(retry5);
@@ -255,7 +255,7 @@ public class ObservableRetryWithPredicateTest {
         Observer<Long> observer = TestHelper.mockObserver();
 
         // Observable that sends every 100ms (timeout fails instead)
-        ObservableRetryTest.SlowObservable so = new ObservableRetryTest.SlowObservable(100, 10);
+        ObservableRetryTest.SlowObservable so = new ObservableRetryTest.SlowObservable(100, 10, "testTimeoutWithRetry");
         Observable<Long> o = Observable
                 .unsafeCreate(so)
                 .timeout(80, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
This PR extends the `SubscriptionArbiter` to optionally allow or disallow cancelling the current `Subscription` if it is replaced by a new one. Some operators do not need to cancel the current `Subscription`: `concat`, `concatMap`, `repeat`, `repeatWhen`, `retry` and `retryWhen`. 

In addition `repeatWhen` and `retryWhen` were cancelling when the handler sequence itself terminated. The code has been updated to disconnect the upstream upon the completion/failure but before signaling the handler.

The Reactive Streams specification also disallows synchronous cancellation after the terminal event anyway.

Others may actually need to cancel, such as `Timeout`. 

`Observable`s don't have a specific arbiter, they use the `DisposableHelper` methods and the relevant ones were changed to `replace()` instead of the disposing `set` call.

Some tests actually checking if the dispose/cancel happens and had to be updated.

The `Flowable.delaySubscription(Publisher)` also used `SubscriptionArbiter` but it was unnecessary. The code has been replaced with a more apt deferred requesting scheme as the downstream requests need to be delayed until the main subscription happens, the other publisher is always consumed unbounded.

Resolves: #6259