### PR TITLE
2.x: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Each reactive base class features operators that can perform such conversions, i
 |----------|----------|------------|--------|-------|-------------|
 |**Flowable**  |          | `toObservable` | `first`, `firstOrError`, `single`, `singleOrError`, `last`, `lastOrError`<sup>1</sup> | `firstElement`, `singleElement`, `lastElement` | `ignoreElements` |
 |**Observable**| `toFlowable`<sup>2</sup> |  | `first`, `firstOrError`, `single`, `singleOrError`, `last`, `lastOrError`<sup>1</sup> | `firstElement`, `singleElement`, `lastElement` | `ignoreElements` |
-|**Single** | `toFlowable`<sup>3</sup> | `toObservable` |  | `toMaybe` | `toCompletable` |
+|**Single** | `toFlowable`<sup>3</sup> | `toObservable` |  | `toMaybe` | `ignoreElement` |
 |**Maybe** | `toFlowable`<sup>3</sup> | `toObservable` | `toSingle` |  | `ignoreElement` |
 |**Completable** | `toFlowable` | `toObservable` | `toSingle` | `toMaybe` |  |
 


### PR DESCRIPTION
This PR updates the [Converting to the desired type](https://github.com/ReactiveX/RxJava#converting-to-the-desired-type) section in the README to use [`Single::ignoreElement`](http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Single.html#ignoreElement--) instead of [`Single::toCompletable`](http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Single.html#toCompletable--) to convert a `Single` to a `Completable`. The reason for that is that the Javadoc mentions that `Single::toCompletable` is considered deprecated and `Single::ignoreElement` should be used instead.
