### PR TITLE
 2.x: Don't dispose the winner of {Single|Maybe|Completable}.amb()

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeAmb.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeAmb.java
@@ -64,64 +64,63 @@ public final class MaybeAmb<T> extends Maybe<T> {
             count = sources.length;
         }
 
-        AmbMaybeObserver<T> parent = new AmbMaybeObserver<T>(observer);
-        observer.onSubscribe(parent);
+        CompositeDisposable set = new CompositeDisposable();
+        observer.onSubscribe(set);
+
+        AtomicBoolean winner = new AtomicBoolean();
 
         for (int i = 0; i < count; i++) {
             MaybeSource<? extends T> s = sources[i];
-            if (parent.isDisposed()) {
+            if (set.isDisposed()) {
                 return;
             }
 
             if (s == null) {
-                parent.onError(new NullPointerException("One of the MaybeSources is null"));
+                set.dispose();
+                NullPointerException ex = new NullPointerException("One of the MaybeSources is null");
+                if (winner.compareAndSet(false, true)) {
+                    observer.onError(ex);
+                } else {
+                    RxJavaPlugins.onError(ex);
+                }
                 return;
             }
 
-            s.subscribe(parent);
+            s.subscribe(new AmbMaybeObserver<T>(observer, set, winner));
         }
 
         if (count == 0) {
             observer.onComplete();
         }
-
     }
 
     static final class AmbMaybeObserver<T>
-    extends AtomicBoolean
-    implements MaybeObserver<T>, Disposable {
-
-        private static final long serialVersionUID = -7044685185359438206L;
+    implements MaybeObserver<T> {
 
         final MaybeObserver<? super T> downstream;
 
+        final AtomicBoolean winner;
+
         final CompositeDisposable set;
 
-        AmbMaybeObserver(MaybeObserver<? super T> downstream) {
+        Disposable upstream;
+
+        AmbMaybeObserver(MaybeObserver<? super T> downstream, CompositeDisposable set, AtomicBoolean winner) {
             this.downstream = downstream;
-            this.set = new CompositeDisposable();
-        }
-
-        @Override
-        public void dispose() {
-            if (compareAndSet(false, true)) {
-                set.dispose();
-            }
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return get();
+            this.set = set;
+            this.winner = winner;
         }
 
         @Override
         public void onSubscribe(Disposable d) {
+            upstream = d;
             set.add(d);
         }
 
         @Override
         public void onSuccess(T value) {
-            if (compareAndSet(false, true)) {
+            if (winner.compareAndSet(false, true)) {
+                set.delete(upstream);
                 set.dispose();
 
                 downstream.onSuccess(value);
@@ -130,7 +129,8 @@ public final class MaybeAmb<T> extends Maybe<T> {
 
         @Override
         public void onError(Throwable e) {
-            if (compareAndSet(false, true)) {
+            if (winner.compareAndSet(false, true)) {
+                set.delete(upstream);
                 set.dispose();
 
                 downstream.onError(e);
@@ -141,12 +141,12 @@ public final class MaybeAmb<T> extends Maybe<T> {
 
         @Override
         public void onComplete() {
-            if (compareAndSet(false, true)) {
+            if (winner.compareAndSet(false, true)) {
+                set.delete(upstream);
                 set.dispose();
 
                 downstream.onComplete();
             }
         }
-
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -19,8 +19,8 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
 import org.junit.*;
 import org.mockito.InOrder;
@@ -30,6 +30,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.util.CrashingMappedIterable;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
@@ -712,5 +713,84 @@ public class FlowableAmbTest {
     public void ambArrayOrder() {
         Flowable<Integer> error = Flowable.error(new RuntimeException());
         Flowable.ambArray(Flowable.just(1), error).test().assertValue(1).assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noWinnerSuccessDispose() throws Exception {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            final AtomicBoolean interrupted = new AtomicBoolean();
+            final CountDownLatch cdl = new CountDownLatch(1);
+
+            Flowable.ambArray(
+                Flowable.just(1)
+                    .subscribeOn(Schedulers.single())
+                    .observeOn(Schedulers.computation()),
+                Flowable.never()
+            )
+            .subscribe(new Consumer<Object>() {
+                @Override
+                public void accept(Object v) throws Exception {
+                    interrupted.set(Thread.currentThread().isInterrupted());
+                    cdl.countDown();
+                }
+            });
+
+            assertTrue(cdl.await(500, TimeUnit.SECONDS));
+            assertFalse("Interrupted!", interrupted.get());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noWinnerErrorDispose() throws Exception {
+        final TestException ex = new TestException();
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            final AtomicBoolean interrupted = new AtomicBoolean();
+            final CountDownLatch cdl = new CountDownLatch(1);
+
+            Flowable.ambArray(
+                Flowable.error(ex)
+                    .subscribeOn(Schedulers.single())
+                    .observeOn(Schedulers.computation()),
+                Flowable.never()
+            )
+            .subscribe(Functions.emptyConsumer(), new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable e) throws Exception {
+                    interrupted.set(Thread.currentThread().isInterrupted());
+                    cdl.countDown();
+                }
+            });
+
+            assertTrue(cdl.await(500, TimeUnit.SECONDS));
+            assertFalse("Interrupted!", interrupted.get());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void noWinnerCompleteDispose() throws Exception {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            final AtomicBoolean interrupted = new AtomicBoolean();
+            final CountDownLatch cdl = new CountDownLatch(1);
+
+            Flowable.ambArray(
+                Flowable.empty()
+                    .subscribeOn(Schedulers.single())
+                    .observeOn(Schedulers.computation()),
+                Flowable.never()
+            )
+            .subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), new Action() {
+                @Override
+                public void run() throws Exception {
+                    interrupted.set(Thread.currentThread().isInterrupted());
+                    cdl.countDown();
+                }
+            });
+
+            assertTrue(cdl.await(500, TimeUnit.SECONDS));
+            assertFalse("Interrupted!", interrupted.get());
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the `Single.amb`, `Maybe.amb` and `Completable.amb` operators to not dispose the winner source, causing potential interruptions as a side-effect on the current thread.

The fix is to [delete](http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/disposables/CompositeDisposable.html#delete-io.reactivex.disposables.Disposable-) the winner from the composite before disposing the rest to avoid the interruption race.

Unit tests were added to verify this behavior on all `amb` implementations. `Flowable` and `Observable` were already working correctly.

Fixes: #6373