### PR TITLE
optimize the ComputationScheduler createWorker() method implementation

### DIFF
--- a/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/internal/schedulers/ComputationScheduler.java
@@ -23,6 +23,9 @@ import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.*;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.util.DefaultSchedulerWorkerChooserFactory;
+import io.reactivex.internal.util.SchedulerWorkerChooserFactory;
+import io.reactivex.internal.util.SchedulerWorkerChooserFactory.SchedulerWorkerChooser;
 
 /**
  * Holds a fixed pool of worker threads and assigns them
@@ -72,6 +75,9 @@ public final class ComputationScheduler extends Scheduler implements SchedulerMu
         final int cores;
 
         final PoolWorker[] eventLoops;
+
+        final SchedulerWorkerChooser chooser;
+
         long n;
 
         FixedSchedulerPool(int maxThreads, ThreadFactory threadFactory) {
@@ -81,6 +87,7 @@ public final class ComputationScheduler extends Scheduler implements SchedulerMu
             for (int i = 0; i < maxThreads; i++) {
                 this.eventLoops[i] = new PoolWorker(threadFactory);
             }
+            this.chooser = DefaultSchedulerWorkerChooserFactory.INSTANCE.newChooser(eventLoops);
         }
 
         public PoolWorker getEventLoop() {
@@ -89,7 +96,8 @@ public final class ComputationScheduler extends Scheduler implements SchedulerMu
                 return SHUTDOWN_WORKER;
             }
             // simple round robin, improvements to come
-            return eventLoops[(int)(n++ % c)];
+            //return eventLoops[(int)(n++ % c)];
+            return (PoolWorker) chooser.next();
         }
 
         public void shutdown() {

--- a/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/internal/schedulers/NewThreadWorker.java
@@ -179,4 +179,11 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
     public boolean isDisposed() {
         return disposed;
     }
+
+    /**
+     *  Get queue size of private field executor {@link ScheduledThreadPoolExecutor}.
+     */
+    public int getInnerQueueSize() {
+        return ((ScheduledThreadPoolExecutor)this.executor).getQueue().size();
+    }
 }

--- a/src/main/java/io/reactivex/internal/util/DefaultSchedulerWorkerChooserFactory.java
+++ b/src/main/java/io/reactivex/internal/util/DefaultSchedulerWorkerChooserFactory.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.util;
+
+import io.reactivex.Scheduler.Worker;
+import io.reactivex.internal.schedulers.NewThreadWorker;
+
+/**
+ * Default implementation to choose next {@link Worker}. There are two options, one is simple round-robin and the other
+ * is non-round-robin. Simple round-robin uses bit operations and modulo operations. Just use bit calculation instead of
+ * modulo calculation when works length is power of two. Non-round-robin operations are only suitable for the worker
+ * selection of sub-class of {@link NewThreadWorker} which essence is to select the minimum computational thread pool by
+ * comparing thread pool inner queue size.
+ */
+public class DefaultSchedulerWorkerChooserFactory implements SchedulerWorkerChooserFactory {
+
+    public static final DefaultSchedulerWorkerChooserFactory INSTANCE = new DefaultSchedulerWorkerChooserFactory();
+
+    private static final String IS_NOT_ROUND_ROBIN = "rx2.no-round-robin";
+
+    private DefaultSchedulerWorkerChooserFactory() {
+    }
+
+    @Override
+    public SchedulerWorkerChooser newChooser(Worker[] eventLoops) {
+        if (eventLoops instanceof NewThreadWorker[] && Boolean.getBoolean(IS_NOT_ROUND_ROBIN)) {
+            return new NoRoundRobinChooserFactory(eventLoops);
+        }
+        if (isPowerOfTwo(eventLoops.length)) {
+            return new PowerOfTwoChooserFactory(eventLoops);
+        } else {
+            return new GenericChooserFactory(eventLoops);
+        }
+    }
+
+    private static boolean isPowerOfTwo(int val) {
+        return (val & -val) == val;
+    }
+
+    private static abstract class AbstractChooserFactory implements SchedulerWorkerChooser {
+
+        private final Worker[] workers;
+
+        private AbstractChooserFactory(Worker[] workers) {
+            this.workers = workers;
+        }
+
+        @Override
+        public abstract Worker next();
+    }
+
+    private static final class PowerOfTwoChooserFactory extends AbstractChooserFactory {
+
+        private long idx = 0L;
+
+        private PowerOfTwoChooserFactory(Worker[] workers) {
+            super(workers);
+        }
+
+        @Override
+        public Worker next() {
+            return super.workers[(int) (idx++ & super.workers.length - 1)];
+        }
+    }
+
+    private static final class GenericChooserFactory extends AbstractChooserFactory {
+
+        private long idx = 0L;
+
+        private GenericChooserFactory(Worker[] workers) {
+            super(workers);
+        }
+
+        @Override
+        public Worker next() {
+            return super.workers[(int) (idx++ % super.workers.length)];
+        }
+    }
+
+    private static final class NoRoundRobinChooserFactory extends AbstractChooserFactory {
+
+        private NoRoundRobinChooserFactory(Worker[] workers) {
+            super(workers);
+        }
+
+        @Override
+        public Worker next() {
+            NewThreadWorker[] workers = (NewThreadWorker[]) super.workers;
+            int minQsWorkIndex = 0;
+            int minQueue = workers[0].getInnerQueueSize();
+
+            for (int i = 1; i < workers.length; i++) {
+                if (minQueue > workers[i].getInnerQueueSize()) {
+                    minQueue = workers[i].getInnerQueueSize();
+                    minQsWorkIndex = i;
+                }
+            }
+
+            return workers[minQsWorkIndex];
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/util/SchedulerWorkerChooserFactory.java
+++ b/src/main/java/io/reactivex/internal/util/SchedulerWorkerChooserFactory.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.util;
+
+import io.reactivex.Scheduler.Worker;
+
+/**
+ * Factory that creates new {@link SchedulerWorkerChooser}s.
+ */
+public interface SchedulerWorkerChooserFactory {
+
+    /**
+     *  Returns a new {@link SchedulerWorkerChooser}.
+     */
+    SchedulerWorkerChooser newChooser(Worker[] eventLoops);
+
+    /**
+     *  Chooses the next {@link Worker} to use.
+     */
+    interface SchedulerWorkerChooser {
+
+        /**
+         *  Returns the new {@link Worker} to use.
+         */
+        Worker next();
+    }
+}


### PR DESCRIPTION
The previous method of **ComputationScheduler** createWorker() internally calling the innner **FixedSchedulerPool** class when creating the worker is to select the worker through a simple round-robin  that is modulo operation. Now make some optimizations that adds simple round-robin and non-round-robin two selection methods. Simple round-robin is different from the previous one. For the length of the workers array,when the array length is power of 2, the modulo operation is replaced by bit operation. non-round-robin method needs to used by setting the system property "rx2.no-round-robin"
with value "true" and only apply to subclasses of **NewThreadWorker** which essence is to select the minimum computational thread pool by comparing thread pool inner queue size.
 Unit test is in **ComputationSchedulerTests** testComputationSchedulerChooseWorker() 