### PR TITLE
2.x: Call the doOn{Dispose|Cancel} handler at most once

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -8046,7 +8046,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Calls the appropriate onXXX method (shared between all Observer) for the lifecycle events of
-     * the sequence (subscription, disposal, requesting).
+     * the sequence (subscription, disposal).
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnLifecycle.o.png" alt="">
      * <dl>

--- a/src/main/java/io/reactivex/internal/observers/DisposableLambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/DisposableLambdaObserver.java
@@ -61,6 +61,7 @@ public final class DisposableLambdaObserver<T> implements Observer<T>, Disposabl
     @Override
     public void onError(Throwable t) {
         if (upstream != DisposableHelper.DISPOSED) {
+            upstream = DisposableHelper.DISPOSED;
             downstream.onError(t);
         } else {
             RxJavaPlugins.onError(t);
@@ -70,19 +71,24 @@ public final class DisposableLambdaObserver<T> implements Observer<T>, Disposabl
     @Override
     public void onComplete() {
         if (upstream != DisposableHelper.DISPOSED) {
+            upstream = DisposableHelper.DISPOSED;
             downstream.onComplete();
         }
     }
 
     @Override
     public void dispose() {
-        try {
-            onDispose.run();
-        } catch (Throwable e) {
-            Exceptions.throwIfFatal(e);
-            RxJavaPlugins.onError(e);
+        Disposable d = upstream;
+        if (d != DisposableHelper.DISPOSED) {
+            upstream = DisposableHelper.DISPOSED;
+            try {
+                onDispose.run();
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                RxJavaPlugins.onError(e);
+            }
+            d.dispose();
         }
-        upstream.dispose();
     }
 
     @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycle.java
@@ -108,13 +108,17 @@ public final class FlowableDoOnLifecycle<T> extends AbstractFlowableWithUpstream
 
         @Override
         public void cancel() {
-            try {
-                onCancel.run();
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                RxJavaPlugins.onError(e);
+            Subscription s = upstream;
+            if (s != SubscriptionHelper.CANCELLED) {
+                upstream = SubscriptionHelper.CANCELLED;
+                try {
+                    onCancel.run();
+                } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
+                    RxJavaPlugins.onError(e);
+                }
+                s.cancel();
             }
-            upstream.cancel();
         }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
@@ -87,7 +87,7 @@ public class FlowableDoOnLifecycleTest {
             );
 
         assertEquals(1, calls[0]);
-        assertEquals(2, calls[1]);
+        assertEquals(1, calls[1]);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
@@ -113,7 +113,7 @@ public class ObservableCacheTest {
         o.subscribe();
         o.subscribe();
         o.subscribe();
-        verify(unsubscribe, times(1)).run();
+        verify(unsubscribe, never()).run();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -938,11 +938,11 @@ public class ObservableReplayTest {
     @Test
     public void testUnsubscribeSource() throws Exception {
         Action unsubscribe = mock(Action.class);
-        Observable<Integer> o = Observable.just(1).doOnDispose(unsubscribe).cache();
+        Observable<Integer> o = Observable.just(1).doOnDispose(unsubscribe).replay().autoConnect();
         o.subscribe();
         o.subscribe();
         o.subscribe();
-        verify(unsubscribe, times(1)).run();
+        verify(unsubscribe, never()).run();
     }
 
     @Test


### PR DESCRIPTION
This PR makes sure the `doOnDispose`, `doOnCancel` and `doOnLifecycle` execute their cancellation handler once.

Resolves: #6268.