### PR TITLE
2.x: Fix javadocs & imports

### DIFF
--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -12,6 +12,8 @@ task javadocCleanup(dependsOn: "javadoc") doLast {
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/subjects/ReplaySubject.html'));
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/processors/ReplayProcessor.html'));
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/plugins/RxJavaPlugins.html'));
+
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/parallel/ParallelFlowable.html'));
 }
 
 def fixJavadocFile(file) {

--- a/src/main/java/io/reactivex/processors/package-info.java
+++ b/src/main/java/io/reactivex/processors/package-info.java
@@ -16,7 +16,7 @@
 
 /**
  * Classes representing so-called hot backpressure-aware sources, aka <strong>processors</strong>,
- * that implement the {@link FlowableProcessor} class,
+ * that implement the {@link io.reactivex.processors.FlowableProcessor FlowableProcessor} class,
  * the Reactive Streams {@link org.reactivestreams.Processor Processor} interface
  * to allow forms of multicasting events to one or more subscribers as well as consuming another
  * Reactive Streams {@link org.reactivestreams.Publisher Publisher}.
@@ -33,7 +33,7 @@
  * </ul>
  * <p>
  * The non-backpressured variants of the {@code FlowableProcessor} class are called
- * {@link io.reactivex.Subject}s and reside in the {@code io.reactivex.subjects} package.
+ * {@link io.reactivex.subjects.Subject}s and reside in the {@code io.reactivex.subjects} package.
  * @see io.reactivex.subjects
  */
 package io.reactivex.processors;

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -299,7 +299,7 @@ public final class Schedulers {
      * a time delay or periodically will use the {@link #single()} scheduler for the timed waiting
      * before posting the actual task to the given executor.
      * <p>
-     * Tasks submitted to the {@link Scheduler.Worker} of this {@code Scheduler} are also not interruptible. Use the
+     * Tasks submitted to the {@link io.reactivex.Scheduler.Worker Scheduler.Worker} of this {@code Scheduler} are also not interruptible. Use the
      * {@link #from(Executor, boolean)} overload to enable task interruption via this wrapper.
      * <p>
      * If the provided executor supports the standard Java {@link ExecutorService} API,
@@ -332,7 +332,7 @@ public final class Schedulers {
      * }
      * </code></pre>
      * <p>
-     * This type of scheduler is less sensitive to leaking {@link Scheduler.Worker} instances, although
+     * This type of scheduler is less sensitive to leaking {@link io.reactivex.Scheduler.Worker Scheduler.Worker} instances, although
      * not disposing a worker that has timed/delayed tasks not cancelled by other means may leak resources and/or
      * execute those tasks "unexpectedly".
      * <p>
@@ -350,7 +350,7 @@ public final class Schedulers {
      * Wraps an {@link Executor} into a new Scheduler instance and delegates {@code schedule()}
      * calls to it.
      * <p>
-     * The tasks scheduled by the returned {@link Scheduler} and its {@link Scheduler.Worker}
+     * The tasks scheduled by the returned {@link Scheduler} and its {@link io.reactivex.Scheduler.Worker Scheduler.Worker}
      * can be optionally interrupted.
      * <p>
      * If the provided executor doesn't support any of the more specific standard Java executor
@@ -388,14 +388,14 @@ public final class Schedulers {
      * }
      * </code></pre>
      * <p>
-     * This type of scheduler is less sensitive to leaking {@link Scheduler.Worker} instances, although
+     * This type of scheduler is less sensitive to leaking {@link io.reactivex.Scheduler.Worker Scheduler.Worker} instances, although
      * not disposing a worker that has timed/delayed tasks not cancelled by other means may leak resources and/or
      * execute those tasks "unexpectedly".
      * <p>
      * Note that this method returns a new {@link Scheduler} instance, even for the same {@link Executor} instance.
      * @param executor
      *          the executor to wrap
-     * @param interruptibleWorker if {@code true} the tasks submitted to the {@link Scheduler.Worker} will
+     * @param interruptibleWorker if {@code true} the tasks submitted to the {@link io.reactivex.Scheduler.Worker Scheduler.Worker} will
      * be interrupted when the task is disposed.
      * @return the new Scheduler wrapping the Executor
      * @since 2.2.6 - experimental

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoOnTerminateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoOnTerminateTest.java
@@ -19,8 +19,6 @@ import io.reactivex.exceptions.CompositeException;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Action;
 import io.reactivex.observers.TestObserver;
-import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.subjects.PublishSubject;
 import org.junit.Test;
 
 import java.util.List;

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTerminateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTerminateTest.java
@@ -19,7 +19,6 @@ import io.reactivex.exceptions.CompositeException;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Action;
 import io.reactivex.observers.TestObserver;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;


### PR DESCRIPTION
- Fix some errors in the Javadoc links.
- Remove unused imports.
- Add the ParallelFlowable page to the javadoc cleanup routine.