### PR TITLE
[Proposal] Add uncaught error hook

### DIFF
--- a/src/main/java/io/reactivex/functions/ThrowablePermittingConsumer.java
+++ b/src/main/java/io/reactivex/functions/ThrowablePermittingConsumer.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.functions;
+
+/**
+ * A functional interface (callback) that accepts a single value and permits throwing of a
+ * {@link Throwable} from the {@link #accept(Object)} method.
+ *
+ * @param <T> the value type
+ */
+public interface ThrowablePermittingConsumer<T> {
+    /**
+     * Consume the given value.
+     * @param t the value
+     * @throws Exception on error
+     */
+    void accept(T t) throws Throwable;
+}

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -523,6 +523,7 @@ public final class RxJavaPlugins {
      */
     public static void reset() {
         setErrorHandler(null);
+        setOnUncaughtHandler(null);
         setScheduleHandler(null);
 
         setComputationSchedulerHandler(null);

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -218,6 +218,11 @@ public class RxJavaPluginsTest {
                     return null;
                 }
             };
+            ThrowablePermittingConsumer tpc = new ThrowablePermittingConsumer() {
+                @Override public void accept(Object o) {
+
+                }
+            };
             Function f1 = Functions.identity();
             BiFunction f2 = new BiFunction() {
                 @Override
@@ -263,6 +268,9 @@ public class RxJavaPluginsTest {
                         } else
                         if (paramType.isAssignableFrom(BooleanSupplier.class)) {
                             m.invoke(null, bs);
+                        } else
+                        if (paramType.isAssignableFrom(ThrowablePermittingConsumer.class)) {
+                            m.invoke(null, tpc);
                         } else {
                             m.invoke(null, f2);
                         }


### PR DESCRIPTION
From #5234

This is a proposal implementation for allowing configuration of how uncaught errors are handled. Currently they are handed directly to the current thread's `UncaughtExceptionHandler`, but this can have collateral effects in some scenarios. Namely:

1 - On Android, this handler will call `System.exit()`. There is no recourse, and no ability to try-catch. This is particularly dangerous for delegating observers that may wish to try/catch the delegate's lifecycle callbacks and safely degrade in the event of an exception.

2 - In JUnit, the opposite extreme happens: the exception is quietly discarded, allowing uncaught errors to go completely unnoticed in tests unless one installs an RxJavaPlugins errors hook.

This adds configuration at the "uncaught()" layer, which is different than what was initially proposed, but I feel the only way to safely control this behavior. Creating a custom onErrorNotImplemented consumer hook didn't work well in my testing because almost every other part of RxJava still try/catches these consumers with their own try/catch that then just re-routes to RxJavaPlugins.onError() anyway, thus preventing one from avoiding the default uncaught behavior that lies in there. By configuring it directly, we can control every facet that directly or indirectly routes through it.

This is effectly acting as a slightly more surgical hook than just using `RxJavaPlugins.onError`, the latter of which will still try/catch and fall back to uncaught behavior and effectly negates any plugin hooks that try to just rethrow exceptions through it. This also happens after the `isBug()` filtering layer.