### PR TITLE
Fix bug in CompositeException.getRootCause

### DIFF
--- a/src/main/java/io/reactivex/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/exceptions/CompositeException.java
@@ -280,7 +280,7 @@ public final class CompositeException extends RuntimeException {
      */
     /*private */Throwable getRootCause(Throwable e) {
         Throwable root = e.getCause();
-        if (root == null || cause == root) {
+        if (root == null || e == root) {
             return e;
         }
         while (true) {

--- a/src/test/java/io/reactivex/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/exceptions/CompositeExceptionTest.java
@@ -364,7 +364,22 @@ public class CompositeExceptionTest {
             }
         };
         CompositeException ex = new CompositeException(throwable);
-        assertSame(ex, ex.getRootCause(ex));
+        assertSame(ex0, ex.getRootCause(ex));
+    }
+
+    @Test
+    public void rootCauseSelf() {
+        Throwable throwable = new Throwable() {
+
+            private static final long serialVersionUID = -4398003222998914415L;
+
+            @Override
+            public synchronized Throwable getCause() {
+                return this;
+            }
+        };
+        CompositeException tmp = new CompositeException(new TestException());
+        assertSame(throwable, tmp.getRootCause(throwable));
     }
 }
 


### PR DESCRIPTION
I found what I believe is a bug in `CompositeException.getRootCause`.

The [original code](https://github.com/ReactiveX/RxJava/commit/487a0ba52137e13d996ad12fc73bfeabb03c4fb7#diff-63dcdf1ecfc9f44d938e86154f465e41R306) use to be `if (root == null || root == e)`, but apparently after some refactoring it ended up as `if (root == null || cause == root)`.

As a side note, I think this method should be made `static` (that would have prevented the bug).

<!--
Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
-->