### PR TITLE
Add globalTimeout operation on Flowable.

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -2409,6 +2409,56 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
+     * Returns a Flowable that emits items until a global timeout time has passed after
+     * subscription.
+     * <p>
+     * If the Flowable is not completed within the defined time frame, the resulting Flowable
+     * terminates and the observer(s) will be notified with a {@link TimeoutException}.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>This version of {@code globalTimeout} operates by default on the {@code computation} {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param timeout
+     *            duration until a {@link TimeoutException} occurs.
+     * @param timeUnit
+     *            the unit of time that applies to the {@code timeout} argument.
+     * @return the new Flowable instance
+     */
+    @CheckReturnValue
+    @NonNull
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public Flowable<T> globalTimeout(long timeout, TimeUnit timeUnit) {
+        return takeUntil(Flowable.never().timeout(timeout, timeUnit));
+    }
+
+
+    /**
+     * Returns a Flowable that emits items until a global timeout time has passed after
+     * subscription.
+     * <p>
+     * If the Flowable is not completed within the defined time frame, the resulting Flowable
+     * terminates and the observer(s) will be notified with a {@link TimeoutException}.
+     *
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
+     * </dl>
+     *
+     * @param timeout
+     *            duration until a {@link TimeoutException} occurs.
+     * @param timeUnit
+     *            the unit of time that applies to the {@code timeout} argument.
+     * @param scheduler
+     *            the {@link Scheduler} to run the timeout timers on
+     * @return the new Flowable instance
+     */
+    public Flowable<T> globalTimeout(long timeout, TimeUnit timeUnit, Scheduler scheduler) {
+        return takeUntil(Flowable.never().timeout(timeout, timeUnit, scheduler));
+    }
+
+    /**
      * Returns a Flowable that emits a {@code 0L} after the {@code initialDelay} and ever-increasing numbers
      * after each {@code period} of time thereafter.
      * <p>

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.schedulers.TestScheduler;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
@@ -892,5 +893,20 @@ public class FlowableTimeoutWithSelectorTest {
         } finally {
             RxJavaPlugins.reset();
         }
+    }
+
+    @Test
+    public void testGlobalTimeoutOnFlowable() {
+        TestScheduler sched = new TestScheduler();
+        TestSubscriber t = Flowable
+            .interval(0, 1, TimeUnit.SECONDS, sched)
+            .globalTimeout(3, TimeUnit.SECONDS, sched)
+            .test();
+
+        sched.advanceTimeBy(2100, TimeUnit.MILLISECONDS);
+        t.assertValueCount(3);
+
+        sched.advanceTimeBy(1, TimeUnit.SECONDS);
+        t.assertError(TimeoutException.class);
     }
 }


### PR DESCRIPTION
Hi, 

While working on a project where we needed to set a finite timeout bound to a flowable and error out if the timeout was reached, I wasn't able to find an operation that would be able to do that in the Flowable class. Only `.timeout()` is available but it is to specify a timeout between each item, not the global Flowable.

After some help from the mailing list I ended up using `originalFlowable.takeUntil(Flowable.never().timeout())` which works very well for the intended purpose (shout-out to David from the mailing list who came up with it).
I think it would be valuable to other users who aren't aware of the `takeUntil(Publisher)` method, to have this operation available in the library. Please let me know if you think it would be useful as well.

I've included a simple unit test as well as Javadocs as best as I could, however I didn't know how to generate a marble schema...

Thanks.