### PR TITLE
Fixing Javadoc duplicate with inheritDoc

### DIFF
--- a/src/main/java/io/reactivex/disposables/Disposable.java
+++ b/src/main/java/io/reactivex/disposables/Disposable.java
@@ -22,8 +22,8 @@ public interface Disposable {
     void dispose();
 
     /**
-     * Returns true if this resource has been disposed.
-     * @return true if this resource has been disposed
+     * Returns true if this resource has been disposed/cancelled.
+     * @return true if this resource has been disposed/cancelled
      */
     boolean isDisposed();
 }

--- a/src/main/java/io/reactivex/observers/ResourceCompletableObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceCompletableObserver.java
@@ -122,8 +122,7 @@ public abstract class ResourceCompletableObserver implements CompletableObserver
     }
 
     /**
-     * Returns true if this ResourceObserver has been disposed/cancelled.
-     * @return true if this ResourceObserver has been disposed/cancelled
+     * {@inheritDoc}
      */
     @Override
     public final boolean isDisposed() {

--- a/src/main/java/io/reactivex/observers/ResourceObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceObserver.java
@@ -130,8 +130,7 @@ public abstract class ResourceObserver<T> implements Observer<T>, Disposable {
     }
 
     /**
-     * Returns true if this ResourceObserver has been disposed/cancelled.
-     * @return true if this ResourceObserver has been disposed/cancelled
+     * {@inheritDoc}
      */
     @Override
     public final boolean isDisposed() {


### PR DESCRIPTION
I'm a PhD Student from University of Bordeaux working on documentation copy-pastes (duplicates).
I've noticed that your project does have a few documentation duplicates.
For my research work, i've tried to fix this duplicate and i'd love to have your feedback about it:

Do you think that this duplicate documentation should co-evolve forever?
Are you aware of copy-pastes in your documentation?
If yes, how do you handle them?
Were you aware of JavaDoc reuse features such as {@inheritdoc}?
Would you like to have a tool that helps you maintain duplicate documentation?
