### PR TITLE
2.x: Expose the Keep-Alive value of the IO Scheduler as System property. (#6279)

### DIFF
--- a/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/IoScheduler.java
@@ -34,7 +34,11 @@ public final class IoScheduler extends Scheduler {
     private static final String EVICTOR_THREAD_NAME_PREFIX = "RxCachedWorkerPoolEvictor";
     static final RxThreadFactory EVICTOR_THREAD_FACTORY;
 
-    private static final long KEEP_ALIVE_TIME = 60;
+    /** The name of the system property for setting the keep-alive time (in seconds) for this Scheduler workers. */
+    private static final String KEY_KEEP_ALIVE_TIME = "rx2.io-keep-alive-time";
+    public static final long KEEP_ALIVE_TIME_DEFAULT = 60;
+
+    private static final long KEEP_ALIVE_TIME;
     private static final TimeUnit KEEP_ALIVE_UNIT = TimeUnit.SECONDS;
 
     static final ThreadWorker SHUTDOWN_THREAD_WORKER;
@@ -45,7 +49,10 @@ public final class IoScheduler extends Scheduler {
     private static final String KEY_IO_PRIORITY = "rx2.io-priority";
 
     static final CachedWorkerPool NONE;
+
     static {
+        KEEP_ALIVE_TIME = Long.getLong(KEY_KEEP_ALIVE_TIME, KEEP_ALIVE_TIME_DEFAULT);
+
         SHUTDOWN_THREAD_WORKER = new ThreadWorker(new RxThreadFactory("RxCachedThreadSchedulerShutdown"));
         SHUTDOWN_THREAD_WORKER.dispose();
 

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -29,6 +29,7 @@ import java.util.concurrent.*;
  * <p>
  * <strong>Supported system properties ({@code System.getProperty()}):</strong>
  * <ul>
+ * <li>{@code rx2.io-keep-alive-time} (long): sets the keep-alive time of the {@link #io()} Scheduler workers, default is {@link IoScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
  * <li>{@code rx2.io-priority} (int): sets the thread priority of the {@link #io()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
  * <li>{@code rx2.computation-threads} (int): sets the number of threads in the {@link #computation()} Scheduler, default is the number of available CPUs</li>
  * <li>{@code rx2.computation-priority} (int): sets the thread priority of the {@link #computation()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
@@ -155,6 +156,7 @@ public final class Schedulers {
      * before the {@link Schedulers} class is referenced in your code.
      * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
+     * <li>{@code rx2.io-keep-alive-time} (long): sets the keep-alive time of the {@link #io()} Scheduler workers, default is {@link IoScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
      * <li>{@code rx2.io-priority} (int): sets the thread priority of the {@link #io()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
      * </ul>
      * <p>


### PR DESCRIPTION
Configuring Keep-Alive through System property.

Resolves: #6279