### PR TITLE
2.x: Update Error Handling Operators docs

### DIFF
--- a/docs/Error-Handling-Operators.md
+++ b/docs/Error-Handling-Operators.md
@@ -52,7 +52,7 @@ Optionally, a `io.reactivex.functions.Predicate` can be specified that gives mor
 Completable.fromAction(() -> {
     throw new IOException();
 }).onErrorComplete(error -> {
-    // only ignore errors of type java.io.IOException
+    // Only ignore errors of type java.io.IOException.
     return error instanceof IOException;
 }).subscribe(
     () -> System.out.println("IOException was ignored"),
@@ -255,15 +255,15 @@ Observable<Long> source = Observable.interval(0, 1, TimeUnit.SECONDS)
 source.retryWhen(errors -> {
     return errors.map(error -> 1)
 
-    // count the number of errors
+    // Count the number of errors.
     .scan(Math::addExact)
 
     .doOnNext(errorCount -> System.out.println("No. of errors: " + errorCount))
 
-    // limit the maximum number of retries
+    // Limit the maximum number of retries.
     .takeWhile(errorCount -> errorCount < 3)
 
-    // signal resubscribe event after some delay
+    // Signal resubscribe event after some delay.
     .flatMapSingle(errorCount -> Single.timer(errorCount, TimeUnit.SECONDS));
 }).blockingSubscribe(
     x -> System.out.println("onNext: " + x),

--- a/docs/Error-Handling-Operators.md
+++ b/docs/Error-Handling-Operators.md
@@ -1,14 +1,92 @@
-There are a variety of operators that you can use to react to or recover from `onError` notifications from Observables. For example, you might:
+There are a variety of operators that you can use to react to or recover from `onError` notifications from reactive sources, such as `Observable`s. For example, you might:
 
 1. swallow the error and switch over to a backup Observable to continue the sequence
 1. swallow the error and emit a default item
 1. swallow the error and immediately try to restart the failed Observable
 1. swallow the error and try to restart the failed Observable after some back-off interval
 
-The following pages explain these operators.
+# Outline
 
-* [**`onErrorResumeNext( )`**](http://reactivex.io/documentation/operators/catch.html) — instructs an Observable to emit a sequence of items if it encounters an error
-* [**`onErrorReturn( )`**](http://reactivex.io/documentation/operators/catch.html) — instructs an Observable to emit a particular item when it encounters an error
-* [**`onExceptionResumeNext( )`**](http://reactivex.io/documentation/operators/catch.html) — instructs an Observable to continue emitting items after it encounters an exception (but not another variety of throwable)
-* [**`retry( )`**](http://reactivex.io/documentation/operators/retry.html) — if a source Observable emits an error, resubscribe to it in the hopes that it will complete without error
-* [**`retryWhen( )`**](http://reactivex.io/documentation/operators/retry.html) — if a source Observable emits an error, pass that error to another Observable to determine whether to resubscribe to the source
+- [`doOnError`](#doonerror)
+- [`onErrorComplete`](#onerrorcomplete)
+- [`onErrorResumeNext`](#onerrorresumenext)
+- [`onErrorReturn`](#onerrorreturn)
+- [`onErrorReturnItem`](#onerrorreturnitem)
+- [`onExceptionResumeNext`](#onexceptionresumenext)
+- [`retry`](#retry)
+- [`retryUntil`](#retryuntil)
+- [`retryWhen`](#retrywhen)
+
+## doOnError
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Completable`
+
+**ReactiveX documentation:** [http://reactivex.io/documentation/operators/do.html](http://reactivex.io/documentation/operators/do.html)
+
+When the source reactive type signals an error event, the given `io.reactivex.functions.Consumer` is invoked.
+
+## onErrorComplete
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Completable`
+
+**ReactiveX documentation:** [http://reactivex.io/documentation/operators/catch.html](http://reactivex.io/documentation/operators/catch.html)
+
+When the reactive type signals an error event, the error will be swallowed and replaced by a complete event.
+
+Optionally, a `io.reactivex.functions.Predicate` can be specified that gives more control over when an error event should be replaced by a complete event, and when not.
+
+## onErrorResumeNext
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Completable`
+
+**ReactiveX documentation:** [http://reactivex.io/documentation/operators/catch.html](http://reactivex.io/documentation/operators/catch.html)
+
+Instructs a reactive type to emit a sequence of items if it encounters an error.
+
+## onErrorReturn
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX documentation:** [http://reactivex.io/documentation/operators/catch.html](http://reactivex.io/documentation/operators/catch.html)
+
+Instructs a reactive type to emit the item returned by the specified `io.reactivex.functions.Function` when it encounters an error.
+
+## onErrorReturnItem
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX documentation:** [http://reactivex.io/documentation/operators/catch.html](http://reactivex.io/documentation/operators/catch.html)
+
+Instructs a reactive type to emit a particular item when it encounters an error.
+
+## onExceptionResumeNext
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX documentation:** [http://reactivex.io/documentation/operators/catch.html](http://reactivex.io/documentation/operators/catch.html)
+
+Instructs a reactive type to continue emitting items after it encounters an `java.lang.Exception`. Unlike [`onErrorResumeNext`](#onerrorresumenext), this one lets other types of `Throwable` continue through.
+
+## retry
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Completable`
+
+**ReactiveX documentation:** [http://reactivex.io/documentation/operators/retry.html](http://reactivex.io/documentation/operators/retry.html)
+
+If a source reactive type emits an error, resubscribe to it in the hopes that it will complete without error.
+
+## retryUntil
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+
+**ReactiveX documentation:** [http://reactivex.io/documentation/operators/retry.html](http://reactivex.io/documentation/operators/retry.html)
+
+If a source reactive type emits an error, resubscribe to it until the given `io.reactivex.functions.BooleanSupplier` returns `true`.
+
+## retryWhen
+
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Completable`
+
+**ReactiveX documentation:** [http://reactivex.io/documentation/operators/retry.html](http://reactivex.io/documentation/operators/retry.html)
+
+If a source reactive type emits an error, pass that error to another `Observable` or `Flowable` to determine whether to resubscribe to the source.

--- a/docs/Error-Handling-Operators.md
+++ b/docs/Error-Handling-Operators.md
@@ -31,9 +31,9 @@ When the source reactive type signals an error event, the given `io.reactivex.fu
 Observable.error(new IOException("Something went wrong"))
     .doOnError(error -> System.err.println("The error message is: " + error.getMessage()))
     .subscribe(
-        x -> System.out.println("This should never be printed!"),
+        x -> System.out.println("onNext should never be printed!"),
         Throwable::printStackTrace,
-        () -> System.out.println("This should never be printed!"));
+        () -> System.out.println("onComplete should never be printed!"));
 ```
 
 ## onErrorComplete
@@ -56,7 +56,7 @@ Completable.fromAction(() -> {
     return error instanceof IOException;
 }).subscribe(
     () -> System.out.println("IOException was ignored"),
-    error -> System.err.println("This should not be printed!"));
+    error -> System.err.println("onError should not be printed!"));
 ```
 
 ## onErrorResumeNext
@@ -80,7 +80,7 @@ numbers.scan(Math::multiplyExact)
     .onErrorResumeNext(Observable.empty())
     .subscribe(
         System.out::println,
-        error -> System.err.println("This should not be printed!"));
+        error -> System.err.println("onError should not be printed!"));
 
 // prints:
 // 1
@@ -116,7 +116,7 @@ Single.just("2A")
     })
     .subscribe(
         System.out::println,
-        error -> System.err.println("This should not be printed!"));
+        error -> System.err.println("onError should not be printed!"));
 
 // prints 0
 ```
@@ -137,7 +137,7 @@ Single.just("2A")
     .onErrorReturnItem(0)
     .subscribe(
         System.out::println,
-        error -> System.err.println("This should not be printed!"));
+        error -> System.err.println("onError should not be printed!"));
 
 // prints 0
 ```

--- a/docs/Error-Handling-Operators.md
+++ b/docs/Error-Handling-Operators.md
@@ -23,7 +23,7 @@ There are a variety of operators that you can use to react to or recover from `o
 
 **ReactiveX documentation:** [http://reactivex.io/documentation/operators/do.html](http://reactivex.io/documentation/operators/do.html)
 
-When the source reactive type signals an error event, the given `io.reactivex.functions.Consumer` is invoked.
+Instructs a reactive type to invoke the given `io.reactivex.functions.Consumer` when it encounters an error.
 
 ### doOnError example
 
@@ -42,9 +42,9 @@ Observable.error(new IOException("Something went wrong"))
 
 **ReactiveX documentation:** [http://reactivex.io/documentation/operators/catch.html](http://reactivex.io/documentation/operators/catch.html)
 
-When the reactive type signals an error event, the error will be swallowed and replaced by a complete event.
+Instructs a reactive type to swallow an error event and replace it by a completion event.
 
-Optionally, a `io.reactivex.functions.Predicate` can be specified that gives more control over when an error event should be replaced by a complete event, and when not.
+Optionally, a `io.reactivex.functions.Predicate` can be specified that gives more control over when an error event should be replaced by a completion event, and when not.
 
 ### onErrorComplete example
 
@@ -175,7 +175,7 @@ Observable.concat(exception, error)
 
 **ReactiveX documentation:** [http://reactivex.io/documentation/operators/retry.html](http://reactivex.io/documentation/operators/retry.html)
 
-If a source reactive type emits an error, resubscribe to it in the hopes that it will complete without error.
+Instructs a reactive type to resubscribe to the source reactive type if it encounters an error in the hopes that it will complete without error.
 
 ### retry example
 
@@ -207,7 +207,7 @@ source.retry((retryCount, error) -> retryCount < 3)
 
 **ReactiveX documentation:** [http://reactivex.io/documentation/operators/retry.html](http://reactivex.io/documentation/operators/retry.html)
 
-If a source reactive type emits an error, resubscribe to it until the given `io.reactivex.functions.BooleanSupplier` returns `true`.
+Instructs a reactive type to resubscribe to the source reactive type if it encounters an error until the given `io.reactivex.functions.BooleanSupplier` returns `true`.
 
 ### retryUntil example
 
@@ -241,7 +241,7 @@ source.retryUntil(() -> errorCounter.intValue() >= 3)
 
 **ReactiveX documentation:** [http://reactivex.io/documentation/operators/retry.html](http://reactivex.io/documentation/operators/retry.html)
 
-If a source reactive type emits an error, pass that error to another `Observable` or `Flowable` to determine whether to resubscribe to the source.
+Instructs a reactive type to pass any error to another `Observable` or `Flowable` to determine whether to resubscribe to the source.
 
 ### retryWhen example
 


### PR DESCRIPTION
This PR updates the `Error-Handling-Operators.md` wiki page as per issue #6132:

- Update operator list
- Add examples

The page now follows the structure that was defined in #6131.  
