### PR TITLE
Undeliverable error handling logic for Completable operators

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -508,6 +508,13 @@ public abstract class Completable implements CompletableSource {
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromRunnable} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd> If the {@link Runnable} throws an exception, the respective {@link Throwable} is
+     *  delivered to the downstream via {@link CompletableObserver#onError(Throwable)},
+     *  except when the downstream has disposed this {@code Completable} source.
+     *  In this latter case, the {@code Throwable} is delivered to the global error handler via
+     *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.exceptions.UndeliverableException UndeliverableException}.
+     *  </dd>
      * </dl>
      * @param run the runnable to run for each subscriber
      * @return the new Completable instance

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromAction.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromAction.java
@@ -17,6 +17,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableFromAction extends Completable {
 
@@ -36,6 +37,8 @@ public final class CompletableFromAction extends Completable {
             Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
                 observer.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
             }
             return;
         }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableFromRunnable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableFromRunnable.java
@@ -18,6 +18,7 @@ import io.reactivex.CompletableObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableFromRunnable extends Completable {
 
@@ -37,6 +38,8 @@ public final class CompletableFromRunnable extends Completable {
             Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
                 observer.onError(e);
+            } else {
+                RxJavaPlugins.onError(e);
             }
             return;
         }


### PR DESCRIPTION
`Completable.fromAction` and `Completable.fromRunnable` operators were missing `RxJavaPlugins` calls to handle Undeliverable errors. This behaviour is fixed in this PR.

 Also added missing error handling java doc for Completable.fromRunnable.