### PR TITLE
Add few implementation for the Flowable.mergeDelayError

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -3921,6 +3921,303 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
+     * Flattens four Publishers into one Publisher, in a way that allows a Subscriber to receive all
+     * successfully emitted items from all of the source Publishers without being interrupted by an error
+     * notification from one of them.
+     * <p>
+     * This behaves like {@link #merge(Publisher, Publisher, Publisher, Publisher)} except that if any of
+     * the merged Publishers notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError}
+     * will refrain from propagating that error notification until all of the merged Publishers have finished
+     * emitting items.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
+     * <p>
+     * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its Subscribers once.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. The source {@code Publisher}s are expected to honor
+     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param source1
+     *            a Publisher to be merged
+     * @param source2
+     *            a Publisher to be merged
+     * @param source3
+     *            a Publisher to be merged
+     * @param source4
+     *            a Publisher to be merged
+     * @param source5
+     *            a Publisher to be merged
+     * @return a Flowable that emits all of the items that are emitted by the source Publishers
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @CheckReturnValue
+    @NonNull
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Flowable<T> mergeDelayError(
+            Publisher<? extends T> source1, Publisher<? extends T> source2,
+            Publisher<? extends T> source3, Publisher<? extends T> source4, Publisher<? extends T> source5) {
+        ObjectHelper.requireNonNull(source1, "source1 is null");
+        ObjectHelper.requireNonNull(source2, "source2 is null");
+        ObjectHelper.requireNonNull(source3, "source3 is null");
+        ObjectHelper.requireNonNull(source4, "source4 is null");
+        ObjectHelper.requireNonNull(source5, "source5 is null");
+        return fromArray(source1, source2, source3, source4, source5).flatMap((Function)Functions.identity(), true, 5);
+    }
+
+    /**
+     * Flattens four Publishers into one Publisher, in a way that allows a Subscriber to receive all
+     * successfully emitted items from all of the source Publishers without being interrupted by an error
+     * notification from one of them.
+     * <p>
+     * This behaves like {@link #merge(Publisher, Publisher, Publisher, Publisher)} except that if any of
+     * the merged Publishers notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError}
+     * will refrain from propagating that error notification until all of the merged Publishers have finished
+     * emitting items.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
+     * <p>
+     * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its Subscribers once.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. The source {@code Publisher}s are expected to honor
+     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param source1
+     *            a Publisher to be merged
+     * @param source2
+     *            a Publisher to be merged
+     * @param source3
+     *            a Publisher to be merged
+     * @param source4
+     *            a Publisher to be merged
+     * @param source5
+     *            a Publisher to be merged
+     * @param source6
+     *            a Publisher to be merged
+     * @return a Flowable that emits all of the items that are emitted by the source Publishers
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @CheckReturnValue
+    @NonNull
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Flowable<T> mergeDelayError(
+            Publisher<? extends T> source1, Publisher<? extends T> source2,
+            Publisher<? extends T> source3, Publisher<? extends T> source4,
+            Publisher<? extends T> source5, Publisher<? extends T> source6) {
+        ObjectHelper.requireNonNull(source1, "source1 is null");
+        ObjectHelper.requireNonNull(source2, "source2 is null");
+        ObjectHelper.requireNonNull(source3, "source3 is null");
+        ObjectHelper.requireNonNull(source4, "source4 is null");
+        ObjectHelper.requireNonNull(source5, "source5 is null");
+        ObjectHelper.requireNonNull(source6, "source6 is null");
+        return fromArray(source1, source2, source3, source4, source5, source6).flatMap((Function)Functions.identity(), true, 6);
+    }
+
+    /**
+     * Flattens four Publishers into one Publisher, in a way that allows a Subscriber to receive all
+     * successfully emitted items from all of the source Publishers without being interrupted by an error
+     * notification from one of them.
+     * <p>
+     * This behaves like {@link #merge(Publisher, Publisher, Publisher, Publisher)} except that if any of
+     * the merged Publishers notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError}
+     * will refrain from propagating that error notification until all of the merged Publishers have finished
+     * emitting items.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
+     * <p>
+     * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its Subscribers once.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. The source {@code Publisher}s are expected to honor
+     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param source1
+     *            a Publisher to be merged
+     * @param source2
+     *            a Publisher to be merged
+     * @param source3
+     *            a Publisher to be merged
+     * @param source4
+     *            a Publisher to be merged
+     * @param source5
+     *            a Publisher to be merged
+     * @param source6
+     *            a Publisher to be merged
+     * @param source7
+     *            a Publisher to be merged
+     * @return a Flowable that emits all of the items that are emitted by the source Publishers
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @CheckReturnValue
+    @NonNull
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Flowable<T> mergeDelayError(
+            Publisher<? extends T> source1, Publisher<? extends T> source2,
+            Publisher<? extends T> source3, Publisher<? extends T> source4,
+            Publisher<? extends T> source5, Publisher<? extends T> source6, Publisher<? extends T> source7) {
+        ObjectHelper.requireNonNull(source1, "source1 is null");
+        ObjectHelper.requireNonNull(source2, "source2 is null");
+        ObjectHelper.requireNonNull(source3, "source3 is null");
+        ObjectHelper.requireNonNull(source4, "source4 is null");
+        ObjectHelper.requireNonNull(source5, "source5 is null");
+        ObjectHelper.requireNonNull(source6, "source6 is null");
+        ObjectHelper.requireNonNull(source7, "source7 is null");
+        return fromArray(source1, source2, source3, source4, source5, source6, source7).flatMap((Function)Functions.identity(), true, 7);
+    }
+
+    /**
+     * Flattens four Publishers into one Publisher, in a way that allows a Subscriber to receive all
+     * successfully emitted items from all of the source Publishers without being interrupted by an error
+     * notification from one of them.
+     * <p>
+     * This behaves like {@link #merge(Publisher, Publisher, Publisher, Publisher)} except that if any of
+     * the merged Publishers notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError}
+     * will refrain from propagating that error notification until all of the merged Publishers have finished
+     * emitting items.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
+     * <p>
+     * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its Subscribers once.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. The source {@code Publisher}s are expected to honor
+     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param source1
+     *            a Publisher to be merged
+     * @param source2
+     *            a Publisher to be merged
+     * @param source3
+     *            a Publisher to be merged
+     * @param source4
+     *            a Publisher to be merged
+     * @param source5
+     *            a Publisher to be merged
+     * @param source6
+     *            a Publisher to be merged
+     * @param source7
+     *            a Publisher to be merged
+     * @param source8
+     *            a Publisher to be merged
+     * @return a Flowable that emits all of the items that are emitted by the source Publishers
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @CheckReturnValue
+    @NonNull
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Flowable<T> mergeDelayError(
+            Publisher<? extends T> source1, Publisher<? extends T> source2,
+            Publisher<? extends T> source3, Publisher<? extends T> source4,
+            Publisher<? extends T> source5, Publisher<? extends T> source6,
+            Publisher<? extends T> source7, Publisher<? extends T> source8) {
+        ObjectHelper.requireNonNull(source1, "source1 is null");
+        ObjectHelper.requireNonNull(source2, "source2 is null");
+        ObjectHelper.requireNonNull(source3, "source3 is null");
+        ObjectHelper.requireNonNull(source4, "source4 is null");
+        ObjectHelper.requireNonNull(source5, "source5 is null");
+        ObjectHelper.requireNonNull(source6, "source6 is null");
+        ObjectHelper.requireNonNull(source7, "source7 is null");
+        ObjectHelper.requireNonNull(source8, "source8 is null");
+        return fromArray(source1, source2, source3, source4, source5, source6, source7, source8).flatMap((Function)Functions.identity(), true, 8);
+    }
+
+    /**
+     * Flattens four Publishers into one Publisher, in a way that allows a Subscriber to receive all
+     * successfully emitted items from all of the source Publishers without being interrupted by an error
+     * notification from one of them.
+     * <p>
+     * This behaves like {@link #merge(Publisher, Publisher, Publisher, Publisher)} except that if any of
+     * the merged Publishers notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError}
+     * will refrain from propagating that error notification until all of the merged Publishers have finished
+     * emitting items.
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
+     * <p>
+     * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its Subscribers once.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. The source {@code Publisher}s are expected to honor
+     *  backpressure; if violated, the operator <em>may</em> signal {@code MissingBackpressureException}.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the common element base type
+     * @param source1
+     *            a Publisher to be merged
+     * @param source2
+     *            a Publisher to be merged
+     * @param source3
+     *            a Publisher to be merged
+     * @param source4
+     *            a Publisher to be merged
+     * @param source5
+     *            a Publisher to be merged
+     * @param source6
+     *            a Publisher to be merged
+     * @param source7
+     *            a Publisher to be merged
+     * @param source8
+     *            a Publisher to be merged
+     * @param source9
+     *            a Publisher to be merged
+     * @return a Flowable that emits all of the items that are emitted by the source Publishers
+     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @CheckReturnValue
+    @NonNull
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Flowable<T> mergeDelayError(
+            Publisher<? extends T> source1, Publisher<? extends T> source2,
+            Publisher<? extends T> source3, Publisher<? extends T> source4,
+            Publisher<? extends T> source5, Publisher<? extends T> source6,
+            Publisher<? extends T> source7, Publisher<? extends T> source8,
+            Publisher<? extends T> source9) {
+        ObjectHelper.requireNonNull(source1, "source1 is null");
+        ObjectHelper.requireNonNull(source2, "source2 is null");
+        ObjectHelper.requireNonNull(source3, "source3 is null");
+        ObjectHelper.requireNonNull(source4, "source3 is null");
+        ObjectHelper.requireNonNull(source5, "source4 is null");
+        ObjectHelper.requireNonNull(source6, "source5 is null");
+        ObjectHelper.requireNonNull(source7, "source6 is null");
+        ObjectHelper.requireNonNull(source8, "source7 is null");
+        ObjectHelper.requireNonNull(source9, "source8 is null");
+        return fromArray(source1, source2, source3, source4, source5, source6, source7, source8, source9).flatMap((Function)Functions.identity(), true, 9);
+    }
+
+    /**
      * Returns a Flowable that never sends any items or notifications to a {@link Subscriber}.
      * <p>
      * <img width="640" height="185" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/never.png" alt="">
@@ -10774,15 +11071,15 @@ public abstract class Flowable<T> implements Publisher<T> {
      * map has been evicted. The next source emission will bring about the completion of the evicted
      * {@link GroupedFlowable}s and the arrival of an item with the same key as a completed {@link GroupedFlowable}
      * will prompt the creation and emission of a new {@link GroupedFlowable} with that key.
-     * 
+     *
      * <p>A use case for specifying an {@code evictingMapFactory} is where the source is infinite and fast and
      * over time the number of keys grows enough to be a concern in terms of the memory footprint of the
      * internal hash map containing the {@link GroupedFlowable}s.
-     * 
+     *
      * <p>The map created by an {@code evictingMapFactory} must be thread-safe.
-     * 
+     *
      * <p>An example of an {@code evictingMapFactory} using <a href="https://google.github.io/guava/releases/24.0-jre/api/docs/com/google/common/cache/CacheBuilder.html">CacheBuilder</a> from the Guava library is below:
-     * 
+     *
      * <pre><code>
      * Function&lt;Consumer&lt;Object&gt;, Map&lt;Integer, Object&gt;&gt; evictingMapFactory =
      *   notify -&gt;
@@ -10809,7 +11106,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *   .flatMap(g -&gt; g)
      *   .forEach(System.out::println);
      * </code></pre>
-     * 
+     *
      * <p>
      * <img width="640" height="360" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/groupBy.png" alt="">
      * <p>
@@ -11142,7 +11439,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Example:
      * <pre><code>
      * // Step 1: Create the consumer type that will be returned by the FlowableOperator.apply():
-     * 
+     *
      * public final class CustomSubscriber&lt;T&gt; implements FlowableSubscriber&lt;T&gt;, Subscription {
      *
      *     // The downstream's Subscriber that will receive the onXXX events

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -13,26 +13,70 @@
 
 package io.reactivex;
 
-import java.util.*;
-import java.util.concurrent.*;
-
 import org.reactivestreams.Publisher;
 
-import io.reactivex.annotations.*;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.annotations.BackpressureKind;
+import io.reactivex.annotations.BackpressureSupport;
+import io.reactivex.annotations.CheckReturnValue;
+import io.reactivex.annotations.Experimental;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.SchedulerSupport;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.*;
-import io.reactivex.internal.functions.*;
+import io.reactivex.functions.Action;
+import io.reactivex.functions.BiConsumer;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.functions.BiPredicate;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.functions.Cancellable;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
+import io.reactivex.functions.Function3;
+import io.reactivex.functions.Function4;
+import io.reactivex.functions.Function5;
+import io.reactivex.functions.Function6;
+import io.reactivex.functions.Function7;
+import io.reactivex.functions.Function8;
+import io.reactivex.functions.Function9;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.ScalarCallable;
-import io.reactivex.internal.observers.*;
-import io.reactivex.internal.operators.flowable.*;
-import io.reactivex.internal.operators.mixed.*;
+import io.reactivex.internal.observers.BlockingFirstObserver;
+import io.reactivex.internal.observers.BlockingLastObserver;
+import io.reactivex.internal.observers.ForEachWhileObserver;
+import io.reactivex.internal.observers.FutureObserver;
+import io.reactivex.internal.observers.LambdaObserver;
+import io.reactivex.internal.operators.flowable.FlowableFromObservable;
+import io.reactivex.internal.operators.flowable.FlowableOnBackpressureError;
+import io.reactivex.internal.operators.mixed.ObservableConcatMapCompletable;
+import io.reactivex.internal.operators.mixed.ObservableConcatMapMaybe;
+import io.reactivex.internal.operators.mixed.ObservableConcatMapSingle;
+import io.reactivex.internal.operators.mixed.ObservableSwitchMapCompletable;
+import io.reactivex.internal.operators.mixed.ObservableSwitchMapMaybe;
+import io.reactivex.internal.operators.mixed.ObservableSwitchMapSingle;
 import io.reactivex.internal.operators.observable.*;
-import io.reactivex.internal.util.*;
-import io.reactivex.observables.*;
-import io.reactivex.observers.*;
+import io.reactivex.internal.util.ArrayListSupplier;
+import io.reactivex.internal.util.ErrorMode;
+import io.reactivex.internal.util.ExceptionHelper;
+import io.reactivex.internal.util.HashMapSupplier;
+import io.reactivex.observables.ConnectableObservable;
+import io.reactivex.observables.GroupedObservable;
+import io.reactivex.observers.SafeObserver;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.*;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.schedulers.Timed;
 
 /**
  * The Observable class is the non-backpressured, optionally multi-valued base reactive class that
@@ -84,12 +128,12 @@ import io.reactivex.schedulers.*;
  *             System.out.println("Done!");
  *         }
  *     });
- * 
+ *
  * Thread.sleep(500);
  * // the sequence can now be disposed via dispose()
  * d.dispose();
  * </code></pre>
- * 
+ *
  * @param <T>
  *            the type of the items emitted by the Observable
  * @see Flowable
@@ -1278,7 +1322,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T> Observable<T> concatArray(ObservableSource<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
-        } else
+        }
         if (sources.length == 1) {
             return wrap((ObservableSource<T>)sources[0]);
         }
@@ -1305,7 +1349,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T> Observable<T> concatArrayDelayError(ObservableSource<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
-        } else
+        }
         if (sources.length == 1) {
             return (Observable<T>)wrap(sources[0]);
         }
@@ -1765,7 +1809,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(items, "items is null");
         if (items.length == 0) {
             return empty();
-        } else
+        }
         if (items.length == 1) {
             return just(items[0]);
         }
@@ -9627,7 +9671,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Example:
      * <pre><code>
      * // Step 1: Create the consumer type that will be returned by the ObservableOperator.apply():
-     * 
+     *
      * public final class CustomObserver&lt;T&gt; implements Observer&lt;T&gt;, Disposable {
      *
      *     // The downstream's Observer that will receive the onXXX events
@@ -12817,10 +12861,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> takeLast(int count) {
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
-        } else
+        }
         if (count == 0) {
             return RxJavaPlugins.onAssembly(new ObservableIgnoreElements<T>(this));
-        } else
+        }
         if (count == 1) {
             return RxJavaPlugins.onAssembly(new ObservableTakeLastOne<T>(this));
         }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -13,70 +13,26 @@
 
 package io.reactivex;
 
+import java.util.*;
+import java.util.concurrent.*;
+
 import org.reactivestreams.Publisher;
 
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-
-import io.reactivex.annotations.BackpressureKind;
-import io.reactivex.annotations.BackpressureSupport;
-import io.reactivex.annotations.CheckReturnValue;
-import io.reactivex.annotations.Experimental;
-import io.reactivex.annotations.NonNull;
-import io.reactivex.annotations.SchedulerSupport;
+import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.BiConsumer;
-import io.reactivex.functions.BiFunction;
-import io.reactivex.functions.BiPredicate;
-import io.reactivex.functions.BooleanSupplier;
-import io.reactivex.functions.Cancellable;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Function;
-import io.reactivex.functions.Function3;
-import io.reactivex.functions.Function4;
-import io.reactivex.functions.Function5;
-import io.reactivex.functions.Function6;
-import io.reactivex.functions.Function7;
-import io.reactivex.functions.Function8;
-import io.reactivex.functions.Function9;
-import io.reactivex.functions.Predicate;
-import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.*;
 import io.reactivex.internal.fuseable.ScalarCallable;
-import io.reactivex.internal.observers.BlockingFirstObserver;
-import io.reactivex.internal.observers.BlockingLastObserver;
-import io.reactivex.internal.observers.ForEachWhileObserver;
-import io.reactivex.internal.observers.FutureObserver;
-import io.reactivex.internal.observers.LambdaObserver;
-import io.reactivex.internal.operators.flowable.FlowableFromObservable;
-import io.reactivex.internal.operators.flowable.FlowableOnBackpressureError;
-import io.reactivex.internal.operators.mixed.ObservableConcatMapCompletable;
-import io.reactivex.internal.operators.mixed.ObservableConcatMapMaybe;
-import io.reactivex.internal.operators.mixed.ObservableConcatMapSingle;
-import io.reactivex.internal.operators.mixed.ObservableSwitchMapCompletable;
-import io.reactivex.internal.operators.mixed.ObservableSwitchMapMaybe;
-import io.reactivex.internal.operators.mixed.ObservableSwitchMapSingle;
+import io.reactivex.internal.observers.*;
+import io.reactivex.internal.operators.flowable.*;
+import io.reactivex.internal.operators.mixed.*;
 import io.reactivex.internal.operators.observable.*;
-import io.reactivex.internal.util.ArrayListSupplier;
-import io.reactivex.internal.util.ErrorMode;
-import io.reactivex.internal.util.ExceptionHelper;
-import io.reactivex.internal.util.HashMapSupplier;
-import io.reactivex.observables.ConnectableObservable;
-import io.reactivex.observables.GroupedObservable;
-import io.reactivex.observers.SafeObserver;
-import io.reactivex.observers.TestObserver;
+import io.reactivex.internal.util.*;
+import io.reactivex.observables.*;
+import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
-import io.reactivex.schedulers.Timed;
+import io.reactivex.schedulers.*;
 
 /**
  * The Observable class is the non-backpressured, optionally multi-valued base reactive class that

--- a/src/test/java/io/reactivex/flowable/FlowableNotificationTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNotificationTest.java
@@ -47,20 +47,9 @@ public class FlowableNotificationTest {
         Assert.assertFalse(integerNotification.equals(integerNotification2));
     }
 
-    @Test
-    @Ignore("Nulls are not allowed")
-    public void testOnErrorIntegerNotificationDoesNotEqualNullNotification() {
-        final Notification<Integer> integerNotification = Notification.createOnError(new Exception());
-        final Notification<Integer> nullNotification = Notification.createOnError(null);
-        Assert.assertFalse(integerNotification.equals(nullNotification));
-    }
-
-    @Test
-    @Ignore("Nulls are not allowed")
-    public void testOnErrorNullNotificationDoesNotEqualIntegerNotification() {
-        final Notification<Integer> integerNotification = Notification.createOnError(new Exception());
-        final Notification<Integer> nullNotification = Notification.createOnError(null);
-        Assert.assertFalse(nullNotification.equals(integerNotification));
+    @Test(expected = NullPointerException.class)
+    public void testOnNullErrorIntegerNotification() {
+        Notification.createOnError(null);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatestTest.java
@@ -168,9 +168,9 @@ public class BlockingFlowableLatestTest {
         Assert.assertEquals(false, it.hasNext());
     }
 
-    @Ignore("THe target is an enum")
+    @Ignore("The target is an enum")
     @Test
-    public void constructorshouldbeprivate() {
+    public void constructorShouldBePrivate() {
         TestHelper.checkUtilityClass(BlockingFlowableLatest.class);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -332,9 +332,9 @@ public class BlockingFlowableNextTest {
         assertEquals(3, BehaviorProcessor.createDefault(3).blockingNext().iterator().next().intValue());
     }
 
-    @Ignore("THe target is an enum")
+    @Ignore("The target is an enum")
     @Test
-    public void constructorshouldbeprivate() {
+    public void constructorShouldBePrivate() {
         TestHelper.checkUtilityClass(BlockingFlowableNext.class);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
@@ -58,8 +58,7 @@ public class BlockingFlowableToFutureTest {
             // we expect an exception since there are more than 1 element
             f.get();
             fail("Should have thrown!");
-        }
-        catch (ExecutionException e) {
+        } catch (ExecutionException e) {
             throw e.getCause();
         }
     }
@@ -109,16 +108,22 @@ public class BlockingFlowableToFutureTest {
         Future<String> f = obs.toFuture();
         try {
             f.get();
-        }
-        catch (ExecutionException e) {
+        } catch (ExecutionException e) {
             throw e.getCause();
         }
     }
 
-    @Ignore("null value is not allowed")
     @Test
     public void testGetWithASingleNullItem() throws Exception {
-        Flowable<String> obs = Flowable.just((String)null);
+        Flowable<String> obs = Flowable
+                .fromCallable(new Callable<String>() {
+                                  @Override public String call() {
+                                      return null;
+                                  }
+                              }
+
+                );
+
         Future<String> f = obs.toFuture();
         assertEquals(null, f.get());
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
@@ -293,8 +293,7 @@ public class FlowableAllTest {
                 return i % 2 == 1;
             }
         })
-        .toFlowable()
-        ;
+        .toFlowable();
 
         assertFalse(allOdd.blockingFirst());
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -641,7 +641,6 @@ public class FlowableConcatMapEagerTest {
     }
 
     @Test
-    @Ignore("Null values are not allowed in RS")
     public void testInnerNull() {
         Flowable.just(1).concatMapEager(new Function<Integer, Flowable<Integer>>() {
             @Override
@@ -650,9 +649,7 @@ public class FlowableConcatMapEagerTest {
             }
         }).subscribe(ts);
 
-        ts.assertNoErrors();
-        ts.assertComplete();
-        ts.assertValue(null);
+        ts.assertError(NullPointerException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
@@ -37,6 +37,7 @@ import io.reactivex.subscribers.*;
 public class FlowableDistinctUntilChangedTest {
 
     Subscriber<String> w;
+
     Subscriber<String> w2;
 
     // nulls lead to exceptions

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -461,6 +461,7 @@ public class FlowableMergeDelayErrorTest {
 
         result.subscribe(new DefaultSubscriber<Integer>() {
             int calls;
+
             @Override
             public void onNext(Integer t) {
                 if (calls++ == 0) {
@@ -654,20 +655,19 @@ public class FlowableMergeDelayErrorTest {
         ts.assertError(CompositeException.class);
         ts.assertNotComplete();
 
-        CompositeException ce = (CompositeException)ts.errors().get(0);
+        CompositeException ce = (CompositeException) ts.errors().get(0);
 
         assertEquals(2, ce.getExceptions().size());
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    @Ignore("No 2-9 parameter mergeDelayError() overloads")
     public void mergeMany() throws Exception {
         for (int i = 2; i < 10; i++) {
             Class<?>[] clazz = new Class[i];
-            Arrays.fill(clazz, Flowable.class);
+            Arrays.fill(clazz, Publisher.class);
 
-            Flowable<Integer>[] obs = new Flowable[i];
+            Publisher<Integer>[] obs = new Flowable[i];
             Arrays.fill(obs, Flowable.just(1));
 
             Integer[] expected = new Integer[i];
@@ -691,11 +691,10 @@ public class FlowableMergeDelayErrorTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    @Ignore("No 2-9 parameter mergeDelayError() overloads")
     public void mergeManyError() throws Exception {
         for (int i = 2; i < 10; i++) {
             Class<?>[] clazz = new Class[i];
-            Arrays.fill(clazz, Flowable.class);
+            Arrays.fill(clazz, Publisher.class);
 
             Flowable<Integer>[] obs = new Flowable[i];
             for (int j = 0; j < i; j++) {
@@ -709,13 +708,13 @@ public class FlowableMergeDelayErrorTest {
 
             TestSubscriber<Integer> ts = TestSubscriber.create();
 
-            ((Flowable<Integer>)m.invoke(null, (Object[])obs)).subscribe(ts);
+            ((Flowable<Integer>) m.invoke(null, (Object[]) obs)).subscribe(ts);
 
             ts.assertValues(expected);
             ts.assertError(CompositeException.class);
             ts.assertNotComplete();
 
-            CompositeException ce = (CompositeException)ts.errors().get(0);
+            CompositeException ce = (CompositeException) ts.errors().get(0);
 
             assertEquals(i, ce.getExceptions().size());
         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -1337,7 +1337,6 @@ public class FlowableMergeTest {
             return Flowable.just(t).hide();
         }
     };
-    ;
 
     void runMerge(Function<Integer, Flowable<Integer>> func, TestSubscriber<Integer> ts) {
         List<Integer> list = new ArrayList<Integer>();
@@ -1426,7 +1425,6 @@ public class FlowableMergeTest {
     }
 
     @Test
-    @Ignore("Nulls are not allowed with RS")
     public void mergeJustNull() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
 
@@ -1438,9 +1436,7 @@ public class FlowableMergeTest {
         }).subscribe(ts);
 
         ts.request(2);
-        ts.assertValues(null, null);
-        ts.assertNoErrors();
-        ts.assertComplete();
+        ts.assertError(NullPointerException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -97,10 +97,12 @@ public class FlowableRefCountTest {
         d2.dispose(); // unsubscribe s2 first as we're counting in 1 and there can be a race between unsubscribe and one subscriber getting a value but not the other
         d1.dispose();
 
-        System.out.println("onNext: " + nextCount.get());
+        int next = nextCount.get();
+
+        System.out.println("onNext: " + next);
 
         // should emit once for both subscribers
-        assertEquals(nextCount.get(), receivedCount.get());
+        assertEquals(next, receivedCount.get());
         // only 1 subscribe
         assertEquals(1, subscribeCount.get());
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToFutureTest.java
@@ -59,8 +59,7 @@ public class BlockingObservableToFutureTest {
             // we expect an exception since there are more than 1 element
             f.get();
             fail("Should have thrown!");
-        }
-        catch (ExecutionException e) {
+        } catch (ExecutionException e) {
             throw e.getCause();
         }
     }
@@ -110,17 +109,8 @@ public class BlockingObservableToFutureTest {
         Future<String> f = obs.toFuture();
         try {
             f.get();
-        }
-        catch (ExecutionException e) {
+        } catch (ExecutionException e) {
             throw e.getCause();
         }
-    }
-
-    @Ignore("null value is not allowed")
-    @Test
-    public void testGetWithASingleNullItem() throws Exception {
-        Observable<String> obs = Observable.just((String)null);
-        Future<String> f = obs.toFuture();
-        assertEquals(null, f.get());
     }
 }

--- a/src/test/java/io/reactivex/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/AsyncProcessorTest.java
@@ -73,20 +73,10 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
         verify(subscriber, times(1)).onComplete();
     }
 
-    @Test
-    @Ignore("Null values not allowed")
+    @Test(expected = NullPointerException.class)
     public void testNull() {
         AsyncProcessor<String> processor = AsyncProcessor.create();
-
-        Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        processor.subscribe(subscriber);
-
         processor.onNext(null);
-        processor.onComplete();
-
-        verify(subscriber, times(1)).onNext(null);
-        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
-        verify(subscriber, times(1)).onComplete();
     }
 
     @Test
@@ -259,6 +249,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     private static class SubjectSubscriberThread extends Thread {
 
         private final AsyncProcessor<String> processor;
+
         private final AtomicReference<String> value = new AtomicReference<String>();
 
         SubjectSubscriberThread(AsyncProcessor<String> processor) {

--- a/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/BehaviorProcessorTest.java
@@ -43,6 +43,12 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         return BehaviorProcessor.create();
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test(expected = NullPointerException.class)
+    public void testNullEmitting() {
+        BehaviorProcessor.createDefault(null);
+    }
+
     @Test
     public void testThatSubscriberReceivesDefaultValueAndSubsequentEvents() {
         BehaviorProcessor<String> processor = BehaviorProcessor.createDefault("default");

--- a/src/test/java/io/reactivex/subjects/AsyncSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/AsyncSubjectTest.java
@@ -72,20 +72,10 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
         verify(observer, times(1)).onComplete();
     }
 
-    @Test
-    @Ignore("Null values not allowed")
+    @Test(expected = NullPointerException.class)
     public void testNull() {
         AsyncSubject<String> subject = AsyncSubject.create();
-
-        Observer<String> observer = TestHelper.mockObserver();
-        subject.subscribe(observer);
-
         subject.onNext(null);
-        subject.onComplete();
-
-        verify(observer, times(1)).onNext(null);
-        verify(observer, Mockito.never()).onError(any(Throwable.class));
-        verify(observer, times(1)).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/BehaviorSubjectTest.java
@@ -42,6 +42,12 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         return BehaviorSubject.create();
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test(expected = NullPointerException.class)
+    public void testNullEmitting() {
+        BehaviorSubject.createDefault(null);
+    }
+
     @Test
     public void testThatSubscriberReceivesDefaultValueAndSubsequentEvents() {
         BehaviorSubject<String> subject = BehaviorSubject.createDefault("default");


### PR DESCRIPTION
1. Add Flowable.mergeDelayError with 2-9 arguments. Now you can use it as a method merge.
2. Update tests which have annotation `@Ignore` for new logic.