### PR TITLE
Null check for BufferExactBoundedObserver

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -13,13 +13,19 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.*;
-import java.util.concurrent.*;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.reactivestreams.*;
-
-import io.reactivex.*;
+import io.reactivex.Flowable;
+import io.reactivex.Scheduler;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
@@ -27,7 +33,8 @@ import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.QueueDrainSubscriber;
-import io.reactivex.internal.subscriptions.*;
+import io.reactivex.internal.subscriptions.EmptySubscription;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.QueueDrainHelper;
 import io.reactivex.subscribers.SerializedSubscriber;
 
@@ -501,13 +508,15 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
                 buffer = null;
             }
 
-            queue.offer(b);
-            done = true;
-            if (enter()) {
-                QueueDrainHelper.drainMaxLoop(queue, downstream, false, this, this);
-            }
+            if (b != null) {
+                queue.offer(b);
+                done = true;
+                if (enter()) {
+                    QueueDrainHelper.drainMaxLoop(queue, downstream, false, this, this);
+                }
 
-            w.dispose();
+                w.dispose();
+            }
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferTimed.java
@@ -13,19 +13,13 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.Flowable;
-import io.reactivex.Scheduler;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
@@ -33,8 +27,7 @@ import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.QueueDrainSubscriber;
-import io.reactivex.internal.subscriptions.EmptySubscription;
-import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.subscriptions.*;
 import io.reactivex.internal.util.QueueDrainHelper;
 import io.reactivex.subscribers.SerializedSubscriber;
 
@@ -514,7 +507,6 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
                 if (enter()) {
                     QueueDrainHelper.drainMaxLoop(queue, downstream, false, this, this);
                 }
-
                 w.dispose();
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -504,10 +504,12 @@ extends AbstractObservableWithUpstream<T, U> {
                 buffer = null;
             }
 
-            queue.offer(b);
-            done = true;
-            if (enter()) {
-                QueueDrainHelper.drainLoop(queue, downstream, false, this, this);
+            if(b != null) {
+                queue.offer(b);
+                done = true;
+                if (enter()) {
+                    QueueDrainHelper.drainLoop(queue, downstream, false, this, this);
+                }
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferTimed.java
@@ -504,7 +504,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 buffer = null;
             }
 
-            if(b != null) {
+            if (b != null) {
                 queue.offer(b);
                 done = true;
                 if (enter()) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -13,65 +13,32 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
-import io.reactivex.Flowable;
-import io.reactivex.Scheduler;
-import io.reactivex.TestHelper;
+import org.junit.*;
+import org.mockito.*;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.ProtocolViolationException;
-import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.BiFunction;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Function;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.flowable.FlowableBufferBoundarySupplier.BufferBoundarySupplierSubscriber;
-import io.reactivex.internal.operators.flowable.FlowableBufferTimed.BufferExactBoundedSubscriber;
-import io.reactivex.internal.operators.flowable.FlowableBufferTimed.BufferExactUnboundedSubscriber;
-import io.reactivex.internal.operators.flowable.FlowableBufferTimed.BufferSkipBoundedSubscriber;
+import io.reactivex.internal.operators.flowable.FlowableBufferTimed.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
-import io.reactivex.internal.util.ArrayListSupplier;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.processors.BehaviorProcessor;
-import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
-import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subscribers.DefaultSubscriber;
-import io.reactivex.subscribers.ResourceSubscriber;
-import io.reactivex.subscribers.TestSubscriber;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import io.reactivex.processors.*;
+import io.reactivex.schedulers.*;
+import io.reactivex.subscribers.*;
 
 public class FlowableBufferTest {
 
@@ -2805,12 +2772,16 @@ public class FlowableBufferTest {
 
     @Test
     public void bufferExactFailingSupplier() {
-        Scheduler.Worker w = new TestScheduler().createWorker();
-        TestSubscriber<List<Integer>> observer = new TestSubscriber<List<Integer>>();
-
-        FlowableBufferTimed.BufferExactBoundedSubscriber<Integer, List<Integer>> buf = new FlowableBufferTimed.BufferExactBoundedSubscriber<Integer, List<Integer>>(observer, ArrayListSupplier.<Integer>asCallable(), 100, TimeUnit.MILLISECONDS, 10, false, w);
-
-        buf.onError(new Throwable());
-        buf.onComplete();
+        Flowable.empty()
+                .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Callable<List<Object>>() {
+                    @Override
+                    public List<Object> call() throws Exception {
+                        throw new TestException();
+                    }
+                }, false)
+                .test()
+                .awaitDone(1, TimeUnit.SECONDS)
+                .assertFailure(TestException.class)
+        ;
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -13,33 +13,62 @@
 
 package io.reactivex.internal.operators.observable;
 
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.*;
-import org.mockito.*;
-
-import io.reactivex.*;
 import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
-import io.reactivex.disposables.*;
-import io.reactivex.exceptions.*;
-import io.reactivex.functions.*;
+import io.reactivex.Scheduler;
+import io.reactivex.TestHelper;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.Disposables;
+import io.reactivex.exceptions.ProtocolViolationException;
+import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Action;
+import io.reactivex.functions.BiFunction;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.observable.ObservableBuffer.BufferExactObserver;
 import io.reactivex.internal.operators.observable.ObservableBufferBoundarySupplier.BufferBoundarySupplierObserver;
-import io.reactivex.internal.operators.observable.ObservableBufferTimed.*;
-import io.reactivex.observers.*;
+import io.reactivex.internal.operators.observable.ObservableBufferTimed.BufferExactBoundedObserver;
+import io.reactivex.internal.operators.observable.ObservableBufferTimed.BufferExactUnboundedObserver;
+import io.reactivex.internal.operators.observable.ObservableBufferTimed.BufferSkipBoundedObserver;
+import io.reactivex.internal.util.ArrayListSupplier;
+import io.reactivex.observers.DisposableObserver;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.*;
-import io.reactivex.subjects.*;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.PublishSubject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class ObservableBufferTest {
 
@@ -2135,5 +2164,16 @@ public class ObservableBufferTest {
                 return o.buffer(1, 2);
             }
         });
+    }
+
+    @Test
+    public void bufferExactFailingSupplier() {
+        Scheduler.Worker w = new TestScheduler().createWorker();
+        TestObserver<List<Integer>> observer = new TestObserver<List<Integer>>();
+
+        BufferExactBoundedObserver<Integer, List<Integer>> buf = new BufferExactBoundedObserver<Integer, List<Integer>>(observer, ArrayListSupplier.<Integer>asCallable(), 100, TimeUnit.MILLISECONDS, 10, false, w);
+
+        buf.onError(new Throwable());
+        buf.onComplete();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -13,62 +13,33 @@
 
 package io.reactivex.internal.operators.observable;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
+import org.junit.*;
+import org.mockito.*;
+
+import io.reactivex.*;
 import io.reactivex.Observable;
-import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
-import io.reactivex.Scheduler;
-import io.reactivex.TestHelper;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.disposables.Disposables;
-import io.reactivex.exceptions.ProtocolViolationException;
-import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.BiFunction;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Function;
+import io.reactivex.disposables.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.observable.ObservableBuffer.BufferExactObserver;
 import io.reactivex.internal.operators.observable.ObservableBufferBoundarySupplier.BufferBoundarySupplierObserver;
-import io.reactivex.internal.operators.observable.ObservableBufferTimed.BufferExactBoundedObserver;
-import io.reactivex.internal.operators.observable.ObservableBufferTimed.BufferExactUnboundedObserver;
-import io.reactivex.internal.operators.observable.ObservableBufferTimed.BufferSkipBoundedObserver;
-import io.reactivex.internal.util.ArrayListSupplier;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.observers.TestObserver;
+import io.reactivex.internal.operators.observable.ObservableBufferTimed.*;
+import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.schedulers.Schedulers;
-import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subjects.BehaviorSubject;
-import io.reactivex.subjects.PublishSubject;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import io.reactivex.schedulers.*;
+import io.reactivex.subjects.*;
 
 public class ObservableBufferTest {
 
@@ -2168,12 +2139,16 @@ public class ObservableBufferTest {
 
     @Test
     public void bufferExactFailingSupplier() {
-        Scheduler.Worker w = new TestScheduler().createWorker();
-        TestObserver<List<Integer>> observer = new TestObserver<List<Integer>>();
-
-        BufferExactBoundedObserver<Integer, List<Integer>> buf = new BufferExactBoundedObserver<Integer, List<Integer>>(observer, ArrayListSupplier.<Integer>asCallable(), 100, TimeUnit.MILLISECONDS, 10, false, w);
-
-        buf.onError(new Throwable());
-        buf.onComplete();
+        Observable.empty()
+                .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Callable<List<Object>>() {
+                    @Override
+                    public List<Object> call() throws Exception {
+                        throw new TestException();
+                    }
+                }, false)
+                .test()
+                .awaitDone(1, TimeUnit.SECONDS)
+                .assertFailure(TestException.class)
+        ;
     }
 }


### PR DESCRIPTION
- [*] Please give a description about what and why you are contributing, even if it's trivial:

**Improve stability of the library.**
Other variants of the onComplete method include this Null check already, e.g. BufferExactUnboundedObserver, this check should fix the case when there is a race condition and buffer is already set to "null" by the time onComplete is called.

It is causing 0.1% crashes in our production app, this should improve stability of other apps too.
 