### PR TITLE
2.x: Update Creating Observables docs

### DIFF
--- a/docs/Creating-Observables.md
+++ b/docs/Creating-Observables.md
@@ -202,7 +202,7 @@ observable.subscribe(
 
 ## generate
 
-**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
+**Available in:** ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Flowable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) `Observable`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Maybe`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Single`, ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) `Completable`
 
 **ReactiveX documentation:** [http://reactivex.io/documentation/operators/create.html](http://reactivex.io/documentation/operators/create.html)
 

--- a/docs/Creating-Observables.md
+++ b/docs/Creating-Observables.md
@@ -7,6 +7,7 @@ This page shows methods that create reactive sources, such as `Observable`s.
 - [`empty`](#empty)
 - [`error`](#error)
 - [`from`](#from)
+- [`generate`](#generate)
 - [`interval`](#interval)
 - [`just`](#just)
 - [`never`](#never)


### PR DESCRIPTION
This PR adds a link to the `generate` section to the outline and fixes a broken image link.

Relates to: #6260 
