### PR TITLE
Fix ignored tests due to internal structure changes of `ExecutorSched…

### DIFF
--- a/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ExecutorScheduler.java
@@ -270,6 +270,13 @@ public final class ExecutorScheduler extends Scheduler {
             }
         }
 
+        public boolean hasTasks() {
+            if (tasks == null || tasks.size() == 0) {
+                return false;
+            }
+            return true;
+        }
+
         static final class BooleanRunnable extends AtomicBoolean implements Runnable, Disposable {
 
             private static final long serialVersionUID = -2421395018820541164L;


### PR DESCRIPTION
Fix ignored tests due to internal structure changes of `ExecutorScheduler`

Expose a method to indicate if there are tasks scheduled for execution
to be used in tests making sure no more tasks after schedule retention.

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [x] Please give a description about what and why you are contributing, even if it's trivial.

  - [x] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [x] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
