### PR TITLE
Remove dependency of Schedulers from ObservableRefCount

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
@@ -25,7 +25,6 @@ import io.reactivex.functions.Consumer;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 /**
  * Returns an observable sequence that stays connected to the source as long as
@@ -49,7 +48,7 @@ public final class FlowableRefCount<T> extends Flowable<T> {
     RefConnection connection;
 
     public FlowableRefCount(ConnectableFlowable<T> source) {
-        this(source, 1, 0L, TimeUnit.NANOSECONDS, Schedulers.trampoline());
+        this(source, 1, 0L, TimeUnit.NANOSECONDS, null);
     }
 
     public FlowableRefCount(ConnectableFlowable<T> source, int n, long timeout, TimeUnit unit,

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
@@ -22,7 +22,6 @@ import io.reactivex.functions.Consumer;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
 
 /**
  * Returns an observable sequence that stays connected to the source as long as
@@ -46,7 +45,7 @@ public final class ObservableRefCount<T> extends Observable<T> {
     RefConnection connection;
 
     public ObservableRefCount(ConnectableObservable<T> source) {
-        this(source, 1, 0L, TimeUnit.NANOSECONDS, Schedulers.trampoline());
+        this(source, 1, 0L, TimeUnit.NANOSECONDS, null);
     }
 
     public ObservableRefCount(ConnectableObservable<T> source, int n, long timeout, TimeUnit unit,


### PR DESCRIPTION
Resolves #6451.

In the constructor of `ObservableRefCount` that takes `ConnectableObservable<T> source` as the argument, we set `timeout` to `0L`. In that specific use case of `ObservableRefCount`, `scheduler` is never needed. It's only referenced in `cancel()` method but if timeout is 0, it won't be triggered at all because there is early return. This commit removes the need to depend on `Schedulers.trampoline()` and instead passes null to be scheduler when the ref count is not time-based. Similarly, applies the same change to `FlowableRefCount`.

The reasons for this change are the following:

1. In projects that don't depend on `Schedulers` class, if there is no reference to `Schedulers`, the whole `Schedulers` can be stripped out of the library after optimizations (e.g., proguard). With constructor that references `Schedulers`, the optimizer can't properly strip it out. In our quick test of our Android app, we were able to reduce the RxJava library size dependency from 51KB to 37KB (after optimization but before compression) by simply avoiding access to `Schedulers` in `ObservableRefCount`.
2. In terms of modularity, `ObservableRefCount` is just an operator so it by itself should probably not have dependency on what available pool of schedulers (`Schedulers`) there are. It should just know that there is some `Scheduler` that could be passed to `ObservableRefCount` when `ObservableRefCount` needs it.