### PR TITLE
2.x: Expand the Javadoc of Flowable

### DIFF
--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -42,7 +42,7 @@ import io.reactivex.schedulers.*;
  * Many operators in the class accept {@code ObservableSource}(s), the base reactive interface
  * for such non-backpressured flows, which {@code Observable} itself implements as well.
  * <p>
- * The Observable's operators, by default, run with a buffer size of 128 elements (see {@link Flowable#bufferSize()},
+ * The Observable's operators, by default, run with a buffer size of 128 elements (see {@link Flowable#bufferSize()}),
  * that can be overridden globally via the system parameter {@code rx2.buffer-size}. Most operators, however, have
  * overloads that allow setting their internal buffer size explicitly.
  * <p>


### PR DESCRIPTION
- Add links to Reactive Streams
- Fix hyphenation
- Turn some `@code` into `@link`s.
- Add a short protocol description
- Add basic example usage
- Add example to use `create` for custom sources
- Mention the synchronous/sequential nature and link in some operators.