### PR TITLE
2.x composite disposable docs

### DIFF
--- a/src/main/java/io/reactivex/disposables/CompositeDisposable.java
+++ b/src/main/java/io/reactivex/disposables/CompositeDisposable.java
@@ -93,7 +93,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      */
     @Override
     public boolean add(@NonNull Disposable d) {
-        ObjectHelper.requireNonNull(d, "d is null");
+        ObjectHelper.requireNonNull(d, "Disposable item is null");
         if (!disposed) {
             synchronized (this) {
                 if (!disposed) {

--- a/src/main/java/io/reactivex/disposables/CompositeDisposable.java
+++ b/src/main/java/io/reactivex/disposables/CompositeDisposable.java
@@ -128,7 +128,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
                         resources = set;
                     }
                     for (Disposable d : ds) {
-                        ObjectHelper.requireNonNull(d, "d is null");
+                        ObjectHelper.requireNonNull(d, "Disposable item is null");
                         set.add(d);
                     }
                     return true;


### PR DESCRIPTION
On CompositeDisposable add and addAll methods, if the param is null, currently the NPE error message (produced by ObjectHelper) is "d is null" which is not very helpful.

This is a small refactor for making the message a bit more helpful.

Resolves #6430
