### PR TITLE
2.x: Add dematerialize(selector), deprecate old

### DIFF
--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -14,22 +14,24 @@
 package io.reactivex.flowable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.Observable;
 import org.junit.*;
 import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
+import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.*;
@@ -341,7 +343,8 @@ public class FlowableTests {
     @Test
     public void testMaterializeDematerializeChaining() {
         Flowable<Integer> obs = Flowable.just(1);
-        Flowable<Integer> chained = obs.materialize().dematerialize();
+        Flowable<Integer> chained = obs.materialize()
+                .dematerialize(Functions.<Notification<Integer>>identity());
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
@@ -1076,7 +1079,7 @@ public class FlowableTests {
             Flowable.error(new RuntimeException("oops"))
                 .materialize()
                 .delay(1, TimeUnit.SECONDS)
-                .dematerialize()
+                .dematerialize(Functions.<Notification<Object>>identity())
                 .subscribe(processor);
 
             processor.subscribe();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
@@ -226,10 +226,10 @@ public class FlowableDematerializeTest {
     public void nonNotificationInstanceAfterDispose() {
         new Flowable<Object>() {
             @Override
-            protected void subscribeActual(Subscriber<? super Object> observer) {
-                observer.onSubscribe(new BooleanSubscription());
-                observer.onNext(Notification.createOnComplete());
-                observer.onNext(1);
+            protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                subscriber.onSubscribe(new BooleanSubscription());
+                subscriber.onNext(Notification.createOnComplete());
+                subscriber.onNext(1);
             }
         }
         .dematerialize()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
@@ -221,4 +221,19 @@ public class FlowableDematerializeTest {
             RxJavaPlugins.reset();
         }
     }
+
+    @Test
+    public void nonNotificationInstanceAfterDispose() {
+        new Flowable<Object>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super Object> observer) {
+                observer.onSubscribe(new BooleanSubscription());
+                observer.onNext(Notification.createOnComplete());
+                observer.onNext(1);
+            }
+        }
+        .dematerialize()
+        .test()
+        .assertResult();
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
@@ -24,11 +24,56 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.TestSubscriber;
 
+@SuppressWarnings("deprecation")
 public class FlowableDematerializeTest {
+
+    @Test
+    public void simpleSelector() {
+        Flowable<Notification<Integer>> notifications = Flowable.just(1, 2).materialize();
+        Flowable<Integer> dematerialize = notifications.dematerialize(Functions.<Notification<Integer>>identity());
+
+        Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
+
+        dematerialize.subscribe(subscriber);
+
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, times(1)).onNext(2);
+        verify(subscriber, times(1)).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void selectorCrash() {
+        Flowable.just(1, 2)
+        .materialize()
+        .dematerialize(new Function<Notification<Integer>, Notification<Object>>() {
+            @Override
+            public Notification<Object> apply(Notification<Integer> v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void selectorNull() {
+        Flowable.just(1, 2)
+        .materialize()
+        .dematerialize(new Function<Notification<Integer>, Notification<Object>>() {
+            @Override
+            public Notification<Object> apply(Notification<Integer> v) throws Exception {
+                return null;
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
 
     @Test
     public void testDematerialize1() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDematerializeTest.java
@@ -24,10 +24,55 @@ import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 
+@SuppressWarnings("deprecation")
 public class ObservableDematerializeTest {
+
+    @Test
+    public void simpleSelector() {
+        Observable<Notification<Integer>> notifications = Observable.just(1, 2).materialize();
+        Observable<Integer> dematerialize = notifications.dematerialize(Functions.<Notification<Integer>>identity());
+
+        Observer<Integer> observer = TestHelper.mockObserver();
+
+        dematerialize.subscribe(observer);
+
+        verify(observer, times(1)).onNext(1);
+        verify(observer, times(1)).onNext(2);
+        verify(observer, times(1)).onComplete();
+        verify(observer, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void selectorCrash() {
+        Observable.just(1, 2)
+        .materialize()
+        .dematerialize(new Function<Notification<Integer>, Notification<Object>>() {
+            @Override
+            public Notification<Object> apply(Notification<Integer> v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void selectorNull() {
+        Observable.just(1, 2)
+        .materialize()
+        .dematerialize(new Function<Notification<Integer>, Notification<Object>>() {
+            @Override
+            public Notification<Object> apply(Notification<Integer> v) throws Exception {
+                return null;
+            }
+        })
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
 
     @Test
     public void testDematerialize1() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDematerializeTest.java
@@ -220,4 +220,19 @@ public class ObservableDematerializeTest {
             RxJavaPlugins.reset();
         }
     }
+
+    @Test
+    public void nonNotificationInstanceAfterDispose() {
+        new Observable<Object>() {
+            @Override
+            protected void subscribeActual(Observer<? super Object> observer) {
+                observer.onSubscribe(Disposables.empty());
+                observer.onNext(Notification.createOnComplete());
+                observer.onNext(1);
+            }
+        }
+        .dematerialize()
+        .test()
+        .assertResult();
+    }
 }

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.observable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -28,6 +29,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.observers.*;
 import io.reactivex.schedulers.*;
@@ -357,7 +359,8 @@ public class ObservableTest {
     @Test
     public void testMaterializeDematerializeChaining() {
         Observable<Integer> obs = Observable.just(1);
-        Observable<Integer> chained = obs.materialize().dematerialize();
+        Observable<Integer> chained = obs.materialize()
+                .dematerialize(Functions.<Notification<Integer>>identity());
 
         Observer<Integer> observer = TestHelper.mockObserver();
 
@@ -1096,7 +1099,7 @@ public class ObservableTest {
         Observable.error(new RuntimeException("oops"))
             .materialize()
             .delay(1, TimeUnit.SECONDS)
-            .dematerialize()
+            .dematerialize(Functions.<Notification<Object>>identity())
             .subscribe(subject);
 
         subject.subscribe();


### PR DESCRIPTION
This PR adds the `dematerialize(Function<T, Notification<R>> selector)` overload to allow type-safe dematerialization of `Notification` signals. The pre-existing `dematerialize()` forced the return type and assumed the items of the source are `Notification` objects, which could not be enforced via the type system. This selector variant establishes the type link from `T` to `Notification<R>` to `R` (where R == T is allowed).

The intended use is

```java
Observable<Notification<T>> source = ...

Observable<T> result = source.dematerialize(notification -> notification);
```

aka identity mapping.

The pre-existing `dematerialize()` methods are marked as deprecated now.

*(Also the actual operator were missing from the examples in the respective Javadocs).*