### PR TITLE
Change javadoc explanation for Mutable List

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -8746,7 +8746,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code CharSequence}s or {@code List}s where the objects will actually have the same
      * references when they are modified and {@code distinctUntilChanged} will evaluate subsequent items as same.
      * To avoid such situation, it is recommended that mutable data is converted to an immutable one,
-     * for example using `map(CharSequence::toString)` or `map(Collections::unmodifiableList)`.
+     * for example using `map(CharSequence::toString)` or `map(list -> Collections.unmodifiableList(new ArrayList<>(list)))`.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s
@@ -8789,7 +8789,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code CharSequence}s or {@code List}s where the objects will actually have the same
      * references when they are modified and {@code distinctUntilChanged} will evaluate subsequent items as same.
      * To avoid such situation, it is recommended that mutable data is converted to an immutable one,
-     * for example using `map(CharSequence::toString)` or `map(Collections::unmodifiableList)`.
+     * for example using `map(CharSequence::toString)` or `map(list -> Collections.unmodifiableList(new ArrayList<>(list)))`.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s
@@ -8828,7 +8828,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code CharSequence}s or {@code List}s where the objects will actually have the same
      * references when they are modified and {@code distinctUntilChanged} will evaluate subsequent items as same.
      * To avoid such situation, it is recommended that mutable data is converted to an immutable one,
-     * for example using `map(CharSequence::toString)` or `map(Collections::unmodifiableList)`.
+     * for example using `map(CharSequence::toString)` or `map(list -> Collections.unmodifiableList(new ArrayList<>(list)))`.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -7830,7 +7830,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code CharSequence}s or {@code List}s where the objects will actually have the same
      * references when they are modified and {@code distinctUntilChanged} will evaluate subsequent items as same.
      * To avoid such situation, it is recommended that mutable data is converted to an immutable one,
-     * for example using `map(CharSequence::toString)` or `map(Collections::unmodifiableList)`.
+     * for example using `map(CharSequence::toString)` or `map(list -> Collections.unmodifiableList(new ArrayList<>(list)))`.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code distinctUntilChanged} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -7869,7 +7869,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code CharSequence}s or {@code List}s where the objects will actually have the same
      * references when they are modified and {@code distinctUntilChanged} will evaluate subsequent items as same.
      * To avoid such situation, it is recommended that mutable data is converted to an immutable one,
-     * for example using `map(CharSequence::toString)` or `map(Collections::unmodifiableList)`.
+     * for example using `map(CharSequence::toString)` or `map(list -> Collections.unmodifiableList(new ArrayList<>(list)))`.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code distinctUntilChanged} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -7904,7 +7904,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code CharSequence}s or {@code List}s where the objects will actually have the same
      * references when they are modified and {@code distinctUntilChanged} will evaluate subsequent items as same.
      * To avoid such situation, it is recommended that mutable data is converted to an immutable one,
-     * for example using `map(CharSequence::toString)` or `map(Collections::unmodifiableList)`.
+     * for example using `map(CharSequence::toString)` or `map(list -> Collections.unmodifiableList(new ArrayList<>(list)))`.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code distinctUntilChanged} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
As per [this](https://github.com/ReactiveX/RxJava/pull/6311#discussion_r234462497) discussion, change javadoc for `distinctUntilChanged()` method for Mutable List.