### PR TITLE
2.x: Fix refCount eager disconnect not resetting the connection

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
@@ -135,10 +135,15 @@ public final class ObservableRefCount<T> extends Observable<T> {
                 connection = null;
                 Disposable connectionObject = rc.get();
                 DisposableHelper.dispose(rc);
+
                 if (source instanceof Disposable) {
                     ((Disposable)source).dispose();
                 } else if (source instanceof ResettableConnectable) {
-                    ((ResettableConnectable)source).resetIf(connectionObject);
+                    if (connectionObject == null) {
+                        rc.disconnectedEarly = true;
+                    } else {
+                        ((ResettableConnectable)source).resetIf(connectionObject);
+                    }
                 }
             }
         }
@@ -157,6 +162,8 @@ public final class ObservableRefCount<T> extends Observable<T> {
 
         boolean connected;
 
+        boolean disconnectedEarly;
+
         RefConnection(ObservableRefCount<?> parent) {
             this.parent = parent;
         }
@@ -169,6 +176,11 @@ public final class ObservableRefCount<T> extends Observable<T> {
         @Override
         public void accept(Disposable t) throws Exception {
             DisposableHelper.replace(this, t);
+            synchronized (parent) {
+                if (disconnectedEarly) {
+                    ((ResettableConnectable)parent.source).resetIf(t);
+                }
+            }
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -1394,4 +1394,20 @@ public class FlowableRefCountTest {
 
         assertTrue(((Disposable)o.source).isDisposed());
     }
+
+    @Test
+    public void disconnectBeforeConnect() {
+        BehaviorProcessor<Integer> processor = BehaviorProcessor.create();
+
+        Flowable<Integer> flowable = processor
+                .replay(1)
+                .refCount();
+
+        // This line causes the test to fail.
+        flowable.takeUntil(Flowable.just(1)).test();
+
+        processor.onNext(2);
+
+        flowable.take(1).test().assertResult(2);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -1403,7 +1403,6 @@ public class FlowableRefCountTest {
                 .replay(1)
                 .refCount();
 
-        // This line causes the test to fail.
         flowable.takeUntil(Flowable.just(1)).test();
 
         processor.onNext(2);

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -1345,4 +1345,19 @@ public class ObservableRefCountTest {
 
         assertTrue(((Disposable)o.source).isDisposed());
     }
+
+    @Test
+    public void disconnectBeforeConnect() {
+        BehaviorSubject<Integer> subject = BehaviorSubject.create();
+
+        Observable<Integer> observable = subject
+                .replay(1)
+                .refCount();
+
+        observable.takeUntil(Observable.just(1)).test();
+
+        subject.onNext(2);
+
+        observable.take(1).test().assertResult(2);
+    }
 }


### PR DESCRIPTION
This PR fixes the case when an observer/subscriber disposes/cancels immediately upon subscribing to a `refCount` operator before it establishes the connection and ends up with a disposed but non-reset connection, preventing further interactions with the connectable source.

The fix is to detect this case and reset the connection when the `connect()` method signals the dispose handler.

Both `ConnectableFlowable.refCount` and `ConnectableFlowable.refCount` is affected.

Fixes: #6296