### PR TITLE
2.x: Fix window() with start/end selector not disposing/cancelling properly

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -256,7 +256,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                                 produced(1);
                             }
                         } else {
-                            stopWindows.set(true);
+                            cancel();
                             a.onError(new MissingBackpressureException("Could not deliver new window due to lack of requests"));
                             continue;
                         }
@@ -266,7 +266,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                         try {
                             p = ObjectHelper.requireNonNull(close.apply(wo.open), "The publisher supplied is null");
                         } catch (Throwable e) {
-                            stopWindows.set(true);
+                            cancel();
                             a.onError(e);
                             continue;
                         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -71,6 +71,8 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
 
         final AtomicLong windows = new AtomicLong();
 
+        final AtomicBoolean stopWindows = new AtomicBoolean();
+
         WindowBoundaryMainSubscriber(Subscriber<? super Flowable<T>> actual,
                 Publisher<B> open, Function<? super B, ? extends Publisher<V>> close, int bufferSize) {
             super(actual, new MpscLinkedQueue<Object>());
@@ -89,14 +91,13 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
 
                 downstream.onSubscribe(this);
 
-                if (cancelled) {
+                if (stopWindows.get()) {
                     return;
                 }
 
                 OperatorWindowBoundaryOpenSubscriber<T, B> os = new OperatorWindowBoundaryOpenSubscriber<T, B>(this);
 
                 if (boundary.compareAndSet(null, os)) {
-                    windows.getAndIncrement();
                     s.request(Long.MAX_VALUE);
                     open.subscribe(os);
                 }
@@ -177,7 +178,12 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
 
         @Override
         public void cancel() {
-            cancelled = true;
+            if (stopWindows.compareAndSet(false, true)) {
+                DisposableHelper.dispose(boundary);
+                if (windows.decrementAndGet() == 0) {
+                    upstream.cancel();
+                }
+            }
         }
 
         void dispose() {
@@ -236,7 +242,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                             continue;
                         }
 
-                        if (cancelled) {
+                        if (stopWindows.get()) {
                             continue;
                         }
 
@@ -250,7 +256,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                                 produced(1);
                             }
                         } else {
-                            cancelled = true;
+                            stopWindows.set(true);
                             a.onError(new MissingBackpressureException("Could not deliver new window due to lack of requests"));
                             continue;
                         }
@@ -260,7 +266,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                         try {
                             p = ObjectHelper.requireNonNull(close.apply(wo.open), "The publisher supplied is null");
                         } catch (Throwable e) {
-                            cancelled = true;
+                            stopWindows.set(true);
                             a.onError(e);
                             continue;
                         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -23,7 +23,7 @@ import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
-import io.reactivex.exceptions.TestException;
+import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
@@ -464,5 +464,25 @@ public class FlowableWindowWithStartEndFlowableTest {
         assertTrue(mainDisposed.get());
         assertTrue(openDisposed.get());
         assertTrue(closeDisposed.get());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void mainWindowMissingBackpressure() {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+        PublishProcessor<Integer> boundary = PublishProcessor.create();
+
+        TestSubscriber<Flowable<Integer>> ts = source.window(boundary, Functions.justFunction(Flowable.never()))
+        .test(0L)
+        ;
+
+        ts.assertEmpty();
+
+        boundary.onNext(1);
+
+        ts.assertFailure(MissingBackpressureException.class);
+
+        assertFalse(source.hasSubscribers());
+        assertFalse(boundary.hasSubscribers());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.*;
 import org.reactivestreams.*;
@@ -254,8 +255,8 @@ public class FlowableWindowWithStartEndFlowableTest {
 
         ts.dispose();
 
-        // FIXME subject has subscribers because of the open window
-        assertTrue(open.hasSubscribers());
+        // Disposing the outer sequence stops the opening of new windows
+        assertFalse(open.hasSubscribers());
         // FIXME subject has subscribers because of the open window
         assertTrue(close.hasSubscribers());
     }
@@ -429,5 +430,39 @@ public class FlowableWindowWithStartEndFlowableTest {
         } finally {
             RxJavaPlugins.reset();
         }
+    }
+
+    static Flowable<Integer> flowableDisposed(final AtomicBoolean ref) {
+        return Flowable.just(1).concatWith(Flowable.<Integer>never())
+                .doOnCancel(new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        ref.set(true);
+                    }
+                });
+    }
+
+    @Test
+    public void mainAndBoundaryDisposeOnNoWindows() {
+        AtomicBoolean mainDisposed = new AtomicBoolean();
+        AtomicBoolean openDisposed = new AtomicBoolean();
+        final AtomicBoolean closeDisposed = new AtomicBoolean();
+
+        flowableDisposed(mainDisposed)
+        .window(flowableDisposed(openDisposed), new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) throws Exception {
+                return flowableDisposed(closeDisposed);
+            }
+        })
+        .test()
+        .assertSubscribed()
+        .assertNoErrors()
+        .assertNotComplete()
+        .dispose();
+
+        assertTrue(mainDisposed.get());
+        assertTrue(openDisposed.get());
+        assertTrue(closeDisposed.get());
     }
 }


### PR DESCRIPTION
This PR fixes the start-end selector variant of `Observable.window` and `Flowable.window` to properly 

- dispose the window-opening sequence upon disposing the main output flow and 
- disposing the main upstream upon disposing the main output flow provided there are no windows open.

Fixes: #6397