### PR TITLE
Update outdated java example in wiki #6331

### DIFF
--- a/docs/How-To-Use-RxJava.md
+++ b/docs/How-To-Use-RxJava.md
@@ -11,15 +11,21 @@ You can find additional code examples in the `/src/examples` folders of each [la
 ### Java
 
 ```java
-public static void hello(String... names) {
-    Observable.fromArray(names).subscribe(s -> System.out.println("Hello " + s));
+public static void main(String[] args) {
+    Flowable.just("Hello world").subscribe(System.out::println);
 }
 ```
+If your platform doesn't support Java 8 lambdas (yet), you have to create an inner class of ```Consumer``` manually:
 
 ```java
-hello("Ben", "George");
-Hello Ben!
-Hello George!
+public static void main(String[] args) {
+    Flowable.just("Hello world")
+        .subscribe(new Consumer<String>() {
+	    @Override public void accept(String s) {
+		System.out.println(s);
+	    }
+	});
+}
 ```
 
 ### Groovy

--- a/docs/How-To-Use-RxJava.md
+++ b/docs/How-To-Use-RxJava.md
@@ -11,21 +11,27 @@ You can find additional code examples in the `/src/examples` folders of each [la
 ### Java
 
 ```java
-public static void main(String[] args) {
-    Flowable.just("Hello world").subscribe(System.out::println);
+public static void hello(String... args) {
+  Flowable.fromArray(args).subscribe(s -> System.out.println("Hello " + s + "!"));
 }
 ```
+
 If your platform doesn't support Java 8 lambdas (yet), you have to create an inner class of ```Consumer``` manually:
+```java
+public static void hello(String... args) {
+  Flowable.fromArray(args).subscribe(new Consumer<String>() {
+      @Override
+      public void accept(String s) {
+          System.out.println("Hello " + s + "!");
+      }
+  });
+}
+```
 
 ```java
-public static void main(String[] args) {
-    Flowable.just("Hello world")
-        .subscribe(new Consumer<String>() {
-	    @Override public void accept(String s) {
-		System.out.println(s);
-	    }
-	});
-}
+hello("Ben", "George");
+Hello Ben!
+Hello George!
 ```
 
 ### Groovy

--- a/docs/How-To-Use-RxJava.md
+++ b/docs/How-To-Use-RxJava.md
@@ -12,14 +12,7 @@ You can find additional code examples in the `/src/examples` folders of each [la
 
 ```java
 public static void hello(String... names) {
-    Observable.from(names).subscribe(new Action1<String>() {
-
-        @Override
-        public void call(String s) {
-            System.out.println("Hello " + s + "!");
-        }
-
-    });
+    Observable.fromArray(names).subscribe(s -> System.out.println("Hello " + s));
 }
 ```
 


### PR DESCRIPTION
Updated java example in docs/How-To-Use-RxJava.md file with java 8 version.

Resolves: #6331