### PR TITLE
Indicate source disposal in timeout(fallback)

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -16442,7 +16442,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Returns a Flowable that mirrors the source Publisher but applies a timeout policy for each emitted
      * item. If the next item isn't emitted within the specified timeout duration starting from its predecessor,
-     * the resulting Publisher begins instead to mirror a fallback Publisher.
+     * the source Publisher is disposed and resulting Publisher begins instead to mirror a fallback Publisher.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.2.png" alt="">
      * <dl>
@@ -16476,7 +16476,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     /**
      * Returns a Flowable that mirrors the source Publisher but applies a timeout policy for each emitted
      * item using a specified Scheduler. If the next item isn't emitted within the specified timeout duration
-     * starting from its predecessor, the resulting Publisher begins instead to mirror a fallback Publisher.
+     * starting from its predecessor, the source Publisher is disposed and resulting Publisher begins
+     * instead to mirror a fallback Publisher.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.2s.png" alt="">
      * <dl>

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -4463,7 +4463,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Returns a Maybe that mirrors the source Maybe but applies a timeout policy for each emitted
      * item. If the next item isn't emitted within the specified timeout duration starting from its predecessor,
-     * the resulting Maybe begins instead to mirror a fallback MaybeSource.
+     * the source MaybeSource is disposed and resulting Maybe begins instead to mirror a fallback MaybeSource.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.2.png" alt="">
      * <dl>
@@ -4491,7 +4491,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Returns a Maybe that mirrors the source Maybe but applies a timeout policy for each emitted
      * item using a specified Scheduler. If the next item isn't emitted within the specified timeout duration
-     * starting from its predecessor, the resulting Maybe begins instead to mirror a fallback MaybeSource.
+     * starting from its predecessor, the source MaybeSource is disposed and resulting Maybe begins instead
+     * to mirror a fallback MaybeSource.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.2s.png" alt="">
      * <dl>

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -13617,7 +13617,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Returns an Observable that mirrors the source ObservableSource but applies a timeout policy for each emitted
      * item. If the next item isn't emitted within the specified timeout duration starting from its predecessor,
-     * the resulting ObservableSource begins instead to mirror a fallback ObservableSource.
+     * the source ObservableSource is disposed and resulting ObservableSource begins instead
+     * to mirror a fallback ObservableSource.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.2.png" alt="">
      * <dl>
@@ -13644,7 +13645,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     /**
      * Returns an Observable that mirrors the source ObservableSource but applies a timeout policy for each emitted
      * item using a specified Scheduler. If the next item isn't emitted within the specified timeout duration
-     * starting from its predecessor, the resulting ObservableSource begins instead to mirror a fallback ObservableSource.
+     * starting from its predecessor, the source ObservableSource is disposed and resulting ObservableSource
+     * begins instead to mirror a fallback ObservableSource.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.2s.png" alt="">
      * <dl>


### PR DESCRIPTION
Some of the overloads of `timeout(…, fallback)` operator didn't indicate that source gets disposed on timeout in the javadoc.